### PR TITLE
BUG FIX: Level name would show for current user not from order.

### DIFF
--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -25,7 +25,7 @@
 		<ul>
 			<?php do_action("pmpro_invoice_bullets_top", $pmpro_invoice); ?>
 			<li><strong><?php _e('Account', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->user->display_name?> (<?php echo $pmpro_invoice->user->user_email?>)</li>
-			<li><strong><?php _e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php echo $current_user->membership_level->name?></li>
+			<li><strong><?php _e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->membership_level->name?></li>
 			<?php if($current_user->membership_level->enddate) { ?>
 				<li><strong><?php _e('Membership Expires', 'paid-memberships-pro' );?>:</strong> <?php echo date_i18n(get_option('date_format'), $current_user->membership_level->enddate)?></li>
 			<?php } ?>


### PR DESCRIPTION
When viewing an order of other users, the top membership level name
(bullet) would show current user opposed to the order’s level.