### PR TITLE
Fix markup of page title

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,4 +1,4 @@
-#Contribute to Paid Memberships Pro
+# Contribute to Paid Memberships Pro
 
 Paid Memberships Pro is the "community solution" for membership sites on WordPress, and so contributions of all kinds are appreciated.
 


### PR DESCRIPTION
Page title doesn't render correctly.
Add space between hash sign and text of page title