### PR TITLE
FIX: PayPal requires HTTP 1.1 from POST request

### DIFF
--- a/classes/gateways/class.pmprogateway_payflowpro.php
+++ b/classes/gateways/class.pmprogateway_payflowpro.php
@@ -588,6 +588,7 @@
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
 					'sslverify' => FALSE,
+					'httpversion' => '1.1',
 					'body' => $nvpreq
 			    )
 			);


### PR DESCRIPTION
Add `httpversion` header