### PR TITLE
Turn off autocomplete for honeypot.

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -224,7 +224,7 @@
 
 			<div class="pmpro_hidden">
 				<label for="fullname"><?php _e('Full Name', 'paid-memberships-pro' );?></label>
-				<input id="fullname" name="fullname" type="text" class="input <?php echo pmpro_getClassForField("fullname");?>" size="30" value="" /> <strong><?php _e('LEAVE THIS BLANK', 'paid-memberships-pro' );?></strong>
+				<input id="fullname" name="fullname" type="text" class="input <?php echo pmpro_getClassForField("fullname");?>" size="30" value="" autocomplete="off"/> <strong><?php _e('LEAVE THIS BLANK', 'paid-memberships-pro' );?></strong>
 			</div> <!-- end pmpro_hidden -->
 
 			<div class="pmpro_checkout-field pmpro_captcha">


### PR DESCRIPTION
Turn off autocomplete for honeypot. Currently we don't get a report of a lot of spam and it seems that Chrome now supports autocomplete properly.

We should look at improving this in the future to work with timestamps.

Issue: https://github.com/strangerstudios/paid-memberships-pro/issues/893