### PR TITLE
Fixes BrainTree Billing Update Bug

### DIFF
--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -175,16 +175,15 @@
 					{
 						$response = Braintree_Customer::update(
 						  $customer_id,
-						  array(
+array(
 							'firstName' => $order->FirstName,
 							'lastName' => $order->LastName,
 							'creditCard' => array(
-								'number' => $order->braintree->number,
-								'expirationDate' => $order->braintree->expiration_date,
+								'number' => $order->accountnumber,
+								'expirationDate' => $order->expirationmonth . '/' . substr($order->expirationyear, -2, 2),
 								'cardholderName' => trim($order->FirstName . " " . $order->LastName),
 								'options' => array(
-									'updateExistingToken' => $customer_id
-								)
+									'updateExistingToken' => $order->Gateway->customer->creditCards[0]->token								)
 							 )
 						  )
 						);


### PR DESCRIPTION
This fixes the bug and makes billing updates work on BrainTree's side of things but validates as an error on PMPro's site. Before, PMPro was validating BrainTree it as a success.
