### PR TITLE
Fixes against V1.8.9.3 

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -197,6 +197,13 @@
 	if(!empty($limit))
 		$sqlQuery .= "LIMIT {$start}, {$limit}";
 
+	/**
+	* Filter to change/manipulate the SQL for the list of members export
+	* @since v1.9.0    Re-introduced
+	* @author: Thomas Sjolshagen <thomas@eighty20results.com>
+	*/
+	$sqlQuery = apply_filters('pmpro_members_list_sql', $sqlQuery);
+
 	// Generate a temporary file to store the data in.
 	$tmp_dir = sys_get_temp_dir();
 	$filename = tempnam( $tmp_dir, 'pmpro_ml_');

--- a/classes/gateways/class.pmprogateway_check.php
+++ b/classes/gateways/class.pmprogateway_check.php
@@ -145,6 +145,7 @@
 		 */
 		static function pmpro_checkout_after_payment_information_fields() {
 			global $gateway;
+			global $pmpro_level;
 
 			if($gateway == "check" && !pmpro_isLevelFree($pmpro_level)) {
 				$instructions = pmpro_getOption("instructions");

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -20,7 +20,13 @@
 	$pmpro_stripe_lite = apply_filters("pmpro_stripe_lite", !pmpro_getOption("stripe_billingaddress")); //default is oposite of the stripe_billingaddress setting
 
 	$level = $current_user->membership_level;
-	if($level)
+
+	/**
+	* Make sure the $level object is a valid level definition
+	* @since   1.9.0 - BUG: Assumed that the level object was well formed and it existed
+	* @author: Thomas Sjolshagen <thomas@eighty20results.com>
+	*/
+	if(isset($level->id) && !empty($level->id))
 	{
 	?>
 		<p><?php printf(__("Logged in as <strong>%s</strong>.", "pmpro"), $current_user->user_login);?> <small><a href="<?php echo wp_logout_url(get_bloginfo("url") . "/membership-checkout/?level=" . $level->id);?>"><?php _e("logout", "pmpro");?></a></small></p>

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -19,10 +19,13 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 	//did they use 'section' instead of 'sections'?
 	if(!empty($section))
 		$sections = $section;
-	
-	//turn into an array
-	$sections = explode(',', $sections);		
-	
+
+	/**
+	* @var $sections - Extract the user-defined sections for the shortcode
+	*
+	* @since 1.9.0 - BUG: Didn't correctly handle whitespace in sections argument.
+	*/
+	$sections = array_map('trim',explode(",",$sections));	
 	ob_start();
 	
 	//if a member is logged in, show them some info here (1. past invoices. 2. billing information with button to update.)


### PR DESCRIPTION
BUG: Assumed that the level object is well formed and it exists
BUG: pmpro_isLevelFree() test would always fail
ENHANCEMENT: Re-introduce the pmpro_members_list_sql filter