### PR TITLE
ENHANCEMENT: Support Up to 8 Decimal Places

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2459,6 +2459,8 @@ function pmpro_formatPrice( $price ) {
 		$formatted = $pmpro_currency_symbol . number_format( $formatted, pmpro_get_decimal_place() );
 	}
 
+	$formatted = rtrim( $formatted, 0 );
+
 	// filter
 	return apply_filters( 'pmpro_format_price', $formatted, $price, $pmpro_currency, $pmpro_currency_symbol );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2443,7 +2443,7 @@ function pmpro_formatPrice( $price ) {
 		// format number do decimals, with decimal_separator and thousands_separator
 		$formatted = number_format(
 			$formatted,
-			( isset( $pmpro_currencies[ $pmpro_currency ]['decimals'] ) ? (int) $pmpro_currencies[ $pmpro_currency ]['decimals'] : 2 ),
+			( isset( $pmpro_currencies[ $pmpro_currency ]['decimals'] ) ? (int) $pmpro_currencies[ $pmpro_currency ]['decimals'] : pmpro_get_decimal_place() ),
 			( isset( $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] ) ? $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] : '.' ),
 			( isset( $pmpro_currencies[ $pmpro_currency ]['thousands_separator'] ) ? $pmpro_currencies[ $pmpro_currency ]['thousands_separator'] : ',' )
 		);
@@ -2456,13 +2456,27 @@ function pmpro_formatPrice( $price ) {
 		}
 	} else {
 		// default to symbol on the left, 2 decimals using . and ,
-		$formatted = $pmpro_currency_symbol . number_format( $formatted, 2 );
+		$formatted = $pmpro_currency_symbol . number_format( $formatted, pmpro_get_decimal_place() );
 	}
 
 	// filter
 	return apply_filters( 'pmpro_format_price', $formatted, $price, $pmpro_currency, $pmpro_currency_symbol );
 }
 
+/**
+ * Allow users to adjust the allowed decimal places.
+ * @since 2.1
+ */
+function pmpro_get_decimal_place() {
+	// filter this to support different decimal places.
+	$decimal_place = apply_filters( 'pmpro_decimal_places', 2 );
+
+	if ( intval( $decimal_place ) > 8 ) {
+		$decimal_place = 8;
+	}
+
+	return $decimal_place;
+}
 /**
  * Which side does the currency symbol go on?
  *
@@ -2487,7 +2501,7 @@ function pmpro_getCurrencyPosition() {
  */
 function pmpro_round_price( $price, $currency = '' ) {
 	global $pmpro_currency, $pmpro_currencies;
-	$decimals = 2;
+	$decimals = pmpro_get_decimal_place();
 
 	if ( '' === $currency && ! empty( $pmpro_currencies[ $pmpro_currency ] ) ) {
 		$currency = $pmpro_currency;

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -225,6 +225,13 @@ function pmpro_checkForUpgrades()
 		$pmpro_db_version = '1.944';
 		pmpro_setOption('db_version', '1.944');
 	}
+
+	if ( $pmpro_db_version < 2.1 ) {
+		pmpro_db_delta();
+
+		$pmpro_db_version = 2.1;
+		pmpro_setOption( 'db_version', '2.1' );
+	}
 }
 
 function pmpro_db_delta()
@@ -250,12 +257,12 @@ function pmpro_db_delta()
 		  `name` varchar(255) NOT NULL,
 		  `description` longtext NOT NULL,
 		  `confirmation` longtext NOT NULL,
-		  `initial_payment` decimal(10,2) NOT NULL DEFAULT '0.00',
-		  `billing_amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+		  `initial_payment` decimal(18,8) NOT NULL DEFAULT '0.00',
+		  `billing_amount` decimal(18,8) NOT NULL DEFAULT '0.00',
 		  `cycle_number` int(11) NOT NULL DEFAULT '0',
 		  `cycle_period` enum('Day','Week','Month','Year') DEFAULT 'Month',
 		  `billing_limit` int(11) NOT NULL COMMENT 'After how many cycles should billing stop?',
-		  `trial_amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+		  `trial_amount` decimal(18,8) NOT NULL DEFAULT '0.00',
 		  `trial_limit` int(11) NOT NULL DEFAULT '0',
 		  `allow_signups` tinyint(4) NOT NULL DEFAULT '1',
 		  `expiration_number` int(10) unsigned NOT NULL,
@@ -354,12 +361,12 @@ function pmpro_db_delta()
 		   `user_id` int(11) unsigned NOT NULL,
 		   `membership_id` int(11) unsigned NOT NULL,
 		   `code_id` int(11) unsigned NOT NULL,
-		   `initial_payment` decimal(10,2) NOT NULL,
-		   `billing_amount` decimal(10,2) NOT NULL,
+		   `initial_payment` decimal(18,8) NOT NULL,
+		   `billing_amount` decimal(18,8) NOT NULL,
 		   `cycle_number` int(11) NOT NULL,
 		   `cycle_period` enum('Day','Week','Month','Year') NOT NULL DEFAULT 'Month',
 		   `billing_limit` int(11) NOT NULL,
-		   `trial_amount` decimal(10,2) NOT NULL,
+		   `trial_amount` decimal(18,8) NOT NULL,
 		   `trial_limit` int(11) NOT NULL,
 		   `status` varchar(20) NOT NULL DEFAULT 'active',
 		   `startdate` datetime NOT NULL,
@@ -397,12 +404,12 @@ function pmpro_db_delta()
 		CREATE TABLE `" . $wpdb->pmpro_discount_codes_levels . "` (
 		  `code_id` int(11) unsigned NOT NULL,
 		  `level_id` int(11) unsigned NOT NULL,
-		  `initial_payment` decimal(10,2) NOT NULL DEFAULT '0.00',
-		  `billing_amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+		  `initial_payment` decimal(18,8) NOT NULL DEFAULT '0.00',
+		  `billing_amount` decimal(18,8) NOT NULL DEFAULT '0.00',
 		  `cycle_number` int(11) NOT NULL DEFAULT '0',
 		  `cycle_period` enum('Day','Week','Month','Year') DEFAULT 'Month',
 		  `billing_limit` int(11) NOT NULL COMMENT 'After how many cycles should billing stop?',
-		  `trial_amount` decimal(10,2) NOT NULL DEFAULT '0.00',
+		  `trial_amount` decimal(18,8) NOT NULL DEFAULT '0.00',
 		  `trial_limit` int(11) NOT NULL DEFAULT '0',
 		  `expiration_number` int(10) unsigned NOT NULL,
 		  `expiration_period` enum('Day','Week','Month','Year') NOT NULL,


### PR DESCRIPTION
ENHANCEMENT: Added support for up to 8 decimal places. This trims any trailing 0's from the amount. For example if you have `5.021000` It would show as `5.021`.

ENHANCEMENT: Filter the decimal places using `pmpro_decimal_places`, this defaults to 2 and max value is 8.

This also updates the database decimal places automatically to 8 decimals.