### PR TITLE
Load print.css on pages that use print feature only

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -68,7 +68,12 @@ function pmpro_init()
 			$print_css = get_template_directory_uri() . "/paid-memberships-pro/print.css";
 		else
 			$print_css = plugins_url('css/print.css',dirname(__FILE__) );
-		wp_enqueue_style('pmpro_print', $print_css, array(), PMPRO_VERSION, "print");
+
+		// Only load it on pages that are using the print feature.
+		if( ! empty( $_REQUEST[ 'invoice' ] ) || ! empty( $_REQUEST[ 'level' ] ) ){
+			wp_enqueue_style('pmpro_print', $print_css, array(), PMPRO_VERSION, "print");
+		}
+		
 	}
 	
 	global $pmpro_pages, $pmpro_core_pages, $pmpro_ready, $pmpro_currencies, $pmpro_currency, $pmpro_currency_symbol;


### PR DESCRIPTION
Load the print.css file only on pages that use the print feature.

Possibility would be to add this to the frontend.css since the CSS code is one line.