### PR TITLE
BUG/FIX: PayPal Standard/Add-on Packages issue

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -409,24 +409,29 @@
 					'item_number'   => $order->code, 
 					'charset'       => get_bloginfo( 'charset' ), 				
 					'rm'            => '2', 
-					'return'        => pmpro_url("confirmation", "?level=" . $order->membership_level->id),
-					'notify_url'    => admin_url("admin-ajax.php") . "?action=ipnhandler",
+					'return'        => add_query_args( array( 'level' => $order->membership_id, 'review' => $order->code ), pmpro_url("checkout") ),
+					'notify_url'    => add_query_args( 'action', 'ipnhandler', admin_url("admin-ajax.php") ),
 					'bn'			=> PAYPAL_BN_CODE
 				 );	
 			}						
+			
+			//anything modders might add
+			$additional_parameters = apply_filters("pmpro_paypal_express_return_url_parameters", array());									
+			
+			foreach( $additional_parameters as $key => $value ) {
+				
+				// Special handling for Addon Packages (Return URL for PayPal)
+				if ( 'ap' == $key ) {
+					$paypal_args['return'] .= urlencode( "&{$key}={$value}" );
+				} else {
+					$paypal_args[$key] = $value;
+				}
+			}
 			
 			$nvpStr = "";
 			foreach($paypal_args as $key => $value)
 			{
 				$nvpStr .= "&" . $key . "=" . urlencode($value);
-			}
-			
-			//anything modders might add
-			$additional_parameters = apply_filters("pmpro_paypal_express_return_url_parameters", array());									
-			if(!empty($additional_parameters))
-			{
-				foreach($additional_parameters as $key => $value)				
-					$nvpStr .= urlencode("&" . $key . "=" . $value);
 			}
 			
 			$account_optional = apply_filters('pmpro_paypal_account_optional', true);


### PR DESCRIPTION
The add-on packages expects to handle assigning a page to the user via the checkout preheader hooks, the PayPal Standard gateway returns the user to the confirmation page. Also, the current way of handling the PayPal arguments for the request assumes that the return URL is the last entry in the NVP string. That's not correct.