### PR TITLE
ENHANCEMENT: pmpro_gateway_change_subscription_delay

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1591,7 +1591,7 @@
                     "amount" => $amount * $currency_unit_multiplier,
                     "interval_count" => $order->BillingFrequency,
                     "interval" => strtolower($order->BillingPeriod),
-                    "trial_period_days" => $trial_period_days,
+                    "trial_period_days" => apply_filters( 'pmpro_gateway_change_subscription_delay', $trial_period_days, $order ), 
                     "name" => $order->membership_name . " for order " . $order->code,
                     "currency" => strtolower($pmpro_currency),
                     "id" => $order->code


### PR DESCRIPTION
Add filter to let programmer change the duration of the plan 'trial' (i.e. time until first payment from the plan). Can be used by the Subscription Delay add-on to ensure billing happens on the same date even when the specified delay value is prior to the current date.