### PR TITLE
added hook to Authorize.net silent post

### DIFF
--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -128,5 +128,7 @@
 			$pmproemail->data = array("body"=>"<p>A payment is being held for review within Authorize.net.</p><p>Payment Information From Authorize.net:<br />" . nl2br(var_export($fields, true)));
 			$pmproemail->sendEmail(get_bloginfo("admin_email"));			
 		}
-	}		
+	}
+
+	do_action("pmpro_authnet_silent_post");
 ?>


### PR DESCRIPTION
Hi Jason,
I was hoping you'd be open to the idea of adding a hook to the Authorize.net silent post script so that you can extend it a bit without hacking the plugin. In my case I needed to add some functionality to detect refunded charges and set the orders status to "refunded" when it gets the notification, but I think having a general hook here would be good.
