### PR TITLE
BUG FIX: remove Stripe billing limit warnings on membership levels page

### DIFF
--- a/adminpages/functions.php
+++ b/adminpages/functions.php
@@ -22,43 +22,10 @@
 	Checks if PMPro settings are complete or if there are any errors.
 	
 	Stripe currently does not support:
-	* Billing Limits.
+	[No current incompatibilities]
 */
 function pmpro_checkLevelForStripeCompatibility($level = NULL)
 {
-	$gateway = pmpro_getOption("gateway");
-	if($gateway == "stripe")
-	{
-		global $wpdb;
-
-		//check ALL the levels
-		if(empty($level))
-		{
-			$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels ORDER BY id ASC";
-			$levels = $wpdb->get_results($sqlQuery, OBJECT);
-			if(!empty($levels))
-			{
-				foreach($levels as $level)
-				{
-					if(!pmpro_checkLevelForStripeCompatibility($level))
-						return false;
-				}
-			}
-		}
-		else
-		{
-			//need to look it up?
-			if(is_numeric($level))
-				$level = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = %d LIMIT 1" , $level ) );
-
-			//check this level
-			if($level->billing_limit > 0)
-			{
-				return false;
-			}
-		}
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
When using Stripe, there used to be text that said you couldn't create a level with billing cycle limits. That warning was removed in commit 649bf536e9ffafd71ec0acef95ed789255a19425.

However, if billing limits are set on the membership level, an error message is displayed on the admin levels page as well as the admin page for the individual level in question.

Assuming the Stripe integration really does support billing cycle limits now, this warning is incorrect and can be removed.