### PR TITLE
fixing membership stats sql

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -186,7 +186,7 @@ function pmpro_report_memberships_page()
 	if($period == "daily")
 	{
 		$startdate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-01';
-		$enddate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-32';
+		$enddate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-31';
 		$date_function = 'DAY';
 	}
 	elseif($period == "monthly")
@@ -221,7 +221,7 @@ function pmpro_report_memberships_page()
 		$sqlQuery .= "WHERE mu.startdate >= '" . esc_sql( $startdate ) . "' ";
 
 		if ( ! empty( $enddate ) ) {
-			$sqlQuery .= "AND mu.startdate < '" . esc_sql( $enddate ) . "' ";
+			$sqlQuery .= "AND mu.startdate <= '" . esc_sql( $enddate ) . "' ";
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ X ] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [ X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? 

### Changes proposed in this Pull Request:

Fixing bad SQL that was causing daily Membership Report to not populate. See https://github.com/strangerstudios/paid-memberships-pro/commit/03c20e7d57fabb479530b681adf4baeff71c0222 for a similar fix applied to the Sales report.

### How to test the changes in this Pull Request:

-Go to Membership Stats report.
-Change period to "Daily", month to current month, then click Generate Report.
-Stats for the current period (in daily view) will be inaccurate or missing.

### Other information:

* [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X ] Have you successfully run tests with your changes locally?

### Changelog entry

BUGFIX: Fixed an issue with Membership Stats Report that was causing daily reports to not show up properly.