### PR TITLE
BUG/FIX: Wouldn't allow cancellation

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -974,7 +974,7 @@ function pmpro_changeMembershipLevel($level, $user_id = NULL, $old_level_status 
 	if(!is_array($level))
 	{
 		//are they even changing?
-		if(pmpro_hasMembershipLevel($level, $user_id)) {
+		if(!pmpro_hasMembershipLevel($level, $user_id)) {
 			$pmpro_error = __("not changing?", 'paid-memberships-pro' );
 			return false; //not changing
 		}


### PR DESCRIPTION
If a member attempted to cancel, the level check would incorrectly return false if the member already had the membership level.