### PR TITLE
FIX: Don't return users w/membership ID of 0 or NULL

### DIFF
--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -291,7 +291,7 @@
 				$recurring_payment = number_format(round((float)$recurring_payment + (float)$recurring_payment_tax, 2), 2, ".", "");
 				$tco_args['li_0_price'] = number_format($recurring_payment, 2, ".", "");
 
-				$tco_args['li_0_recurrence'] = ( $order->BillingFrequency == 1 ) ? $order->BillingFrequency . ' ' . $order->BillingPeriod : $order->BillingFrequency . ' ' . $order->BillingPeriod . 's';
+				$tco_args['li_0_recurrence'] = ( $order->BillingFrequency == 1 ) ? $order->BillingFrequency . ' ' . $order->BillingPeriod : $order->BillingFrequency . ' ' . $order->BillingPeriod;
 
 				if( property_exists( $order, 'TotalBillingCycles' ) )
 					$tco_args['li_0_duration'] = ($order->BillingFrequency * $order->TotalBillingCycles ) . ' ' . $order->BillingPeriod;

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -67,7 +67,7 @@ function pmpro_cron_expiration_warnings()
 	AND mu.enddate <> ''
 	AND mu.enddate <> '0000-00-00 00:00:00'
 	AND DATE_SUB(mu.enddate, INTERVAL " . $pmpro_email_days_before_expiration . " Day) <= '" . $today . "'
-	AND (um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL " . $pmpro_email_days_before_expiration . " Day) <= '" . $today . "')
+	AND ((um.meta_value IS NULL) OR (DATE_ADD(um.meta_value, INTERVAL " . $pmpro_email_days_before_expiration . " Day) <= '" . $today . "'))
 	ORDER BY mu.enddate";
 
 	if(defined('PMPRO_CRON_LIMIT'))

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -62,6 +62,7 @@ function pmpro_cron_expiration_warnings()
 	LEFT JOIN $wpdb->usermeta um ON um.user_id = mu.user_id
 	AND um.meta_key = 'pmpro_expiration_notice'
 	WHERE mu.status = 'active'
+	AND ((mu.membership_id != 0) AND (mu.membership_id IS NOT NULL))
 	AND mu.enddate IS NOT NULL
 	AND mu.enddate <> ''
 	AND mu.enddate <> '0000-00-00 00:00:00'


### PR DESCRIPTION
When processing for membership expiration notices, the system would return users who'd been deleted or had NULL or 0 as their membership_id.