### PR TITLE
FIX: PayPal requires HTTP 1.1 from POST request

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -498,6 +498,7 @@
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
 					'sslverify' => FALSE,
+					'httpversion' => '1.1',
 					'body' => $nvpreq
 			    )
 			);


### PR DESCRIPTION
Add `httpversion` to header