### PR TITLE
Fix 2checkout pmpro_after_checkout_update_consent

### DIFF
--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -494,7 +494,7 @@ function pmpro_after_checkout_update_consent( $user_id, $order ) {
 }
 add_action( 'pmpro_after_checkout', 'pmpro_after_checkout_update_consent', 10, 2 );
 add_action( 'pmpro_before_send_to_paypal_standard', 'pmpro_after_checkout_update_consent', 10, 2);
-add_action( 'pmpro_before_send_to_twocheckout', 'pmpro_after_checkout_update_consent' );
+add_action( 'pmpro_before_send_to_twocheckout', 'pmpro_after_checkout_update_consent', 10, 2);
 
 /**
  * Convert a consent entry into a English sentence.


### PR DESCRIPTION
Specify priority and number of arguments when pmpro_after_checkout_update_consent is installed as action. When this is not done, 2checkout flow errors with:

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function pmpro_after_checkout_update_consent(),
1 passed in /home/cpbotha/webapps/wp_vxuni/wp-includes/class-wp-hook.php on line 288 and
exactly 2 expected in /home/cpbotha/webapps/wp_vxuni/wp-content/plugins/paid-memberships-pro/includes/privacy.php:483
``