### PR TITLE
Updating to use 'blocklist' and adding a deprecated file

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Deprecated hooks, filters and functions
+ *
+ * @since  2.0
+ */
+
+/**
+ * Handle renamed hooks
+ */
+global $pmpro_map_deprecated_hooks;
+
+$pmpro_map_deprecated_hooks = array(
+	'pmpro_getfile_extension_blocklist'    => 'pmpro_getfile_extension_blacklist',
+);
+
+// anonymous function used below is only supported in php 5.3+
+foreach ( $pmpro_map_deprecated_hooks as $new => $old ) {
+	// assumes hooks with no parameters
+	if ( version_compare( phpversion(), '5.3.0', '>=' ) ) {
+		// Using anonmyous functions for PHP 5.3+
+		$func = function() use ( $new, $old ) {
+			pmpro_maybe_show_deprecated_hook_message( $new, $old );
+		};
+	} else {
+		// Using create_function for PHP 5.2
+		$func = create_function( '', "pmpro_maybe_show_deprecated_hook_message( '$new', '$old' );" );
+	}
+	add_action( $new, $func );
+}
+
+function pmpro_maybe_show_deprecated_hook_message( $new, $old ) {
+	if ( has_filter( $old ) ) {
+		/* translators: 1: the old hook name, 2: the new or replacement hook name */
+		trigger_error( sprintf( esc_html__( 'The %1$s hook has been deprecated since version 2.0 of Paid Memberships Pro. Please use the %2$s hook instead.', 'paid-memberships-pro' ), $old, $new ) );
+		do_action( $old );
+	}
+}

--- a/services/getfile.php
+++ b/services/getfile.php
@@ -99,17 +99,17 @@
         die("File not found.");
 	}
 	
-	//if blacklistsed file type, redirect to it instead
+	//if blocklisted file type, redirect to it instead
 	$basename = basename($filename);
 	$parts = explode('.', $basename);
 	$ext = strtolower($parts[count($parts)-1]);
 	
-	//build blacklist and allow for filtering
-	$blacklist = array("inc", "php", "php3", "php4", "php5", "phps", "phtml");
-	$blacklist = apply_filters("pmpro_getfile_extension_blacklist", $blacklist);
-	
+	//build blocklist and allow for filtering
+	$blocklist = array("inc", "php", "php3", "php4", "php5", "phps", "phtml");
+	$blocklist = apply_filters("pmpro_getfile_extension_blocklist", $blocklist);
+
 	//check
-	if(in_array($ext, $blacklist))
+	if(in_array($ext, $blocklist))
 	{		
 		//add a noloop param to avoid infinite loops
 		$uri = add_query_arg("noloop", 1, $uri);


### PR DESCRIPTION
Updated getfile service to use "blocklist" instead of "blacklist". Create a new "deprecated" file for holding our no longer used actions.