### PR TITLE
Update checkout.php

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -53,7 +53,7 @@
 
 				<?php
 					if(!empty($pmpro_level->description))
-						echo apply_filters("the_content", stripslashes($pmpro_level->description));
+						echo wpautop( stripslashes( $pmpro_level->description ) );
 				?>
 
 				<div id="pmpro_level_cost">


### PR DESCRIPTION
applying filter "the_content" to the level description breaks my site on line  on line 56 :)
I think that's because this page is included in a shortcode used inside a page content on which the filter is already applyed ?
not sure, but replacing it with wpautop seems to do the trick !
