### PR TITLE
True in strict conditions on sanitize_user

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -216,7 +216,7 @@ if ( isset( $_REQUEST['discount_code'] ) ) {
 	$discount_code = "";
 }
 if ( isset( $_REQUEST['username'] ) ) {
-	$username = sanitize_user( $_REQUEST['username'] );
+	$username = sanitize_user( $_REQUEST['username'] , true);
 } else {
 	$username = "";
 }


### PR DESCRIPTION
If there are character like '+' in the username wordpress will remove that character in the insert_user. 