### PR TITLE
Bug Fix Cancel email data.

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -142,7 +142,7 @@
 			$this->email = $user->user_email;
 			$this->subject = sprintf(__('Your membership at %s has been CANCELLED', 'paid-memberships-pro'), get_option("blogname"));
 
-			$this->data = array("name" => $user->display_name, "user_login" => $user->user_login, "sitename" => get_option("blogname"), "siteemail" => pmpro_getOption("from_email"));
+			$this->data = array("user_email" => $user->user_email, "display_name" => $user->display_name, "user_login" => $user->user_login, "sitename" => get_option("blogname"), "siteemail" => pmpro_getOption("from_email"));
 
 			if(!empty($old_level_id)) {
 				if(!is_array($old_level_id))


### PR DESCRIPTION
Use "display_name" and "user_email" in the array. The cancel email template is using this fields, but the sendCancelEmail method isn't.
To avoid that the email contains !!display_name!! (!!user_email!!) I include those in the data array.