### PR TITLE
Updated pmpro_page_meta() in paid-memberships-pro.php

### DIFF
--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -1180,7 +1180,7 @@ function pmpro_page_meta()
     ?>
     </ul>
 	<?php if('post' == get_post_type($post)) { ?>
-		<p class="pmpro_meta_notice">This post may also require membership if it is within a category that requires membership.</p>
+		<p class="pmpro_meta_notice">^ This post is already protected for this level because it is within a category that requires membership.</p>
 	<?php } ?>
 <?php
 }


### PR DESCRIPTION
Enhanced the Require Membership metabox to indicate via ^ symbol on the membership level if the post is already in a category that's protected by that level; changed the descriptive text below the metabox accordingly.
