### PR TITLE
Adding level meta option to include confirmation message in email

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -49,6 +49,10 @@
 		$ml_name = wp_kses(wp_unslash($_REQUEST['name']), $allowedposttags);
 		$ml_description = wp_kses(wp_unslash($_REQUEST['description']), $allowedposttags);
 		$ml_confirmation = wp_kses(wp_unslash($_REQUEST['confirmation']), $allowedposttags);
+		if(!empty($_REQUEST['confirmation_in_email']))
+			$ml_confirmation_in_email = 1;
+		else
+			$ml_confirmation_in_email = 0;
 
 		$ml_initial_payment = sanitize_text_field($_REQUEST['initial_payment']);
 		if(!empty($_REQUEST['recurring']))
@@ -130,7 +134,7 @@
 				'%d',		//allow_signups
 			)
 		);
-
+				
 		if($saveid < 1) {
 			//added a level
 			$saveid = $wpdb->insert_id;
@@ -162,6 +166,11 @@
 			}
 		}
 
+		// Update the Level Meta to Add Confirmation Message to Email.
+		if ( isset( $ml_confirmation_in_email ) ) {
+			update_pmpro_membership_level_meta( $saveid, 'confirmation_in_email', $ml_confirmation_in_email );
+		}
+		
 		do_action("pmpro_save_membership_level", $saveid);
 	}
 	elseif($action == "delete_membership_level")
@@ -310,6 +319,11 @@
 				) );
 			if(empty($level->categories))
 				$level->categories = array();
+			
+			// grab the meta for the given level...
+			if ( ! empty( $temp_id ) ) {
+				$confirmation_in_email = get_pmpro_membership_level_meta( $temp_id, 'confirmation_in_email', true );
+			}
 
 		?>
 		<form action="" method="post" enctype="multipart/form-data">
@@ -363,6 +377,7 @@
 							}
 						?>
 						</div>
+						<input id="confirmation_in_email" name="confirmation_in_email" type="checkbox" value="yes" <?php checked( $confirmation_in_email, 1); ?> /> <label for="confirmation_in_email"><?php _e('Check to include this message in the membership confiramtion email.', 'paid-memberships-pro' );?></label>
 					</td>
 				</tr>
 			</tbody>

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -214,6 +214,13 @@
 			
 			if(!$user)
 				return false;
+				
+			$confirmation_in_email = get_pmpro_membership_level_meta( $user->membership_level->id, 'confirmation_in_email', true );
+			if ( ! empty( $confirmation_in_email ) ) {
+				$confirmation_message = $user->membership_level->confirmation;
+			} else {
+				$confirmation_message = '';
+			}
 			
 			$this->email = $user->user_email;
 			$this->subject = sprintf(__("Your membership confirmation for %s", 'paid-memberships-pro' ), get_option("blogname"));	
@@ -226,6 +233,7 @@
 								"siteemail" => pmpro_getOption("from_email"),
 								"membership_id" => $user->membership_level->id,
 								"membership_level_name" => $user->membership_level->name,
+								"membership_level_confirmation_message" => $confirmation_message,
 								"membership_cost" => pmpro_getLevelCost($user->membership_level),								
 								"login_link" => wp_login_url(pmpro_url("account")),
 								"display_name" => $user->display_name,

--- a/email/checkout_check.html
+++ b/email/checkout_check.html
@@ -1,5 +1,7 @@
 <p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
 
+!!membership_level_confirmation_message!!
+
 !!instructions!!
 
 <p>Below are details about your membership account and a receipt for your initial membership invoice.</p>

--- a/email/checkout_express.html
+++ b/email/checkout_express.html
@@ -1,4 +1,5 @@
 <p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+!!membership_level_confirmation_message!!
 <p>Below are details about your membership account and a receipt for your initial membership invoice.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>

--- a/email/checkout_free.html
+++ b/email/checkout_free.html
@@ -1,4 +1,5 @@
 <p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+!!membership_level_confirmation_message!!
 <p>Below are details about your membership account.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>

--- a/email/checkout_freetrial.html
+++ b/email/checkout_freetrial.html
@@ -1,4 +1,5 @@
 <p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+!!membership_level_confirmation_message!!
 <p>Below are details about your membership account.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>

--- a/email/checkout_paid.html
+++ b/email/checkout_paid.html
@@ -1,4 +1,5 @@
 <p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+!!membership_level_confirmation_message!!
 <p>Below are details about your membership account and a receipt for your initial membership invoice.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>

--- a/email/checkout_trial.html
+++ b/email/checkout_trial.html
@@ -1,4 +1,5 @@
 <p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+!!membership_level_confirmation_message!!
 <p>Below are details about your membership account and a receipt for your initial membership invoice.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>


### PR DESCRIPTION
Updates the email class and email templates to respect the level setting and include the confirmation message if set.