### PR TITLE
Updating action to use $morder; Fixing action misspelling

### DIFF
--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -460,7 +460,8 @@
 	function pmpro_insRecurringStopped( $morder ) {
 		global $pmpro_error;
 		//hook to do other stuff when payments stop
-		do_action("pmpro_subscription_recuring_stopped", $last_order);
+		do_action( 'pmpro_subscription_recuring_stopped', $morder );
+		do_action( 'pmpro_subscription_recurring_stopped', $morder);
 
 		$worked = pmpro_changeMembershipLevel( false, $morder->user->ID , 'inactive');
 		if( $worked === true ) {
@@ -492,7 +493,8 @@
 	function pmpro_insRecurringRestarted( $morder ) {
 		global $pmpro_error;
 		//hook to do other stuff when payments restart
-		do_action("pmpro_subscription_recuring_restarted", $last_order);
+		do_action( 'pmpro_subscription_recuring_restarted', $morder);
+		do_action( 'pmpro_subscription_recurring_restarted', $morder);
 
 		$worked = pmpro_changeMembershipLevel( $morder->membership_level->id, $morder->user->ID );
 		if( $worked === true ) {


### PR DESCRIPTION
Updated the `pmpro_subscription_recuring_stopped` and `pmpro_subscription_recuring_restarted` actions to filter the $morder (not the $last_order which isn't passed to the function). Added a duplicate action to correct the spelling of "recurring". 

We will need to deprecate this incorrect filter name and remove eventually. See issue: https://github.com/strangerstudios/paid-memberships-pro/issues/942