### PR TITLE
Add filter for sending emails from checkout preheader.

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -444,7 +444,7 @@
 		 */
 		function saveOrder()
 		{
-			global $current_user, $wpdb;
+			global $current_user, $wpdb, $pmpro_checkout_id;
 
 			//get a random code to use for the public ID
 			if(empty($this->code))
@@ -527,6 +527,7 @@
 			if(empty($this->checkout_id) || intval($this->checkout_id)<1) {
 				$highestval = $wpdb->get_var("SELECT MAX(checkout_id) FROM $wpdb->pmpro_membership_orders");
 				$this->checkout_id = intval($highestval)+1;
+				$pmpro_checkout_id = $this->checkout_id;
 			}
 
 			//build query

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -550,6 +550,7 @@ function pmpro_getLevelsExpiration(&$levels)
 {
 	$expirystrings = array();
 	$ongoinglevelnum = 0;
+	if(!empty($levels) && !is_array($levels)) { $levels = array($levels); } elseif(empty($levels)) { $levels = array(); }
 	foreach($levels as $curlevel) {
 		if($curlevel->expiration_number) {
 			$expirystrings[] = sprintf(__("%s membership expires after %d %s", "pmpro"), $curlevel->name, $curlevel->expiration_number, pmpro_translate_billing_period($curlevel->expiration_period, $curlevel->expiration_number));

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -766,21 +766,26 @@ if ( ! empty( $pmpro_confirmed ) ) {
 			//hook
 			do_action( "pmpro_after_checkout", $user_id, $morder );    //added $morder param in v2.0
 
-			//setup some values for the emails
-			if ( ! empty( $morder ) ) {
-				$invoice = new MemberOrder( $morder->id );
-			} else {
-				$invoice = null;
+			$sendemails = apply_filters( "pmpro_send_checkout_emails", true);
+	
+			if($sendemails) { // Send the e-mails only if the flag is set to true
+
+				//setup some values for the emails
+				if ( ! empty( $morder ) ) {
+					$invoice = new MemberOrder( $morder->id );
+				} else {
+					$invoice = null;
+				}
+				$current_user->membership_level = $pmpro_level; //make sure they have the right level info
+
+				//send email to member
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendCheckoutEmail( $current_user, $invoice );
+
+				//send email to admin
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendCheckoutAdminEmail( $current_user, $invoice );
 			}
-			$current_user->membership_level = $pmpro_level; //make sure they have the right level info
-
-			//send email to member
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendCheckoutEmail( $current_user, $invoice );
-
-			//send email to admin
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendCheckoutAdminEmail( $current_user, $invoice );
 
 			//redirect to confirmation
 			$rurl = pmpro_url( "confirmation", "?level=" . $pmpro_level->id );


### PR DESCRIPTION
Added a filter - pmpro_send_checkout_emails - that can be set to true
or false (default is true) to turn the checkout e-mails on and off. For
MMPU, we’ll turn it off, then replace with our own.