### PR TITLE
moving check for subscription earlier when retrieving subscription from Stripe

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1366,6 +1366,11 @@ class PMProGateway_stripe extends PMProGateway
 			return false;
 		}			
 
+		//no subscriptions object in customer
+		if(empty($this->customer->subscriptions)) {
+			return false;
+		}
+
 		//is there a subscription transaction id pointing to a sub?
 		if(!empty($order->subscription_transaction_id) && strpos($order->subscription_transaction_id, "sub_") !== false) {
 			try {
@@ -1377,11 +1382,6 @@ class PMProGateway_stripe extends PMProGateway
 			}
 
 			return $sub;
-		}
-
-		//no subscriptions object in customer
-		if(empty($this->customer->subscriptions)) {
-			return false;
 		}
 
 		//find subscription based on customer id and order/plan id


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

During the getSubscription() function for Stripe, we check whether $this->customer->subscriptions is empty after we call $this->customer->subscriptions->retrieve(), so if the subscription object is empty, it causes an error. This error is handled on PHP <7 due to the enclosing try/catch, but not on PHP 7+. See here: https://www.php.net/manual/en/language.errors.php7.php Need to create separate PR to update all try/catch blocks to handle Throwables.

Forum topic (mods only):
https://www.paidmembershipspro.com/forums/topic/wordpress-notification-experiencing-a-technical-issue/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

Test environment: Wordpress 5.2.2, PHP 7.2.15, PMPro 2.0.7
<!-- Mark completed items with an [x] -->

### Changelog entry

BUGFIX: checking for subscription object before retrieving subscriptions by ID when checking at Stripe