### PR TITLE
FIX: Cancellations in reports weren't always accurate 

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -501,8 +501,14 @@
 		//close the temp file
 		fclose($csv_fh);
 
-		//make sure we get the right file size
-		clearstatcache( true, $filename );
+		if (version_compare(phpversion(), '5.3.0', '>')) {
+
+			//make sure we get the right file size
+			clearstatcache( true, $filename );
+		} else {
+			// for any PHP version prior to v5.3.0
+			clearstatcache();
+		}
 
 		//did we accidentally send errors/warnings to browser?
 		if (headers_sent())

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -532,7 +532,7 @@ function pmpro_getCancellations($period = null, $levels = 'all', $status = array
 	mu2.modified > mu1.enddate AND
 	DATE_ADD(mu1.modified, INTERVAL 1 DAY) > mu2.startdate
 	WHERE mu1.status IN('" . implode("','", $status) . "')
-		AND mu2.membership_id IS NOT NULL
+		AND mu2.id IS NULL
 		AND mu1.enddate >= '" . $startdate . "'
 		AND mu1.enddate <= " . $enddate . "
 	";

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -471,8 +471,16 @@ function pmpro_getSignups($period = false, $levels = 'all')
 	return $signups;
 }
 
-//get cancellations by status
-function pmpro_getCancellations($period = false, $levels = 'all', $status = array('inactive','expired','cancelled','cancelled_admin') )
+//
+/**
+ * get cancellations by status
+ *
+ * @param string $period - Either a string description ('today', 'this month', 'this year')
+ * @param array(int)|string $levels - Either an array of level IDs or the string 'all'
+ * @param array(string) $status - Array of statuses to fetch data for
+ * @return null|int - The # of cancellations for the period specified
+ */
+function pmpro_getCancellations($period = null, $levels = 'all', $status = array('inactive','expired','cancelled','cancelled_admin') )
 {
 	//make sure status is an array
 	if(!is_array($status))
@@ -487,25 +495,26 @@ function pmpro_getCancellations($period = false, $levels = 'all', $status = arra
 	//figure out start date
 	$now = current_time('timestamp');
 	$year = date("Y", $now);
+
 	if( $period == 'today' )
 	{
 		$startdate = date('Y-m-d', $now) . " 00:00:00";
-		$enddate = date('Y-m-d', $now) . " 23:59:59";
+		$enddate = "'" . date('Y-m-d', $now) . " 23:59:59'";
 	}
 	elseif( $period == 'this month')
 	{
 		$startdate = date( 'Y-m', $now ) . '-01 00:00:00';
-		$enddate = date( 'Y-m', $now ) . '-32 00:00:00';
+		$enddate = "CONCAT(LAST_DAY('" . date( 'Y-m', $now ) . '-01' ."'), ' 23:59:59')";
 	}
 	elseif( $period == 'this year')
 	{
 		$startdate = date( 'Y', $now ) . '-01-01 00:00:00';
-		$enddate = date( 'Y', $now ) . '-12-32 00:00:00';
+		$enddate = "'" . date( 'Y', $now ) . "-12-31 23:59:59'";
 	}
 	else
 	{
 		//all time
-		$startdate = '1960-01-01';	//all time
+		$startdate = '1970-01-01';	//all time (no point in using a value prior to the start of the UNIX epoch)
 		$enddate = strval(intval($year)+1) . '-01-01';
 	}
 		
@@ -516,20 +525,29 @@ function pmpro_getCancellations($period = false, $levels = 'all', $status = arra
 	*/
 	global $wpdb;
 
-	$sqlQuery = "SELECT COUNT(mu1.id)
-	FROM $wpdb->pmpro_memberships_users mu1
-	LEFT JOIN $wpdb->pmpro_memberships_users mu2 ON mu1.user_id = mu2.user_id AND
+	$sqlQuery = "
+	SELECT COUNT(mu1.id)
+	FROM {$wpdb->pmpro_memberships_users} AS mu1
+		LEFT JOIN {$wpdb->pmpro_memberships_users} AS mu2 ON mu1.user_id = mu2.user_id AND
 	mu2.modified > mu1.enddate AND
 	DATE_ADD(mu1.modified, INTERVAL 1 DAY) > mu2.startdate
 	WHERE mu1.status IN('" . implode("','", $status) . "')
-	AND mu2.id IS NULL 
-	AND mu1.enddate >= '" . $startdate . "' 
-	AND mu1.enddate <= '" . $enddate . "'
+		AND mu2.membership_id IS NOT NULL
+		AND mu1.enddate >= '" . $startdate . "'
+		AND mu1.enddate <= " . $enddate . "
 	";
  
 	//restrict by level
-	if(!empty($levels) && $levels != 'all')
-		$sqlQuery .= "AND membership_id IN(" . $levels . ") ";
+	if(!empty($levels) && $levels != 'all') {
+
+		// the levels provided wasn't in array form
+		if ( ! is_array($levels) ) {
+
+			$levels = array($levels);
+		}
+
+		$sqlQuery .= "AND membership_id IN(" . implode(", ", $levels) . ") ";
+	}
 	
 	/**
 	 * Filter query to get cancellation numbers in signups vs cancellations detailed report.

--- a/includes/content.php
+++ b/includes/content.php
@@ -158,15 +158,27 @@ function pmpro_search_filter($query)
 		//get page ids that are in my levels
         $levels = pmpro_getMembershipLevelsForUser($current_user->ID);
         $my_pages = array();
+		$member_pages = array();
 
         if($levels) {
             foreach($levels as $key => $level) {
                 //get restricted posts for level
-                $sql = "SELECT page_id FROM $wpdb->pmpro_memberships_pages WHERE membership_id=" . $current_user->membership_level->ID;
-                $member_pages = $wpdb->get_col($sql);
-                $my_pages = array_unique(array_merge($my_pages, $member_pages));
-            }
-        }
+
+				// make sure the object contains membership info.
+				if (isset($level->ID)) {
+
+					$sql = $wpdb->prepare("
+						SELECT page_id
+						FROM {$wpdb->pmpro_memberships_pages}
+						WHERE membership_id = %d",
+						$level->ID
+					);
+
+					$member_pages = $wpdb->get_col($sql);
+					$my_pages = array_unique(array_merge($my_pages, $member_pages));
+				}
+            } // foreach
+        } // if($levels)
 
         //get hidden page ids
         if(!empty($my_pages))

--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -104,6 +104,8 @@
 				//email the user their invoice
 				$pmproemail = new PMProEmail();
 				$pmproemail->sendInvoiceEmail($user, $morder);
+
+				do_action('pmpro_subscription_payment_completed');
 			}
 		}
 		elseif($fields['x_response_code'] == 2 || $fields['x_response_code'] == 3)

--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -105,7 +105,9 @@
 				$pmproemail = new PMProEmail();
 				$pmproemail->sendInvoiceEmail($user, $morder);
 
-				do_action('pmpro_subscription_payment_completed');
+				//hook for successful subscription payments
+				do_action("pmpro_subscription_payment_completed", $morder);
+
 			}
 		}
 		elseif($fields['x_response_code'] == 2 || $fields['x_response_code'] == 3)

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -132,7 +132,7 @@
 		$pmproemail = new PMProEmail();
 		$pmproemail->sendInvoiceEmail($user, $morder);
 
-		do_action('pmpro_subscription_payment_completed');
+		do_action('pmpro_subscription_payment_completed', $morder);
 
 		exit;
 	}

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -132,6 +132,8 @@
 		$pmproemail = new PMProEmail();
 		$pmproemail->sendInvoiceEmail($user, $morder);
 
+		do_action('pmpro_subscription_payment_completed');
+
 		exit;
 	}
 

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -687,9 +687,6 @@
 
 		if(empty($old_txn))
 		{
-			//hook for successful subscription payments
-			do_action("pmpro_subscription_payment_completed");
-
 			//save order
 			$morder = new MemberOrder();
 			$morder->user_id = $last_order->user_id;
@@ -763,6 +760,9 @@
 			//email the user their invoice
 			$pmproemail = new PMProEmail();
 			$pmproemail->sendInvoiceEmail(get_userdata($last_order->user_id), $morder);
+
+			//hook for successful subscription payments
+			do_action("pmpro_subscription_payment_completed", $morder);
 
 			ipnlog("New order (" . $morder->code . ") created.");
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -217,7 +217,7 @@
 						update_user_meta($user_id, "pmpro_stripe_updates", $user_updates);
 					}
 
-					do_action('pmpro_subscription_payment_completed');
+					do_action('pmpro_subscription_payment_completed', $morder);
 
 					pmpro_stripeWebhookExit();
 				}

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -217,6 +217,8 @@
 						update_user_meta($user_id, "pmpro_stripe_updates", $user_updates);
 					}
 
+					do_action('pmpro_subscription_payment_completed');
+
 					pmpro_stripeWebhookExit();
 				}
 				else

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -83,6 +83,7 @@
 		}
 		elseif (pmpro_insChangeMembershipLevel( $txn_id, $morder ) ) {
 			inslog( "Checkout processed (" . $morder->code . ") success!" );
+
 		}
 		else {
 			inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );
@@ -104,6 +105,10 @@
 			//update membership
 			if( pmpro_insChangeMembershipLevel( $txn_id, $morder ) ) {
 				inslog( "Checkout processed (" . $morder->code . ") success!" );
+
+				//hook for successful subscription payments
+				do_action("pmpro_subscription_payment_completed", $morder);
+
 			}
 			else {
 				inslog( "ERROR: Couldn't change level for order (" . $morder->code . ")." );
@@ -411,8 +416,6 @@
 		$old_txn = $wpdb->get_var("SELECT payment_transaction_id FROM $wpdb->pmpro_membership_orders WHERE payment_transaction_id = '" . $txn_id . "' LIMIT 1");
 
 		if( empty( $old_txn ) ) {
-			//hook for successful subscription payments
-			do_action("pmpro_subscription_payment_completed");
 
 			//save order
 			$morder = new MemberOrder();


### PR DESCRIPTION
(or didn't return any data when it ought to have)

FIX: Arrays of level IDs weren't handled properly in `pmpro_getCancellations()`
FIX: All-time startdate value set to 1970-01-01 which makes sense in an OS & plugin context
ENH: Use `LAST_DAY()` SQL function to find last day of month when using the "this month" option for Cancellation reports.
ENH: Added PHPdoc for `pmpro_getCancellations()`