### PR TITLE
Revert of javascript check

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -15,7 +15,6 @@
 <form id="pmpro_form" class="pmpro_form" action="<?php if(!empty($_REQUEST['review'])) echo pmpro_url("checkout", "?level=" . $pmpro_level->id); ?>" method="post">
 
 	<input type="hidden" id="level" name="level" value="<?php echo esc_attr($pmpro_level->id) ?>" />
-	<input type="hidden" id="checkjavascript" name="checkjavascript" value="1" />
 	<?php if ($discount_code && $pmpro_review) { ?>
 		<input class="input <?php echo pmpro_getClassForField("discount_code");?>" id="discount_code" name="discount_code" type="hidden" size="20" value="<?php echo esc_attr($discount_code) ?>" />
 	<?php } ?>
@@ -671,11 +670,5 @@
 		   jQuery('#other_discount_code_button').click();
 	    }
 	});
--->
-</script>
-<script>
-<!--
-//add javascriptok hidden field to checkout
-jQuery("input[name=submit-checkout]").after('<input type="hidden" name="javascriptok" value="1" />');
 -->
 </script>

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -284,11 +284,6 @@ $pmpro_confirmed = false;
 //check their fields if they clicked continue
 if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 
-	//make sure javascript is ok
-	if ( apply_filters( "pmpro_require_javascript_for_checkout", true ) && ! empty( $_REQUEST['checkjavascript'] ) && empty( $_REQUEST['javascriptok'] ) ) {
-		pmpro_setMessage( __( "There are JavaScript errors on the page. Please contact the webmaster.", 'paid-memberships-pro' ), "pmpro_error" );
-	}
-
 	//if we're skipping the account fields and there is no user, we need to create a username and password
 	if ( $skip_account_fields && ! $current_user->ID ) {
 		$username = pmpro_generateUsername( $bfirstname, $blastname, $bemail );


### PR DESCRIPTION
I'm basically reverting the changes made in #144. Does anyone (@ideadude?) remember why it was added? If we assume that javascript must be enabled in order for paid-memberships-pro to function correctly [1], is this really the best way to detect that? In my experience, and the experience of many googlers, this check leads to numerous false positives including some due to errors outside of the scope of paid-memberships-pro.

When it comes to accepting money from my users, the false positives are very painful. Does the plugin still need this check? If yes, should `pmpro_require_javascript_for_checkout` default to `false`?

----------
[1] In my limited testing with PayPal Express, the registration flow works fine without JS. I assume other gateways aren't as accessible.