### PR TITLE
Allow customization of user creation during checkout

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -563,12 +563,14 @@
 																				"last_name" => $last_name)
 																				);
 
-			$user_id = wp_insert_user($new_user_array);
+			$user_id = apply_filters('pmpro_new_user', '', $new_user_array);
+			if (!$user_id)
+				$user_id = wp_insert_user($new_user_array);
 
 			if (!$user_id || is_wp_error($user_id)) {
 				$pmpro_msg = __("Your payment was accepted, but there was an error setting up your account. Please contact us.", "pmpro");
 				$pmpro_msgt = "pmpro_error";
-			} else {
+			} elseif ( apply_filters('pmpro_setup_new_user', true, $user_id, $new_user_array) ) {
 
 				//check pmpro_wp_new_user_notification filter before sending the default WP email
 				if (apply_filters("pmpro_wp_new_user_notification", true, $user_id, $pmpro_level->id))


### PR DESCRIPTION
On one hand, I like PMPro's streamlined registration process, but on another, I like Buddypress' activation system (aka email confirmation). I have merged the two with these changes in the plugin, and I could submit my code as a Gist for others wanting to use BP's activation system with PMPro.

Obviously, I avoid changing a plugin's code like the plague, but I didn't see any way to use BP's system without changing PMPro. What I found is that PMPro needs a couple extra filters to make the registration process more flexible. I had to replace the user creation with Buddypress', and then skip PMPro's user setup, so that it didn't automatically login the user.

In case you're interested, here's how I'm using those filters in `functions.php` to integrate Buddypress' system. I used the Register Helper plugin to add a "Name" field for the user's Buddypress profile (most of my users don't fill in billing info), hence `$_REQUEST['pmpro_name']`.
```php
// Add new user via Buddypress after PMPro checkout
function add_new_user_with_buddypress( $user_id, $userdata ) {
    if ( ! function_exists( 'bp_core_signup_user' ) ) {
		return $user_id;
	}
	do_action( 'bp_signup_validate' );
	$usermeta = array( 'field_1' => $_REQUEST['pmpro_name'] );
	$user_id = bp_core_signup_user( $userdata['user_login'], $userdata['user_pass'], $userdata['user_email'], $usermeta );
	do_action( 'bp_complete_signup' );
	return $user_id;
}
add_filter( 'pmpro_new_user', 'add_new_user_with_buddypress', 10, 2 );

// Skip PMPro user setup
add_filter( 'pmpro_setup_new_user', '__return_false' );

// Change confirmation url for users needing to activate their account
function change_pmpro_confirmation_url( $url, $user_id, $pmpro_level ) {
    if ( ! function_exists( 'bp_get_activate_slug' ) ) {
		return $url;
	}
	// Redirect new / inactive users to the activation page
	if ( ! ( empty( $user_id ) || is_wp_error( $user_id ) ) && 2 == BP_Signup::check_user_status( $user_id ) ) {
		return add_query_arg( 'redirect', 'checkout', bp_get_activate_slug() );
	}
	return $url;
}
add_filter( 'pmpro_confirmation_url', 'change_pmpro_confirmation_url', 10, 3 );

// Add info to activation page
function add_bp_activation_info() {
	if ( 'checkout' == $_GET['redirect'] && ! bp_account_was_activated() ) { ?>
		<div id="message" class="bp-template-notice updated">
			<p><?php _e( 'You have successfully created your account! To begin using this site you will need to activate your account via the email we have just sent to your address.', 'buddypress' ); ?></p>
		</div>
	<?php }
}
add_action( 'bp_before_activate_content', 'add_bp_activation_info' );
```