### PR TITLE
removed 'membership_code' from attribute.

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -26,7 +26,6 @@ function pmpro_member_shortcode($atts, $content=null, $code='')
 		'membership_name',
 		'membership_description',
 		'membership_confirmation',
-		'membership_code_id',
 		'membership_initial_payment',
 		'membership_billing_amount',
 		'membership_cycle_number',

--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -24,8 +24,9 @@ function pmpro_member_shortcode($atts, $content=null, $code='')
 	$pmpro_level_fields = array(
 		'membership_id',
 		'membership_name',
+		'membership_description',
+		'membership_confirmation',
 		'membership_code_id',
-		'membership_code',
 		'membership_initial_payment',
 		'membership_billing_amount',
 		'membership_cycle_number',


### PR DESCRIPTION
Bug Fix: Removed the "membership_code" attribute from the `[pmpro_member]` as it was non existent in our getmembershiplevelforuser call.

ENHANCEMENT: added membership_description and membership_confirmation attributes in the shortcode. This may be useful for users.