### PR TITLE
Master

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -27,6 +27,10 @@
 		//tos
 		pmpro_setOption("tospage");		
 		
+        //level list sort by
+        pmpro_setOption("levelsortby");
+        pmpro_setOption("levelsortby_direction");
+        
 		//footer link
 		pmpro_setOption("hide_footer_link");
 		
@@ -52,7 +56,10 @@
 	$tospage = pmpro_getOption("tospage");
 	
 	$hide_footer_link = pmpro_getOption("hide_footer_link");
-		
+	
+    $levelsortby = pmpro_getOption("levelsortby");
+    $levelsortby_direction = pmpro_getOption("levelsortby_direction");
+    	
 	//default settings
 	if(!$nonmembertext)
 	{
@@ -69,8 +76,18 @@
 		$rsstext = "This content is for members only. Visit the site and log in/register to read.";
 		pmpro_setOption("rsstext", $rsstext);
 	}   				
-		
-	$levels = $wpdb->get_results( "SELECT * FROM {$wpdb->pmpro_membership_levels}", OBJECT );
+    
+    //add the sortby fields
+	if($levelsortby == null || strlen($levelsortby) == 0)
+    {
+        $levelsortby = 'id';
+    }   
+    if($levelsortby_direction == null || strlen($levelsortby_direction) == 0)
+    {
+        $levelsortby_direction = 'ASC';
+    }   
+    	
+	$levels = $wpdb->get_results( "SELECT * FROM {$wpdb->pmpro_membership_levels} order by {$levelsortby}", OBJECT );
 	
 	require_once(dirname(__FILE__) . "/admin_header.php");		
 ?>
@@ -225,6 +242,39 @@ if(pmpro_displayAds())
 					<small><?php _e('If yes, create a WordPress page containing your TOS agreement and assign it using the dropdown above.', 'pmpro');?></small>
 				</td>
 			</tr> 
+            <tr>
+                <th scope="row" valign="top">
+                    <label for="levelsortby">Sort Level By: <?php //_e('Require Terms of Service on signups?', 'pmpro');?></label>
+                </th>
+                <td>                     
+                    <select name="levelsortby" >
+                    <?php                
+                        $table_column_level = array("id", "name","initial_payment", "billing_amount", "sort_order");                    
+                        
+                        foreach($table_column_level as $tc_level)
+                        {
+                            ?>
+                            <option value="<?php echo $tc_level;?>" <?php if($tc_level == $levelsortby) echo "selected";  ?> ><?php echo ucwords(strtolower(str_replace("_", " ", $tc_level))); ?></option>
+                            <?php   
+                        }
+                    ?>
+                    </select>                    
+                    <select name="levelsortby_direction" >
+                    <?php                
+                        $column_direction = array("ASC", "DESC",);                    
+                        
+                        foreach($column_direction as $tc_direction)
+                        {
+                            ?>
+                            <option value="<?php echo $tc_direction;?>" <?php if($tc_direction == $levelsortby_direction) echo "selected";  ?> ><?php echo $tc_direction; ?></option>
+                            <?php   
+                        }
+                    ?>
+                    </select>                    
+                    
+                    
+                </td>
+            </tr> 
 			
 			<?php /*
 			<tr>

--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -271,8 +271,6 @@ if(pmpro_displayAds())
                         }
                     ?>
                     </select>                    
-                    
-                    
                 </td>
             </tr> 
 			

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -62,13 +62,16 @@
 		$ml_expiration_number = addslashes($_REQUEST['expiration_number']);
 		$ml_expiration_period = addslashes($_REQUEST['expiration_period']);
 		$ml_categories = array();
-		
+        
 		//reversing disable to allow here
 		if(empty($_REQUEST['disable_signups']))
 			$ml_allow_signups = 1;
 		else
 			$ml_allow_signups = 0;
 
+        $ml_sort_order = addslashes($_REQUEST['sort_order']);
+        
+            
 		foreach ( $_REQUEST as $key => $value )
 		{
 			if ( $value == 'yes' && preg_match( '/^membershipcategory_(\d+)$/i', $key, $matches ) )
@@ -106,7 +109,8 @@
 						  trial_limit = '" . $wpdb->escape($ml_trial_limit) . "',                    
 						  expiration_number = '" . $wpdb->escape($ml_expiration_number) . "',
 						  expiration_period = '" . $wpdb->escape($ml_expiration_period) . "',
-						  allow_signups = '" . $wpdb->escape($ml_allow_signups) . "'
+						  allow_signups = '" . $wpdb->escape($ml_allow_signups) . "',
+                          sort_order = '".$wpdb->escape($ml_sort_order)."'
 						WHERE id = '$saveid' LIMIT 1;";	 
 			$wpdb->query($sqlQuery);
 			
@@ -256,6 +260,7 @@
 				$level->trial_limit = NULL;
 				$level->expiration_number = NULL;
 				$level->expiration_period = NULL;
+                $level->sort_order = 0;
 				$edit = -1;
 			}	
 
@@ -472,6 +477,11 @@
 						?>
 					</td>
 				</tr>
+                <tr><th scope="row" valign="top"><label>Sort Order:</label></th>
+                <td>
+                    <input name="sort_order" type="text" size="3" value="<?php echo $level->sort_order?>" />
+                </td>
+                </tr>
 			</tbody>
 		</table>				
 		<p class="submit topborder">
@@ -503,12 +513,12 @@
 	<thead>
 		<tr>
 			<th><?php _e('ID', 'pmpro');?></th>
-			<th><?php _e('Name', 'pmpro');?></th>
-			<th><?php _e('Initial Payment', 'pmpro');?></th>
+			<th><?php _e('Name', 'pmpro');?></th>			
 			<th><?php _e('Billing Cycle', 'pmpro');?></th>        
 			<th><?php _e('Trial Cycle', 'pmpro');?></th>
 			<th><?php _e('Expiration', 'pmpro');?></th>
 			<th><?php _e('Allow Signups', 'pmpro');?></th>
+            <th>Sort Order</th>
 			<th></th>
 			<th></th>
 			<th></th>
@@ -519,7 +529,7 @@
 			$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels ";
 			if($s)
 				$sqlQuery .= "WHERE name LIKE '%$s%' ";
-			$sqlQuery .= "ORDER BY id ASC";
+			$sqlQuery .= "ORDER BY sort_order ASC";
 			
 			$levels = $wpdb->get_results($sqlQuery, OBJECT);
 						
@@ -528,14 +538,7 @@
 		?>
 		<tr class="<?php if(!$level->allow_signups) { ?>pmpro_gray<?php } ?> <?php if(!pmpro_checkLevelForStripeCompatibility($level) || !pmpro_checkLevelForBraintreeCompatibility($level) || !pmpro_checkLevelForPayflowCompatibility($level)) { ?>pmpro_error<?php } ?>">			
 			<td><?php echo $level->id?></td>
-			<td><?php echo $level->name?></td>
-			<td>
-				<?php if(pmpro_isLevelFree($level)) { ?>
-					<?php _e('FREE', 'pmpro');?>
-				<?php } else { ?>
-					<?php echo $pmpro_currency_symbol?><?php echo $level->initial_payment?>
-				<?php } ?>
-			</td>
+			<td><?php echo $level->name?></td>			
 			<td>
 				<?php if(!pmpro_isLevelRecurring($level)) { ?>
 					--
@@ -561,6 +564,7 @@
 				<?php } ?>
 			</td>
 			<td><?php if($level->allow_signups) { ?><?php _e('Yes', 'pmpro');?><?php } else { ?><?php _e('No', 'pmpro');?><?php } ?></td>
+            <td><?php echo $level->sort_order; ?></td>
 			<td align="center"><a href="admin.php?page=pmpro-membershiplevels&edit=<?php echo $level->id?>" class="edit"><?php _e('edit', 'pmpro');?></a></td>
 			<td align="center"><a href="admin.php?page=pmpro-membershiplevels&copy=<?php echo $level->id?>&edit=-1" class="edit"><?php _e('copy', 'pmpro');?></a></td>
 			<td align="center"><a href="javascript: askfirst('<?php printf(__("Are you sure you want to delete membership level %s? All subscriptions will be cancelled.", "pmpro"), $level->name);?>','admin.php?page=pmpro-membershiplevels&action=delete_membership_level&deleteid=<?php echo $level->id?>'); void(0);" class="delete"><?php _e('delete', 'pmpro');?></a></td>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1300,8 +1300,11 @@
 		if(!$include_hidden)
 			$sqlQuery .= " WHERE allow_signups = 1";
             
+        $orderby_column = pmpro_getOption("levelsortby"); 
+        $orderby_direction = pmpro_getOption("levelsortby_direction"); 
+           
         //put the sort  outside of the if
-        $sqlQuery .= " ORDER BY id";
+        $sqlQuery .= " ORDER BY ".$orderby_column. " ".$orderby_direction;
 			
 		//get levels from the DB
 		$raw_levels = $wpdb->get_results($sqlQuery);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1298,7 +1298,10 @@
 		//build query
 		$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels ";
 		if(!$include_hidden)
-			$sqlQuery .= " WHERE allow_signups = 1 ORDER BY id";
+			$sqlQuery .= " WHERE allow_signups = 1";
+            
+        //put the sort  outside of the if
+        $sqlQuery .= " ORDER BY id";
 			
 		//get levels from the DB
 		$raw_levels = $wpdb->get_results($sqlQuery);

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -245,6 +245,12 @@
 				
 				<?php
 					do_action('pmpro_checkout_after_captcha');
+                    
+                    //this widget is for the openAuth login so that we can also use that to simplify the logins
+                    if (class_exists('oa_social_login_widget')) {
+                    $widget_oa = new oa_social_login_widget();
+                    $widget_oa->widget($args);
+                    }
 				?>
 				
 			</td>

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -88,8 +88,10 @@ global $all_membership_levels;
 
 //we sometimes refer to this array of levels
 global $membership_levels;
-$membership_levels = $wpdb->get_results( "SELECT * FROM {$wpdb->pmpro_membership_levels}", OBJECT );
-
+//updated to single source the list generation and the code for sorting.
+//$membership_levels = $wpdb->get_results( "SELECT * FROM {$wpdb->pmpro_membership_levels}", OBJECT );
+$membership_levels = pmpro_getAllLevels();
+  
 /*
 	Activation/Deactivation
 */


### PR DESCRIPTION
Updated the code for a few changes to support EASY sorting of the levels.

1) TODO not sure how you wanted to handle it.. was the 

`sort_order` int(11) NOT NULL DEFAULT '0',    added to the Table structure for table `wp_pmpro_membership_levels`

2) Fixed what looked to be a bug for the orginal order by clause since if that condition was not true the order by would be skipped.

