### PR TITLE
added custom hook to modify order before submitting to gateway

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -675,7 +675,9 @@
 						//$gateway = pmpro_getOption("gateway");										
 						$morder->gateway = $gateway;
 						$morder->setGateway();
-													
+						
+						$morder = apply_filters("pmpro_custom_order_modification", $morder );
+										
 						//setup level var
 						$morder->getMembershipLevel();
 						$morder->membership_level = apply_filters("pmpro_checkout_level", $morder->membership_level);


### PR DESCRIPTION
Would you consider adding hook before the order is sent to gateway for processing, so that you could modify initialPayment. In my case, users can add some product and donation to their membership order so I need to adjust payment amount accordingly so that they can pay with single transaction.
