### PR TITLE
Avoid warning on "Add new order" in admin area

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -303,7 +303,15 @@
 			else
 			{
 				$order = new MemberOrder();			//new order
-
+				
+				// empty order object?
+				if (true === $order) 
+				{
+					// Avoid PHP warnings
+					$order = new stdClass();
+					$order->billing = new stdClass();
+				}
+				
 				//defaults
 				$order->code = $order->getRandomCode();
 				$order->user_id = "";


### PR DESCRIPTION
User gets PHP warning message because MemberOrder::__construct() returns boolean, and not an actual stdClass() object when creating new MemberOrder. IMHO, MemberOrder::__construct() should always return a true MemberOrder object. However, considering the number of places where MemberOrder is instantiated without an argument (and as a result will return a boolean true, rather than an actual object), there may be compatibility reasons to _not_ do so. This will work around the warning in the page instead.