### PR TITLE
Add edit profile capability consistency and a filter

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -7,7 +7,7 @@ function pmpro_membership_level_profile_fields($user)
 {
 	global $current_user, $pmpro_currency_symbol;
 
-	$membership_level_capability = apply_filters("pmpro_profile_membership_level_capability", "manage_options");
+	$membership_level_capability = apply_filters("pmpro_edit_member_capability", "manage_options");
 	if(!current_user_can($membership_level_capability))
 		return false;
 
@@ -165,7 +165,7 @@ function pmpro_membership_level_profile_fields_update()
 	if(!empty($_REQUEST['user_id'])) 
 		$user_ID = $_REQUEST['user_id'];
 
-	$membership_level_capability = apply_filters("pmpro_profile_membership_level_capability", "manage_options");
+	$membership_level_capability = apply_filters("pmpro_edit_member_capability", "manage_options");
 	if(!current_user_can($membership_level_capability))
 		return false;
 		


### PR DESCRIPTION
Changed default capability check to 'manage_options' (administrator), and added a filter named 'pmpro_edit_member_capability' to allow dev's to change this capability.
