### PR TITLE
Corrected acronym "Card Verifcation Value"

### DIFF
--- a/pages/popup-cvv.html
+++ b/pages/popup-cvv.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
-<title>Locating Your Credit Card CCV/CCV2 Number</title>
+<title>Locating Your Credit Card CVV/CVV2 Number</title>
 <style>
 
 body {margin: 10px; padding: 0; font: .85em Arial, Helvetica, "Nimbus Sans L", sans-serif; background: #E6E6E6; color: #222; }
@@ -29,7 +29,7 @@ img {float: right; margin: 0 0 15px 15px; }
 	<img src="../images/CCV-back.jpg" width="262" height="179" border="0" alt="Back of Card" />
 	<img src="../images/CCV-front.jpg" width="262" height="179" border="0" alt="Front of Card" />
 	
-	<h2>Locating your Credit Card CCV/CCV2 Security Code</h2>
+	<h2>Locating your Credit Card CVV/CVV2 Security Code</h2>
 	
 	<p><strong>Visa/MasterCard/Discover</strong><br />
 	Your card security code for your MasterCard, Visa or Discover card is a three-digit number on the back of your credit card, immediately following your main card number.</p>


### PR DESCRIPTION
The correct term is CVV (Card Verification Value) but the page uses CCV instead. This fixes that error. (Didn't touch the image names though.)