### PR TITLE
Set timeout for server connection to 60 seconds

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -497,6 +497,7 @@
 						
 			//post to PayPal
 			$response = wp_remote_post( $API_Endpoint, array(
+					'timeout' => 60,
 					'sslverify' => FALSE,
 					'httpversion' => '1.1',
 					'body' => $nvpreq


### PR DESCRIPTION
Default setting is 5 seconds. PayPal typically needs more than that to process the request.