### PR TITLE
 BUG FIX: Didn't unslash instructions for check gateway

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -28,11 +28,11 @@
 		*/
 		foreach($payment_options as $option) {
 			//for now we make a special case for sslseal, but we need a way to specify sanitize functions for other fields
-			if($option == 'sslseal') {
+			if( in_array( $option, array( 'sslseal', 'instructions' ) ) ) {
 				global $allowedposttags;
-				$sslseal = wp_kses(wp_unslash($_POST['sslseal']), $allowedposttags);
-				update_option('pmpro_sslseal', $sslseal);
-			} else {
+				$html = wp_kses(wp_unslash($_POST[$option]), $allowedposttags);
+				update_option("pmpro_{$option}", $html);
+            } else {
 				pmpro_setOption($option);
 			}
 		}

--- a/classes/gateways/class.pmprogateway_check.php
+++ b/classes/gateways/class.pmprogateway_check.php
@@ -106,7 +106,7 @@
 				<label for="instructions"><?php _e('Instructions', 'paid-memberships-pro' );?></label>					
 			</th>
 			<td>
-				<textarea id="instructions" name="instructions" rows="3" cols="80"><?php echo wpautop( $values['instructions'] ); ?></textarea>
+				<textarea id="instructions" name="instructions" rows="3" cols="80"><?php echo wpautop(  wp_unslash( $values['instructions'] ) ); ?></textarea>
 				<p><small><?php _e('Who to write the check out to. Where to mail it. Shown on checkout, confirmation, and invoice pages.', 'paid-memberships-pro' );?></small></p>
 			</td>
 		</tr>	
@@ -149,7 +149,7 @@
 
 			if($gateway == "check" && !pmpro_isLevelFree($pmpro_level)) {
 				$instructions = pmpro_getOption("instructions");
-				echo '<div class="pmpro_check_instructions">' . wpautop($instructions) . '</div>';
+				echo '<div class="pmpro_check_instructions">' . wpautop(wp_unslash( $instructions )) . '</div>';
 			}
 		}
 

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -598,11 +598,10 @@
 			if("sandbox" === $environment || "beta-sandbox" === $environment) {
 				$API_Endpoint = "https://api-3t.$environment.paypal.com/nvp";
 			}						
-			
-			$version = '72.0';
+            
             $nvp_args = array(
                 'METHOD' => $methodName_,
-                'VERSION' => $version,
+                'VERSION' => '72.0',
                 'bn' => PAYPAL_BN_CODE,
             );
 			

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -599,7 +599,7 @@
 				$API_Endpoint = "https://api-3t.$environment.paypal.com/nvp";
 			}						
 			
-			$version = urlencode('72.0');
+			$version = '72.0';
             $nvp_args = array(
                 'METHOD' => $methodName_,
                 'VERSION' => $version,

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -29,7 +29,7 @@
 		
 		//check instructions
 		if($pmpro_invoice->gateway == "check" && !pmpro_isLevelFree($pmpro_invoice->membership_level))
-			$confirmation_message .= wpautop(pmpro_getOption("instructions"));
+			$confirmation_message .= wpautop(wp_unslash( pmpro_getOption("instructions") ) );
 		
 		/**
 		 * All devs to filter the confirmation message.


### PR DESCRIPTION
BUG FIX: Avoid double-encoding the API version in PayPal Standard gateway
ENHANCEMENT/FIX: Avoid double-encoding the PayPal API version number
