### PR TITLE
Ensure the object used for body class is of type post

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -514,7 +514,7 @@ function pmpro_body_classes( $classes ) {
 	
 	$post = get_queried_object();
 	
-	if(empty($post))
+	if(empty($post) || !is_singular())
 		return $classes;
 	
 	$post_levels = array();


### PR DESCRIPTION
The function `pmpro_body_classes()` returnes a notice error on archives because in that case `$post` object does not have the `ID` property. On taxonomy archives there's `term_id` instead of `ID` for instance.