### PR TITLE
Adding a new filter called pmpro_stripe_create_subscription_array

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1,10 +1,10 @@
-<?php	
+<?php
 	//include pmprogateway
-	require_once(dirname(__FILE__) . "/class.pmprogateway.php");		
-	
+	require_once(dirname(__FILE__) . "/class.pmprogateway.php");
+
 	//load classes init method
 	add_action('init', array('PMProGateway_stripe', 'init'));
-		
+
 	/**
 	 * PMProGateway_stripe Class
 	 *
@@ -16,23 +16,23 @@
 	{
 		/**
 		 * Stripe Class Constructor
-		 *		
+		 *
 		 * @since 1.4
 		 */
 		function PMProGateway_stripe($gateway = NULL)
 		{
 			$this->gateway = $gateway;
 			$this->gateway_environment = pmpro_getOption("gateway_environment");
-			
-			$this->loadStripeLibrary();			
+
+			$this->loadStripeLibrary();
 			Stripe::setApiKey(pmpro_getOption("stripe_secretkey"));
-			
+
 			return $this->gateway;
-		}										
-		
+		}
+
 		/**
 		 * Load the Stripe API library.
-		 *		
+		 *
 		 * @since 1.8
 		 * Moved into a method in version 2.0 so we only load it when needed.
 		 */
@@ -42,66 +42,66 @@
 			if(!class_exists("Stripe"))
 				require_once(dirname(__FILE__) . "/../../includes/lib/Stripe/Stripe.php");
 		}
-		
+
 		/**
 		 * Run on WP init
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function init()
-		{			
+		{
 			//make sure Stripe is a gateway option
 			add_filter('pmpro_gateways', array('PMProGateway_stripe', 'pmpro_gateways'));
-			
+
 			//add fields to payment settings
 			add_filter('pmpro_payment_options', array('PMProGateway_stripe', 'pmpro_payment_options'));
 			add_filter('pmpro_payment_option_fields', array('PMProGateway_stripe', 'pmpro_payment_option_fields'), 10, 2);
-			
+
 			//add some fields to edit user page (Updates)
 			add_action('pmpro_after_membership_level_profile_fields', array('PMProGateway_stripe', 'user_profile_fields'));
 			add_action('profile_update', array('PMProGateway_stripe', 'user_profile_fields_save'));
-			
+
 			//old global RE showing billing address or not
 			global $pmpro_stripe_lite;
 			$pmpro_stripe_lite = apply_filters("pmpro_stripe_lite", !pmpro_getOption("stripe_billingaddress"));	//default is oposite of the stripe_billingaddress setting
-			
+
 			//updates cron
 			add_action('pmpro_activation', array('PMProGateway_stripe', 'pmpro_activation'));
 			add_action('pmpro_deactivation', array('PMProGateway_stripe', 'pmpro_deactivation'));
 			add_action('pmpro_cron_stripe_subscription_updates', array('PMProGateway_stripe', 'pmpro_cron_stripe_subscription_updates'));
-			
+
 			//code to add at checkout if Stripe is the current gateway
 			$gateway = pmpro_getOption("gateway");
 			if($gateway == "stripe")
 			{
-				add_action('pmpro_checkout_preheader', array('PMProGateway_stripe', 'pmpro_checkout_preheader'));			
+				add_action('pmpro_checkout_preheader', array('PMProGateway_stripe', 'pmpro_checkout_preheader'));
 				add_filter('pmpro_checkout_order', array('PMProGateway_stripe', 'pmpro_checkout_order'));
 				add_filter('pmpro_include_billing_address_fields', array('PMProGateway_stripe', 'pmpro_include_billing_address_fields'));
 				add_filter('pmpro_include_cardtype_field', array('PMProGateway_stripe', 'pmpro_include_billing_address_fields'));
 				add_filter('pmpro_include_payment_information_fields', array('PMProGateway_stripe', 'pmpro_include_payment_information_fields'));
 			}
 		}
-		
+
 		/**
 		 * Make sure Stripe is in the gateways list
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_gateways($gateways)
 		{
 			if(empty($gateways['stripe']))
 				$gateways['stripe'] = __('Stripe', 'pmpro');
-		
+
 			return $gateways;
 		}
-		
+
 		/**
 		 * Get a list of payment options that the Stripe gateway needs/supports.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function getGatewayOptions()
-		{			
+		{
 			$options = array(
 				'sslseal',
 				'nuclear_HTTPS',
@@ -115,35 +115,35 @@
 				'tax_rate',
 				'accepted_credit_cards'
 			);
-			
+
 			return $options;
 		}
-		
+
 		/**
 		 * Set payment options for payment settings page.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_payment_options($options)
-		{			
+		{
 			//get stripe options
 			$stripe_options = PMProGateway_stripe::getGatewayOptions();
-			
+
 			//merge with others.
 			$options = array_merge($stripe_options, $options);
-			
+
 			return $options;
 		}
-		
+
 		/**
 		 * Display fields for Stripe options.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_payment_option_fields($values, $gateway)
 		{
 		?>
-		<tr class="pmpro_settings_divider gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>>				
+		<tr class="pmpro_settings_divider gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>>
 			<td colspan="2">
 				<?php _e('Stripe Settings', 'pmpro'); ?>
 			</td>
@@ -171,7 +171,7 @@
 			<td>
 				<select id="stripe_billingaddress" name="stripe_billingaddress">
 					<option value="0" <?php if(empty($values['stripe_billingaddress'])) { ?>selected="selected"<?php } ?>><?php _e('No', 'pmpro');?></option>
-					<option value="1" <?php if(!empty($values['stripe_billingaddress'])) { ?>selected="selected"<?php } ?>><?php _e('Yes', 'pmpro');?></option>						
+					<option value="1" <?php if(!empty($values['stripe_billingaddress'])) { ?>selected="selected"<?php } ?>><?php _e('Yes', 'pmpro');?></option>
 				</select>
 				<small><?php _e("Stripe doesn't require billing address fields. Choose 'No' to hide them on the checkout page.<br /><strong>If No, make sure you disable address verification in the Stripe dashboard settings.</strong>", 'pmpro');?></small>
 			</td>
@@ -183,39 +183,39 @@
 			<td>
 				<p><?php _e('To fully integrate with Stripe, be sure to set your Web Hook URL to', 'pmpro');?> <pre><?php echo admin_url("admin-ajax.php") . "?action=stripe_webhook";?></pre></p>
 			</td>
-		</tr>		
+		</tr>
 		<?php
 		}
-		
+
 		/**
 		 * Code added to checkout preheader.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_checkout_preheader()
-		{			
+		{
 			global $gateway, $pmpro_level;
-			
+
 			if($gateway == "stripe" && !pmpro_isLevelFree($pmpro_level))
 			{
 				//stripe js library
 				wp_enqueue_script("stripe", "https://js.stripe.com/v2/", array(), NULL);
-				
+
 				//stripe js code for checkout
 				function pmpro_stripe_javascript()
 				{
 					global $pmpro_gateway, $pmpro_level, $pmpro_stripe_lite;
 				?>
 				<script type="text/javascript">
-					// this identifies your website in the createToken call below			
+					// this identifies your website in the createToken call below
 					Stripe.setPublishableKey('<?php echo pmpro_getOption("stripe_publishablekey"); ?>');
-					
-					var pmpro_require_billing = true;			
-					
+
+					var pmpro_require_billing = true;
+
 					jQuery(document).ready(function() {
 						jQuery("#pmpro_form, .pmpro_form").submit(function(event) {
-										
-						//double check in case a discount code made the level free				
+
+						//double check in case a discount code made the level free
 						if(pmpro_require_billing)
 						{
 							//build array for creating token
@@ -231,18 +231,18 @@
 									?>
 									,address_line1: jQuery('#baddress1').val(),
 									address_line2: jQuery('#baddress2').val(),
-									address_city: jQuery('#bcity').val(),					
-									address_state: jQuery('#bstate').val(),					
-									address_zip: jQuery('#bzipcode').val(),							
+									address_city: jQuery('#bcity').val(),
+									address_state: jQuery('#bstate').val(),
+									address_zip: jQuery('#bzipcode').val(),
 									address_country: jQuery('#bcountry').val()
 								<?php
 									}
-								?>	
+								?>
 							};
-							
+
 							if (jQuery('#bfirstname').length && jQuery('#blastname').length)
 								args['name'] = jQuery.trim(jQuery('#bfirstname').val() + ' ' + jQuery('#blastname').val());
-																
+
 							//create token
 							Stripe.createToken(args, stripeResponseHandler);
 
@@ -261,19 +261,19 @@
 
 							//hide processing message
 							jQuery('#pmpro_processing_message').css('visibility', 'hidden');
-							
+
 							// show the errors on the form
 							alert(response.error.message);
 							jQuery(".payment-errors").text(response.error.message);
 						} else {
-							var form$ = jQuery("#pmpro_form, .pmpro_form");					
+							var form$ = jQuery("#pmpro_form, .pmpro_form");
 							// token contains id, last4, and card type
-							var token = response['id'];					
+							var token = response['id'];
 							// insert the token into the form so it gets submitted to the server
 							form$.append("<input type='hidden' name='stripeToken' value='" + token + "'/>");
-							
+
 							console.log(response);
-							
+
 							//insert fields for other card fields
 							if(jQuery('#CardType[name=CardType]').length)
 								jQuery('#CardType').val(response['card']['brand']);
@@ -281,8 +281,8 @@
 								form$.append("<input type='hidden' name='CardType' value='" + response['card']['brand'] + "'/>");
 							form$.append("<input type='hidden' name='AccountNumber' value='XXXXXXXXXXXXX" + response['card']['last4'] + "'/>");
 							form$.append("<input type='hidden' name='ExpirationMonth' value='" + ("0" + response['card']['exp_month']).slice(-2) + "'/>");
-							form$.append("<input type='hidden' name='ExpirationYear' value='" + response['card']['exp_year'] + "'/>");							
-							
+							form$.append("<input type='hidden' name='ExpirationYear' value='" + response['card']['exp_year'] + "'/>");
+
 							// and submit
 							form$.get(0).submit();
 						}
@@ -291,20 +291,20 @@
 				<?php
 				}
 				add_action("wp_head", "pmpro_stripe_javascript");
-				
+
 				//don't require the CVV
 				function pmpro_stripe_dont_require_CVV($fields)
 				{
-					unset($fields['CVV']);			
+					unset($fields['CVV']);
 					return $fields;
 				}
 				add_filter("pmpro_required_billing_fields", "pmpro_stripe_dont_require_CVV");
 			}
 		}
-		
+
 		/**
 		 * Filtering orders at checkout.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_checkout_order($morder)
@@ -314,13 +314,13 @@
 			{
 				$morder->stripeToken = $_REQUEST['stripeToken'];
 			}
-		
+
 			//stripe lite code to get name from other sources if available
 			global $pmpro_stripe_lite, $current_user;
 			if(!empty($pmpro_stripe_lite) && empty($morder->FirstName) && empty($morder->LastName))
 			{
 				if(!empty($current_user->ID))
-				{									
+				{
 					$morder->FirstName = get_user_meta($current_user->ID, "first_name", true);
 					$morder->LastName = get_user_meta($current_user->ID, "last_name", true);
 				}
@@ -330,19 +330,19 @@
 					$morder->LastName = $_REQUEST['last_name'];
 				}
 			}
-		
+
 			return $morder;
 		}
-		
+
 		/**
 		 * Code to run after checkout
-		 *		
+		 *
 		 * @since 1.8
 		 */
-		static function pmpro_after_checkout($user_id, $morder)		
+		static function pmpro_after_checkout($user_id, $morder)
 		{
 			global $gateway;
-						
+
 			if($gateway == "stripe")
 			{
 				if(!empty($morder) && !empty($morer->Gateway) && !empty($morder->Gateway->customer) && !empty($morder->Gateway->customer->id))
@@ -351,7 +351,7 @@
 				}
 			}
 		}
-				
+
 		/**
 		 * Check settings if billing address should be shown.
 		 * @since 1.8
@@ -361,24 +361,24 @@
 			//check settings RE showing billing address
 			if(!pmpro_getOption("stripe_billingaddress"))
 				$include = false;
-				
+
 			return $include;
 		}
-		
+
 		/**
 		 * Use our own payment fields at checkout. (Remove the name attributes.)
 		 * @since 1.8
 		 */
 		static function pmpro_include_payment_information_fields($include)
-		{			
+		{
 			//global vars
 			global $pmpro_requirebilling, $pmpro_show_discount_code, $discount_code, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
-			
+
 			//get accepted credit cards
 			$pmpro_accepted_credit_cards = pmpro_getOption("accepted_credit_cards");
 			$pmpro_accepted_credit_cards = explode(",", $pmpro_accepted_credit_cards);
-			$pmpro_accepted_credit_cards_string = pmpro_implodeToEnglish($pmpro_accepted_credit_cards);	
-			
+			$pmpro_accepted_credit_cards_string = pmpro_implodeToEnglish($pmpro_accepted_credit_cards);
+
 			//include ours
 			?>
 			<table id="pmpro_payment_information_fields" class="pmpro_checkout top1em" width="100%" cellpadding="0" cellspacing="0" border="0" <?php if(!$pmpro_requirebilling || apply_filters("pmpro_hide_payment_information_fields", false) ) { ?>style="display: none;"<?php } ?>>
@@ -388,8 +388,8 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr valign="top">		
-					<td>	
+				<tr valign="top">
+					<td>
 						<?php
 							$sslseal = pmpro_getOption("sslseal");
 							if($sslseal)
@@ -409,7 +409,7 @@
 								<select id="CardType" class=" <?php echo pmpro_getClassForField("CardType");?>">
 									<?php foreach($pmpro_accepted_credit_cards as $cc) { ?>
 										<option value="<?php echo $cc?>" <?php if($CardType == $cc) { ?>selected="selected"<?php } ?>><?php echo $cc?></option>
-									<?php } ?>												
+									<?php } ?>
 								</select>
 							</div>
 						<?php
@@ -419,8 +419,8 @@
 							?>
 							<input type="hidden" id="CardType" name="CardType" value="<?php echo esc_attr($CardType);?>" />
 							<script>
-								jQuery(document).ready(function() {												
-										jQuery('#AccountNumber').validateCreditCard(function(result) {								
+								jQuery(document).ready(function() {
+										jQuery('#AccountNumber').validateCreditCard(function(result) {
 											var cardtypenames = {
 												"amex":"American Express",
 												"diners_club_carte_blanche":"Diners Club Carte Blanche",
@@ -433,23 +433,23 @@
 												"visa":"Visa",
 												"visa_electron":"Visa Electron"
 											}
-											
+
 											if(result.card_type)
 												jQuery('#CardType').val(cardtypenames[result.card_type.name]);
 											else
 												jQuery('#CardType').val('Unknown Card Type');
-										});						
+										});
 								});
 							</script>
 							<?php
 							}
 						?>
-					
+
 						<div class="pmpro_payment-account-number">
 							<label for="AccountNumber"><?php _e('Card Number', 'pmpro');?></label>
 							<input id="AccountNumber" class="input <?php echo pmpro_getClassForField("AccountNumber");?>" type="text" size="25" value="<?php echo esc_attr($AccountNumber)?>" autocomplete="off" />
 						</div>
-					
+
 						<div class="pmpro_payment-expiration">
 							<label for="ExpirationMonth"><?php _e('Expiration Date', 'pmpro');?></label>
 							<select id="ExpirationMonth" class=" <?php echo pmpro_getClassForField("ExpirationMonth");?>">
@@ -474,9 +474,9 @@
 								<?php
 									}
 								?>
-							</select> 					
+							</select>
 						</div>
-					
+
 						<?php
 							$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
 							if($pmpro_show_cvv)
@@ -489,7 +489,7 @@
 						<?php
 							}
 						?>
-						
+
 						<?php if($pmpro_show_discount_code) { ?>
 						<div class="pmpro_payment-discount-code">
 							<label for="discount_code"><?php _e('Discount Code', 'pmpro');?></label>
@@ -498,20 +498,20 @@
 							<p id="discount_code_message" class="pmpro_message" style="display: none;"></p>
 						</div>
 						<?php } ?>
-						
-					</td>			
+
+					</td>
 				</tr>
 			</tbody>
 			</table>
 			<?php
-			
+
 			//don't include the default
 			return false;
 		}
-		
+
 		/**
 		 * Fields shown on edit user page
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function user_profile_fields($user)
@@ -521,48 +521,48 @@
 			$cycles = array( __('Day(s)', 'pmpro') => 'Day', __('Week(s)', 'pmpro') => 'Week', __('Month(s)', 'pmpro') => 'Month', __('Year(s)', 'pmpro') => 'Year' );
 			$current_year = date("Y");
 			$current_month = date("m");
-			
+
 			//make sure the current user has privileges
 			$membership_level_capability = apply_filters("pmpro_edit_member_capability", "manage_options");
 			if(!current_user_can($membership_level_capability))
 				return false;
 
-			//more privelges they should have			
+			//more privelges they should have
 			$show_membership_level = apply_filters("pmpro_profile_show_membership_level", true, $user);
 			if(!$show_membership_level)
 				return false;
-				
+
 			//check that user has a current subscription at Stripe
 			$last_order = new MemberOrder();
 			$last_order->getLastMemberOrder($user->ID);
-			
+
 			//assume no sub to start
 			$sub = false;
-			
+
 			//check that gateway is Stripe
 			if($last_order->gateway == "stripe")
-			{				
+			{
 				//is there a customer?
-				$sub = $last_order->Gateway->getSubscription($last_order);								
-			}			
-			
+				$sub = $last_order->Gateway->getSubscription($last_order);
+			}
+
 			$customer_id = $user->pmpro_stripe_customerid;
-			
+
 			if(empty($sub))
 			{
 				//make sure we delete stripe updates
 				update_user_meta($user->ID, "pmpro_stripe_updates", array());
-								
+
 				//if the last order has a sub id, let the admin know there is no sub at Stripe
 				if(!empty($last_order) && $last_order->gateway == "stripe" && !empty($last_order->subscription_transaction_id) && strpos($last_order->subscription_transaction_id, "sub_") !== false)
 				{
 				?>
 				<p><strong>Note:</strong> Subscription <strong><?php echo $last_order->subscription_transaction_id;?></strong> could not be found at Stripe. It might have been deleted.</p>
 				<?php
-				}				
+				}
 			}
-			else			
-			{				
+			else
+			{
 			?>
 			<h3><?php _e("Subscription Updates", "pmpro"); ?></h3>
 			<p>
@@ -578,7 +578,7 @@
 					<th><label for="membership_level"><?php _e("Update", "pmpro"); ?></label></th>
 					<td id="updates_td">
 						<?php
-							$old_updates = $user->pmpro_stripe_updates;							
+							$old_updates = $user->pmpro_stripe_updates;
 							if(is_array($old_updates))
 							{
 								$updates = array_merge(
@@ -588,19 +588,19 @@
 							}
 							else
 								$updates = array(array('template'=>true, 'when'=>'now', 'date_month'=>'', 'date_day'=>'', 'date_year'=>'', 'billing_amount'=>'', 'cycle_number'=>'', 'cycle_period'=>'Month'));
-														
+
 							foreach($updates as $update)
 							{
 							?>
 							<div class="updates_update" <?php if(!empty($update['template'])) { ?>style="display: none;"<?php } ?>>
-								<select class="updates_when" name="updates_when[]">							
+								<select class="updates_when" name="updates_when[]">
 									<option value="now" <?php selected($update['when'], "now");?>>Now</option>
 									<option value="payment" <?php selected($update['when'], "payment");?>>After Next Payment</option>
 									<option value="date" <?php selected($update['when'], "date");?>>On Date</option>
 								</select>
 								<span class="updates_date" <?php if($uwhen != "date") { ?>style="display: none;"<?php } ?>>
 									<select name="updates_date_month[]">
-										<?php																
+										<?php
 											for($i = 1; $i < 13; $i++)
 											{
 											?>
@@ -619,7 +619,7 @@
 									<small><?php _e('per', 'pmpro');?></small>
 									<input name="updates_cycle_number[]" type="text" size="5" value="<?php echo esc_attr($update['cycle_number']);?>" />
 									<select name="updates_cycle_period[]">
-									  <?php							
+									  <?php
 										foreach ( $cycles as $name => $value ) {
 										  echo "<option value='$value'";
 										  if(!empty($update['cycle_period']) && $update['cycle_period'] == $value) echo " selected='selected'";
@@ -627,18 +627,18 @@
 										}
 									  ?>
 									</select>
-								</span>	
+								</span>
 								<span>
-									<a class="updates_remove" href="javascript:void(0);">Remove</a>								
+									<a class="updates_remove" href="javascript:void(0);">Remove</a>
 								</span>
 							</div>
 							<?php
 							}
-							?>						
+							?>
 						<p><a id="updates_new_update" href="javascript:void(0);">+ New Update</a></p>
 					</td>
-				</tr>				
-			</table>						
+				</tr>
+			</table>
 			<script>
 				jQuery(document).ready(function() {
 					//function to update dropdowns/etc based on when field
@@ -648,45 +648,45 @@
 							jQuery(when).parent().children('.updates_date').show();
 						else
 							jQuery(when).parent().children('.updates_date').hide();
-							
+
 						if(jQuery(when).val() == 'no')
 							jQuery(when).parent().children('.updates_billing').hide();
 						else
 							jQuery(when).parent().children('.updates_billing').show();
-					}										
+					}
 
 					//and update on page load
 					jQuery('.updates_when').each(function() { if(jQuery(this).parent().css('display') != 'none') updateSubscriptionUpdateFields(this); });
-					
+
 					//add a new update when clicking to
 					var num_updates_divs = <?php echo count($updates);?>;
 					jQuery('#updates_new_update').click(function() {
 						//get updates
 						updates = jQuery('.updates_update').toArray();
-												
+
 						//clone the first one
-						new_div = jQuery(updates[0]).clone();													
-												
+						new_div = jQuery(updates[0]).clone();
+
 						//append
 						new_div.insertBefore('#updates_new_update');
-												
+
 						//update events
 						addUpdateEvents()
-												
+
 						//unhide it
 						new_div.show();
-						updateSubscriptionUpdateFields(new_div.children('.updates_when'));												
+						updateSubscriptionUpdateFields(new_div.children('.updates_when'));
 					});
-										
+
 					function addUpdateEvents()
 					{
 						//update when when changes
 						jQuery('.updates_when').change(function() {
 							updateSubscriptionUpdateFields(this);
 						});
-						
+
 						//remove updates when clicking
-						jQuery('.updates_remove').click(function() {						
+						jQuery('.updates_remove').click(function() {
 							jQuery(this).parent().parent().remove();
 						});
 					}
@@ -696,40 +696,40 @@
 			<?php
 			}
 		}
-		
+
 		/**
 		 * Process fields from the edit user page
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function user_profile_fields_save($user_id)
 		{
 			global $wpdb;
-			
+
 			//check capabilities
 			$membership_level_capability = apply_filters("pmpro_edit_member_capability", "manage_options");
 			if(!current_user_can($membership_level_capability))
 				return false;
-			
+
 			//make sure some value was passed
 			if(!isset($_POST['updates_when']) || !is_array($_POST['updates_when']))
 				return;
-			
+
 			//vars
 			$updates = array();
 			$next_on_date_update = "";
-			
+
 			//build array of updates (we skip the first because it's the template field for the JavaScript
 			for($i = 1; $i < count($_POST['updates_when']); $i++)
 			{
 				$update = array();
-				
+
 				//all updates have these values
 				$update['when'] = $_POST['updates_when'][$i];
 				$update['billing_amount'] = $_POST['updates_billing_amount'][$i];
 				$update['cycle_number'] = $_POST['updates_cycle_number'][$i];
 				$update['cycle_period'] = $_POST['updates_cycle_period'][$i];
-								
+
 				//these values only for on date updates
 				if($_POST['updates_when'][$i] == "date")
 				{
@@ -737,17 +737,17 @@
 					$update['date_day'] = str_pad($_POST['updates_date_day'][$i], 2, "0", STR_PAD_LEFT);
 					$update['date_year'] = $_POST['updates_date_year'][$i];
 				}
-				
+
 				//make sure the update is valid
 				if(empty($update['cycle_number']))
 					continue;
-				
+
 				//if when is now, update the subscription
 				if($update['when'] == "now")
 				{
 					//get level for user
 					$user_level = pmpro_getMembershipLevelForUser($user_id);
-					
+
 					//get current plan at Stripe to get payment date
 					$last_order = new MemberOrder();
 					$last_order->getLastMemberOrder($user_id);
@@ -755,30 +755,30 @@
 					$last_order->Gateway->getCustomer($last_order);
 
 					$subscription = $last_order->Gateway->getSubscription($last_order);
-										
+
 					if(!empty($subscription))
-					{						
+					{
 						$end_timestamp = $subscription->current_period_end;
-							
-						//cancel the old subscription						
+
+						//cancel the old subscription
 						if(!$last_order->Gateway->cancelSubscriptionAtGateway($subscription))
 						{
 							//throw error and halt save
-							function pmpro_stripe_user_profile_fields_save_error($errors, $update, $user) 
+							function pmpro_stripe_user_profile_fields_save_error($errors, $update, $user)
 							{
 								$errors->add('pmpro_stripe_updates',__('Could not cancel the old subscription. Updates have not been processed.', 'pmpro'));
 							}
 							add_filter('user_profile_update_errors', 'pmpro_stripe_user_profile_fields_save_error', 10, 3);
-							
+
 							//stop processing updates
 							return;
 						}
 					}
-										
+
 					//if we didn't get an end date, let's set one one cycle out
 					if(empty($end_timestamp))
 						$end_timestamp = strtotime("+" . $update['cycle_number'] . " " . $update['cycle_period'], current_time('timestamp'));
-										
+
 					//build order object
 					$update_order = new MemberOrder();
 					$update_order->setGateway('stripe');
@@ -789,14 +789,14 @@
 					$update_order->PaymentAmount = $update['billing_amount'];
 					$update_order->ProfileStartDate = date("Y-m-d", $end_timestamp);
 					$update_order->BillingPeriod = $update['cycle_period'];
-					$update_order->BillingFrequency = $update['cycle_number'];									
-					
+					$update_order->BillingFrequency = $update['cycle_number'];
+
 					//need filter to reset ProfileStartDate
 					add_filter('pmpro_profile_start_date', create_function('$startdate, $order', 'return "' . $update_order->ProfileStartDate . 'T0:0:0";'), 10, 2);
-					
+
 					//update subscription
 					$update_order->Gateway->subscribe($update_order, false);
-					
+
 					//update membership
 					$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users
 									SET billing_amount = '" . esc_sql($update['billing_amount']) . "',
@@ -808,13 +808,13 @@
 										AND membership_id = '" . esc_sql($last_order->membership_id) . "'
 										AND status = 'active'
 									LIMIT 1";
-													
+
 					$wpdb->query($sqlQuery);
-					
+
 					//save order so we know which plan to look for at stripe (order code = plan id)
 					$update_order->status = "success";
 					$update_order->saveOrder();
-					
+
 					continue;
 				}
 				elseif($update['when'] == 'date')
@@ -824,41 +824,41 @@
 					else
 						$next_on_date_update = $update['date_year'] . "-" . $update['date_month'] . "-" . $update['date_day'];
 				}
-				
-				//add to array				
-				$updates[] = $update;				
+
+				//add to array
+				$updates[] = $update;
 			}
-			
+
 			//save in user meta
 			update_user_meta($user_id, "pmpro_stripe_updates", $updates);
-			
+
 			//save date of next on-date update to make it easier to query for these in cron job
 			update_user_meta($user_id, "pmpro_stripe_next_on_date_update", $next_on_date_update);
 		}
-				
+
 		/**
 		 * Cron activation for subscription updates.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_activation()
 		{
 			wp_schedule_event(time(), 'daily', 'pmpro_cron_stripe_subscription_updates');
 		}
-		
+
 		/**
 		 * Cron deactivation for subscription updates.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_deactivation()
 		{
 			wp_clear_scheduled_hook('pmpro_cron_stripe_subscription_updates');
 		}
-		
+
 		/**
 		 * Cron job for subscription updates.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		static function pmpro_cron_stripe_subscription_updates()
@@ -866,41 +866,41 @@
 			global $wpdb;
 
 			//get all updates for today (or before today)
-			$sqlQuery = "SELECT * 
-						 FROM $wpdb->usermeta 
-						 WHERE meta_key = 'pmpro_stripe_next_on_date_update' 
-							AND meta_value IS NOT NULL 
-							AND meta_value < '" . date("Y-m-d", strtotime("+1 day")) . "'";		
+			$sqlQuery = "SELECT *
+						 FROM $wpdb->usermeta
+						 WHERE meta_key = 'pmpro_stripe_next_on_date_update'
+							AND meta_value IS NOT NULL
+							AND meta_value < '" . date("Y-m-d", strtotime("+1 day")) . "'";
 			$updates = $wpdb->get_results($sqlQuery);
-					
+
 			if(!empty($updates))
-			{								
+			{
 				//loop through
 				foreach($updates as $update)
-				{						
+				{
 					//pull values from update
 					$user_id = $update->user_id;
-									
+
 					$user = get_userdata($user_id);
 					$user_updates = $user->pmpro_stripe_updates;
-					$next_on_date_update = "";		
-									
+					$next_on_date_update = "";
+
 					//loop through updates looking for updates happening today or earlier
 					foreach($user_updates as $key => $update)
-					{				
+					{
 						if($update['when'] == 'date' &&
 							$update['date_year'] . "-" . $update['date_month'] . "-" . $update['date_day'] <= date("Y-m-d")
 						)
 						{
 							//get level for user
 							$user_level = pmpro_getMembershipLevelForUser($user_id);
-							
+
 							//get current plan at Stripe to get payment date
 							$last_order = new MemberOrder();
 							$last_order->getLastMemberOrder($user_id);
 							$last_order->setGateway('stripe');
 							$last_order->Gateway->getCustomer($last_order);
-																	
+
 							if(!empty($last_order->Gateway->customer))
 							{
 								//find the first subscription
@@ -910,10 +910,10 @@
 									$end_timestamp = $first_sub['current_period_end'];
 								}
 							}
-							
+
 							//if we didn't get an end date, let's set one one cycle out
 							$end_timestamp = strtotime("+" . $update['cycle_number'] . " " . $update['cycle_period']);
-												
+
 							//build order object
 							$update_order = new MemberOrder();
 							$update_order->setGateway('stripe');
@@ -925,28 +925,28 @@
 							$update_order->ProfileStartDate = date("Y-m-d", $end_timestamp);
 							$update_order->BillingPeriod = $update['cycle_period'];
 							$update_order->BillingFrequency = $update['cycle_number'];
-							
+
 							//update subscription
 							$update_order->Gateway->subscribe($update_order, false);
-													
+
 							//update membership
-							$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users 
-											SET billing_amount = '" . esc_sql($update['billing_amount']) . "', 
-												cycle_number = '" . esc_sql($update['cycle_number']) . "', 
-												cycle_period = '" . esc_sql($update['cycle_period']) . "' 
-											WHERE user_id = '" . esc_sql($user_id) . "' 
-												AND membership_id = '" . esc_sql($last_order->membership_id) . "' 
-												AND status = 'active' 
+							$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users
+											SET billing_amount = '" . esc_sql($update['billing_amount']) . "',
+												cycle_number = '" . esc_sql($update['cycle_number']) . "',
+												cycle_period = '" . esc_sql($update['cycle_period']) . "'
+											WHERE user_id = '" . esc_sql($user_id) . "'
+												AND membership_id = '" . esc_sql($last_order->membership_id) . "'
+												AND status = 'active'
 											LIMIT 1";
-															
+
 							$wpdb->query($sqlQuery);
-							
+
 							//save order
 							$update_order->status = "success";
 							$update_order->save();
-							
+
 							//remove update from list
-							unset($user_updates[$key]);									
+							unset($user_updates[$key]);
 						}
 						elseif($update['when'] == 'date')
 						{
@@ -957,19 +957,19 @@
 								$next_on_date_update = $update['date_year'] . "-" . $update['date_month'] . "-" . $update['date_day'];
 						}
 					}
-					
+
 					//save updates in case we removed some
 					update_user_meta($user_id, "pmpro_stripe_updates", $user_updates);
-					
+
 					//save date of next on-date update to make it easier to query for these in cron job
 					update_user_meta($user_id, "pmpro_stripe_next_on_date_update", $next_on_date_update);
 				}
 			}
 		}
-		
+
 		/**
 		 * Process checkout and decide if a charge and or subscribe is needed
-		 *		
+		 *
 		 * @since 1.4
 		 */
 		function process(&$order)
@@ -986,7 +986,7 @@
 				if($this->charge($order))
 				{
 					if(pmpro_isLevelRecurring($order->membership_level))
-					{						
+					{
 						if($this->subscribe($order))
 						{
 							//yay!
@@ -1001,7 +1001,7 @@
 					else
 					{
 						//only a one time charge
-						$order->status = "success";	//saved on checkout page											
+						$order->status = "success";	//saved on checkout page
 						return true;
 					}
 				}
@@ -1011,39 +1011,39 @@
 						$order->error = __("Unknown error: Initial payment failed.", "pmpro");
 					return false;
 				}
-			}				
-		}		
-		
+			}
+		}
+
 		/**
 		 * Make a one-time charge with Stripe
-		 *		
+		 *
 		 * @since 1.4
 		 */
 		function charge(&$order)
 		{
 			global $pmpro_currency;
-			
+
 			//create a code for the order
 			if(empty($order->code))
 				$order->code = $order->getRandomCode();
-			
-			//what amount to charge?			
+
+			//what amount to charge?
 			$amount = $order->InitialPayment;
-						
+
 			//tax
 			$order->subtotal = $amount;
 			$tax = $order->getTax(true);
 			$amount = round((float)$order->subtotal + (float)$tax, 2);
-						
+
 			//create a customer
 			$result = $this->getCustomer($order);
-						
+
 			if(empty($result))
-			{				
+			{
 				//failed to create customer
 				return false;
-			}			
-						
+			}
+
 			//charge
 			try
 			{
@@ -1063,13 +1063,13 @@
 				$order->shorterror = $order->error;
 				return false;
 			}
-			
+
 			if(empty($response["failure_message"]))
 			{
 				//successful charge
 				$order->payment_transaction_id = $response["id"];
-				$order->updateStatus("success");					
-				return true;		
+				$order->updateStatus("success");
+				return true;
 			}
 			else
 			{
@@ -1078,12 +1078,12 @@
 				$order->error = $response['failure_message'];
 				$order->shorterror = $response['failure_message'];
 				return false;
-			}									
+			}
 		}
-				
+
 		/**
 		 * Get a Stripe customer object.
-		 *		
+		 *
 		 * If $this->customer is set, it returns it.
 		 * It first checks if the order has a subscription_transaction_id. If so, that's the customer id.
 		 * If not, it checks for a user_id on the order and searches for a customer id in the user meta.
@@ -1097,42 +1097,42 @@
 		function getCustomer(&$order = false, $force = false)
 		{
 			global $current_user;
-			
+
 			//already have it?
 			if(!empty($this->customer) && !$force)
 				return $this->customer;
-			
+
 			//figure out user_id and user
 			if(!empty($order->user_id))
 				$user_id = $order->user_id;
-			
+
 			//if no id passed, check the current user
 			if(empty($user_id) && !empty($current_user->ID))
 				$user_id = $current_user->ID;
-			
+
 			if(!empty($user_id))
 				$user = get_userdata($user_id);
 			else
 				$user = NULL;
-			
+
 			//transaction id?
 			if(!empty($order->subscription_transaction_id) && strpos($order->subscription_transaction_id, "cus_") !== false)
 				$customer_id = $order->subscription_transaction_id;
 			else
 			{
-				//try based on user id	
+				//try based on user id
 				if(!empty($user_id))
-				{			
-					$customer_id = get_user_meta($user_id, "pmpro_stripe_customerid", true);	
+				{
+					$customer_id = get_user_meta($user_id, "pmpro_stripe_customerid", true);
 				}
-			}			
-			
+			}
+
 			//get name and email values from order in case we update
 			$name = trim($order->FirstName . " " . $order->LastName);
 			if(empty($name) && !empty($user->ID))
 			{
 				$name = trim($user->first_name . " " . $user->last_name);
-				
+
 				//still empty?
 				if(empty($name))
 					$name = $user->user_login;
@@ -1140,41 +1140,41 @@
 			elseif(empty($name))
 				$name = "No Name";
 
-			$email = $order->Email;						
+			$email = $order->Email;
 			if(empty($email) && !empty($user->ID))
 			{
 				$email = $user->user_email;
 			}
 			elseif(empty($email))
 				$email = "No Email";
-						
+
 			//check for an existing stripe customer
 			if(!empty($customer_id))
 			{
 				try
 				{
 					$this->customer = Stripe_Customer::retrieve($customer_id);
-					
+
 					//update the customer description and card
 					if(!empty($order->stripeToken))
-					{												
+					{
 						$this->customer->description = $name . " (" . $email . ")";
 						$this->customer->email = $email;
 						$this->customer->card = $order->stripeToken;
 						$this->customer->save();
 					}
-					
+
 					return $this->customer;
 				}
 				catch (Exception $e)
 				{
-					//assume no customer found					
+					//assume no customer found
 				}
 			}
-			
+
 			//no customer id, create one
 			if(!empty($order->stripeToken))
-			{				
+			{
 				try
 				{
 					$this->customer = Stripe_Customer::create(array(
@@ -1189,11 +1189,11 @@
 					$order->shorterror = $order->error;
 					return false;
 				}
-				
+
 				if(!empty($user_id))
 				{
 					//user logged in/etc
-					update_user_meta($user_id, "pmpro_stripe_customerid", $this->customer->id);	
+					update_user_meta($user_id, "pmpro_stripe_customerid", $this->customer->id);
 				}
 				else
 				{
@@ -1210,29 +1210,29 @@
 
                 return apply_filters('pmpro_stripe_create_customer', $this->customer);
 			}
-			
-			return false;			
+
+			return false;
 		}
-		
+
 		/**
 		 * Get a Stripe subscription from a PMPro order
-		 *		
+		 *
 		 * @since 1.8
 		 */
-		function getSubscription(&$order)		
+		function getSubscription(&$order)
 		{
 			global $wpdb;
-						
+
 			//no order?
 			if(empty($order) || empty($order->code))
-				return false;						
-						
+				return false;
+
 			$result = $this->getCustomer($order, true);	//force so we don't get a cached sub for someone else
-									
+
 			//no customer?
 			if(empty($result))
 				return false;
-			
+
 			//is there a subscription transaction id pointing to a sub?
 			if(!empty($order->subscription_transaction_id) && strpos($order->subscription_transaction_id, "sub_") !== false)
 			{
@@ -1246,49 +1246,49 @@
 					$order->shorterror = $order->error;
 					return false;
 				}
-				
+
 				return $sub;
-			}						
-			
+			}
+
 			//find subscription based on customer id and order/plan id
-			$subscriptions = $this->customer->subscriptions->all();			
-			
+			$subscriptions = $this->customer->subscriptions->all();
+
 			//no subscriptions
 			if(empty($subscriptions) || empty($subscriptions->data))
-				return false;			
-			
+				return false;
+
 			//we really want to test against the order codes of all orders with the same subscription_transaction_id (customer id)
 			$codes = $wpdb->get_col("SELECT code FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $order->user_id . "' AND subscription_transaction_id = '" . $order->subscription_transaction_id . "' AND status NOT IN('refunded', 'review', 'token', 'error')");
-			
+
 			//find the one for this order
 			foreach($subscriptions->data as $sub)
-			{				
+			{
 				if(in_array($sub->plan->id, $codes))
 				{
 					return $sub;
 				}
 			}
-			
-			//didn't find anything yet			
+
+			//didn't find anything yet
 			return false;
 		}
-		
+
 		/**
 		 * Create a new subscription with Stripe
-		 *		
+		 *
 		 * @since 1.4
 		 */
 		function subscribe(&$order, $checkout = true)
 		{
 			global $pmpro_currency;
-			
+
 			//create a code for the order
 			if(empty($order->code))
 				$order->code = $order->getRandomCode();
-			
+
 			//filter order before subscription. use with care.
 			$order = apply_filters("pmpro_subscribe_order", $order, $this);
-			
+
 			//figure out the user
 			if(!empty($order->user_id))
 				$user_id = $order->user_id;
@@ -1297,28 +1297,28 @@
 				global $current_user;
 				$user_id = $current_user->ID;
 			}
-			
+
 			//setup customer
 			$result = $this->getCustomer($order);
 			if(empty($result))
 				return false;	//error retrieving customer
-						
+
 			//set subscription id to custom id
 			$order->subscription_transaction_id = $this->customer['id'];	//transaction id is the customer id, we save it in user meta later too
-			
+
 			//figure out the amounts
 			$amount = $order->PaymentAmount;
-			$amount_tax = $order->getTaxForPrice($amount);			
+			$amount_tax = $order->getTaxForPrice($amount);
 			$amount = round((float)$amount + (float)$amount_tax, 2);
 
 			/*
 				There are two parts to the trial. Part 1 is simply the delay until the first payment
 				since we are doing the first payment as a separate transaction.
 				The second part is the actual "trial" set by the admin.
-				
+
 				Stripe only supports Year or Month for billing periods, but we account for Days and Weeks just in case.
 			*/
-			//figure out the trial length (first payment handled by initial charge)			
+			//figure out the trial length (first payment handled by initial charge)
 			if($order->BillingPeriod == "Year")
 				$trial_period_days = $order->BillingFrequency * 365;	//annual
 			elseif($order->BillingPeriod == "Day")
@@ -1327,18 +1327,18 @@
 				$trial_period_days = $order->BillingFrequency * 7;		//weekly
 			else
 				$trial_period_days = $order->BillingFrequency * 30;	//assume monthly
-				
+
 			//convert to a profile start date
 			$order->ProfileStartDate = date("Y-m-d", strtotime("+ " . $trial_period_days . " Day", current_time("timestamp"))) . "T0:0:0";
-			
+
 			//filter the start date
-			$order->ProfileStartDate = apply_filters("pmpro_profile_start_date", $order->ProfileStartDate, $order);						
-			
+			$order->ProfileStartDate = apply_filters("pmpro_profile_start_date", $order->ProfileStartDate, $order);
+
 			//convert back to days
 			$trial_period_days = ceil(abs(strtotime(date("Y-m-d"), current_time("timestamp")) - strtotime($order->ProfileStartDate, current_time("timestamp"))) / 86400);
 
 			//for free trials, just push the start date of the subscription back
-			if(!empty($order->TrialBillingCycles) && $order->TrialAmount == 0)				
+			if(!empty($order->TrialBillingCycles) && $order->TrialAmount == 0)
 			{
 				$trialOccurrences = (int)$order->TrialBillingCycles;
 				if($order->BillingPeriod == "Year")
@@ -1354,23 +1354,23 @@
 			{
 				/*
 					Let's set the subscription to the trial and give the user an "update" to change the sub later to full price (since v2.0)
-					
+
 					This will force TrialBillingCycles > 1 to act as if they were 1
-				*/				
+				*/
 				$new_user_updates = array();
 				$new_user_updates[] = array(
 					'when' => 'payment',
 					'billing_amount' => $order->PaymentAmount,
 					'cycle_period' => $order->BillingPeriod,
 					'cycle_number' => $order->BillingFrequency
-				);				
-				
+				);
+
 				//now amount to equal the trial #s
 				$amount = $order->TrialAmount;
 				$amount_tax = $order->getTaxForPrice($amount);
 				$amount = round((float)$amount + (float)$amount_tax, 2);
-			}			
-						
+			}
+
 			//create a plan
 			try
 			{
@@ -1384,7 +1384,7 @@
                     "id" => $order->code
                 );
 
-				$plan = Stripe_Plan::create(apply_filters('pmpro_stripe_create_plan_array', $plan));				
+				$plan = Stripe_Plan::create(apply_filters('pmpro_stripe_create_plan_array', $plan));
 			}
 			catch (Exception $e)
 			{
@@ -1392,54 +1392,55 @@
 				$order->shorterror = $order->error;
 				return false;
 			}
-			
+
 			//before subscribing, let's clear out the updates so we don't trigger any during sub
 			if(!empty($user_id))
-			{				
+			{
 				$old_user_updates = get_user_meta($user_id, "pmpro_stripe_updates", true);
-				update_user_meta($user_id, "pmpro_stripe_updates", array());	
-			}			
-			
+				update_user_meta($user_id, "pmpro_stripe_updates", array());
+			}
+
 			if(empty($order->subscription_transaction_id) && !empty($this->customer['id']))
 				$order->subscription_transaction_id = $this->customer['id'];
-				
+
 			//subscribe to the plan
 			try
 			{
-				$result = $this->customer->subscriptions->create(array("plan" => $order->code));
+				$subscription = array("plan" => $order->code);
+				$result = $this->customer->subscriptions->create(apply_filters('pmpro_stripe_create_subscription_array', $subscription));
 			}
 			catch (Exception $e)
 			{
 				//try to delete the plan
 				$plan->delete();
-				
+
 				//give the user any old updates back
 				if(!empty($user_id))
 					update_user_meta($user_id, "pmpro_stripe_updates", $old_user_updates);
-				
+
 				//return error
 				$order->error = __("Error subscribing customer to plan with Stripe:", "pmpro") . $e->getMessage();
 				$order->shorterror = $order->error;
 				return false;
 			}
-			
+
 			//delete the plan
 			$plan = Stripe_Plan::retrieve($order->code);
-			$plan->delete();		
+			$plan->delete();
 
-			//if we got this far, we're all good						
-			$order->status = "success";		
+			//if we got this far, we're all good
+			$order->status = "success";
 			$order->subscription_transaction_id = $result['id'];
-			
+
 			//save new updates if this is at checkout
 			if($checkout)
-			{				
+			{
 				//empty out updates unless set above
 				if(empty($new_user_updates))
 					$new_user_updates = array();
-					
+
 				//update user meta
-				if(!empty($user_id))				
+				if(!empty($user_id))
 					update_user_meta($user_id, "pmpro_stripe_updates", $new_user_updates);
 				else
 				{
@@ -1459,33 +1460,33 @@
 				//give them their old updates back
 				update_user_meta($user_id, "pmpro_stripe_updates", $old_user_updates);
 			}
-			
+
 			return true;
-		}	
-		
+		}
+
 		/**
 		 * Helper method to update the customer info via getCustomer
-		 *		
+		 *
 		 * @since 1.4
 		 */
 		function update(&$order)
 		{
 			//we just have to run getCustomer which will look for the customer and update it with the new token
 			$result = $this->getCustomer($order);
-			
+
 			if(!empty($result))
 			{
 				return true;
-			}			
+			}
 			else
 			{
 				return false;	//couldn't find the customer
 			}
 		}
-		
+
 		/**
 		 * Cancel a subscription at Stripe
-		 *		
+		 *
 		 * @since 1.4
 		 */
 		function cancel(&$order, $update_status = true)
@@ -1493,21 +1494,21 @@
 			//no matter what happens below, we're going to cancel the order in our system
 			if($update_status)
 				$order->updateStatus("cancelled");
-					
+
 			//require a subscription id
 			if(empty($order->subscription_transaction_id))
 				return false;
-			
+
 			//find the customer
-			$result = $this->getCustomer($order);									
-											
+			$result = $this->getCustomer($order);
+
 			if(!empty($result))
 			{
 				//find subscription with this order code
-				$subscription = $this->getSubscription($order);												
+				$subscription = $this->getSubscription($order);
 
 				if(!empty($subscription))
-				{				
+				{
 					if($this->cancelSubscriptionAtGateway($subscription))
 					{
 						//we're okay, going to return true later
@@ -1516,17 +1517,17 @@
 					{
 						$order->error = __("Could not cancel old subscription.", "pmpro");
 						$order->shorterror = $order->error;
-						
-						return false;											
-					}					
-				}				
-				
+
+						return false;
+					}
+				}
+
 				/*
 					Clear updates for this user. (But not if checking out, we would have already done that.)
 				*/
 				if(empty($_REQUEST['submit-checkout']))
 					update_user_meta($order->user_id, "pmpro_stripe_updates", array());
-				
+
 				return true;
 			}
 			else
@@ -1534,12 +1535,12 @@
 				$order->error = __("Could not find the customer.", "pmpro");
 				$order->shorterror = $order->error;
 				return false;	//no customer found
-			}						
-		}							
-	
+			}
+		}
+
 		/**
 		 * Helper method to cancel a subscription at Stripe and also clear up any upaid invoices.
-		 *		
+		 *
 		 * @since 1.8
 		 */
 		function cancelSubscriptionAtGateway($subscription)
@@ -1547,50 +1548,50 @@
 			//need a valid sub
 			if(empty($subscription->id))
 				return false;
-		
+
 			//make sure we get the customer for this subscription
 			$order = new MemberOrder();
-			$order->getLastMemberOrderBySubscriptionTransactionID($subscription->id);			
-			
+			$order->getLastMemberOrderBySubscriptionTransactionID($subscription->id);
+
 			//no order?
 			if(empty($order))
 			{
 				//lets cancel anyway, but this is suspicious
 				$r = $subscription->cancel();
-								
+
 				return true;
 			}
-			
+
 			//okay have an order, so get customer so we can cancel invoices too
 			$this->getCustomer($order);
-			
+
 			//get open invoices
 			$invoices = $this->customer->invoices();
 			$invoices = $invoices->all();
-										
+
 			//found it, cancel it
 			try
-			{								
+			{
 				//find any open invoices for this subscription and forgive them
 				if(!empty($invoices))
 				{
 					foreach($invoices->data as $invoice)
-					{										
+					{
 						if(!$invoice->closed && $invoice->subscription == $subscription->id)
-						{											
+						{
 							$invoice->closed = true;
 							$invoice->save();
 						}
 					}
-				}	
-								
+				}
+
 				//cancel
 				$r = $subscription->cancel();
-				
+
 				return true;
 			}
 			catch(Exception $e)
-			{			
+			{
 				return false;
 			}
 		}


### PR DESCRIPTION
**NOTE**: The only real change here is lines 1409-1410.  The rest was removing excess whitespace and converting all line endings to CRLF.  (general cleanup)

--
This change is to allow other plugins to modify the subscription object before sending to Stripe. This is most useful for setting a custom ‘trial_end’ timestamp inside Stripe (which cannot be done inside the Stripe plan object).

https://stripe.com/docs/api/php#create_subscription

The Stripe plan object only lets you set a number of ‘trial_period_days’ — which is not granular enough if you want subscriptions to renew at a specific time of day — like noon or 3pm or whatever.

--
This pull request suggested by Jason in the v1.8 BETA blog post:
http://www.paidmembershipspro.com/2015/03/v1-8-beta-download-available-now-full-release-in-1-week/#comment-21751