### PR TITLE
BUG: Fixed redirect error if PMPro Levels page was not set.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -151,11 +151,15 @@ function pmpro_url($page = NULL, $querystring = "", $scheme = NULL)
 	//figure out querystring
 	$querystring = str_replace("?", "", $querystring);
 	parse_str( $querystring, $query_args );
-	$url = esc_url_raw( add_query_arg( $query_args, $url ) );
+	
+	if(!empty($url)) {
+		
+		$url = esc_url_raw( add_query_arg( $query_args, $url ) );
 
-	//figure out scheme
-	if(is_ssl())
-		$url = str_replace("http:", "https:", $url);
+		//figure out scheme
+		if(is_ssl())
+			$url = str_replace("http:", "https:", $url);
+	}
 
 	return $url;
 }


### PR DESCRIPTION
If PMPro Levels page was not set (ie: `$url` is empty) the value returned from `add_query_arg()` was `/wp-login.php?action=register` resulting in a redirect loop.