### PR TITLE
Ensure discount codes passed in URL is preserved through PayPal review step

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -16,6 +16,9 @@
 
 	<input type="hidden" id="level" name="level" value="<?php echo esc_attr($pmpro_level->id) ?>" />
 	<input type="hidden" id="checkjavascript" name="checkjavascript" value="1" />
+	<?php if ($discount_code && $pmpro_review) { ?>
+		<input class="input <?php echo pmpro_getClassForField("discount_code");?>" id="discount_code" name="discount_code" type="hidden" size="20" value="<?php echo esc_attr($discount_code) ?>" />
+	<?php } ?>
 
 	<?php if($pmpro_msg)
 		{


### PR DESCRIPTION
If a site chooses to offer discount codes but declines to use the discount code UI, in order to reduce checkout page friction, it is possible to include `?discount_code=<code>` in the URL. This works in conjunction with hiding the checkout form field by returning `false` from the `pmpro_show_discount_code` filter. 

In this case, the discount code gets lost at the PayPal order review step. This diff ensures that the discount code, as passed back by PayPal in the callback URL, gets submitted with the checkout form at order review.