### PR TITLE
Update wp_new_user_notification()

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -573,8 +573,12 @@
 			} elseif (apply_filters('pmpro_setup_new_user', true, $user_id, $new_user_array, $pmpro_level)) {
 
 				//check pmpro_wp_new_user_notification filter before sending the default WP email
-				if (apply_filters("pmpro_wp_new_user_notification", true, $user_id, $pmpro_level->id))
-					wp_new_user_notification($user_id, $new_user_array['user_pass']);
+				if (apply_filters("pmpro_wp_new_user_notification", true, $user_id, $pmpro_level->id)) {
+					if (version_compare($wp_version, "4.3.0") >= 0)
+						wp_new_user_notification($user_id, null, 'both');
+					else
+						wp_new_user_notification($user_id, $new_user_array['user_pass']);
+				}
 
 				$wpuser = get_userdata($user_id);
 


### PR DESCRIPTION
Changes made in version 4.3.1 of WordPress deprecated the second parameter of wp_new_user_notification().  It was also changed in version 4.0 - see core trac ticket: https://core.trac.wordpress.org/changeset/34116

Changes to this file offer backwards compatibility for wp_new_user_notification() and offers support for the most recent changes.