### PR TITLE
Fix direct access detection

### DIFF
--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -1,14 +1,14 @@
 <?php
 	global $isapage;
-	$isapage = true;		
-	
+	$isapage = true;
+
 	//in case the file is loaded directly
-	if(!defined("WP_USE_THEMES"))
+	if(!defined("ABSPATH"))
 	{
 		define('WP_USE_THEMES', false);
 		require_once(dirname(__FILE__) . '/../../../../wp-load.php');
 	}
-	
+
 	//vars
 	global $wpdb;
 	if(!empty($_REQUEST['code']))
@@ -21,17 +21,17 @@
 		$discount_code = "";
 		$discount_code_id = "";
 	}
-	
+
 	if(!empty($_REQUEST['level']))
 		$level_id = (int)$_REQUEST['level'];
 	else
 		$level_id = NULL;
-		
+
 	if(!empty($_REQUEST['msgfield']))
 		$msgfield = preg_replace("/[^A-Za-z0-9\_\-]/", "", $_REQUEST['msgfield']);
 	else
-		$msgfield = NULL;	
-	
+		$msgfield = NULL;
+
 	//check that the code is valid
 	$codecheck = pmpro_checkDiscountCode($discount_code, $level_id, true);
 	if($codecheck[0] == false)
@@ -39,36 +39,36 @@
 		//uh oh. show code error
 		echo pmpro_no_quotes($codecheck[1]);
 		?>
-		<script>			
+		<script>
 			jQuery('#<?php echo $msgfield?>').show();
 			jQuery('#<?php echo $msgfield?>').removeClass('pmpro_success');
 			jQuery('#<?php echo $msgfield?>').addClass('pmpro_error');
 			jQuery('#<?php echo $msgfield?>').addClass('pmpro_discount_code_msg');
-			
+
 			//filter to insert your own code
 			<?php do_action('pmpro_applydiscountcode_return_js', $discount_code, $discount_code_id, $level_id, false); ?>
 		</script>
 		<?php
-		
+
 		exit(0);
-	}			
-	
+	}
+
 	//okay, send back new price info
-	$sqlQuery = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.code = '" . $discount_code . "' AND cl.level_id = '" . $level_id . "' LIMIT 1";			
+	$sqlQuery = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.code = '" . $discount_code . "' AND cl.level_id = '" . $level_id . "' LIMIT 1";
 	$code_level = $wpdb->get_row($sqlQuery);
-	
+
 	//if the discount code doesn't adjust the level, let's just get the straight level
 	if(empty($code_level))
 		$code_level = $wpdb->get_row("SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . $level_id . "' LIMIT 1");
 
 	//filter adjustments to the level
 	$code_level = apply_filters("pmpro_discount_code_level", $code_level, $discount_code_id);
-	
+
 	printf(__("The %s code has been applied to your order. ", "pmpro"), $discount_code);
 	?>
-	<script>		
-		var code_level = <?php echo json_encode($code_level); ?>;				
-		
+	<script>
+		var code_level = <?php echo json_encode($code_level); ?>;
+
 		jQuery('#<?php echo $msgfield?>').show();
 		jQuery('#<?php echo $msgfield?>').removeClass('pmpro_error');
 		jQuery('#<?php echo $msgfield?>').addClass('pmpro_success');
@@ -84,18 +84,18 @@
 				value: '<?php echo $discount_code?>'
 			}).appendTo('#pmpro_form');
 		}
-		
+
 		jQuery('#other_discount_code_tr').hide();
 		jQuery('#other_discount_code_p').html('<a id="other_discount_code_a" href="javascript:void(0);"><?php _e('Click here to change your discount code', 'pmpro');?></a>.');
 		jQuery('#other_discount_code_p').show();
-		
+
 		jQuery('#other_discount_code_a').click(function() {
 			jQuery('#other_discount_code_tr').show();
-			jQuery('#other_discount_code_p').hide();			
+			jQuery('#other_discount_code_p').hide();
 		});
-		
+
 		jQuery('#pmpro_level_cost').html('<p><?php printf(__('The <strong>%s</strong> code has been applied to your order.', 'pmpro'), $discount_code);?></p><p><?php echo pmpro_no_quotes(pmpro_getLevelCost($code_level), array('"', "'", "\n", "\r"))?><?php echo pmpro_no_quotes(pmpro_getLevelExpiration($code_level), array('"', "'", "\n", "\r"))?></p>');
-		
+
 		<?php
 			//tell gateway javascripts whether or not to fire (e.g. no Stripe on free levels)
 			if(pmpro_isLevelFree($code_level))
@@ -103,49 +103,49 @@
 			?>
 				pmpro_require_billing = false;
 			<?php
-			}			
+			}
 			else
 			{
 			?>
 				pmpro_require_billing = true;
 			<?php
 			}
-			
+
 			//hide/show billing
 			if(pmpro_isLevelFree($code_level) || pmpro_getGateway() == "paypalexpress" || pmpro_getGateway() == "paypalstandard" || pmpro_getGateway() == 'check')
-			{				
+			{
 				?>
 				jQuery('#pmpro_billing_address_fields').hide();
-				jQuery('#pmpro_payment_information_fields').hide();			
+				jQuery('#pmpro_payment_information_fields').hide();
 				<?php
 			}
-			else			
+			else
 			{
-				?>			
+				?>
 				jQuery('#pmpro_billing_address_fields').show();
-				jQuery('#pmpro_payment_information_fields').show();			
+				jQuery('#pmpro_payment_information_fields').show();
 				<?php
 			}
-			
+
 			//hide/show paypal button
-			if(pmpro_getGateway() == "paypalexpress" || pmpro_getGateway() == "paypalstandard")			
+			if(pmpro_getGateway() == "paypalexpress" || pmpro_getGateway() == "paypalstandard")
 			{
 				if(pmpro_isLevelFree($code_level))
 				{
-					?>					
+					?>
 					jQuery('#pmpro_paypalexpress_checkout').hide();
 					jQuery('#pmpro_submit_span').show();
 					<?php
 				}
 				else
 				{
-					?>					
+					?>
 					jQuery('#pmpro_submit_span').hide();
-					jQuery('#pmpro_paypalexpress_checkout').show();				
+					jQuery('#pmpro_paypalexpress_checkout').show();
 					<?php
 				}
 			}
-			
+
 			//filter to insert your own code
 			do_action('pmpro_applydiscountcode_return_js', $discount_code, $discount_code_id, $level_id, $code_level);
 		?>

--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -6,7 +6,7 @@
 	$logstr = "";
 
 	//in case the file is loaded directly
-	if(!defined("WP_USE_THEMES"))
+	if(!defined("ABSPATH"))
 	{
 		define('WP_USE_THEMES', false);
 		require_once(dirname(__FILE__) . '/../../../../wp-load.php');

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -11,7 +11,7 @@
     $logstr = "";
 
 	//in case the file is loaded directly
-	if(!defined("WP_USE_THEMES"))
+	if(!defined("ABSPATH"))
 	{
 		define('WP_USE_THEMES', false);
 		require_once(dirname(__FILE__) . '/../../../../wp-load.php');

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -1,6 +1,6 @@
 <?php
 	//in case the file is loaded directly
-	if(!defined("WP_USE_THEMES"))
+	if(!defined("ABSPATH"))
 	{
 		global $isapage;
 		$isapage = true;
@@ -723,4 +723,3 @@
 			return false;
 		}
 	}
-

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -10,7 +10,7 @@
 		define('PMPRO_STRIPE_WEBHOOK_DELAY', 2);
 
 	//in case the file is loaded directly
-	if(!defined("WP_USE_THEMES"))
+	if(!defined("ABSPATH"))
 	{
 		define('WP_USE_THEMES', false);
 		require_once(dirname(__FILE__) . '/../../../../wp-load.php');

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -1,13 +1,13 @@
 <?php
 	//set this in your wp-config.php for debugging
 	//define('PMPRO_INS_DEBUG', true);
-	
-	//in case the file is loaded directly	
-	if(!defined("WP_USE_THEMES"))
+
+	//in case the file is loaded directly
+	if(!defined("ABSPATH"))
 	{
 		global $isapage;
 		$isapage = true;
-		
+
 		define('WP_USE_THEMES', false);
 		require_once(dirname(__FILE__) . '/../../../../wp-load.php');
 	}
@@ -15,16 +15,16 @@
 	// Require TwoCheckout class
 	if(!class_exists("Twocheckout"))
 		require_once(PMPRO_DIR . "/includes/lib/Twocheckout/Twocheckout.php");
-		
+
 	//some globals
 	global $wpdb, $gateway_environment, $logstr;
 	$logstr = "";	//will put debug info here and write to inslog.txt
 
 	//validate?
 	if( ! pmpro_twocheckoutValidate() ) {
-		
+
 		inslog("(!!FAILED VALIDATION!!)");
-		
+
 		//validation failed
 		pmpro_twocheckoutExit();
 	}
@@ -51,9 +51,9 @@
 		$morder = new MemberOrder( $order_id );
 		$morder->getMembershipLevel();
 		$morder->getUser();
-		
+
 		inslog("NO MESSAGE: ORDER: " . var_export($morder, true) . "\n---\n");
-		
+
 		//update membership
 		if( ! empty ( $morder ) && ! empty ( $morder->status ) && $morder->status === 'success' ) {
 			inslog( "Checkout was already processed (" . $morder->code . "). Ignoring this request." );
@@ -62,9 +62,9 @@
 			inslog( "Checkout processed (" . $morder->code . ") success!" );
 		}
 		else {
-			inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );		
+			inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );
 		}
-		
+
 		pmpro_twocheckoutExit(pmpro_url("confirmation", "?level=" . $morder->membership_level->id));
 	}
 
@@ -74,9 +74,9 @@
 		$morder = new MemberOrder( $order_id );
 		$morder->getMembershipLevel();
 		$morder->getUser();
-		
+
 		inslog("ORDER_CREATED: ORDER: " . var_export($morder, true) . "\n---\n");
-		
+
 		//update membership
 		if( ! empty ( $morder ) && ! empty ( $morder->status ) && $morder->status === 'success' ) {
 			inslog( "Checkout was already processed (" . $morder->code . "). Ignoring this request." );
@@ -85,9 +85,9 @@
 			inslog( "Checkout processed (" . $morder->code . ") success!" );
 		}
 		else {
-			inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );		
+			inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );
 		}
-		
+
 		pmpro_twocheckoutExit(pmpro_url("confirmation", "?level=" . $morder->membership_level->id));
 	}
 
@@ -96,17 +96,17 @@
 		//is this a first payment?
 		$last_subscr_order = new MemberOrder();
 		if( $last_subscr_order->getLastMemberOrderBySubscriptionTransactionID( $txn_id ) == false) {
-			//first payment, get order			
-			$morder = new MemberOrder( $order_id );												
+			//first payment, get order
+			$morder = new MemberOrder( $order_id );
 			$morder->getMembershipLevel();
 			$morder->getUser();
 
 			//update membership
-			if( pmpro_insChangeMembershipLevel( $txn_id, $morder ) ) {									
-				inslog( "Checkout processed (" . $morder->code . ") success!" );		
+			if( pmpro_insChangeMembershipLevel( $txn_id, $morder ) ) {
+				inslog( "Checkout processed (" . $morder->code . ") success!" );
 			}
 			else {
-				inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );		
+				inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );
 			}
 		}
 		else {
@@ -126,7 +126,7 @@
 		pmpro_twocheckoutExit();
 	}
 
-	
+
 	/*
 	// Recurring Payment Stopped (recurring stopped and recurring is true)
 	if( $message_type == 'RECURRING_STOPPED' && $recurring ) {
@@ -140,13 +140,13 @@
 			inslog( "Recurring stopped for order (" . $morder->code . ")!" );
 		}
 		else {
-			inslog( "Recurring NOT stopped for order (" . $morder->code . ")!" );		
-		}	
-		
+			inslog( "Recurring NOT stopped for order (" . $morder->code . ")!" );
+		}
+
 		pmpro_twocheckoutExit();
 	}
 
-	
+
 	// Recurring Payment Restarted (recurring restarted and recurring is true)
 	if( $message_type == 'RECURRING_RESTART' && $recurring ) {
 		//initial payment, get the order
@@ -159,27 +159,27 @@
 			inslog( "Recurring restarted for order (" . $morder->code . ")!" );
 		}
 		else {
-			inslog( "Recurring NOT restarted for order (" . $morder->code . ")!" );		
-		}	
-		
+			inslog( "Recurring NOT restarted for order (" . $morder->code . ")!" );
+		}
+
 		pmpro_twocheckoutExit();
 	}
 	*/
-	
+
 	//Other
 	//if we got here, this is a different kind of txn
-	inslog("The PMPro INS handler does not process this type of message. message_type = " . $message_type);	
-	pmpro_twocheckoutExit();	
-	
+	inslog("The PMPro INS handler does not process this type of message. message_type = " . $message_type);
+	pmpro_twocheckoutExit();
+
 	/*
 		Add message to inslog string
 	*/
 	function inslog( $s )
-	{		
-		global $logstr;		
+	{
+		global $logstr;
 		$logstr .= "\t" . $s . "\n";
 	}
-	
+
 	/*
 		Output inslog and exit;
 	*/
@@ -187,31 +187,31 @@
 	{
 		global $logstr;
 		//echo $logstr;
-	
-		$logstr = var_export($_REQUEST, true) . "Logged On: " . date("m/d/Y H:i:s") . "\n" . $logstr . "\n-------------\n";		
-					
+
+		$logstr = var_export($_REQUEST, true) . "Logged On: " . date("m/d/Y H:i:s") . "\n" . $logstr . "\n-------------\n";
+
 		//log in file or email?
 		if(defined('PMPRO_INS_DEBUG') && PMPRO_INS_DEBUG === "log")
-		{			
+		{
 			//file
-			$loghandle = fopen(dirname(__FILE__) . "/../logs/ipn.txt", "a+");	
+			$loghandle = fopen(dirname(__FILE__) . "/../logs/ipn.txt", "a+");
 			fwrite($loghandle, $logstr);
 			fclose($loghandle);
 		}
 		elseif(defined('PMPRO_INS_DEBUG'))
-		{			
+		{
 			//email
 			if(strpos(PMPRO_INS_DEBUG, "@"))
 				$log_email = PMPRO_INS_DEBUG;	//constant defines a specific email address
 			else
 				$log_email = get_option("admin_email");
-			
+
 			wp_mail($log_email, get_option("blogname") . " 2Checkout INS Log", nl2br($logstr));
-		}		
-		
+		}
+
 		if(!empty($redirect))
 			wp_redirect($redirect);
-		
+
 		exit;
 	}
 
@@ -222,17 +222,17 @@
 		$params = array();
 		foreach ( $_REQUEST as $k => $v )
 			$params[$k] = $v;
-		
+
 		//2Checkout uses an order number of 1 in the hash for demo orders for some reason
 		if(!empty($params['demo']) && $params['demo'] == 'Y')
 			$params['order_number'] = 1;
-		
+
 		//is this a return call or notification
 		if(empty($params['message_type']))
 			$check = Twocheckout_Return::check( $params, pmpro_getOption( 'twocheckout_secretword' ), 'array' );
-		else		
-			$check = Twocheckout_Notification::check( $params, pmpro_getOption( 'twocheckout_secretword' ), 'array' );				
-		
+		else
+			$check = Twocheckout_Notification::check( $params, pmpro_getOption( 'twocheckout_secretword' ), 'array' );
+
 		if( empty ( $check ) )
 			$r = false;	//HTTP failure
 		else if( empty ( $check['response_code'] ) )
@@ -252,18 +252,18 @@
 
 		return $check['response_code'] === 'Success';
 	}
-	
+
 	/*
 		Change the membership level. We also update the membership order to include filtered valus.
 	*/
 	function pmpro_insChangeMembershipLevel($txn_id, &$morder)
 	{
 		$recurring = pmpro_getParam( 'recurring', 'POST' );
-		
+
 		//filter for level
 		$morder->membership_level = apply_filters("pmpro_inshandler_level", $morder->membership_level, $morder->user_id);
-					
-		//fix expiration date		
+
+		//fix expiration date
 		if(!empty($morder->membership_level->expiration_number))
 		{
 			$enddate = "'" . date("Y-m-d", strtotime("+ " . $morder->membership_level->expiration_number . " " . $morder->membership_level->expiration_period, current_time("timestamp"))) . "'";
@@ -272,21 +272,21 @@
 		{
 			$enddate = "NULL";
 		}
-		
+
 		//get discount code
 		$morder->getDiscountCode();
 		if(!empty($morder->discount_code))
-		{		
+		{
 			//update membership level
 			$morder->getMembershipLevel(true);
 			$discount_code_id = $morder->discount_code->id;
 		}
 		else
 			$discount_code_id = "";
-		
+
 		//set the start date to current_time('mysql') but allow filters
 		$startdate = apply_filters("pmpro_checkout_start_date", "'" . current_time('mysql') . "'", $morder->user_id, $morder->membership_level);
-		
+
 		//custom level to change user to
 		$custom_level = array(
 			'user_id' => $morder->user_id,
@@ -306,11 +306,11 @@
 		if(!empty($pmpro_error))
 		{
 			echo $pmpro_error;
-			inslog($pmpro_error);				
+			inslog($pmpro_error);
 		}
-		
+
 		if( pmpro_changeMembershipLevel($custom_level, $morder->user_id) !== false ) {
-			//update order status and transaction ids					
+			//update order status and transaction ids
 			$morder->status = "success";
 			$morder->payment_transaction_id = $txn_id;
 			if( $recurring )
@@ -318,13 +318,13 @@
 			else
 				$morder->subscription_transaction_id = '';
 			$morder->saveOrder();
-			
+
 			//add discount code use
 			if(!empty($discount_code) && !empty($use_discount_code))
 			{
 				$wpdb->query("INSERT INTO $wpdb->pmpro_discount_codes_uses (code_id, user_id, order_id, timestamp) VALUES('" . $discount_code_id . "', '" . $morder->user_id . "', '" . $morder->id . "', '" . current_time('mysql') . "')");
-			}									
-		
+			}
+
 			//save first and last name fields
 			if(!empty($_POST['first_name']))
 			{
@@ -338,103 +338,103 @@
 				if(!empty($old_lastname))
 					update_user_meta($morder->user_id, "last_name", $_POST['last_name']);
 			}
-												
+
 			//hook
-			do_action("pmpro_after_checkout", $morder->user_id);						
-		
+			do_action("pmpro_after_checkout", $morder->user_id);
+
 			//setup some values for the emails
 			if(!empty($morder))
-				$invoice = new MemberOrder($morder->id);						
+				$invoice = new MemberOrder($morder->id);
 			else
 				$invoice = NULL;
-		
+
 			inslog("CHANGEMEMBERSHIPLEVEL: ORDER: " . var_export($morder, true) . "\n---\n");
-		
-			$user = get_userdata($morder->user_id);					
+
+			$user = get_userdata($morder->user_id);
 			if(empty($user))
 				return false;
-				
+
 			$user->membership_level = $morder->membership_level;		//make sure they have the right level info
-		
+
 			//send email to member
-			$pmproemail = new PMProEmail();				
+			$pmproemail = new PMProEmail();
 			$pmproemail->sendCheckoutEmail($user, $invoice);
-										
+
 			//send email to admin
 			$pmproemail = new PMProEmail();
 			$pmproemail->sendCheckoutAdminEmail($user, $invoice);
-			
+
 			return true;
 		}
 		else
 			return false;
 	}
-	
+
 	/*
 		Send an email RE a failed payment.
 		$last_order passed in is the previous order for this subscription.
 	*/
-	function pmpro_insFailedPayment( $last_order ) {		
-		//hook to do other stuff when payments fail		
-		do_action("pmpro_subscription_payment_failed", $last_order);							
-	
-		//create a blank order for the email			
+	function pmpro_insFailedPayment( $last_order ) {
+		//hook to do other stuff when payments fail
+		do_action("pmpro_subscription_payment_failed", $last_order);
+
+		//create a blank order for the email
 		$morder = new MemberOrder();
 		$morder->user_id = $last_order->user_id;
-				
-		// Email the user and ask them to update their credit card information			
-		$pmproemail = new PMProEmail();				
+
+		// Email the user and ask them to update their credit card information
+		$pmproemail = new PMProEmail();
 		$pmproemail->sendBillingFailureEmail($user, $morder);
-	
+
 		// Email admin so they are aware of the failure
-		$pmproemail = new PMProEmail();				
-		$pmproemail->sendBillingFailureAdminEmail(get_bloginfo("admin_email"), $morder);	
-	
-		inslog("Payment failed. Emails sent to " . $user->user_email . " and " . get_bloginfo("admin_email") . ".");	
-		
+		$pmproemail = new PMProEmail();
+		$pmproemail->sendBillingFailureAdminEmail(get_bloginfo("admin_email"), $morder);
+
+		inslog("Payment failed. Emails sent to " . $user->user_email . " and " . get_bloginfo("admin_email") . ".");
+
 		return true;
 	}
-	
+
 	/*
 		Save a new order from IPN info.
 		$last_order passed in is the previous order for this subscription.
 	*/
 	function pmpro_insSaveOrder( $txn_id, $last_order ) {
 		global $wpdb;
-			
+
 		//check that txn_id has not been previously processed
 		$old_txn = $wpdb->get_var("SELECT payment_transaction_id FROM $wpdb->pmpro_membership_orders WHERE payment_transaction_id = '" . $txn_id . "' LIMIT 1");
-		
-		if( empty( $old_txn ) ) {	
+
+		if( empty( $old_txn ) ) {
 			//hook for successful subscription payments
 			do_action("pmpro_subscription_payment_completed");
-															
+
 			//save order
 			$morder = new MemberOrder();
 			$morder->user_id = $last_order->user_id;
-			$morder->membership_id = $last_order->membership_id;			
+			$morder->membership_id = $last_order->membership_id;
 			$morder->payment_transaction_id = $txn_id;
 			$morder->subscription_transaction_id = $last_order->subscription_transaction_id;
 			$morder->InitialPayment = $_POST['item_list_amount_1'];	//not the initial payment, but the class is expecting that
 			$morder->PaymentAmount = $_POST['item_list_amount_1'];
-			
+
 			$morder->FirstName = $_POST['customer_first_name'];
 			$morder->LastName = $_POST['customer_last_name'];
 			$morder->Email = $_POST['customer_email'];
-			
+
 			$morder->gateway = $last_order->gateway;
 			$morder->gateway_environment = $last_order->gateway_environment;
-			
+
 			//save
 			$morder->saveOrder();
 			$morder->getMemberOrderByID( $morder->id );
-							
-			//email the user their invoice				
-			$pmproemail = new PMProEmail();				
-			$pmproemail->sendInvoiceEmail( get_userdata( $last_order->user_id ), $morder );	
-			
+
+			//email the user their invoice
+			$pmproemail = new PMProEmail();
+			$pmproemail->sendInvoiceEmail( get_userdata( $last_order->user_id ), $morder );
+
 			inslog( "New order (" . $morder->code . ") created." );
-			
+
 			return true;
 		}
 		else {
@@ -442,8 +442,8 @@
 			return false;
 		}
 	}
-	
-	
+
+
 	/*
 		Cancel a subscription and send an email RE a recurring.
 		$morder passed in is the previous order for this subscription.
@@ -451,10 +451,10 @@
 	function pmpro_insRecurringStopped( $morder ) {
 		global $pmpro_error;
 		//hook to do other stuff when payments stop
-		do_action("pmpro_subscription_recuring_stopped", $last_order);							
-	
+		do_action("pmpro_subscription_recuring_stopped", $last_order);
+
 		$worked = pmpro_changeMembershipLevel( false, $morder->user->ID , 'inactive');
-		if( $worked === true ) {			
+		if( $worked === true ) {
 			//$pmpro_msg = __("Your membership has been cancelled.", 'pmpro');
 			//$pmpro_msgt = "pmpro_success";
 
@@ -466,40 +466,40 @@
 			$myemail = new PMProEmail();
 			$myemail->sendCancelAdminEmail( $morder->user, $morder->membership_level->id );
 
-			inslog("Subscription cancelled due to 'recurring stopped' INS notification.");	
-		
+			inslog("Subscription cancelled due to 'recurring stopped' INS notification.");
+
 			return true;
 		}
 		else {
 			return false;
 		}
 	}
-	
-	
+
+
 	/*
 		Restart a subscription and send an email RE a recurring.
 		$morder passed in is the previous order for this subscription.
 	*/
 	function pmpro_insRecurringRestarted( $morder ) {
 		global $pmpro_error;
-		//hook to do other stuff when payments restart	
-		do_action("pmpro_subscription_recuring_restarted", $last_order);							
-	
+		//hook to do other stuff when payments restart
+		do_action("pmpro_subscription_recuring_restarted", $last_order);
+
 		$worked = pmpro_changeMembershipLevel( $morder->membership_level->id, $morder->user->ID );
-		if( $worked === true ) {			
+		if( $worked === true ) {
 			//$pmpro_msg = __("Your membership has been cancelled.", 'pmpro');
 			//$pmpro_msgt = "pmpro_success";
 
 			//send an email to the member
-			$pmproemail = new PMProEmail();				
+			$pmproemail = new PMProEmail();
 			$pmproemail->sendCheckoutEmail( $morder->user, $morder );
 
 			//send email to admin
 			$pmproemail = new PMProEmail();
 			$pmproemail->sendCheckoutAdminEmail( $morder->user, $morder );
 
-			inslog("Subscription restarted due to 'recurring restarted' INS notification.");	
-		
+			inslog("Subscription restarted due to 'recurring restarted' INS notification.");
+
 			return true;
 		}
 		else {


### PR DESCRIPTION
Fix an issue happening when applying discount code on checkout when WordPress is setup as a sub-directory. #61

I replaced the direct access detection from `if ( !defined('WP_USE_THEMES') )` with `if ( !defined('ABSPATH') )` which fixed the issue in my case.

If someone tries to access the file directly with the same WordPress configuration it'll still fail but if I understood well direct access has been deprecated.

PS: Sorry for the white space diffs. Might be worth adding a .editorconfig to avoid that in the future