### PR TITLE
Pbrx gutenberg

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1,3 +1,6 @@
+#pmpro_page_meta #membershipschecklist {
+	list-style: none;
+}
 /* icon */
 #wp-admin-bar-paid-memberships-pro .ab-item .ab-icon:before {
     font-family: "dashicons";


### PR DESCRIPTION
Removes bullet from level checkboxes from Gutenberg post-editor. Non-gutenberg screen seem unaffected, as seen in screencast.

[Screencast shows checkbox with/without Gutenberg](https://api.monosnap.com/rpc/file/download?id=RhNMtK6KT2jXT7CTByNBnIb54QR03h)