### PR TITLE
ENH: Nondescript error message

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -505,7 +505,7 @@
 
 			if ( is_wp_error( $response ) ) {
 			   $error_message = $response->get_error_message();
-			   die( "methodName_ failed: $error_message" );
+			   die( "{$methodName_} failed: $error_message" );
 			} else {
 				//extract the response details
 				$httpParsedResponseAr = array();


### PR DESCRIPTION
Probably meant to include the actual variable in the `die()` call.