### PR TITLE
Allow dequeueing of jquery.creditCardValidator on billing page

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -34,11 +34,11 @@ if (empty($user_order->gateway)) {
 // Set the gateway, ideally using the gateway used to pay for the last order (if it exists)
 $gateway = !empty( $user_order->gateway ) ? $user_order->gateway : pmpro_getOption("gateway");
 
-//action to run extra code for gateways/etc
-do_action( 'pmpro_billing_preheader' );
-
 //enqueue some scripts
 wp_enqueue_script( 'jquery.creditCardValidator', plugins_url( '/js/jquery.creditCardValidator.js', dirname( __FILE__ ) ), array( 'jquery' ) );
+
+//action to run extra code for gateways/etc
+do_action( 'pmpro_billing_preheader' );
 
 //_x stuff in case they clicked on the image button with their mouse
 if (isset($_REQUEST['update-billing']))


### PR DESCRIPTION
Move the `wp_euqueue_script` call to before `do_action( 'pmpro_billing_preheader')` so we can use that action to dequeue the script. Use case is replacing the form on the page with a custom form that has its own validation.

**NOTE:** In the checkout preheader, the action already comes after enqueueing the script.