### PR TITLE
Minor fixes for hiding Stripe Version

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -303,7 +303,7 @@
 			</td>
 		</tr>
 
-		<tr class="gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>class="gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_stripe" <?php if($gateway != "stripe") { ?>style="display: none;"<?php } ?>>
 			<th><?php _e( 'Stripe API Version', 'paid-memberships-pro' ); ?>:</th>
 			<td><?php echo PMPRO_STRIPE_API_VERSION; ?></td>
 		</tr>


### PR DESCRIPTION
There was an issue that it was duplicate logic code to hide the Stripe Version. Removed the duplicate code.