### PR TITLE
Added filter for Braintree Plan ID's

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -452,7 +452,7 @@
 						    $has_bt_plan = PMProGateway_braintree::checkLevelForPlan( $level->id );
 							?>
 							<p class="pmpro_message <?php if ( ! $has_bt_plan ) {?>pmpro_error<?php } ?>">
-                                <strong><?php _e('Note', 'paid-memberships-pro' );?>:</strong> <?php printf( __('You will need to create a "Plan" in your Braintree dashboard with the same settings and the "Plan ID" set to %s.', 'paid-memberships-pro' ), 'pmpro_' . $level->id ); ?></p>
+                                <strong><?php _e('Note', 'paid-memberships-pro' );?>:</strong> <?php printf( __('You will need to create a "Plan" in your Braintree dashboard with the same settings and the "Plan ID" set to %s.', 'paid-memberships-pro' ), PMProGateway_braintree::get_plan_id( $level->id ) ); ?></p>
 						<?php } ?>
 					</td>
 				</tr>

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -200,7 +200,9 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 		 */
 		static function checkLevelForPlan($level_id) {
 			$Gateway = new PMProGateway_braintree();
-			$plan = $Gateway->getPlanByID('pmpro_' . $level_id);
+
+			$plan = $Gateway->getPlanByID( $Gateway->get_plan_id( $level_id ) );
+
 			if(!empty($plan))
 				return true;
 			else
@@ -917,9 +919,10 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 			//subscribe to the plan
 			try
 			{
+				
 				$details = array(
 				  'paymentMethodToken' => $this->customer->creditCards[0]->token,
-				  'planId' => 'pmpro_' . $order->membership_id,
+				  'planId' => $this->get_plan_id( $order->membership_id ),
 				  'price' => $amount
 				);
 
@@ -1058,4 +1061,23 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 				update_user_meta($user_id, 'pmpro_braintree_customerid', $pmpro_braintree_customerid);
 			}
 		}
+
+		/**
+		 * Gets the Braintree plan ID for a given level ID
+		 * @param  int $level_id level to get plan ID for
+		 * @return string        Braintree plan ID
+		 */
+	static function get_plan_id( $level_id ) {
+		/**
+			* Filter pmpro_braintree_plan_id
+			*
+			* Used to change the Braintree plan ID for a given level
+			*
+			* @since 2.1.0
+			*
+			* @param string  $plan_id for the given level
+			* @param int $level_id the level id to make a plan id for
+			*/
+			return apply_filters( 'pmpro_braintree_plan_id', 'pmpro_' . $level_id, $level_id );
 	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Make Braintree plan ID's filterable to avoid conflicts if using multiple sites

Resolves #1040 

### How to test the changes in this Pull Request:

1. Create new recurring level
2. Insert this Gist in a PMPro Customizations plugin: https://gist.github.com/dparker1005/302a691d0ae7c82b4bbc0e65b552b950
3. Verify that error messages tell you to create a Braintree plan that is consistent with the one you built via the Gist
4. Create the plan in Braintree
5. Checkout
6. Verify that transaction and subscription were successful in Braintree

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Added filter pmpro_braintree_plan_id