### PR TITLE
Fixed bug with checks/discount codes

### DIFF
--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -98,7 +98,7 @@
 			}
 			
 			//hide/show billing
-			if(pmpro_isLevelFree($code_level) || pmpro_getOption("gateway") == "paypalexpress" || pmpro_getOption("gateway") == "paypalstandard")
+			if(pmpro_isLevelFree($code_level) || pmpro_getOption("gateway") == "paypalexpress" || pmpro_getOption("gateway") == "paypalstandard" || pmpro_getOption('gateway') == 'check')
 			{				
 				?>
 				jQuery('#pmpro_billing_address_fields').hide();


### PR DESCRIPTION
Billing info was showing up when applying a discount code while payment gateway is set to check.
