### PR TITLE
BUG FIX: Still showing Stripe ver for other GW

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -303,7 +303,7 @@
 			</td>
 		</tr>
 
-		<tr>
+		<tr class="gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>>
 			<th><?php _e( 'Stripe API Version', 'paid-memberships-pro' ); ?>:</th>
 			<td><?php echo PMPRO_STRIPE_API_VERSION; ?></td>
 		</tr>


### PR DESCRIPTION
Not hiding the Stripe version when displaying settings for gateways other than Stripe.com (thought there already was a bug fix for this, but it's still being displayed in master & dev branches)