### PR TITLE
Hide 'couponamount' in order edit and order csv export

### DIFF
--- a/adminpages/orders-csv.php
+++ b/adminpages/orders-csv.php
@@ -330,6 +330,14 @@ $default_columns = array(
 	array( "discount_code", "code" )
 );
 
+// Hiding couponamount by default.
+$coupons = apply_filters( 'pmpro_orders_show_coupon_amounts', false );
+if ( empty( $coupons ) ) {
+	$csv_file_header_array = array_diff( $csv_file_header_array, array( 'couponamount' ) );
+	$couponamount_array_key = array_keys( $default_columns, array( 'order', 'couponamount' ) );
+	unset( $default_columns[ $couponamount_array_key[0] ] );
+}
+
 $default_columns = apply_filters( "pmpro_order_list_csv_default_columns", $default_columns );
 
 $csv_file_header_array = apply_filters( "pmpro_order_list_csv_export_header_array", $csv_file_header_array );

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -243,9 +243,15 @@ if ( ! empty( $_REQUEST['save'] ) ) {
 	if ( ! in_array( 'tax', $read_only_fields ) && isset( $_POST['tax'] ) ) {
 		$order->tax = sanitize_text_field( $_POST['tax'] );
 	}
-	if ( ! in_array( 'couponamount', $read_only_fields ) && isset( $_POST['couponamount'] ) ) {
-		$order->couponamount = sanitize_text_field( $_POST['couponamount'] );
+
+	// Hiding couponamount by default.
+	$coupons = apply_filters( 'pmpro_orders_show_coupon_amounts', false );
+	if ( ! empty( $coupons ) ) {
+		if ( ! in_array( 'couponamount', $read_only_fields ) && isset( $_POST['couponamount'] ) ) {
+			$order->couponamount = sanitize_text_field( $_POST['couponamount'] );
+		}
 	}
+
 	if ( ! in_array( 'total', $read_only_fields ) && isset( $_POST['total'] ) ) {
 		$order->total = sanitize_text_field( $_POST['total'] );
 	}
@@ -608,20 +614,27 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' );
 					<?php } ?>
 				</td>
 			</tr>
-			<tr>
-				<th scope="row" valign="top"><label for="couponamount"><?php _e( 'Coupon Amount', 'paid-memberships-pro' ); ?>:</label>
-				</th>
-				<td>
-					<?php
-					if ( in_array( 'couponamount', $read_only_fields ) && $order_id > 0 ) {
-						echo $order->couponamount;
-					} else {
-										?>
-											<input id="couponamount" name="couponamount" type="text" size="10"
-												   value="<?php echo esc_attr( $order->couponamount ); ?>"/>
-					<?php } ?>
-				</td>
-			</tr>
+			<?php
+				// Hiding couponamount by default.
+				$coupons = apply_filters( 'pmpro_orders_show_coupon_amounts', false );
+				if ( ! empty( $coupons ) ) { ?>
+				<tr>
+					<th scope="row" valign="top"><label for="couponamount"><?php _e( 'Coupon Amount', 'paid-memberships-pro' ); ?>:</label>
+					</th>
+					<td>
+						<?php
+						if ( in_array( 'couponamount', $read_only_fields ) && $order_id > 0 ) {
+							echo $order->couponamount;
+						} else {
+											?>
+												<input id="couponamount" name="couponamount" type="text" size="10"
+													   value="<?php echo esc_attr( $order->couponamount ); ?>"/>
+						<?php } ?>
+					</td>
+				</tr>
+				<?php
+				}
+			?>
 			<tr>
 				<th scope="row" valign="top"><label for="total"><?php _e( 'Total', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
@@ -633,8 +646,6 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' );
 											<input id="total" name="total" type="text" size="10"
 												   value="<?php echo esc_attr( $order->total ); ?>"/>
 					<?php } ?>
-					<small
-						class="pmpro_lite"><?php _e( 'Should be subtotal + tax - couponamount.', 'paid-memberships-pro' ); ?></small>
 				</td>
 			</tr>
 


### PR DESCRIPTION
Added filter 'pmpro_orders_show_coupon_amounts' to allow site to reenable these fields.