### PR TITLE
Fix for issue with [pmpro_levels] with [membership] shortcode

### DIFF
--- a/preheaders/levels.php
+++ b/preheaders/levels.php
@@ -42,7 +42,7 @@ if(!empty($pmpro_level_order))
     foreach($order as $level_id) {
         foreach($pmpro_levels as $key=>$level) {
             if($level_id == $level->id)
-                $reordered_levels[] = $pmpro_levels[$key];
+                $reordered_levels[$key] = $pmpro_levels[$key];
         }
     }
 


### PR DESCRIPTION
Fix for issue where [pmpro_levels] shortcode is used on same page as [membership level="2"] shortcode (level value is just an example) and membership levels have been reordered in WP Admin. [membership] uses the function pmpro_getLevel() which expects the global $pmpro_levels to have arrays keys values that match the membership level id.

As the code currently stands it chamges the global $pmpro_levels so that its array key values differ from the membership level id. This fix honors the sort order specified by pmpro_getOption('level_order') but makes sure the array key values in $pmpro_levels correspond to the membership level id.

An alternative fix may be to remove the section of code from lines 31-52 from /preheaders/levels.php since similar code is already included in /pages/levels.php