### PR TITLE
Stripe response handler, change e-mail template call

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -246,9 +246,6 @@
 				else
 					$this->template = "checkout_paid";
 
-				//BUG: Didn't apply template filter before it was being used in sendEmail()
-				$this->template = apply_filters("pmpro_email_template", $this->template, $this);
-
 				$this->data["invoice_id"] = $invoice->code;
 				$this->data["invoice_total"] = pmpro_formatPrice($invoice->total);
 				$this->data["invoice_date"] = date_i18n(get_option('date_format'), $invoice->timestamp);
@@ -302,6 +299,9 @@
 			else
 				$this->data["membership_expiration"] = "";
 			
+			//BUG: Didn't apply template filter before it was being used in sendEmail()
+			$this->template = apply_filters("pmpro_email_template", $this->template, $this);
+
 			return $this->sendEmail();
 		}
 		

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -376,10 +376,10 @@
 								if (jQuery('#level').length) {
 									var levelnums = jQuery("#level").val().split(",");
 									for(var cnt = 0, len = levelnums.length; cnt < len; cnt++) {
-										Stripe.createToken(args, stripeResponseHandler);
+										Stripe.createToken(args, pmpro_stripeResponseHandler);
 									}
 								} else {
-									Stripe.createToken(args, stripeResponseHandler);
+									Stripe.createToken(args, pmpro_stripeResponseHandler);
 								}
 									
 								// prevent the form from submitting with the default action							
@@ -391,7 +391,7 @@
 							});
 						});
 
-						function stripeResponseHandler(status, response) {
+						function pmpro_stripeResponseHandler(status, response) {
 							if (response.error) {
 								// re-enable the submit button
 								jQuery('.pmpro_btn-submit-checkout,.pmpro_btn-submit').removeAttr("disabled");


### PR DESCRIPTION
To avoid namespace collision, added a prefix to the Stripe Response
Handler. Addresses issue when other plug-ins are also invoking Stripe with the default handler.