### PR TITLE
Adjusting placement of divider hr on checkout page for consistency.

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -164,8 +164,8 @@
 	?>
 
 	<?php if(!$skip_account_fields && !$pmpro_review) { ?>
-	<hr />
 	<div id="pmpro_user_fields" class="pmpro_checkout">
+		<hr />
 		<h3>
 			<span class="pmpro_checkout-h3-name"><?php _e('Account Information', 'paid-memberships-pro' );?></span>
 			<span class="pmpro_checkout-h3-msg"><?php _e('Already have an account?', 'paid-memberships-pro' );?> <a href="<?php echo wp_login_url(pmpro_url("checkout", "?level=" . $pmpro_level->id)); ?>"><?php _e('Log in here', 'paid-memberships-pro' );?></a></span>


### PR DESCRIPTION
One of the dividers on the checkout page was outside the checkout section. I moved this for consistency and to make sure that you can target and hide or adjust these dividers using CSS and the box it contains.