### PR TITLE
FIX: 500 Error during the_content filter

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -5,9 +5,12 @@
 function pmpro_has_membership_access($post_id = NULL, $user_id = NULL, $return_membership_levels = false)
 {
 	global $post, $wpdb, $current_user;
-
-	//use queried object if no value is supplied
-	$queried_object = get_queried_object();
+	
+	// queried_object doesn't exist if we're on the admin dashboard
+	if (! is_admin() && ! current_user_can('manage_options') )
+		//use queried object if no value is supplied
+		$queried_object = get_queried_object();
+		
 	if(!$post_id && !empty($queried_object) && !empty($queried_object->ID))
 		$post_id = $queried_object->ID;
 	


### PR DESCRIPTION
FIX: If  the `the_content` filter is executed while user is in the Admin Dashboard, the get_queried_object() will be run against a NULL object and die w/a 500 Internal Error status.