### PR TITLE
database error Key column 'enddate'

### DIFF
--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -180,7 +180,7 @@ ADD  `expiration_period` ENUM(  'Day',  'Week',  'Month',  'Year' ) NOT NULL
 	$wpdb->query($sqlQuery);
 	
 	$sqlQuery = "
-		ALTER TABLE  `" . $wpdb->pmpro_membership_levels . "` ADD INDEX (  `enddate` )
+		ALTER TABLE  `" . $wpdb->pmpro_memberships_users . "` ADD INDEX (  `enddate` )
 	";
 	$wpdb->query($sqlQuery);
 	


### PR DESCRIPTION
 WordPress database error Key column 'enddate' doesn't exist in table for query 
        ALTER TABLE  `wp_pmpro_membership_levels` ADD INDEX (  `enddate` )
     made by activate_plugin, include_once('/plugins/paid-memberships-pro/paid-memberships-pro.php'), pmpro_checkForUpgrades, pmpro_upgrade_1_2_3
