### PR TITLE
BUG: Arrays would lose data when saved to options

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -97,7 +97,12 @@ function pmpro_setOption($s, $v = NULL, $sanitize_function = 'sanitize_text_fiel
 {
 	//no value is given, set v to the p var
 	if($v === NULL && isset($_POST[$s]))
-		$v = call_user_func($sanitize_function, $_POST[$s]);
+	{	
+		if(is_array($_POST[$s]))
+			$v = array_map($sanitize_function, $_POST[$s]);
+		else
+			$v = call_user_func($sanitize_function, $_POST[$s]);
+	}
 
 	if(is_array($v))
 		$v = implode(",", $v);


### PR DESCRIPTION
An example is the "Choose Levels to Hide Ads From" settings under Memberships >> Advanced. Selected levels would not be saved.