### PR TITLE
BUG FIX/ENHANCEMENT: Added pmpro_checkout_preheader_before_get_level_…

### DIFF
--- a/includes/sessions.php
+++ b/includes/sessions.php
@@ -29,7 +29,7 @@ function pmpro_start_session() {
 	}
 }
 
-add_action( 'pmpro_checkout_preheader', 'pmpro_start_session', -1 );
+add_action( 'pmpro_checkout_preheader_before_get_level_at_checkout', 'pmpro_start_session', -1 );
 
 /**
  * Close the session object for new updates

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -11,7 +11,7 @@ if (! is_user_logged_in()) {
 }
 
 //need to be secure?
-global $besecure, $show_paypal_link;
+global $besecure, $gateway, $show_paypal_link;
 $user_order = new MemberOrder();
 $user_order->getLastMemberOrder( null, array( 'success', 'pending' ) );
 if (empty($user_order->gateway)) {

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -13,7 +13,7 @@ if (! is_user_logged_in()) {
 //need to be secure?
 global $besecure, $show_paypal_link;
 $user_order = new MemberOrder();
-$user_order->getLastMemberOrder();
+$user_order->getLastMemberOrder( null, array( 'success', 'pending' ) );
 if (empty($user_order->gateway)) {
     //no order
     $besecure = false;

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -35,8 +35,22 @@ if ( ! in_array( $gateway, $valid_gateways ) ) {
 	$pmpro_msgt = "pmpro_error";
 }
 
+/**
+ * Action to run extra preheader code before setting checkout level.
+ *
+ * @since 2.0.5
+ */
+do_action( 'pmpro_checkout_preheader_before_get_level_at_checkout' );
+
 //what level are they purchasing? (discount code passed)
 $pmpro_level = pmpro_getLevelAtCheckout();
+
+/**
+ * Action to run extra preheader code after setting checkout level.
+ *
+ * @since 2.0.5
+ */
+do_action( 'pmpro_checkout_preheader_after_get_level_at_checkout' );
 
 if ( empty( $pmpro_level->id ) ) {
 	wp_redirect( pmpro_url( "levels" ) );

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,9 @@ Not sure? You can find out by doing a bit a research.
 
 == Changelog ==
 
+= 2.0.5 =
+* BUG FIX/ENHANCEMENT: Added pmpro_checkout_preheader_before_get_level_at_checkout and pmpro_checkout_preheader_after_get_level_at_checkout action hooks. Using pmpro_checkout_preheader_before_get_level_at_checkout to start the session earlier now.
+
 = 2.0.4 - 2019-01-14 =
 * BUG FIX: Fixed warning in code added in 2.0.3 that could cause issues at checkout.
 * BUG FIX: Setting priority of pmpro_check_admin_capabilities to 5 to ensure it runs before dashboard redirect.

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ Not sure? You can find out by doing a bit a research.
 == Changelog ==
 
 = 2.0.5 =
+* BUG FIX/ENHANCEMENT: Now searching for the last order with "success" or "pending" status on the Billing page.
 * BUG FIX/ENHANCEMENT: Added pmpro_checkout_preheader_before_get_level_at_checkout and pmpro_checkout_preheader_after_get_level_at_checkout action hooks. Using pmpro_checkout_preheader_before_get_level_at_checkout to start the session earlier now.
 
 = 2.0.4 - 2019-01-14 =


### PR DESCRIPTION
…at_checkout and pmpro_checkout_preheader_after_get_level_at_checkout action hooks. Using pmpro_checkout_preheader_before_get_level_at_checkout to start the session earlier now.