### PR TITLE
Fixed bug when searching for level by name

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1343,7 +1343,7 @@ function pmpro_getLevel($level)
 	{
 		global $wpdb;
 		$level_obj = $wpdb->get_row("SELECT * FROM $wpdb->pmpro_membership_levels WHERE name = '" . $level . "' LIMIT 1");
-		$level_id = $level->ID;
+		$level_id = $level_obj->id;
 		$pmpro_levels[$level_id] = $level_obj;
 		return $pmpro_levels[$level_id];
 	}


### PR DESCRIPTION
Prior code was attempting to find a property on the $level string instead of the $level_obj object.

Looks like not many people are doing things the way I am... I prefer the names of the levels to the ID's.
