### PR TITLE
Fix for issue #198 (Uninitiated variable)

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -554,7 +554,9 @@
 			$sqlQuery .= "ORDER BY id ASC";
 			
 			$levels = $wpdb->get_results($sqlQuery, OBJECT);
-						
+			
+			$count = 0; // Bugfix for issue #198
+			
 			foreach($levels as $level)
 			{			
 		?>


### PR DESCRIPTION
Set $count = 0 before use/increment. PHP allows uninitiated variables, but has started complaining in recent versions.