### PR TITLE
BUG FIX: Ignored TrialBillingCycles value

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1551,7 +1551,7 @@
 					'when' => 'payment',
 					'billing_amount' => $order->PaymentAmount,
 					'cycle_period' => $order->BillingPeriod,
-					'cycle_number' => $order->BillingFrequency
+					'cycle_number' => $order->TrialBillingCycles
 				);
 
 				//now amount to equal the trial #s


### PR DESCRIPTION
When scheduling an update to a custom trial payment amount, the value supplied for the # of payment periods and used the Recurring Billing period value.