### PR TITLE
Set timeout for server connection to 60 seconds

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -849,6 +849,7 @@
 
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
+					'timeout' => 60,
 					'sslverify' => FALSE,
 					'httpversion' => '1.1',
 					'body' => $nvpreq


### PR DESCRIPTION
PayPal may need more than the default 5 seconds before processing/responding to the request