### PR TITLE
Set timeout for server connection to 60 seconds

### DIFF
--- a/classes/gateways/class.pmprogateway_payflowpro.php
+++ b/classes/gateways/class.pmprogateway_payflowpro.php
@@ -587,6 +587,7 @@
 
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
+					'timeout' => 60,
 					'sslverify' => FALSE,
 					'httpversion' => '1.1',
 					'body' => $nvpreq


### PR DESCRIPTION
Allow PayPal's servers more than 5 seconds to respond to the request(s).