### PR TITLE
Updating Expiration Date to pull data for invoice user not current_user.

### DIFF
--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -27,8 +27,8 @@
 			<li><strong><?php _e('Account', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->user->display_name?> (<?php echo $pmpro_invoice->user->user_email?>)</li>
 			<li><strong><?php _e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->membership_level->name?></li>
 			<li><strong><?php _e('Status', 'paid-memberships-pro' ); ?>:</strong> <?php echo ! empty( $pmpro_invoice->status ) ? $pmpro_invoice->status : __( 'success', 'paid-memberships-pro' ); ?></li>
-			<?php if($current_user->membership_level->enddate) { ?>
-				<li><strong><?php _e('Membership Expires', 'paid-memberships-pro' );?>:</strong> <?php echo date_i18n(get_option('date_format'), $current_user->membership_level->enddate)?></li>
+			<?php if($pmpro_invoice->membership_level->enddate) { ?>
+				<li><strong><?php _e('Membership Expires', 'paid-memberships-pro' );?>:</strong> <?php echo date_i18n(get_option('date_format'), $pmpro_invoice->membership_level->enddate)?></li>
 			<?php } ?>
 			<?php if($pmpro_invoice->getDiscountCode()) { ?>
 				<li><strong><?php _e('Discount Code', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->discount_code->code?></li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Updating the membership invoice frontend page to pull expiration date from the invoice user.

Closes Issue: #1018.

### How to test the changes in this Pull Request:

1. Set expiration date on a user
2. View an invoice on the frontend.
3. See their correct expiration date on the invoice. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
BUG FIX: Showing invoice user's expiration date not the current_user so that administrator or membership manager can view accurate invoices on the frontend.