### PR TITLE
Added filter for other order IDs to cancel

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1055,6 +1055,8 @@ function pmpro_changeMembershipLevel($level, $user_id = NULL, $old_level_status 
 		$other_order_ids = $wpdb->get_col("SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $user_id . "' AND status = 'success' ORDER BY id DESC");
 	}
 	
+	$other_order_ids = apply_filters("pmpro_other_order_ids_to_cancel", $other_order_ids);
+	
 	//cancel any other subscriptions they have (updates pmpro_membership_orders table)
 	if($pmpro_cancel_previous_subscriptions && !empty($other_order_ids))
 	{		


### PR DESCRIPTION
For both single and MMPU instances, you may want to filter the orders
that get cancelled on cancellation (e.g., only cancel most recent; only
cancel some but not others based on criteria). This adds a filter to
allow people to hook on and do that.