### PR TITLE
Resolve issues accessing non-existent membership object when canceling a membership

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -754,8 +754,8 @@
 			$this->email = $user->user_email;
 			$this->subject = sprintf(__("Your membership at %s has been changed", "pmpro"), get_option("blogname"));
 			$this->template = "admin_change";
-			$this->data = array("subject" => $this->subject, "name" => $user->display_name, "user_login" => $user->user_login, "sitename" => get_option("blogname"), "membership_id" => $user->membership_level->id, "membership_level_name" => $user->membership_level->name, "siteemail" => pmpro_getOption("from_email"), "login_link" => wp_login_url());
-			if($user->membership_level->ID)
+			$this->data = array("subject" => $this->subject, "name" => $user->display_name, "user_login" => $user->user_login, "sitename" => get_option("blogname"), "membership_id" => (empty($user->membership_level->id) ? '' : $user->membership_level->id), "membership_level_name" => (empty($user->membership_level->name) ? '' : $user->membership_level->name), "siteemail" => pmpro_getOption("from_email"), "login_link" => wp_login_url());
+			if(!empty($user->membership_level->ID))
 				$this->data["membership_change"] = sprintf(__("The new level is %s.", "pmpro"), $user->membership_level->name);
 			else
 				$this->data["membership_change"] = __("Your membership has been cancelled", "pmpro");
@@ -792,8 +792,8 @@
 			$this->email = get_bloginfo("admin_email");
 			$this->subject = sprintf(__("Membership for %s at %s has been changed", "pmpro"), $user->user_login, get_option("blogname"));
 			$this->template = "admin_change_admin";
-			$this->data = array("subject" => $this->subject, "name" => $user->display_name, "user_login" => $user->user_login, "sitename" => get_option("blogname"), "membership_level_name" => $user->membership_level->name, "siteemail" => get_bloginfo("admin_email"), "login_link" => wp_login_url());
-			if($user->membership_level->ID)
+			$this->data = array("subject" => $this->subject, "name" => $user->display_name, "user_login" => $user->user_login, "sitename" => get_option("blogname"), "membership_level_name" => (empty($user->membership_level->name) ? '' : $user->membership_level->name), "siteemail" => get_bloginfo("admin_email"), "login_link" => wp_login_url());
+			if(!empty($user->membership_level->ID))
 				$this->data["membership_change"] = sprintf(__("The new level is %s. This membership is free", "pmpro"), $user->membership_level->name);
 			else
 				$this->data["membership_change"] = __("Membership has been cancelled", "pmpro");

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -40,7 +40,7 @@ function pmpro_membership_level_profile_fields($user)
 				<?php
 					foreach($levels as $level)
 					{
-						$current_level = ($user->membership_level->ID == $level->id);
+						$current_level = (!empty($user->membership_level->ID) && $user->membership_level->ID == $level->id);
 				?>
 					<option value="<?php echo $level->id?>" <?php if($current_level) { ?>selected="selected"<?php } ?>><?php echo $level->name?></option>
 				<?php


### PR DESCRIPTION
When changing a user's membership to 'None' in the Wp Admin user profile, several debug notices are generated regarding accessing non existent membership attributes on the user object. This pull request is intended to address that.