### PR TITLE
Added filter so plugin or theme developers can find the actual protected...

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -31,6 +31,9 @@ function pmpro_has_membership_access($post_id = NULL, $user_id = NULL, $return_m
 	{
 		$mypost = get_post($mypost->post_parent);
 	}
+        
+        // Allow plugins and themes to find the protected post        
+        $mypost = apply_filters( 'pmpro_get_mypost', $mypost );
 
 	if($mypost->post_type == "post")
 	{


### PR DESCRIPTION
Added filter so plugin or theme developers can find the actual protected post. This was implemented to protect wp-content files attached bbpress forum topics and replies using the getfile.php service.

For example:

```
function get_forum_topic_parent( $mypost ) {
    if ( bbp_is_topic( $mypost->ID ) ) {
        $mypost = get_post( $mypost->post_parent );
        // The forum id is one level up from the topic, which is one level up from attachment
        $forum_id = $mypost->ID;
    } 
    return $mypost;
}
add_filter( 'pmpro_get_mypost', 'get_forum_topic_parent' );
```