### PR TITLE
Use "strict checking" with in_array() and 0.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -478,7 +478,7 @@ function pmpro_hasMembershipLevel($levels = NULL, $user_id = NULL)
 		if(empty($membership_levels))
 		{
 			//user has no levels just check if 0 was sent in one of the levels
-			if(in_array(0, $levels) || in_array("0", $levels))
+			if(in_array(0, $levels, true) || in_array("0", $levels))
 				$return = true;					
 		}
 		else


### PR DESCRIPTION
See [This PHP snippet](http://viper-7.com/DWpx92) -- `in_array()` will always return `true` when zero is passed as the needle and the values in the array are all strings UNLESS you tell it to use strict checking (pass `true` for the third argument). 
Without this fix, `pmpro_hasMembershipLevel` will return `true` for anonymous users when you pass in a membership level name instead of an ID.
