### PR TITLE
Trim trailing zeroes for numbers with long decimal places

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2458,18 +2458,23 @@ function pmpro_formatPrice( $price ) {
 	// start with the rounded price
 	$formatted = pmpro_round_price( $price );
 
+	$decimals = isset( $pmpro_currencies[ $pmpro_currency ]['decimals'] ) ? (int) $pmpro_currencies[ $pmpro_currency ]['decimals'] : pmpro_get_decimal_place();
+	$decimal_separator = isset( $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] ) ? $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] : '.';
+	$thousands_separator = isset( $pmpro_currencies[ $pmpro_currency ]['thousands_separator'] ) ? $pmpro_currencies[ $pmpro_currency ]['thousands_separator'] : ',';
+	$symbol_position = isset( $pmpro_currencies[ $pmpro_currency ]['position'] ) ? $pmpro_currencies[ $pmpro_currency ]['position'] : 'left';
+
 	// settings stored in array?
 	if ( ! empty( $pmpro_currencies[ $pmpro_currency ] ) && is_array( $pmpro_currencies[ $pmpro_currency ] ) ) {
 		// format number do decimals, with decimal_separator and thousands_separator
 		$formatted = number_format(
 			$formatted,
-			( isset( $pmpro_currencies[ $pmpro_currency ]['decimals'] ) ? (int) $pmpro_currencies[ $pmpro_currency ]['decimals'] : pmpro_get_decimal_place() ),
-			( isset( $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] ) ? $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] : '.' ),
-			( isset( $pmpro_currencies[ $pmpro_currency ]['thousands_separator'] ) ? $pmpro_currencies[ $pmpro_currency ]['thousands_separator'] : ',' )
+			$decimals,
+			$decimal_separator,
+			$thousands_separator
 		);
 
 		// which side is the symbol on?
-		if ( ! empty( $pmpro_currencies[ $pmpro_currency ]['position'] ) && $pmpro_currencies[ $pmpro_currency ]['position'] == 'left' ) {
+		if ( ! empty( $symbol_position ) && $symbol_position == 'left' ) {
 			$formatted = $pmpro_currency_symbol . $formatted;
 		} else {
 			$formatted = $formatted . $pmpro_currency_symbol;
@@ -2479,10 +2484,50 @@ function pmpro_formatPrice( $price ) {
 		$formatted = $pmpro_currency_symbol . number_format( $formatted, pmpro_get_decimal_place() );
 	}
 
-	$formatted = rtrim( $formatted, 0 );
+	// Trim the trailing zero values.
+	$formatted = pmpro_trim_trailing_zeroes( $formatted, $decimals, $decimal_separator, $pmpro_currency_symbol, $symbol_position );
 
 	// filter
 	return apply_filters( 'pmpro_format_price', $formatted, $price, $pmpro_currency, $pmpro_currency_symbol );
+}
+
+
+/**
+ * Function to trim trailing zeros from an amount.
+ * @since 2.1
+ * @return float $amount The trimmed amount (removed trailing zeroes).
+ */
+function pmpro_trim_trailing_zeroes( $amount, $decimals, $decimal_separator, $symbol, $symbol_position = "left" ) {
+
+	if ( $decimals <= 2 ) {
+		return $amount;
+	}
+	//Check to see if decimal places are only 0. if so, then don't trim it.
+	$decimal_value = explode( $decimal_separator, $amount );
+
+	if ( empty( $decimal_value[1] ) ) {
+		return $amount;
+	}
+
+	$is_zero = round( intval( $decimal_value[1] ) );
+	// Store this in a variable for another time.
+	$original_amount = $amount;
+
+	if ( $is_zero > 0 ) {
+		if ( $symbol_position == 'right' ) {
+			$amount = rtrim( $amount, $symbol ); // remove currency symbol.
+			$amount = rtrim( $amount, 0 ); // remove trailing 0's.
+
+			// put the symbol back.
+			$amount .= $symbol;
+		} else {
+			$amount = rtrim( $amount, 0 ); // remove trailing 0's.
+		}
+	}
+
+	$amount = apply_filters( 'pmpro_trim_cost_amount', $amount, $original_amount, $decimal_separator, $symbol, $symbol_position );
+
+	return $amount;
 }
 
 /**


### PR DESCRIPTION
Trim decimal places for amounuts that may have a lot of decimal places. (2+)

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes minor bug where prices like `$25.00 now` will be converted to `$25. now`

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: N/A.

### How to test the changes in this Pull Request:

1. Create a membership price that ends in .00
2. See the memberships level page.
3. Run tests by setting decimal places to 8 and set price to variations of xx.0001000 or xx.0123001300

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Bug Fix: prices would be trimmed down if ending on .00 and this should only happen if the number is not .00 and something like .120130