### PR TITLE
Adjust gateway name for only free levels.

### DIFF
--- a/adminpages/admin_header.php
+++ b/adminpages/admin_header.php
@@ -25,7 +25,7 @@
 			$msgt .= " <a href=\"" . admin_url('admin.php?page=pmpro-membershiplevels&edit=-1') . "\">" . __("Add a membership level to get started.", 'paid-memberships-pro' ) . "</a>";
 		elseif($pmpro_level_ready && !$pmpro_pages_ready && $view != "pmpro-pagesettings")
 			$msgt .= " <strong>" . __( 'Next step:', 'paid-memberships-pro' ) . "</strong> <a href=\"" . admin_url('admin.php?page=pmpro-pagesettings') . "\">" . __("Set up the membership pages", 'paid-memberships-pro' ) . "</a>.";
-		elseif($pmpro_level_ready && $pmpro_pages_ready && !$pmpro_gateway_ready && $view != "pmpro-paymentsettings")
+		elseif($pmpro_level_ready && $pmpro_pages_ready && !$pmpro_gateway_ready && $view != "pmpro-paymentsettings" && ! pmpro_onlyFreeLevels())
 			$msgt .= " <strong>" . __( 'Next step:', 'paid-memberships-pro' ) . "</strong> <a href=\"" . admin_url('admin.php?page=pmpro-paymentsettings') . "\">" . __("Set up your SSL certificate and payment gateway", 'paid-memberships-pro' ) . "</a>.";
 
 		if(empty($msgt))

--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -134,7 +134,9 @@
 							}
 						?>
 					</select>
-					<div id='pmpro-default-gateway-message' style="display:none;"><small><?php echo __( 'This gateway is for membership sites with Free levels or for sites that accept payment offline.', 'paid-memberships-pro' ) . '<br/>' . __( 'It is not connected to a live gateway environment and cannot accept payments.', 'paid-memberships-pro' ); ?></small></div>
+					<?php if( pmpro_onlyFreeLevels() ) { ?>
+						<div id='pmpro-default-gateway-message' style="display:none;"><small><?php echo __( 'This gateway is for membership sites with Free levels or for sites that accept payment offline.', 'paid-memberships-pro' ) . '<br/>' . __( 'It is not connected to a live gateway environment and cannot accept payments.', 'paid-memberships-pro' ); ?></small></div>
+					<?php } ?>
 				</td>
 			</tr>
 			<tr>

--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -134,6 +134,7 @@
 							}
 						?>
 					</select>
+					<div id='pmpro-default-gateway-message' style="display:none;"><small><?php echo __( 'This gateway is for membership sites with Free levels or for sites that accept payment offline.', 'paid-memberships-pro' ) . '<br/>' . __( 'It is not connected to a live gateway environment and cannot accept payments.', 'paid-memberships-pro' ); ?></small></div>
 				</td>
 			</tr>
 			<tr>
@@ -151,6 +152,12 @@
 							//hide all gateway options
 							jQuery('tr.gateway').hide();
 							jQuery('tr.gateway_'+gateway).show();
+
+							if ( jQuery('#gateway').val() === '' ) {
+								jQuery('#pmpro-default-gateway-message').show();
+							} else {
+								jQuery('#pmpro-default-gateway-message').hide();
+							}
 						}
 						pmpro_changeGateway(jQuery('#gateway').val());
 					</script>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -184,6 +184,19 @@ function pmpro_areLevelsFree( $levelarr ) {
 	return true;
 }
 
+/**
+ * Check to see if only free levels are available.
+ * @return boolean This will return true if only free levels are available for signup.
+ * @internal Creates a filter 'pmpro_only_free_levels'.
+ * @since 2.1
+ */
+function pmpro_onlyFreeLevels() {
+	// Get levels that are available for checkout only.
+	$levels = pmpro_getAllLevels( false, true );
+	
+	return apply_filters( 'pmpro_only_free_levels', pmpro_areLevelsFree( $levels ) );
+}
+
 function pmpro_isLevelRecurring( &$level ) {
 	if ( ! empty( $level ) && ( $level->billing_amount > 0 || $level->trial_amount > 0 ) ) {
 		return true;

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -155,6 +155,10 @@ function pmpro_gateways() {
 		'cybersource'       => __( 'Cybersource', 'paid-memberships-pro' ),
 	);
 
+	if ( pmpro_onlyFreeLevels() ) {
+		$pmpro_gateways[''] = __( 'Default', 'paid-memberships-pro' );
+	}
+
 	return apply_filters( 'pmpro_gateways', $pmpro_gateways );
 }
 


### PR DESCRIPTION
This will adjust the "Testing Only" gateway to "Default" if there are only free levels available for signup.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This will change the gateway name to "Default" if only free levels are available for signup. This will help reduce confusion when running a free membership level site.

Closes Issue: https://github.com/strangerstudios/paid-memberships-pro/issues/897

### How to test the changes in this Pull Request:

1. Ensure only 'free' levels are available for new signups.
2. The gateway name should change to "Default" and the notification about "SSL & Payment gateway" should disappear.
3. Enabling non-free levels for new signups should revert back the gateway name to "Testing Only" and show the "SSL & Payment gateway" notification in the admin area.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Enhancement: This changes the "Testing Only" gateway name to "Default" if a memberships site only has free levels available for signup.

Enhancement: Added in the filter 'pmpro_only_free_levels' which accepts a Boolean. This allows developers to overwrite this function results as needed.