### PR TITLE
Hook for a post-expiration / pre email action

### DIFF
--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -20,10 +20,12 @@
 				
 		foreach($expired as $e)
 		{						
+			do_action("pmpro_membership_pre_membership_expiry", $e->user_id, $e->membership_id );
+			
 			//remove their membership
 			pmpro_changeMembershipLevel(false, $e->user_id);
 			
-			do_action("pmpro_membership_has_expired", $e->user_id, $e->membership_id );
+			do_action("pmpro_membership_post_membership_expiry", $e->user_id, $e->membership_id );
 			
 			$send_email = apply_filters("pmpro_send_expiration_email", true, $e->user_id);
 			if($send_email)

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -23,6 +23,8 @@
 			//remove their membership
 			pmpro_changeMembershipLevel(false, $e->user_id);
 			
+			do_action("pmpro_membership_has_expired", $e->user_id, $e->membership_id );
+			
 			$send_email = apply_filters("pmpro_send_expiration_email", true, $e->user_id);
 			if($send_email)
 			{


### PR DESCRIPTION
Let us execute our own expiration actions at the time the membership expires (clean up roles, delete DB entries, etc)