### PR TITLE
fix conflict with pmpro-email-templates when emails are disabled

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -104,6 +104,11 @@
 			
 			//filters
 			$temail = apply_filters("pmpro_email_filter", $this);		//allows filtering entire email at once
+
+			if ( empty( $temail ) ) {
+				return false;
+			}
+
 			$this->email = apply_filters("pmpro_email_recipient", $temail->email, $this);
 			$this->from = apply_filters("pmpro_email_sender", $temail->from, $this);
 			$this->fromname = apply_filters("pmpro_email_sender_name", $temail->fromname, $this);


### PR DESCRIPTION
I've been using `pmpro-email-templates` and I disabled the admin email on checkout.

When successfully registering, the page dies because the hooks handling the emails aren't expecting a potential `false` value.

I noticed the same conflict in `pmpro-register-helper`, I also submitted a pull request there. I haven't checked the other addons.