### PR TITLE
ENHANCEMENT: Cache user levels to reduce MySQL queries

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1082,6 +1082,10 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	// remove cached level
 	global $all_membership_levels;
 	unset( $all_membership_levels[ $user_id ] );
+	
+	// remove levels cache for user
+	$cache_key = 'user_' . $user_id . '_levels';
+	wp_cache_delete( $cache_key, 'pmpro' );
 
 	// update user data and call action
 	pmpro_set_current_user();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1797,6 +1797,13 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 
 	global $wpdb;
 	
+	/**
+	 * We are going to see if cache is set before doing the query and use that if it is.
+	 * 
+	 * In a default environment with no external object cache, the value is cached in that request and
+	 * reduces future MySQL requests. If there is an external object cache like Redis then it will be
+	 * persisted until the user level changes.
+	 **/
 	$cache_key = 'user_' . $user_id . '_levels';
     	$levels = wp_cache_get( $cache_key, 'pmpro' );
 	
@@ -1825,7 +1832,7 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 								WHERE mu.user_id = $user_id" . ( $include_inactive ? '' : " AND mu.status = 'active'
 								GROUP BY ID" )
 		);
-		wp_cache_set( $cache_key, $levels, 'pmpro', DAY_IN_SECONDS );
+		wp_cache_set( $cache_key, $levels, 'pmpro' );
 	}
 	
 	// Round off prices


### PR DESCRIPTION
We have a site that is firing off this specific function multiple times (I haven't done a trace but I assume it's because there is a large number of "posts" on the page and it's checking members level for each one).

This is just a quick solution to reduce those queries and is limited to each request if there is no persistent object cache and will be persisted if there is (making future references quicker as well).

I set expiration to one day but it might need to be shorter depending on your opinion of how often levels change.