### PR TITLE
Preventing double cancellations of Stripe subscriptions.

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1827,6 +1827,7 @@
 				$subscription = $this->getSubscription($order);
 
 				if(!empty($subscription) 
+				        && empty( $subscription->canceled_at )
 					&& ( empty( $pmpro_stripe_event ) || empty( $pmpro_stripe_event->type ) || $pmpro_stripe_event->type != 'customer.subscription.deleted' ) )
 				{
 					if($this->cancelSubscriptionAtGateway($subscription))


### PR DESCRIPTION
cancelSubscriptionAtGateway() was being called from Stripe's pmpro_checkout_before_processing() code first and then later during pmpro_changeMembershipLevel().

There may be a better way to fix this like enabling and disabling the pmpro_cancel_previous_subscriptions filter before and after membership level change, but this fix patched it on a support user's site.