### PR TITLE
FIX: PayPal requires HTTP 1.1 from POST request

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -850,6 +850,7 @@
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
 					'sslverify' => FALSE,
+					'httpversion' => '1.1',
 					'body' => $nvpreq
 			    )
 			);


### PR DESCRIPTION
Add the `httpversion` argument to the header.