### PR TITLE
BUG FIX: Stripe API version showing at incorrect times

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -303,7 +303,7 @@
 			</td>
 		</tr>
 
-		<tr>
+		<tr class="gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>class="gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>>
 			<th><?php _e( 'Stripe API Version', 'paid-memberships-pro' ); ?>:</th>
 			<td><?php echo PMPRO_STRIPE_API_VERSION; ?></td>
 		</tr>


### PR DESCRIPTION
BUG FIX: Stripe API version showing all the time, added in conditional to only show on when Stripe is selected.