### PR TITLE
Set timeout for server connection to 60 seconds

### DIFF
--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -638,6 +638,7 @@
 
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
+					'timeout' => 60,
 					'sslverify' => FALSE,
 					'httpversion' => '1.1',
 					'body' => $nvpreq


### PR DESCRIPTION
Allow PayPal more than the default 5 seconds before timing out the request