### PR TITLE
PayPal Express 7.2.0 bug fix.

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -540,10 +540,12 @@ $pmpro_confirmed_data = apply_filters( 'pmpro_checkout_confirmed', $pmpro_confir
  */
 if ( is_array( $pmpro_confirmed_data ) ) {
 	extract( $pmpro_confirmed_data );
+} else {
+	$pmpro_confirmed = $pmpro_confirmed_data;
 }
 
 //if payment was confirmed create/update the user.
-if ( ! empty( $pmpro_confirmed_data ) ) {
+if ( ! empty( $pmpro_confirmed ) ) {
 	//just in case this hasn't been set yet
 	$submit = true;
 

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -533,13 +533,17 @@ if ( empty( $morder ) ) {
 }
 
 //Hook to check payment confirmation or replace it. If we get an array back, pull the values (morder) out
-$pmpro_confirmed = apply_filters( 'pmpro_checkout_confirmed', $pmpro_confirmed, $morder );
-if ( is_array( $pmpro_confirmed ) ) {
-	extract( $pmpro_confirmed );
+$pmpro_confirmed_data = apply_filters( 'pmpro_checkout_confirmed', $pmpro_confirmed, $morder );
+
+/**
+ * @todo Refactor this to avoid using extract.
+ */
+if ( is_array( $pmpro_confirmed_data ) ) {
+	extract( $pmpro_confirmeddata );
 }
 
 //if payment was confirmed create/update the user.
-if ( ! empty( $pmpro_confirmed ) ) {
+if ( ! empty( $pmpro_confirmed_data ) ) {
 	//just in case this hasn't been set yet
 	$submit = true;
 

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -539,7 +539,7 @@ $pmpro_confirmed_data = apply_filters( 'pmpro_checkout_confirmed', $pmpro_confir
  * @todo Refactor this to avoid using extract.
  */
 if ( is_array( $pmpro_confirmed_data ) ) {
-	extract( $pmpro_confirmeddata );
+	extract( $pmpro_confirmed_data );
 }
 
 //if payment was confirmed create/update the user.


### PR DESCRIPTION
PHP 7.2.0 was causing issues with the `$pmpro_confirmed` variable.

Temporarily fix this by renaming the $pmpro_confirmed variable with the extract call.