### PR TITLE
Add filter for modifying the order description in Stripe

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1189,7 +1189,7 @@
 				  "amount" => $amount * $currency_unit_multiplier, # amount in cents, again
 				  "currency" => strtolower($pmpro_currency),
 				  "customer" => $this->customer->id,
-				  "description" => "Order #" . $order->code . ", " . trim($order->FirstName . " " . $order->LastName) . " (" . $order->Email . ")"
+				  "description" => apply_filters('pmpro_stripe_order_description', "Order #" . $order->code . ", " . trim($order->FirstName . " " . $order->LastName) . " (" . $order->Email . ")", $order)
 				  )
 				);
 			}


### PR DESCRIPTION
Will enable users to add unique identifiers or otherwise modify order descriptions in order to aid accounting departments in differentiating these payments from other lines of business paid through the same gateway