### PR TITLE
BUG: Incorrect timestamp was being saved for invoices and orders if t…

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -619,7 +619,7 @@
 				$this->gateway_environment = pmpro_getOption("gateway_environment");
 
 			if(empty($this->datetime) && empty($this->timestamp))
-				$this->datetime = date("Y-m-d H:i:s", current_time("timestamp"));		//use current time
+				$this->datetime = date("Y-m-d H:i:s", time());
 			elseif(empty($this->datetime) && !empty($this->timestamp) && is_numeric($this->timestamp))
 				$this->datetime = date("Y-m-d H:i:s", $this->timestamp);	//get datetime from timestamp
 			elseif(empty($this->datetime) && !empty($this->timestamp))


### PR DESCRIPTION
…imezone was different than UTC.

This is because we were using `current_time("timezone")` which will save the incorrect UNIX timestamp if a time zone other than UTC is set. Replacing it with the PHP `time()` function fixes the issue. It is also in line with WordPress recommendation:

https://codex.wordpress.org/Function_Reference/current_time