### PR TITLE
BUG: Added exit() after wp_redirect().

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -2,9 +2,10 @@
 	global $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $show_paypal_link;
 	global $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
 
-	if (! is_user_logged_in())
+	if (! is_user_logged_in()) {	
 		wp_redirect(pmpro_url('levels'));
-
+		exit();
+	}
 	/**
 	 * Filter to set if PMPro uses email or text as the type for email field inputs.
 	 * 


### PR DESCRIPTION
According the WP documentation:

https://developer.wordpress.org/reference/functions/wp_redirect/

`wp_redirect()` does not exit automatically and must be followed by an exit() statement.