### PR TITLE
ENH: pmpro_loadTemplate() & fix I18N issues w/_ex()

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -707,7 +707,7 @@
 
 	<ul class="subsubsub">
 		<li>
-			<?php _ex('Show', 'Dropdown label, e.g. Show Daily Orders for January', 'pmpro')?>
+			<?php _e('Show', 'pmpro')?>
 			<select id="filter" name="filter">
 				<option value="all" <?php selected($filter, "all");?>><?php _e('All', 'pmpro');?></option>
 				<option value="within-a-date-range" <?php selected($filter, "within-a-date-range");?>><?php _e('Within a Date Range', 'pmpro');?></option>
@@ -716,7 +716,7 @@
 				<option value="within-a-status" <?php selected($filter, "within-a-status");?>><?php _e('Within a Status', 'pmpro');?></option>
 			</select>
 
-			<span id="from"><?php _ex('From', 'Dropdown label', 'pmpro')?></span>
+			<span id="from"><?php _e('From', 'pmpro')?></span>
 
 			<select id="start-month" name="start-month">
 				<?php for($i = 1; $i < 13; $i++) { ?>
@@ -728,7 +728,7 @@
 			<input id='start-year' name="start-year" type="text" size="4" value="<?php echo esc_attr($start_year);?>" />
 
 
-			<span id="to"><?php _ex('To', 'Dropdown label', 'pmpro')?></span>
+			<span id="to"><?php _e('To', 'pmpro')?></span>
 
 			<select id="end-month" name="end-month">
 				<?php for($i = 1; $i < 13; $i++) { ?>
@@ -740,7 +740,7 @@
 			<input id='end-day' name="end-day" type="text" size="2" value="<?php echo esc_attr($end_day);?>" />
 			<input id='end-year' name="end-year" type="text" size="4" value="<?php echo esc_attr($end_year);?>" />
 
-			<span id="filterby"><?php _ex('filter by ', 'Dropdown label', 'pmpro')?></span>
+			<span id="filterby"><?php _e('filter by ', 'pmpro')?></span>
 
 			<select id="predefined-date" name="predefined-date">
 
@@ -777,7 +777,7 @@
 	</select>
 
 
-		<input id="submit" type="submit" value="<?php _ex('Filter', 'Submit button value.', 'pmpro');?>" />
+		<input id="submit" type="submit" value="<?php _e('Filter', 'pmpro');?>" />
 		</li>
 	</ul>
 

--- a/adminpages/reports/login.php
+++ b/adminpages/reports/login.php
@@ -80,7 +80,7 @@ function pmpro_report_login_page()
 	</h1>		
 	<ul class="subsubsub">
 		<li>			
-			<?php _ex('Show', 'Dropdown label, e.g. Show All Users', 'pmpro')?> <select name="l" onchange="jQuery('#posts-filter').submit();">
+			<?php _e('Show', 'pmpro')?> <select name="l" onchange="jQuery('#posts-filter').submit();">
 				<option value="" <?php if(!$l) { ?>selected="selected"<?php } ?>><?php _e('All Users', 'pmpro')?></option>
 				<option value="all" <?php if($l == "all") { ?>selected="selected"<?php } ?>><?php _e('All Levels', 'pmpro')?></option>
 				<?php
@@ -96,7 +96,7 @@ function pmpro_report_login_page()
 		</li>
 	</ul>
 	<p class="search-box">
-		<label class="hidden" for="post-search-input"><?php _ex('Search', 'Search form label', 'pmpro')?> <?php if(empty($l)) echo "Users"; else echo "Members";?>:</label>
+		<label class="hidden" for="post-search-input"><?php _e('Search', 'pmpro')?> <?php if(empty($l)) echo "Users"; else echo "Members";?>:</label>
 		<input type="hidden" name="page" value="pmpro-reports" />		
 		<input type="hidden" name="report" value="login" />		
 		<input id="post-search-input" type="text" value="<?php echo esc_attr($s)?>" name="s"/>

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -273,7 +273,7 @@ function pmpro_report_memberships_page()
 	</h1>
 	<ul class="subsubsub">
 		<li>
-			<?php _ex('Show', 'Dropdown label, e.g. Show Daily Revenue for January', 'pmpro')?>
+			<?php _e('Show', 'pmpro')?>
 			<select id="period" name="period">
 				<option value="daily" <?php selected($period, "daily");?>><?php _e('Daily', 'pmpro');?></option>
 				<option value="monthly" <?php selected($period, "monthly");?>><?php _e('Monthly', 'pmpro');?></option>
@@ -287,7 +287,7 @@ function pmpro_report_memberships_page()
 				<option value="mrr_ltv" <?php selected($type, "mrr_ltv");?>><?php _e('MRR & LTV', 'pmpro');?></option>
 				*/ ?>
 			</select>
-			<span id="for"><?php _ex('for', 'Dropdown label, e.g. Show Daily Revenue for January', 'pmpro')?></span>
+			<span id="for"><?php _e('for', 'pmpro')?></span>
 			<select id="month" name="month">
 				<?php for($i = 1; $i < 13; $i++) { ?>
 					<option value="<?php echo $i;?>" <?php selected($month, $i);?>><?php echo date("F", mktime(0, 0, 0, $i, 2));?></option>
@@ -298,7 +298,7 @@ function pmpro_report_memberships_page()
 					<option value="<?php echo $i;?>" <?php selected($year, $i);?>><?php echo $i;?></option>
 				<?php } ?>
 			</select>
-			<span id="for"><?php _ex('for', 'Dropdown label, e.g. Show Daily Revenue for January', 'pmpro')?></span>
+			<span id="for"><?php _e('for', 'pmpro')?></span>
 			<select name="level">
 				<option value="" <?php if(!$l) { ?>selected="selected"<?php } ?>><?php _e('All Levels', 'pmpro');?></option>
 				<?php
@@ -314,7 +314,7 @@ function pmpro_report_memberships_page()
 			
 			<input type="hidden" name="page" value="pmpro-reports" />		
 			<input type="hidden" name="report" value="memberships" />	
-			<input type="submit" class="button" value="<?php _ex('Generate Report', 'Submit button value.', 'pmpro');?>" />
+			<input type="submit" class="button" value="<?php _e('Generate Report', 'pmpro');?>" />
 		</li>
 	</ul>
 	

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -199,7 +199,7 @@ function pmpro_report_sales_page()
 	</h1>
 	
 	<div class="tablenav top">
-		<?php _ex('Show', 'Dropdown label, e.g. Show Daily Revenue for January', 'pmpro')?>
+		<?php _e('Show', 'pmpro')?>
 		<select id="period" name="period">
 			<option value="daily" <?php selected($period, "daily");?>><?php _e('Daily', 'pmpro');?></option>
 			<option value="monthly" <?php selected($period, "monthly");?>><?php _e('Monthly', 'pmpro');?></option>
@@ -209,7 +209,7 @@ function pmpro_report_sales_page()
 			<option value="revenue" <?php selected($type, "revenue");?>><?php _e('Revenue', 'pmpro');?></option>
 			<option value="sales" <?php selected($type, "sales");?>><?php _e('Sales', 'pmpro');?></option>
 		</select>
-		<span id="for"><?php _ex('for', 'Dropdown label, e.g. Show Daily Revenue for January', 'pmpro')?></span>
+		<span id="for"><?php _e('for', 'pmpro')?></span>
 		<select id="month" name="month">
 			<?php for($i = 1; $i < 13; $i++) { ?>
 				<option value="<?php echo $i;?>" <?php selected($month, $i);?>><?php echo date("F", mktime(0, 0, 0, $i, 2));?></option>
@@ -220,7 +220,7 @@ function pmpro_report_sales_page()
 				<option value="<?php echo $i;?>" <?php selected($year, $i);?>><?php echo $i;?></option>
 			<?php } ?>
 		</select>
-		<span id="for"><?php _ex('for', 'Dropdown label, e.g. Show Daily Revenue for January', 'pmpro')?></span>
+		<span id="for"><?php _e('for', 'pmpro')?></span>
 		<select name="level">
 			<option value="" <?php if(!$l) { ?>selected="selected"<?php } ?>><?php _e('All Levels', 'pmpro');?></option>
 			<?php
@@ -236,7 +236,7 @@ function pmpro_report_sales_page()
 		
 		<input type="hidden" name="page" value="pmpro-reports" />		
 		<input type="hidden" name="report" value="sales" />	
-		<input type="submit" class="button action" value="<?php _ex('Generate Report', 'Submit button value.', 'pmpro');?>" />
+		<input type="submit" class="button action" value="<?php _e('Generate Report', 'pmpro');?>" />
 	</div>
 	
 	<div id="chart_div" style="clear: both; width: 100%; height: 500px;"></div>				

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -350,10 +350,11 @@
 							$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
 							if($pmpro_show_cvv)
 							{
+								$cvv_template = pmpro_loadTemplate('popup-cvv', 'url', 'pages', 'html');
 						?>
 						<div class="pmpro_payment-cvv">
-							<label for="CVV"><?php _ex('CVV', 'Credit card security code, CVV/CCV/CVV2', 'pmpro');?></label>
-							<input class="input" id="CVV" name="cvv" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" data-encrypted-name="cvv" />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter(PMPRO_URL)?>/pages/popup-cvv.html','cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _ex("what's this?", 'link to CVV help', 'pmpro');?></a>)</small>
+							<label for="CVV"><?php _e('CVV', 'pmpro');?></label>
+							<input class="input" id="CVV" name="cvv" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" data-encrypted-name="cvv" />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter($cvv_template); ?>','cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _e("what's this?", 'pmpro');?></a>)</small>
 						</div>
 						<?php
 							}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -522,10 +522,11 @@
 							$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
 							if($pmpro_show_cvv)
 							{
+								$cvv_template = pmpro_loadTemplate('popup-cvv', 'url', 'pages', 'html');
 						?>
 						<div class="pmpro_payment-cvv">
-							<label for="CVV"><?php _ex('CVV', 'Credit card security code, CVV/CCV/CVV2', 'pmpro');?></label>
-							<input class="input" id="CVV" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter(PMPRO_URL)?>/pages/popup-cvv.html','cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _ex("what's this?", 'link to CVV help', 'pmpro');?></a>)</small>
+							<label for="CVV"><?php _e('CVV', 'pmpro');?></label>
+							<input class="input" id="CVV" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter($cvv_template); ?>,'cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _e("what's this?", 'pmpro');?></a>)</small>
 						</div>
 						<?php
 							}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -240,13 +240,14 @@ function pmpro_isLevelExpiringSoon( &$level ) {
  * Loads a template from one of the default paths (PMPro plugin or theme), or from filtered path
  *
  * @param null $page_name - Name of the page/template
- * @param string $type - Type of template (valid: 'email' or 'pages'
+ * @oaram string $protocol - `local` or `url` (whether to load from FS or over http)
+ * @param string $type - Type of template (valid: 'email' or 'pages', 'adminpages', 'preheader')
  * @param string $ext - File extension ('php', 'html', 'htm', etc)
  * @return string - The HTML for the template.
  *
  * @since 1.8.9
  */
-function pmpro_loadTemplate($page_name = null, $type = 'pages', $ext = 'php' )
+function pmpro_loadTemplate($page_name = null, $protocol = 'local', $type = 'pages', $ext = 'php' )
 {
 	// called from page handler shortcode
 	if (is_null($page_name))
@@ -255,15 +256,23 @@ function pmpro_loadTemplate($page_name = null, $type = 'pages', $ext = 'php' )
 		$page_name = $pmpro_page_name;
 	}
 
-	// template paths in order of priority (array gets reversed)
-	$default_templates = array(
-		PMPRO_DIR . "/{$type}/{$page_name}.{$ext}", // default plugin path
-		get_template_directory() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // parent theme
-		get_stylesheet_directory() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // child / active theme
-	);
+	if ($protocol == 'local') {
+		// template paths in order of priority (array gets reversed)
+		$default_templates = array(
+			PMPRO_DIR . "/{$type}/{$page_name}.{$ext}", // default plugin path
+			get_template_directory() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // parent theme
+			get_stylesheet_directory() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // child / active theme
+		);
+	} elseif( $protocol == 'url' ) {
+		$default_templates = array(
+			PMPRO_URL . "/{$type}/{$page_name}.{$ext}", // default plugin path
+			get_template_directory_uri() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // parent theme
+			get_stylesheet_directory_uri() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // child / active theme
+		);
 
+	}
 	// Valid types: 'email', 'pages'
-	$templates = apply_filters("pmpro_{$type}_custom_template_path", $default_templates);
+	$templates = apply_filters("pmpro_{$type}_custom_template_path", $default_templates, $page_name, $type, $protocol, $ext);
 	$user_templates = array_diff($templates, $default_templates);
 
 	//user specified a custom template path, so it has priority.
@@ -280,9 +289,17 @@ function pmpro_loadTemplate($page_name = null, $type = 'pages', $ext = 'php' )
 		$included = get_included_files();
 
 		// only attempt to include if the file isn't already included & it exists in the file system
-		if (!in_array( $template_path, $included ) && file_exists($template_path) ) {
-			include $template_path;
-			break;
+		if (!in_array( $template_path, $included ) )
+		{
+			// since we allow the user to specify a path for a template, we'll sanitize it.
+			$template_path = sanitize_file_name($template_path);
+
+			// Only include if the file exists.
+			if (file_exists($template_path))
+			{
+				include $template_path;
+				break;
+			}
 		}
 	}
 	$template = ob_get_clean();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -240,14 +240,16 @@ function pmpro_isLevelExpiringSoon( &$level ) {
  * Loads a template from one of the default paths (PMPro plugin or theme), or from filtered path
  *
  * @param null $page_name - Name of the page/template
- * @oaram string $protocol - `local` or `url` (whether to load from FS or over http)
+ * @oaram string $where - `local` or `url` (whether to load from FS or over http)
  * @param string $type - Type of template (valid: 'email' or 'pages', 'adminpages', 'preheader')
  * @param string $ext - File extension ('php', 'html', 'htm', etc)
  * @return string - The HTML for the template.
  *
+ * TODO - Allow localized template files to be loaded?
+ *
  * @since 1.8.9
  */
-function pmpro_loadTemplate($page_name = null, $protocol = 'local', $type = 'pages', $ext = 'php' )
+function pmpro_loadTemplate($page_name = null, $where = 'local', $type = 'pages', $ext = 'php' )
 {
 	// called from page handler shortcode
 	if (is_null($page_name))
@@ -256,14 +258,14 @@ function pmpro_loadTemplate($page_name = null, $protocol = 'local', $type = 'pag
 		$page_name = $pmpro_page_name;
 	}
 
-	if ($protocol == 'local') {
+	if ($where == 'local') {
 		// template paths in order of priority (array gets reversed)
 		$default_templates = array(
 			PMPRO_DIR . "/{$type}/{$page_name}.{$ext}", // default plugin path
 			get_template_directory() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // parent theme
 			get_stylesheet_directory() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // child / active theme
 		);
-	} elseif( $protocol == 'url' ) {
+	} elseif( $where == 'url' ) {
 		$default_templates = array(
 			PMPRO_URL . "/{$type}/{$page_name}.{$ext}", // default plugin path
 			get_template_directory_uri() . "/paid-memberships-pro/{$type}/{$page_name}.{$ext}", // parent theme
@@ -272,7 +274,7 @@ function pmpro_loadTemplate($page_name = null, $protocol = 'local', $type = 'pag
 
 	}
 	// Valid types: 'email', 'pages'
-	$templates = apply_filters("pmpro_{$type}_custom_template_path", $default_templates, $page_name, $type, $protocol, $ext);
+	$templates = apply_filters("pmpro_{$type}_custom_template_path", $default_templates, $page_name, $type, $where, $ext);
 	$user_templates = array_diff($templates, $default_templates);
 
 	//user specified a custom template path, so it has priority.

--- a/includes/init.php
+++ b/includes/init.php
@@ -138,13 +138,17 @@ function pmpro_wp()
 				{
 					global $pmpro_page_name;
 					ob_start();
+
+					$shortcode_template = pmpro_loadTemplate($pmpro_page_name, 'local', 'pages');
+					include($shortcode_template);
+					/*
 					if(file_exists(get_stylesheet_directory() . "/paid-memberships-pro/pages/" . $pmpro_page_name . ".php"))
 						include(get_stylesheet_directory() . "/paid-memberships-pro/pages/" . $pmpro_page_name . ".php");
 					elseif(file_exists(get_template_directory() . "/paid-memberships-pro/pages/" . $pmpro_page_name . ".php"))
 						include(get_template_directory() . "/paid-memberships-pro/pages/" . $pmpro_page_name . ".php");
 					else
 						include(PMPRO_DIR . "/pages/" . $pmpro_page_name . ".php");
-					
+					*/
 					$temp_content = ob_get_contents();
 					ob_end_clean();
 					return apply_filters("pmpro_pages_shortcode_" . $pmpro_page_name, $temp_content);
@@ -155,7 +159,8 @@ function pmpro_wp()
 			elseif(!empty($pmpro_page_id) && is_page($pmpro_page_id))
 			{
 				//shortcode has params, but we still want to load the preheader
-				require_once(PMPRO_DIR . "/preheaders/" . $pmpro_page_name . ".php");
+				$preheader_path = apply_filters("pmpro_preheader_shortcode_{$pmpro_page_name}", PMPRO_DIR . "/preheaders/" . $pmpro_page_name . ".php" );
+				require_once($preheader_path);
 			}
 		}				
 	}

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -292,10 +292,11 @@
 							$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
 							if($pmpro_show_cvv)
 							{
+								$cvv_template = pmpro_loadTemplate('popup-cvv', 'url', 'pages', 'html');
 						?>
 						<div>
-							<label for="CVV"><?php _ex('CVV', 'Credit card security code, CVV/CCV/CVV2', 'pmpro');?></label>
-							<input class="input" id="CVV" <?php if($gateway != "stripe" && $gateway != "braintree") { ?>name="CVV"<?php } ?> type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" <?php if($gateway == "braintree") { ?>data-encrypted-name="cvv"<?php } ?> />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter(PMPRO_URL)?>/pages/popup-cvv.html','cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _ex("what's this?", 'link to CVV help', 'pmpro');?></a>)</small>
+							<label for="CVV"><?php _e('CVV', 'pmpro');?></label>
+							<input class="input" id="CVV" <?php if($gateway != "stripe" && $gateway != "braintree") { ?>name="CVV"<?php } ?> type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" <?php if($gateway == "braintree") { ?>data-encrypted-name="cvv"<?php } ?> />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter($cvv_template); ?>,'cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _e("what's this?", 'pmpro');?></a>)</small>
 						</div>
 						<?php
 							}

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -602,10 +602,11 @@
 						$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
 						if($pmpro_show_cvv)
 						{
+							$cvv_template = pmpro_loadTemplate('popup-cvv', 'url', 'pages', 'html');
 					?>
 					<div class="pmpro_payment-cvv">
 						<label for="CVV"><?php _e('CVV', 'pmpro');?></label>
-						<input class="input" id="CVV" name="CVV" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter(PMPRO_URL)?>/pages/popup-cvv.html','cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _e("what's this?", 'pmpro');?></a>)</small>
+						<input class="input" id="CVV" name="CVV" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr($_REQUEST['CVV']); }?>" class=" <?php echo pmpro_getClassForField("CVV");?>" />  <small>(<a href="javascript:void(0);" onclick="javascript:window.open('<?php echo pmpro_https_filter($cvv_template); ?>,'cvv','toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=600, height=475');"><?php _e("what's this?", 'pmpro');?></a>)</small>
 					</div>
 					<?php
 						}

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -102,7 +102,7 @@
 	?>	
 	<ul>
 		<li><strong><?php _e('Account', 'pmpro');?>:</strong> <?php echo $current_user->display_name?> (<?php echo $current_user->user_email?>)</li>
-		<li><strong><?php _e('Membership Level', 'pmpro');?>:</strong> <?php if(!empty($current_user->membership_level)) echo $current_user->membership_level->name; else _ex("Pending", "User without membership is in {pending} status.", "pmpro");?></li>
+		<li><strong><?php _e('Membership Level', 'pmpro');?>:</strong> <?php if(!empty($current_user->membership_level)) echo $current_user->membership_level->name; else _e("Pending", "pmpro");?></li>
 	</ul>	
 <?php 
 	} 


### PR DESCRIPTION
ENH: Add 'pmpro_loadTemplate()` function to load templates from themes or plugin depedning on configuraiton (supports email, page, adminpage, local & remote templates).
ENH: Allow replacing the preheader/{page_name}.php for PMPro membership page processing.
FIX: Couldn't always translate text
FIX: Add template support for CVV "What's this" pop-up page
