### PR TITLE
Checkout Preheader for MMPU (plus related function includes)

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -39,7 +39,6 @@
 			$order->subtotal = "";
 			$order->tax = "";
 			$order->couponamount = "";
-			$order->checkout_id = "";
 			$order->total = "";
 			$order->payment_type = "";
 			$order->cardtype = "";
@@ -54,6 +53,7 @@
 			$order->affiliate_id = "";
 			$order->affiliate_subid = "";
 			$order->notes = "";
+			$order->checkout_id = 0;
 
 			$order->billing = new stdClass();
 			$order->billing->name = "";
@@ -117,7 +117,6 @@
 				$this->subtotal = $dbobj->subtotal;
 				$this->tax = $dbobj->tax;
 				$this->couponamount = $dbobj->couponamount;
-				$this->checkout_id = $dbobj->checkout_id;
 				$this->certificate_id = $dbobj->certificate_id;
 				$this->certificateamount = $dbobj->certificateamount;
 				$this->total = $dbobj->total;
@@ -141,6 +140,7 @@
 				$this->affiliate_subid = $dbobj->affiliate_subid;
 
 				$this->notes = $dbobj->notes;
+				$this->checkout_id = $dbobj->checkout_id;
 
 				//reset the gateway
 				if(empty($this->nogateway))
@@ -523,6 +523,11 @@
 
 			if(empty($this->notes))
 				$this->notes = "";
+				
+			if(empty($this->checkout_id) || intval($this->checkout_id)<1) {
+				$highestval = $wpdb->get_var("SELECT MAX(checkout_id) FROM $wpdb->pmpro_membership_orders");
+				$this->checkout_id = intval($highestval)+1;
+			}
 
 			//build query
 			if(!empty($this->id))
@@ -563,7 +568,8 @@
 									`timestamp` = '" . esc_sql($this->datetime) . "',
 									`affiliate_id` = '" . esc_sql($this->affiliate_id) . "',
 									`affiliate_subid` = '" . esc_sql($this->affiliate_subid) . "',
-									`notes` = '" . esc_sql($this->notes) . "'
+									`notes` = '" . esc_sql($this->notes) . "',
+									`checkout_id` = " . intval($this->checkout_id) . "
 									WHERE id = '" . $this->id . "'
 									LIMIT 1";
 			}
@@ -574,7 +580,7 @@
 				$after_action = "pmpro_added_order";
 				//insert
 				$this->sqlQuery = "INSERT INTO $wpdb->pmpro_membership_orders
-								(`code`, `session_id`, `user_id`, `membership_id`, `paypal_token`, `billing_name`, `billing_street`, `billing_city`, `billing_state`, `billing_zip`, `billing_country`, `billing_phone`, `subtotal`, `tax`, `couponamount`, `certificate_id`, `certificateamount`, `total`, `payment_type`, `cardtype`, `accountnumber`, `expirationmonth`, `expirationyear`, `status`, `gateway`, `gateway_environment`, `payment_transaction_id`, `subscription_transaction_id`, `timestamp`, `affiliate_id`, `affiliate_subid`, `notes`)
+								(`code`, `session_id`, `user_id`, `membership_id`, `paypal_token`, `billing_name`, `billing_street`, `billing_city`, `billing_state`, `billing_zip`, `billing_country`, `billing_phone`, `subtotal`, `tax`, `couponamount`, `certificate_id`, `certificateamount`, `total`, `payment_type`, `cardtype`, `accountnumber`, `expirationmonth`, `expirationyear`, `status`, `gateway`, `gateway_environment`, `payment_transaction_id`, `subscription_transaction_id`, `timestamp`, `affiliate_id`, `affiliate_subid`, `notes`, `checkout_id`)
 								VALUES('" . $this->code . "',
 									   '" . session_id() . "',
 									   " . intval($this->user_id) . ",
@@ -606,7 +612,8 @@
 									   '" . esc_sql($this->datetime) . "',
 									   '" . esc_sql($this->affiliate_id) . "',
 									   '" . esc_sql($this->affiliate_subid) . "',
-									    '" . esc_sql($this->notes) . "'
+										'" . esc_sql($this->notes) . "',
+									    " . intval($this->checkout_id) . "
 									   )";
 			}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -251,6 +251,8 @@
 
 					var pmpro_require_billing = true;
 
+					var tokenNum = 0;
+
 					jQuery(document).ready(function() {
 						jQuery("#pmpro_form, .pmpro_form").submit(function(event) {
 
@@ -286,8 +288,11 @@
 							if (jQuery('#bfirstname').length && jQuery('#blastname').length)
 								args['name'] = jQuery.trim(jQuery('#bfirstname').val() + ' ' + jQuery('#blastname').val());
 
-							//create token
-							Stripe.createToken(args, stripeResponseHandler);
+							//create token(s)
+							var levelnums = jQuery("#level").val().split(",");
+							for(var cnt = 0, len = levelnums.length; cnt < len; cnt++) {
+								Stripe.createToken(args, stripeResponseHandler);
+							}
 
 							// prevent the form from submitting with the default action
 							return false;
@@ -313,8 +318,9 @@
 							// token contains id, last4, and card type
 							var token = response['id'];
 							// insert the token into the form so it gets submitted to the server
-							form$.append("<input type='hidden' name='stripeToken' value='" + token + "'/>");
-
+							form$.append("<input type='hidden' name='stripeToken" + tokenNum + "' value='" + token + "'/>");
+							tokenNum++;
+							
 							//console.log(response);
 
 							//insert fields for other card fields
@@ -354,9 +360,21 @@
 		static function pmpro_checkout_order($morder)
 		{
 			//load up token values
-			if(isset($_REQUEST['stripeToken']))
+			if(isset($_REQUEST['stripeToken0']))
 			{
-				$morder->stripeToken = $_REQUEST['stripeToken'];
+				// find the highest one still around, and use it - then remove it from $_REQUEST.
+				$thetoken = "";
+				$tokennum = -1;
+				foreach($_REQUEST as $key => $param) {
+					if(preg_match('/stripeToken(\d+)/', $key, $matches)) {
+						if(intval($matches[1])>$tokennum) {
+							$thetoken = $param;
+							$tokennum = intval($matches[1]);
+						}
+					}
+				}
+				$morder->stripeToken = $thetoken;
+				unset($_REQUEST['stripeToken'.$tokennum]);
 			}
 
 			//stripe lite code to get name from other sources if available
@@ -1315,12 +1333,14 @@
 					//user not registered yet, queue it up
 					global $pmpro_stripe_customer_id;
 					$pmpro_stripe_customer_id = $this->customer->id;
-					function pmpro_user_register_stripe_customerid($user_id)
-					{
-						global $pmpro_stripe_customer_id;
-						update_user_meta($user_id, "pmpro_stripe_customerid", $pmpro_stripe_customer_id);
+					if(! function_exists('pmpro_user_register_stripe_customerid')) {
+						function pmpro_user_register_stripe_customerid($user_id)
+						{
+							global $pmpro_stripe_customer_id;
+							update_user_meta($user_id, "pmpro_stripe_customerid", $pmpro_stripe_customer_id);
+						}
+						add_action("user_register", "pmpro_user_register_stripe_customerid");
 					}
-					add_action("user_register", "pmpro_user_register_stripe_customerid");
 				}
 
                 return apply_filters('pmpro_stripe_create_customer', $this->customer);

--- a/includes/content.php
+++ b/includes/content.php
@@ -96,8 +96,13 @@ function pmpro_has_membership_access($post_id = NULL, $user_id = NULL, $return_m
 		}
 		elseif(!empty($myuser->ID))
 		{
-			$myuser->membership_level = pmpro_getMembershipLevelForUser($myuser->ID);
-			if(!empty($myuser->membership_level->ID) && in_array($myuser->membership_level->ID, $post_membership_levels_ids))
+			$myuser->membership_level = pmpro_getMembershipLevelForUser($myuser->ID); // kept in for legacy filter users below.
+			$myuser->membership_levels = pmpro_getMembershipLevelsForUser($myuser->ID);
+			$mylevelids = array();
+			foreach($myuser->membership_levels as $curlevel) {
+				$mylevelids[] = $curlevel->id;
+			}
+			if(count($myuser->membership_levels)>0 && count(array_intersect($mylevelids, $post_membership_levels_ids))>0)
 			{
 				//the users membership id is one that will grant access
 				$hasaccess = true;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -172,7 +172,7 @@ function pmpro_isLevelFree(&$level)
 function pmpro_areLevelsFree($levelarr) {
 	if(! is_array($levelarr)) { return false; }
 	foreach($levelarr as $curlevel) {
-		if(!empty($level) && ($level->initial_payment > 0 || $level->billing_amount > 0 || $level->trial_amount > 0)) {
+		if(!empty($curlevel) && ($curlevel->initial_payment > 0 || $curlevel->billing_amount > 0 || $curlevel->trial_amount > 0)) {
 			return false;
 		}
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -168,6 +168,17 @@ function pmpro_isLevelFree(&$level)
 		return false;
 }
 
+// Given an array of levels, will return true if all of them are free.
+function pmpro_areLevelsFree($levelarr) {
+	if(! is_array($levelarr)) { return false; }
+	foreach($levelarr as $curlevel) {
+		if(!empty($level) && ($level->initial_payment > 0 || $level->billing_amount > 0 || $level->trial_amount > 0)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 function pmpro_isLevelRecurring(&$level)
 {
 	if(!empty($level) && ($level->billing_amount > 0 || $level->trial_amount > 0))
@@ -1352,15 +1363,12 @@ function pmpro_getDiscountCode($seed = NULL)
 	return strtoupper($code);
 }
 
-//is a discount code valid
+//is a discount code valid - level_id could be a scalar or an array (or unset)
 function pmpro_checkDiscountCode($code, $level_id = NULL, $return_errors = false)
 {
 	global $wpdb;
 
 	$error = false;
-
-	//make sure level id is int for security
-	$level_id = intval($level_id);
 
 	//no code, no code
 	if(empty($code))
@@ -1415,7 +1423,14 @@ function pmpro_checkDiscountCode($code, $level_id = NULL, $return_errors = false
 		$pmpro_check_discount_code_levels = apply_filters("pmpro_check_discount_code_levels", true, $dbcode->id);
 		if(!empty($level_id) && $pmpro_check_discount_code_levels)
 		{
-			$code_level = $wpdb->get_row("SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id WHERE cl.code_id = '" . $dbcode->id . "' AND cl.level_id = '" . $level_id . "' LIMIT 1");
+			// clean up level id for security before the database call
+			if(is_array($level_id)) {
+				$levelnums = array_map('intval', $level_id);
+				$level_id = implode(',', $levelnums);
+			} else {
+				$level_id = intval($level_id);
+			}
+			$code_level = $wpdb->get_row("SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id WHERE cl.code_id = '" . $dbcode->id . "' AND cl.level_id IN (" . $level_id . ") LIMIT 1");
 
 			if(empty($code_level))
 				$error = __("This discount code does not apply to this membership level.", "pmpro");

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -961,7 +961,9 @@ function pmpro_changeMembershipLevel($level, $user_id = NULL, $old_level_status 
 	$old_levels = pmpro_getMembershipLevelsForUser($user_id);
 
 	//deactivate old memberships based on the old_level_status passed in (updates pmpro_memberships_users table)
-	if($old_levels)
+	$pmpro_deactivate_old_levels = true;
+	$pmpro_deactivate_old_levels = apply_filters("pmpro_deactivate_old_levels", $pmpro_deactivate_old_levels);
+	if($old_levels && $pmpro_deactivate_old_levels)
 	{
 		foreach($old_levels as $old_level) {
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -417,6 +417,119 @@ function pmpro_getLevelCost(&$level, $tags = true, $short = false)
 	return $r;
 }
 
+// Similar to pmpro_getLevelCost, but loops through all levels in the incoming array and puts it all together.
+function pmpro_getLevelsCost(&$levels, $tags = true, $short = false)
+{
+	// let's build the array to work from to consolidate recurring info.
+	// recurpmts[cycle_period][cycle_number][billing_limit] = total_amount
+	$initpmt = 0;
+	$recurpmts = array();
+	$trialperiods = 0;
+	foreach($levels as $curlevel) {
+		$initpmt += $curlevel->initial_payment;
+		if($curlevel->billing_amount != '0.00') {
+			if(array_key_exists($curlevel->cycle_period, $recurpmts)) {
+				if(array_key_exists($curlevel->cycle_number, $recurpmts[$curlevel->cycle_period])) {
+					if(array_key_exists($curlevel->billing_limit, $recurpmts[$curlevel->cycle_period][$curlevel->cycle_number])) {
+						$recurpmts[$curlevel->cycle_period][$curlevel->cycle_number][$curlevel->billing_limit] += $curlevel->billing_amount;
+					} else {
+						$recurpmts[$curlevel->cycle_period][$curlevel->cycle_number][$curlevel->billing_limit] = $curlevel->billing_amount;
+					}
+				} else {
+					$recurpmts[$curlevel->cycle_period][$curlevel->cycle_number] = array();
+					$recurpmts[$curlevel->cycle_period][$curlevel->cycle_number][$curlevel->billing_limit] = $curlevel->billing_amount;
+				}
+			} else {
+				$recurpmts[$curlevel->cycle_period] = array();
+				$recurpmts[$curlevel->cycle_period][$curlevel->cycle_number] = array();
+				$recurpmts[$curlevel->cycle_period][$curlevel->cycle_number][$curlevel->billing_limit] = $curlevel->billing_amount;
+			}
+		}
+		if($curlevel->trial_limit && intval($curlevel->trial_limit)>$trialperiods) {
+			$trialperiods = intval($curlevel->trial_limit);
+		}
+	}
+
+	// initial payment
+	if(!$short)
+		$r = sprintf(__('The price for membership is <strong>%s</strong> now', 'pmpro'), pmpro_formatPrice($initpmt));
+	else
+		$r = sprintf(__('<strong>%s</strong> now', 'pmpro'), pmpro_formatPrice($initpmt));
+
+	//recurring part
+	$billtextparts = array();
+	if(count($recurpmts)>0) {
+		foreach($recurpmts as $curperiod => $curpddata) {
+			foreach($curpddata as $curcyclenum => $curcycledata) {
+				foreach($curcycledata as $curbilllimit => $curtotal) {
+					if($curbilllimit > 1)
+					{
+						if($curcyclenum == '1')
+						{
+							$billtextparts[] = sprintf(__('<strong>%s per %s for %d more %s</strong>', 'pmpro'), pmpro_formatPrice($curtotal), pmpro_translate_billing_period($curperiod), $curbilllimit, pmpro_translate_billing_period($curperiod, $curbilllimit));
+						}
+						else
+						{
+							$billtextparts[] = sprintf(__('<strong>%s every %d %s for %d more payments</strong>', 'pmpro'), pmpro_formatPrice($curtotal), $curcyclenum, pmpro_translate_billing_period($curperiod, $curcyclenum), $curbilllimit);
+						}
+					}
+					elseif($curbilllimit == 1)
+					{
+						$billtextparts[] = sprintf(__('<strong>%s after %d %s</strong>', 'pmpro'), pmpro_formatPrice($curtotal), $curcyclenum, pmpro_translate_billing_period($curperiod, $curcyclenum));
+					}
+					else
+					{
+						if($curcyclenum == '1')
+						{
+							$billtextparts[] = sprintf(__('<strong>%s every %s</strong>', 'pmpro'), pmpro_formatPrice($curtotal), pmpro_translate_billing_period($curperiod));
+						}
+						else
+						{
+							$billtextparts[] = sprintf(__('<strong>%s every %d %s</strong>', 'pmpro'), pmpro_formatPrice($curtotal), $curcyclenum, pmpro_translate_billing_period($curperiod, $curcyclenum));
+						}
+					}
+				}
+			}
+		}
+		$laststanza = array_pop($billtextparts);
+		if(count($billtextparts)>0) {
+			$r .= ", ";
+			$r .= implode(', ', $billtextparts);
+		}
+		$r .= ", and ".$laststanza.".";
+	} else {
+		$r .= ".";
+	}
+	
+
+	//add a space
+	$r .= ' ';
+
+	//trial part - not as detailed as the single-level counterpart. Could be improved in the future.
+	if($trialperiods>0) {
+		if($trialperiods==1) {
+			$r .= __('Trial pricing has been applied to the first payment.', 'mmpu');
+		} else {
+			$r .= sprintf(__('Trial pricing has been applied to the first %d payments.', 'mmpu'), $trialperiods);
+		}
+	}
+
+	//taxes part
+	$tax_state = pmpro_getOption("tax_state");
+	$tax_rate = pmpro_getOption("tax_rate");
+
+	if($tax_state && $tax_rate && !pmpro_isLevelFree($level))
+	{
+		$r .= sprintf(__('Customers in %s will be charged %s%% tax.', 'pmpro'), $tax_state, round($tax_rate * 100, 2));
+	}
+
+	if(!$tags)
+		$r = strip_tags($r);
+
+	$r = apply_filters("pmpro_level_cost_text", $r, $level, $tags, $short);	//passing $tags and $short since v1.8
+	return $r;
+}
+
 function pmpro_getLevelExpiration(&$level)
 {
 	if($level->expiration_number)
@@ -425,6 +538,36 @@ function pmpro_getLevelExpiration(&$level)
 	}
 	else
 		$expiration_text = "";
+
+	$expiration_text = apply_filters("pmpro_level_expiration_text", $expiration_text, $level);
+	return $expiration_text;
+}
+
+function pmpro_getLevelsExpiration(&$levels)
+{
+	$expirystrings = array();
+	$ongoinglevelnum = 0;
+	foreach($levels as $curlevel) {
+		if($curlevel->expiration_number) {
+			$expirystrings[] = sprintf(__("%s membership expires after %d %s", "pmpro"), $curlevel->name, $curlevel->expiration_number, pmpro_translate_billing_period($curlevel->expiration_period, $curlevel->expiration_number));
+		} else {
+			$ongoinglevelnum++;
+		}
+	}
+
+	$expiration_text = "";
+	if(count($expirystrings)>0) {
+		$laststanza = array_pop($expirystrings);
+		$expiration_text = implode(', ', $expirystrings);
+		if(count($expirystrings)>0) { $expiration_text .= ", and "; }
+		$expiration_text .= $laststanza;
+		$expiration_text .= ". ";
+		if($ongoinglevelnum>0) {
+			$expiration_text .= "The remaining membership";
+			if($ongoinglevelnum>1) { $expiration_text .= "s are"; } else { $expiration_text .= " is"; }
+			$expiration_text .= " ongoing.";
+		}
+	}
 
 	$expiration_text = apply_filters("pmpro_level_expiration_text", $expiration_text, $level);
 	return $expiration_text;

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -343,6 +343,8 @@ $pmpro_required_user_fields    = apply_filters( "pmpro_required_user_fields", $p
 //pmpro_confirmed is set to true later if payment goes through
 $pmpro_confirmed = false;
 
+$checkout_statuses = array();
+
 //check their fields if they clicked continue
 if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 
@@ -481,7 +483,6 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 			if ( $pmpro_msgt != "pmpro_error" ) {
 				do_action( 'pmpro_checkout_before_processing' );
 
-				$checkout_statuses = array();
 				foreach($checkout_levels as $curlevel) {
 					//process checkout if required
 					if ( $pmpro_requirebilling ) {

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -589,6 +589,7 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 }
 
 $canredirectaway = true;
+$checkoutid = 0;
 foreach($checkout_statuses as $curstatus) {
 	//Hook to check payment confirmation or replace it. If we get an array back, pull the values (morder) out
 	$curstatus['confirmed'] = apply_filters( 'pmpro_checkout_confirmed', $curstatus['confirmed'], $curstatus['order'] );
@@ -742,9 +743,13 @@ foreach($checkout_statuses as $curstatus) {
 
 				//add an item to the history table, cancel old subscriptions
 				if ( ! empty( $curstatus['order'] ) ) {
+					if($checkoutid>0) {
+						$curstatus['order']->checkout_id = $checkoutid; // so they all have the same ID right now.
+					}
 					$curstatus['order']->user_id       = $user_id;
 					$curstatus['order']->membership_id = $curstatus['id'];
-					$curstatus['order']->saveOrder();
+					$theorder = $curstatus['order']->saveOrder();
+					if($checkoutid<1) { $checkoutid = $theorder->checkout_id; } // it'll asssign one if there wasn't one already there.
 				}
 
 				//update the current user

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -855,7 +855,9 @@ foreach($checkout_statuses as $curstatus) {
 	}
 }
 
-do_action( "pmpro_after_all_checkouts", $user_id, $checkout_statuses);
+if(! empty($submit)) {
+	do_action( "pmpro_after_all_checkouts", $user_id, $checkout_statuses);
+}
 
 if(! empty( $submit ) && $canredirectaway) {
 	$success_levelids = array();

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -446,7 +446,7 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 		if ( $pmpro_msgt != "pmpro_error" ) {
 			//check recaptcha first
 			global $recaptcha;
-			if ( ! $skip_account_fields && ( $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) ) {
+			if ( ! $skip_account_fields && ( $recaptcha == 2 || ( $recaptcha == 1 && pmpro_areLevelsFree( $checkout_levels ) ) ) ) {
 				global $recaptcha_privatekey;
 
 				if ( isset( $_POST["recaptcha_challenge_field"] ) ) {

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -35,13 +35,17 @@ if ( ! in_array( $gateway, $valid_gateways ) ) {
 	$pmpro_msgt = "pmpro_error";
 }
 
+// Let's turn the level parameter into an array (with one element, or more if comma-sep levels were passed in)
+$inlevelids = explode(',', $_REQUEST['level']);
+$inlevelids = array_map('intval', $inlevelids); // these should always be integers
+
 //what level are they purchasing? (discount code passed)
 if ( ! empty( $_REQUEST['level'] ) && ! empty( $_REQUEST['discount_code'] ) ) {
 	$discount_code    = preg_replace( "/[^A-Za-z0-9\-]/", "", $_REQUEST['discount_code'] );
 	$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . $discount_code . "' LIMIT 1" );
 
 	//check code
-	$code_check = pmpro_checkDiscountCode( $discount_code, (int) $_REQUEST['level'], true );
+	$code_check = pmpro_checkDiscountCode( $discount_code, $inlevelids, true );
 	if ( $code_check[0] == false ) {
 		//error
 		$pmpro_msg  = $code_check[1];
@@ -50,37 +54,53 @@ if ( ! empty( $_REQUEST['level'] ) && ! empty( $_REQUEST['discount_code'] ) ) {
 		//don't use this code
 		$use_discount_code = false;
 	} else {
-		$sqlQuery    = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.code = '" . $discount_code . "' AND cl.level_id = '" . (int) $_REQUEST['level'] . "' LIMIT 1";
+		$sqlQuery    = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.code = '" . $discount_code . "' AND cl.level_id IN (" . implode(',', $inlevelids) . ") LIMIT 1";
 		$pmpro_level = $wpdb->get_row( $sqlQuery );
 
 		//if the discount code doesn't adjust the level, let's just get the straight level
-		if ( empty( $pmpro_level ) ) {
-			$pmpro_level = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . (int) $_REQUEST['level'] . "' LIMIT 1" );
-		}
+		// Would this ever be empty, barring a discount code error? Commenting out for now.
+// 		if ( empty( $pmpro_level ) ) {
+// 			$pmpro_level = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . (int) $_REQUEST['level'] . "' LIMIT 1" );
+// 		}
 
 		//filter adjustments to the level
-		$pmpro_level->code_id = $discount_code_id;
-		$pmpro_level          = apply_filters( "pmpro_discount_code_level", $pmpro_level, $discount_code_id );
+		if(! empty($pmpro_level)) {
+			$pmpro_level->code_id = $discount_code_id;
+			$pmpro_level          = apply_filters( "pmpro_discount_code_level", $pmpro_level, $discount_code_id );
 
-		$use_discount_code = true;
+			$use_discount_code = true;
+		}
 	}
 }
 
-//what level are they purchasing? (no discount code)
-if ( empty( $pmpro_level ) && ! empty( $_REQUEST['level'] ) ) {
-	$pmpro_level = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . esc_sql( $_REQUEST['level'] ) . "' AND allow_signups = 1 LIMIT 1" );
-} elseif ( empty( $pmpro_level ) ) {
+$checkout_levels = array(); // this will contain an array of all levels they're checking out with
+
+$discount_code_level_id = -1;
+if(! empty($pmpro_level)) {  // if we applied a discount code to a level, that's in the mix.
+	$checkout_levels[] = $pmpro_level;
+	$discount_code_level_id = $pmpro_level->id;
+}
+
+//what level are they purchasing? (in addition to a level added with a discount code, if any)
+if (! empty( $_REQUEST['level'] ) ) {
+	$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id IN (" . implode(',', $inlevelids) . ") AND id != $discount_code_level_id AND allow_signups = 1";
+	$selected_levels = $wpdb->get_results($sqlQuery);
+	if(count($selected_levels)>0 && empty( $pmpro_level )) { $pmpro_level = $selected_levels[0]; } // stick a scalar into the variable so the later filter isn't confused.
+	$checkout_levels = array_merge($selected_levels, $checkout_levels);
+} elseif ( empty( $pmpro_level ) ) { // No discount code level. No level on input. So let's look to the custom fields.
 	//check if a level is defined in custom fields
 	$default_level = get_post_meta( $post->ID, "pmpro_default_level", true );
 	if ( ! empty( $default_level ) ) {
 		$pmpro_level = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . esc_sql( $default_level ) . "' AND allow_signups = 1 LIMIT 1" );
+		$checkout_levels[] = $pmpro_level;
 	}
 }
 
-//filter the level (for upgrades, etc)
+//filter the level(s) (for upgrades, etc) - for multiple levels, this will always be the first one.
 $pmpro_level = apply_filters( "pmpro_checkout_level", $pmpro_level );
+array_splice($checkout_levels, 0, 1, $pmpro_level); // update the array post-filter to incorporate changes
 
-if ( empty( $pmpro_level->id ) ) {
+if ( empty( $checkout_levels ) ) {
 	wp_redirect( pmpro_url( "levels" ) );
 	exit( 0 );
 }
@@ -91,7 +111,7 @@ wp_enqueue_script( 'jquery.creditCardValidator', plugins_url( '/js/jquery.credit
 global $wpdb, $current_user, $pmpro_requirebilling;
 //unless we're submitting a form, let's try to figure out if https should be used
 
-if ( ! pmpro_isLevelFree( $pmpro_level ) ) {
+if ( ! pmpro_areLevelsFree( $checkout_levels ) ) {
 	//require billing and ssl
 	$pagetitle            = __( "Checkout: Payment Information", 'pmpro' );
 	$pmpro_requirebilling = true;
@@ -461,375 +481,386 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 			if ( $pmpro_msgt != "pmpro_error" ) {
 				do_action( 'pmpro_checkout_before_processing' );
 
-				//process checkout if required
-				if ( $pmpro_requirebilling ) {
-					$morder                   = new MemberOrder();
-					$morder->membership_id    = $pmpro_level->id;
-					$morder->membership_name  = $pmpro_level->name;
-					$morder->discount_code    = $discount_code;
-					$morder->InitialPayment   = $pmpro_level->initial_payment;
-					$morder->PaymentAmount    = $pmpro_level->billing_amount;
-					$morder->ProfileStartDate = date( "Y-m-d", current_time( "timestamp" ) ) . "T0:0:0";
-					$morder->BillingPeriod    = $pmpro_level->cycle_period;
-					$morder->BillingFrequency = $pmpro_level->cycle_number;
+				$checkout_statuses = array();
+				foreach($checkout_levels as $curlevel) {
+					//process checkout if required
+					if ( $pmpro_requirebilling ) {
+						$morder                   = new MemberOrder();
+						$morder->membership_id    = $curlevel->id;
+						$morder->membership_name  = $curlevel->name;
+						$morder->discount_code    = $discount_code;
+						$morder->InitialPayment   = $curlevel->initial_payment;
+						$morder->PaymentAmount    = $curlevel->billing_amount;
+						$morder->ProfileStartDate = date( "Y-m-d", current_time( "timestamp" ) ) . "T0:0:0";
+						$morder->BillingPeriod    = $curlevel->cycle_period;
+						$morder->BillingFrequency = $curlevel->cycle_number;
 
-					if ( $pmpro_level->billing_limit ) {
-						$morder->TotalBillingCycles = $pmpro_level->billing_limit;
-					}
-
-					if ( pmpro_isLevelTrial( $pmpro_level ) ) {
-						$morder->TrialBillingPeriod    = $pmpro_level->cycle_period;
-						$morder->TrialBillingFrequency = $pmpro_level->cycle_number;
-						$morder->TrialBillingCycles    = $pmpro_level->trial_limit;
-						$morder->TrialAmount           = $pmpro_level->trial_amount;
-					}
-
-					//credit card values
-					$morder->cardtype              = $CardType;
-					$morder->accountnumber         = $AccountNumber;
-					$morder->expirationmonth       = $ExpirationMonth;
-					$morder->expirationyear        = $ExpirationYear;
-					$morder->ExpirationDate        = $ExpirationMonth . $ExpirationYear;
-					$morder->ExpirationDate_YdashM = $ExpirationYear . "-" . $ExpirationMonth;
-					$morder->CVV2                  = $CVV;
-
-					//not saving email in order table, but the sites need it
-					$morder->Email = $bemail;
-
-					//sometimes we need these split up
-					$morder->FirstName = $bfirstname;
-					$morder->LastName  = $blastname;
-					$morder->Address1  = $baddress1;
-					$morder->Address2  = $baddress2;
-
-					//other values
-					$morder->billing          = new stdClass();
-					$morder->billing->name    = $bfirstname . " " . $blastname;
-					$morder->billing->street  = trim( $baddress1 . " " . $baddress2 );
-					$morder->billing->city    = $bcity;
-					$morder->billing->state   = $bstate;
-					$morder->billing->country = $bcountry;
-					$morder->billing->zip     = $bzipcode;
-					$morder->billing->phone   = $bphone;
-
-					//$gateway = pmpro_getOption("gateway");
-					$morder->gateway = $gateway;
-					$morder->setGateway();
-
-					//setup level var
-					$morder->getMembershipLevel();
-					$morder->membership_level = apply_filters( "pmpro_checkout_level", $morder->membership_level );
-
-					//tax
-					$morder->subtotal = $morder->InitialPayment;
-					$morder->getTax();
-
-					//filter for order, since v1.8
-					$morder = apply_filters( "pmpro_checkout_order", $morder );
-
-					$pmpro_processed = $morder->process();
-
-					if ( ! empty( $pmpro_processed ) ) {
-						$pmpro_msg       = __( "Payment accepted.", "pmpro" );
-						$pmpro_msgt      = "pmpro_success";
-						$pmpro_confirmed = true;
-					} else {
-						$pmpro_msg = $morder->error;
-						if ( empty( $pmpro_msg ) ) {
-							$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", "pmpro" );
+						if ( $curlevel->billing_limit ) {
+							$morder->TotalBillingCycles = $curlevel->billing_limit;
 						}
-						$pmpro_msgt = "pmpro_error";
-					}
 
-				} else // !$pmpro_requirebilling
-				{
-					//must have been a free membership, continue
-					$pmpro_confirmed = true;
+						if ( pmpro_isLevelTrial( $curlevel ) ) {
+							$morder->TrialBillingPeriod    = $curlevel->cycle_period;
+							$morder->TrialBillingFrequency = $curlevel->cycle_number;
+							$morder->TrialBillingCycles    = $curlevel->trial_limit;
+							$morder->TrialAmount           = $curlevel->trial_amount;
+						}
+
+						//credit card values
+						$morder->cardtype              = $CardType;
+						$morder->accountnumber         = $AccountNumber;
+						$morder->expirationmonth       = $ExpirationMonth;
+						$morder->expirationyear        = $ExpirationYear;
+						$morder->ExpirationDate        = $ExpirationMonth . $ExpirationYear;
+						$morder->ExpirationDate_YdashM = $ExpirationYear . "-" . $ExpirationMonth;
+						$morder->CVV2                  = $CVV;
+
+						//not saving email in order table, but the sites need it
+						$morder->Email = $bemail;
+
+						//sometimes we need these split up
+						$morder->FirstName = $bfirstname;
+						$morder->LastName  = $blastname;
+						$morder->Address1  = $baddress1;
+						$morder->Address2  = $baddress2;
+
+						//other values
+						$morder->billing          = new stdClass();
+						$morder->billing->name    = $bfirstname . " " . $blastname;
+						$morder->billing->street  = trim( $baddress1 . " " . $baddress2 );
+						$morder->billing->city    = $bcity;
+						$morder->billing->state   = $bstate;
+						$morder->billing->country = $bcountry;
+						$morder->billing->zip     = $bzipcode;
+						$morder->billing->phone   = $bphone;
+
+						//$gateway = pmpro_getOption("gateway");
+						$morder->gateway = $gateway;
+						$morder->setGateway();
+
+						//setup level var
+						$morder->getMembershipLevel();
+						$morder->membership_level = apply_filters( "pmpro_checkout_level", $morder->membership_level );
+
+						//tax
+						$morder->subtotal = $morder->InitialPayment;
+						$morder->getTax();
+
+						//filter for order, since v1.8
+						$morder = apply_filters( "pmpro_checkout_order", $morder );
+
+						$pmpro_processed = $morder->process();
+
+						if ( ! empty( $pmpro_processed ) ) {
+							$pmpro_msg       = __( "Payment accepted.", "pmpro" );
+							$pmpro_msgt      = "pmpro_success";
+							$pmpro_confirmed = true;
+							$checkout_statuses[] = array('id' => $curlevel->id, 'level' => $curlevel, 'confirmed' => true, 'order' => $morder);
+						} else {
+							$pmpro_msg = $morder->error;
+							if ( empty( $pmpro_msg ) ) {
+								$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", "pmpro" );
+							}
+							$pmpro_msgt = "pmpro_error";
+							$checkout_statuses[] = array('id' => $curlevel->id, 'level' => $curlevel, 'confirmed' => false, 'order' => $morder);
+						}
+
+					} else // !$pmpro_requirebilling
+					{
+						//must have been a free membership, continue
+						$pmpro_confirmed = true;
+						$morder                 = new MemberOrder();
+						$morder->InitialPayment = 0;
+						$morder->Email          = $bemail;
+						$morder->gateway        = "free";
+
+						$morder = apply_filters( "pmpro_checkout_order_free", $morder );
+						$checkout_statuses[] = array('id' => $curlevel->id, 'level' => $curlevel, 'confirmed' => true, 'order' => $morder);
+
+					}
 				}
+
 			}
 		}
 	}    //endif ($pmpro_continue_registration)
 }
 
-//make sure we have at least an empty morder here to avoid a warning
-if ( empty( $morder ) ) {
-	$morder = false;
-}
-
-//Hook to check payment confirmation or replace it. If we get an array back, pull the values (morder) out
-$pmpro_confirmed = apply_filters( 'pmpro_checkout_confirmed', $pmpro_confirmed, $morder );
-if ( is_array( $pmpro_confirmed ) ) {
-	extract( $pmpro_confirmed );
-}
-
-//if payment was confirmed create/update the user.
-if ( ! empty( $pmpro_confirmed ) ) {
-	//just in case this hasn't been set yet
-	$submit = true;
-
-	//do we need to create a user account?
-	if ( ! $current_user->ID ) {
-		/*
-			create user
-		*/
-		if ( version_compare( $wp_version, "3.1" ) < 0 ) {
-			require_once( ABSPATH . WPINC . '/registration.php' );
-		}    //need this for WP versions before 3.1
-
-		//first name
-		if ( ! empty( $_REQUEST['first_name'] ) ) {
-			$first_name = $_REQUEST['first_name'];
-		} else {
-			$first_name = $bfirstname;
-		}
-		//last name
-		if ( ! empty( $_REQUEST['last_name'] ) ) {
-			$last_name = $_REQUEST['last_name'];
-		} else {
-			$last_name = $blastname;
-		}
-
-		//insert user
-		$new_user_array = apply_filters( 'pmpro_checkout_new_user_array', array(
-				"user_login" => $username,
-				"user_pass"  => $password,
-				"user_email" => $bemail,
-				"first_name" => $first_name,
-				"last_name"  => $last_name
-			)
-		);
-
-		$user_id = apply_filters( 'pmpro_new_user', '', $new_user_array );
-		if ( empty( $user_id ) ) {
-			$user_id = wp_insert_user( $new_user_array );
-		}
-
-		if ( empty( $user_id ) || is_wp_error( $user_id ) ) {
-			$e_msg = '';
-
-			if ( is_wp_error( $user_id ) ) {
-				$e_msg = $user_id->get_error_message();
-			}
-
-			$pmpro_msg  = __( "Your payment was accepted, but there was an error setting up your account. Please contact us.", "pmpro" ) . sprintf( " %s", $e_msg ); // Dirty 'don't break translation hack.
-			$pmpro_msgt = "pmpro_error";
-		} elseif ( apply_filters( 'pmpro_setup_new_user', true, $user_id, $new_user_array, $pmpro_level ) ) {
-
-			//check pmpro_wp_new_user_notification filter before sending the default WP email
-			if ( apply_filters( "pmpro_wp_new_user_notification", true, $user_id, $pmpro_level->id ) ) {
-				if ( version_compare( $wp_version, "4.3.0" ) >= 0 ) {
-					wp_new_user_notification( $user_id, null, 'both' );
-				} else {
-					wp_new_user_notification( $user_id, $new_user_array['user_pass'] );
-				}
-			}
-
-			$wpuser = get_userdata( $user_id );
-
-			//make the user a subscriber
-			$wpuser->set_role( get_option( 'default_role', 'subscriber' ) );
-
-			//okay, log them in to WP
-			$creds                  = array();
-			$creds['user_login']    = $new_user_array['user_login'];
-			$creds['user_password'] = $new_user_array['user_pass'];
-			$creds['remember']      = true;
-			$user                   = wp_signon( $creds, false );
-
-			//setting some cookies
-			wp_set_current_user( $user_id, $username );
-			wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
-		}
-	} else {
-		$user_id = $current_user->ID;
+$canredirectaway = true;
+foreach($checkout_statuses as $curstatus) {
+	//Hook to check payment confirmation or replace it. If we get an array back, pull the values (morder) out
+	$curstatus['confirmed'] = apply_filters( 'pmpro_checkout_confirmed', $curstatus['confirmed'], $curstatus['order'] );
+	if ( is_array( $curstatus['confirmed'] ) ) {
+		extract( $curstatus['confirmed'] );
 	}
 
-	if ( ! empty( $user_id ) && ! is_wp_error( $user_id ) ) {
-		do_action( 'pmpro_checkout_before_change_membership_level', $user_id, $morder );
+	//if payment was confirmed create/update the user.
+	if ( $curstatus['confirmed'] ) {
+		//just in case this hasn't been set yet
+		$submit = true;
 
-		//start date is NOW() but filterable below
-		$startdate = current_time( "mysql" );
+		//do we need to create a user account?
+		if ( ! $current_user->ID ) {
+			/*
+				create user
+			*/
+			if ( version_compare( $wp_version, "3.1" ) < 0 ) {
+				require_once( ABSPATH . WPINC . '/registration.php' );
+			}    //need this for WP versions before 3.1
 
-		/**
-		 * Filter the start date for the membership/subscription.
-		 *
-		 * @since 1.8.9
-		 *
-		 * @param string $startdate , datetime formatsted for MySQL (NOW() or YYYY-MM-DD)
-		 * @param int $user_id , ID of the user checking out
-		 * @param object $pmpro_level , object of level being checked out for
-		 */
-		$startdate = apply_filters( "pmpro_checkout_start_date", $startdate, $user_id, $pmpro_level );
-
-		//calculate the end date
-		if ( ! empty( $pmpro_level->expiration_number ) ) {
-			$enddate =  date( "Y-m-d", strtotime( "+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, current_time( "timestamp" ) ) );
-		} else {
-			$enddate = "NULL";
-		}
-
-		/**
-		 * Filter the end date for the membership/subscription.
-		 *
-		 * @since 1.8.9
-		 *
-		 * @param string $enddate , datetime formatsted for MySQL (YYYY-MM-DD)
-		 * @param int $user_id , ID of the user checking out
-		 * @param object $pmpro_level , object of level being checked out for
-		 * @param string $startdate , startdate calculated above
-		 */
-		$enddate = apply_filters( "pmpro_checkout_end_date", $enddate, $user_id, $pmpro_level, $startdate );
-
-		//update membership_user table.
-		if ( ! empty( $discount_code ) && ! empty( $use_discount_code ) ) {
-			$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
-		} else {
-			$discount_code_id = "";
-		}
-
-
-		$custom_level = array(
-			'user_id'         => $user_id,
-			'membership_id'   => $pmpro_level->id,
-			'code_id'         => $discount_code_id,
-			'initial_payment' => $pmpro_level->initial_payment,
-			'billing_amount'  => $pmpro_level->billing_amount,
-			'cycle_number'    => $pmpro_level->cycle_number,
-			'cycle_period'    => $pmpro_level->cycle_period,
-			'billing_limit'   => $pmpro_level->billing_limit,
-			'trial_amount'    => $pmpro_level->trial_amount,
-			'trial_limit'     => $pmpro_level->trial_limit,
-			'startdate'       => $startdate,
-			'enddate'         => $enddate
-		);
-
-		if ( pmpro_changeMembershipLevel( $custom_level, $user_id, 'changed' ) ) {
-			//we're good
-			//blank order for free levels
-			if ( empty( $morder ) ) {
-				$morder                 = new MemberOrder();
-				$morder->InitialPayment = 0;
-				$morder->Email          = $bemail;
-				$morder->gateway        = "free";
-
-				$morder = apply_filters( "pmpro_checkout_order_free", $morder );
+			//first name
+			if ( ! empty( $_REQUEST['first_name'] ) ) {
+				$first_name = $_REQUEST['first_name'];
+			} else {
+				$first_name = $bfirstname;
+			}
+			//last name
+			if ( ! empty( $_REQUEST['last_name'] ) ) {
+				$last_name = $_REQUEST['last_name'];
+			} else {
+				$last_name = $blastname;
 			}
 
-			//add an item to the history table, cancel old subscriptions
-			if ( ! empty( $morder ) ) {
-				$morder->user_id       = $user_id;
-				$morder->membership_id = $pmpro_level->id;
-				$morder->saveOrder();
+			//insert user
+			$new_user_array = apply_filters( 'pmpro_checkout_new_user_array', array(
+					"user_login" => $username,
+					"user_pass"  => $password,
+					"user_email" => $bemail,
+					"first_name" => $first_name,
+					"last_name"  => $last_name
+				)
+			);
+
+			$user_id = apply_filters( 'pmpro_new_user', '', $new_user_array );
+			if ( empty( $user_id ) ) {
+				$user_id = wp_insert_user( $new_user_array );
 			}
 
-			//update the current user
-			global $current_user;
-			if ( ! $current_user->ID && $user->ID ) {
-				$current_user = $user;
-			} //in case the user just signed up
-			pmpro_set_current_user();
+			if ( empty( $user_id ) || is_wp_error( $user_id ) ) {
+				$e_msg = '';
 
-			//add discount code use
-			if ( $discount_code && $use_discount_code ) {
-				if ( ! empty( $morder->id ) ) {
-					$code_order_id = $morder->id;
+				if ( is_wp_error( $user_id ) ) {
+					$e_msg = $user_id->get_error_message();
+				}
+
+				$pmpro_msg  = __( "Your payment was accepted, but there was an error setting up your account. Please contact us.", "pmpro" ) . sprintf( " %s", $e_msg ); // Dirty 'don't break translation hack.
+				$pmpro_msgt = "pmpro_error";
+			} elseif ( apply_filters( 'pmpro_setup_new_user', true, $user_id, $new_user_array, $curstatus['level'] ) ) {
+
+				//check pmpro_wp_new_user_notification filter before sending the default WP email
+				if ( apply_filters( "pmpro_wp_new_user_notification", true, $user_id, $curstatus['id'] ) ) {
+					if ( version_compare( $wp_version, "4.3.0" ) >= 0 ) {
+						wp_new_user_notification( $user_id, null, 'both' );
+					} else {
+						wp_new_user_notification( $user_id, $new_user_array['user_pass'] );
+					}
+				}
+
+				$wpuser = get_userdata( $user_id );
+
+				//make the user a subscriber
+				$wpuser->set_role( get_option( 'default_role', 'subscriber' ) );
+
+				//okay, log them in to WP
+				$creds                  = array();
+				$creds['user_login']    = $new_user_array['user_login'];
+				$creds['user_password'] = $new_user_array['user_pass'];
+				$creds['remember']      = true;
+				$user                   = wp_signon( $creds, false );
+
+				//setting some cookies
+				wp_set_current_user( $user_id, $username );
+				wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
+			}
+		} else {
+			$user_id = $current_user->ID;
+		}
+
+		if ( ! empty( $user_id ) && ! is_wp_error( $user_id ) ) {
+			do_action( 'pmpro_checkout_before_change_membership_level', $user_id, $curstatus['order'] );
+
+			//start date is NOW() but filterable below
+			$startdate = current_time( "mysql" );
+
+			/**
+			 * Filter the start date for the membership/subscription.
+			 *
+			 * @since 1.8.9
+			 *
+			 * @param string $startdate , datetime formatsted for MySQL (NOW() or YYYY-MM-DD)
+			 * @param int $user_id , ID of the user checking out
+			 * @param object $pmpro_level , object of level being checked out for
+			 */
+			$startdate = apply_filters( "pmpro_checkout_start_date", $startdate, $user_id, $curstatus['level'] );
+
+			//calculate the end date
+			if ( ! empty( $curstatus['level']->expiration_number ) ) {
+				$enddate =  date( "Y-m-d", strtotime( "+ " . $curstatus['level']->expiration_number . " " . $curstatus['level']->expiration_period, current_time( "timestamp" ) ) );
+			} else {
+				$enddate = "NULL";
+			}
+
+			/**
+			 * Filter the end date for the membership/subscription.
+			 *
+			 * @since 1.8.9
+			 *
+			 * @param string $enddate , datetime formatsted for MySQL (YYYY-MM-DD)
+			 * @param int $user_id , ID of the user checking out
+			 * @param object $pmpro_level , object of level being checked out for
+			 * @param string $startdate , startdate calculated above
+			 */
+			$enddate = apply_filters( "pmpro_checkout_end_date", $enddate, $user_id, $curstatus['level'], $startdate );
+
+			//update membership_user table.
+			if ( ! empty( $discount_code ) && ! empty( $use_discount_code ) ) {
+				$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
+			} else {
+				$discount_code_id = "";
+			}
+
+
+			$custom_level = array(
+				'user_id'         => $user_id,
+				'membership_id'   => $curstatus['id'],
+				'code_id'         => $discount_code_id,
+				'initial_payment' => $curstatus['level']->initial_payment,
+				'billing_amount'  => $curstatus['level']->billing_amount,
+				'cycle_number'    => $curstatus['level']->cycle_number,
+				'cycle_period'    => $curstatus['level']->cycle_period,
+				'billing_limit'   => $curstatus['level']->billing_limit,
+				'trial_amount'    => $curstatus['level']->trial_amount,
+				'trial_limit'     => $curstatus['level']->trial_limit,
+				'startdate'       => $startdate,
+				'enddate'         => $enddate
+			);
+
+			if ( pmpro_changeMembershipLevel( $custom_level, $user_id, 'changed' ) ) {
+				//we're good
+
+				//add an item to the history table, cancel old subscriptions
+				if ( ! empty( $curstatus['order'] ) ) {
+					$curstatus['order']->user_id       = $user_id;
+					$curstatus['order']->membership_id = $pmpro_level->id;
+					$curstatus['order']->saveOrder();
+				}
+
+				//update the current user
+				global $current_user;
+				if ( ! $current_user->ID && $user->ID ) {
+					$current_user = $user;
+				} //in case the user just signed up
+				pmpro_set_current_user();
+
+				//add discount code use
+				if ( $discount_code && $use_discount_code ) {
+					if ( ! empty( $morder->id ) ) {
+						$code_order_id = $morder->id;
+					} else {
+						$code_order_id = "";
+					}
+
+					$wpdb->query( "INSERT INTO $wpdb->pmpro_discount_codes_uses (code_id, user_id, order_id, timestamp) VALUES('" . $discount_code_id . "', '" . $user_id . "', '" . intval( $code_order_id ) . "', '" . current_time( "mysql" ) . "')" );
+					$use_discount_code = false; // once the use has been inserted, we turn the flag off so we don't insert it multiple times for multiple level subscriptions at once.
+				}
+
+				//save billing info ect, as user meta
+				$meta_keys   = array(
+					"pmpro_bfirstname",
+					"pmpro_blastname",
+					"pmpro_baddress1",
+					"pmpro_baddress2",
+					"pmpro_bcity",
+					"pmpro_bstate",
+					"pmpro_bzipcode",
+					"pmpro_bcountry",
+					"pmpro_bphone",
+					"pmpro_bemail",
+					"pmpro_CardType",
+					"pmpro_AccountNumber",
+					"pmpro_ExpirationMonth",
+					"pmpro_ExpirationYear"
+				);
+				$meta_values = array(
+					$bfirstname,
+					$blastname,
+					$baddress1,
+					$baddress2,
+					$bcity,
+					$bstate,
+					$bzipcode,
+					$bcountry,
+					$bphone,
+					$bemail,
+					$CardType,
+					hideCardNumber( $AccountNumber ),
+					$ExpirationMonth,
+					$ExpirationYear
+				);
+				pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values );
+
+				//save first and last name fields
+				if ( ! empty( $bfirstname ) ) {
+					$old_firstname = get_user_meta( $user_id, "first_name", true );
+					if ( empty( $old_firstname ) ) {
+						update_user_meta( $user_id, "first_name", $bfirstname );
+					}
+				}
+				if ( ! empty( $blastname ) ) {
+					$old_lastname = get_user_meta( $user_id, "last_name", true );
+					if ( empty( $old_lastname ) ) {
+						update_user_meta( $user_id, "last_name", $blastname );
+					}
+				}
+
+				//show the confirmation
+				$ordersaved = true;
+
+				//hook
+				do_action( "pmpro_after_checkout", $user_id, $curstatus['order'] );    //added $morder param in v2.0
+
+				//setup some values for the emails
+				if ( ! empty( $curstatus['order'] ) ) {
+					$invoice = new MemberOrder( $curstatus['id'] );
 				} else {
-					$code_order_id = "";
+					$invoice = null;
 				}
+				$current_user->membership_level = $curstatus['level']; //make sure they have the right level info
 
-				$wpdb->query( "INSERT INTO $wpdb->pmpro_discount_codes_uses (code_id, user_id, order_id, timestamp) VALUES('" . $discount_code_id . "', '" . $user_id . "', '" . intval( $code_order_id ) . "', '" . current_time( "mysql" ) . "')" );
-			}
+				//send email to member
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendCheckoutEmail( $current_user, $invoice );
 
-			//save billing info ect, as user meta
-			$meta_keys   = array(
-				"pmpro_bfirstname",
-				"pmpro_blastname",
-				"pmpro_baddress1",
-				"pmpro_baddress2",
-				"pmpro_bcity",
-				"pmpro_bstate",
-				"pmpro_bzipcode",
-				"pmpro_bcountry",
-				"pmpro_bphone",
-				"pmpro_bemail",
-				"pmpro_CardType",
-				"pmpro_AccountNumber",
-				"pmpro_ExpirationMonth",
-				"pmpro_ExpirationYear"
-			);
-			$meta_values = array(
-				$bfirstname,
-				$blastname,
-				$baddress1,
-				$baddress2,
-				$bcity,
-				$bstate,
-				$bzipcode,
-				$bcountry,
-				$bphone,
-				$bemail,
-				$CardType,
-				hideCardNumber( $AccountNumber ),
-				$ExpirationMonth,
-				$ExpirationYear
-			);
-			pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values );
-
-			//save first and last name fields
-			if ( ! empty( $bfirstname ) ) {
-				$old_firstname = get_user_meta( $user_id, "first_name", true );
-				if ( empty( $old_firstname ) ) {
-					update_user_meta( $user_id, "first_name", $bfirstname );
-				}
-			}
-			if ( ! empty( $blastname ) ) {
-				$old_lastname = get_user_meta( $user_id, "last_name", true );
-				if ( empty( $old_lastname ) ) {
-					update_user_meta( $user_id, "last_name", $blastname );
-				}
-			}
-
-			//show the confirmation
-			$ordersaved = true;
-
-			//hook
-			do_action( "pmpro_after_checkout", $user_id, $morder );    //added $morder param in v2.0
-
-			//setup some values for the emails
-			if ( ! empty( $morder ) ) {
-				$invoice = new MemberOrder( $morder->id );
+				//send email to admin
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendCheckoutAdminEmail( $current_user, $invoice );
 			} else {
-				$invoice = null;
-			}
-			$current_user->membership_level = $pmpro_level; //make sure they have the right level info
 
-			//send email to member
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendCheckoutEmail( $current_user, $invoice );
+				//uh oh. we charged them then the membership creation failed
 
-			//send email to admin
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendCheckoutAdminEmail( $current_user, $invoice );
-
-			//redirect to confirmation
-			$rurl = pmpro_url( "confirmation", "?level=" . $pmpro_level->id );
-			$rurl = apply_filters( "pmpro_confirmation_url", $rurl, $user_id, $pmpro_level );
-			wp_redirect( $rurl );
-			exit;
-		} else {
-
-			//uh oh. we charged them then the membership creation failed
-
-			// test that the order object contains data
-			$test = (array) $morder;
-			if ( ! empty( $test ) && $morder->cancel() ) {
-				$pmpro_msg = __( "IMPORTANT: Something went wrong during membership creation. Your credit card authorized, but we cancelled the order immediately. You should not try to submit this form again. Please contact the site owner to fix this issue.", "pmpro" );
-				$morder    = null;
-			} else {
-				$pmpro_msg = __( "IMPORTANT: Something went wrong during membership creation. Your credit card was charged, but we couldn't assign your membership. You should not submit this form again. Please contact the site owner to fix this issue.", "pmpro" );
+				// test that the order object contains data
+				$test = (array) $morder;
+				if ( ! empty( $test ) && $morder->cancel() ) {
+					$pmpro_msg = __( "IMPORTANT: Something went wrong during membership creation. Your credit card authorized, but we cancelled the order immediately. You should not try to submit this form again. Please contact the site owner to fix this issue.", "pmpro" );
+					$morder    = null;
+				} else {
+					$pmpro_msg = __( "IMPORTANT: Something went wrong during membership creation. Your credit card was charged, but we couldn't assign your membership. You should not submit this form again. Please contact the site owner to fix this issue.", "pmpro" );
+				}
+				$canredirectaway = false;
 			}
 		}
 	}
+}
+
+if(! empty( $submit ) && $canredirectaway) {
+	$success_levelids = array();
+	foreach($checkout_statuses as $curstatus) {
+		$success_levelids[] = $curstatus['id'];
+	}
+	//redirect to confirmation
+	$rurl = pmpro_url( "confirmation", "?level=" . implode(',', $success_levelids) );
+	$rurl = apply_filters( "pmpro_confirmation_url", $rurl, $user_id, implode(',', $success_levelids) );
+	wp_redirect( $rurl );
+	exit;
 }
 
 //default values

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -1,5 +1,6 @@
 <?php
 global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_levels, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user;
+global $checkout_levels;
 
 //make sure we know current user's membership level
 if ( $current_user->ID ) {
@@ -98,7 +99,9 @@ if (! empty( $_REQUEST['level'] ) ) {
 
 //filter the level(s) (for upgrades, etc) - for multiple levels, this will always be the first one.
 $pmpro_level = apply_filters( "pmpro_checkout_level", $pmpro_level );
-array_splice($checkout_levels, 0, 1, $pmpro_level); // update the array post-filter to incorporate changes
+
+array_shift($checkout_levels); // update the array to account for any changes from the filter
+array_unshift($checkout_levels, $pmpro_level);
 
 if ( empty( $checkout_levels ) ) {
 	wp_redirect( pmpro_url( "levels" ) );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -346,6 +346,7 @@ $pmpro_required_user_fields    = apply_filters( "pmpro_required_user_fields", $p
 //pmpro_confirmed is set to true later if payment goes through
 $pmpro_confirmed = false;
 
+
 $checkout_statuses = array();
 
 //check their fields if they clicked continue
@@ -485,7 +486,6 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 			//no errors yet
 			if ( $pmpro_msgt != "pmpro_error" ) {
 				do_action( 'pmpro_checkout_before_processing' );
-
 				foreach($checkout_levels as $curlevel) {
 					//process checkout if required
 					if ( $pmpro_requirebilling ) {
@@ -554,7 +554,6 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 						$morder = apply_filters( "pmpro_checkout_order", $morder );
 
 						$pmpro_processed = $morder->process();
-
 						if ( ! empty( $pmpro_processed ) ) {
 							$pmpro_msg       = __( "Payment accepted.", "pmpro" );
 							$pmpro_msgt      = "pmpro_success";
@@ -744,7 +743,7 @@ foreach($checkout_statuses as $curstatus) {
 				//add an item to the history table, cancel old subscriptions
 				if ( ! empty( $curstatus['order'] ) ) {
 					$curstatus['order']->user_id       = $user_id;
-					$curstatus['order']->membership_id = $pmpro_level->id;
+					$curstatus['order']->membership_id = $curstatus['id'];
 					$curstatus['order']->saveOrder();
 				}
 

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -748,8 +748,8 @@ foreach($checkout_statuses as $curstatus) {
 					}
 					$curstatus['order']->user_id       = $user_id;
 					$curstatus['order']->membership_id = $curstatus['id'];
-					$theorder = $curstatus['order']->saveOrder();
-					if($checkoutid<1) { $checkoutid = $theorder->checkout_id; } // it'll asssign one if there wasn't one already there.
+					$curstatus['order']->saveOrder();
+					if($checkoutid<1) { $checkoutid = $curstatus['order']->checkout_id; } // it'll asssign one if there wasn't one already there.
 				}
 
 				//update the current user

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -855,6 +855,8 @@ foreach($checkout_statuses as $curstatus) {
 	}
 }
 
+do_action( "pmpro_after_all_checkouts", $user_id, $checkout_statuses);
+
 if(! empty( $submit ) && $canredirectaway) {
 	$success_levelids = array();
 	foreach($checkout_statuses as $curstatus) {

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -29,10 +29,11 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 	{
 		$ssorder = new MemberOrder();
 		$ssorder->getLastMemberOrder();
+		$mylevels = pmpro_getMembershipLevelsForUser();
+		$pmpro_levels = pmpro_getAllLevels(false, true); // just to be sure - include only the ones that allow signups
 		$invoices = $wpdb->get_results("SELECT *, UNIX_TIMESTAMP(timestamp) as timestamp FROM $wpdb->pmpro_membership_orders WHERE user_id = '$current_user->ID' AND status NOT IN('refunded', 'review', 'token', 'error') ORDER BY timestamp DESC LIMIT 6");		
 		?>	
 	<div id="pmpro_account">		
-		
 		<?php if(in_array('membership', $sections) || in_array('memberships', $sections)) { ?>
 			<div id="pmpro_account-membership" class="pmpro_box">
 				
@@ -47,17 +48,16 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 					</thead>
 					<tbody>
 						<?php
-							//TODO: v2.0 will loop through levels here
-							$level = $current_user->membership_level;
+							foreach($mylevels as $level) {
 						?>
 						<tr>
 							<td class="pmpro_account-membership-levelname">
-								<?php echo $current_user->membership_level->name?>
+								<?php echo $level->name?>
 								<div class="pmpro_actionlinks">
 									<?php do_action("pmpro_member_action_links_before"); ?>
 									
-									<?php if( $current_user->membership_level->allow_signups && pmpro_isLevelExpiringSoon( $current_user->membership_level) ) { ?>
-										<a href="<?php echo pmpro_url("checkout", "?level=" . $current_user->membership_level->id, "https")?>"><?php _e("Renew", "pmpro");?></a>
+									<?php if( array_key_exists($level->id, $pmpro_levels) && pmpro_isLevelExpiringSoon( $level ) ) { ?>
+										<a href="<?php echo pmpro_url("checkout", "?level=" . $level->id, "https")?>"><?php _e("Renew", "pmpro");?></a>
 									<?php } ?>
 
 									<?php if((isset($ssorder->status) && $ssorder->status == "success") && (isset($ssorder->gateway) && in_array($ssorder->gateway, array("authorizenet", "paypal", "stripe", "braintree", "payflow", "cybersource")))) { ?>
@@ -69,7 +69,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 										if(count($pmpro_levels) > 1 && !defined("PMPRO_DEFAULT_LEVEL")) { ?>
 										<a href="<?php echo pmpro_url("levels")?>"><?php _e("Change", "pmpro");?></a>
 									<?php } ?>
-									<a href="<?php echo pmpro_url("cancel", "?level=" . $current_user->membership_level->id)?>"><?php _e("Cancel", "pmpro");?></a>
+									<a href="<?php echo pmpro_url("cancel", "?level=" . $level->id)?>"><?php _e("Cancel", "pmpro");?></a>
 									<?php do_action("pmpro_member_action_links_after"); ?>
 								</div> <!-- end pmpro_actionlinks -->
 							</td>
@@ -78,13 +78,14 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 							</td>
 							<td class="pmpro_account-membership-expiration">
 							<?php 
-								if($current_user->membership_level->enddate) 
-									echo date(get_option('date_format'), $current_user->membership_level->enddate);
+								if($level->enddate) 
+									echo date(get_option('date_format'), $level->enddate);
 								else
 									echo "---";
 							?>
 							</td>
 						</tr>
+						<?php } ?>
 					</tbody>
 				</table>
 				<?php //Todo: If there are multiple levels defined that aren't all in the same group defined as upgrades/downgrades ?>


### PR DESCRIPTION
Mostly, this is a reworking of the preheader for the checkout page to
accommodate MMPU. But to support it, a new function needed to be added
- pmpro_areLevelsFree - that checks if multiple levels are all free;
and the pmpro_checkDiscountCode function was also reworked to
accommodate MMPU in addition to the current static level call.

There are some unresolved issues with the checkout preheader still:

- current_user->membership_level is set on line 6 (for no reason?) but
then on line 826. This is problematic both for setting, but also later
for getting.

- I left a note on line 61 for Jason to check on.

- We’ll still need to modify pmpro_changeMembershipLevel a little bit,
but can get that next.

- Emails are still oogly; they will send once per level purchased,
which isn’t what most purchasers are expecting, I think. Probably need
to move those calls from line 829 and put them in their own conditional
block around line 854.