### PR TITLE
Fixed Braintree payments

### DIFF
--- a/includes/lib/Braintree/Braintree/Util.php
+++ b/includes/lib/Braintree/Braintree/Util.php
@@ -136,7 +136,9 @@ class Braintree_Util
      */
     public static function delimiterToCamelCase($string, $delimiter = '[\-\_]')
     {
-        return preg_replace('/' . $delimiter . '(\w)/e', 'strtoupper("$1")',$string);
+        return preg_replace_callback('/' . $delimiter . '(\w)/',function($matches) {
+            return strtoupper($matches[1]);
+        }, $string);
     }
 
     /**
@@ -161,7 +163,9 @@ class Braintree_Util
      */
     public static function camelCaseToDelimiter($string, $delimiter = '-')
     {
-        return preg_replace('/([A-Z])/e', '"' . $delimiter . '" . strtolower("$1")', $string);
+        return preg_replace_callback('/([A-Z])/',function($matches) use ($delimiter) {
+            return $delimiter.strtolower($matches[1]);
+        }, $string);
     }
 
     /**


### PR DESCRIPTION
Braintree payments do not work unless you use these new non-deprecated functions. Found this fix at: http://doginthehat.com.au/2015/03/deprecated-error-with-lemonstand-v1-and-braintree-payments/