### PR TITLE
BUGFIX: fixed issue where default templates would fail to load if a custom template was specified

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -291,10 +291,11 @@ function pmpro_loadTemplate( $page_name = null, $where = 'local', $type = 'pages
 	// Valid types: 'email', 'pages'
 	$templates = apply_filters( "pmpro_{$type}_custom_template_path", $default_templates, $page_name, $type, $where, $ext );
 	$user_templates = array_diff( $templates, $default_templates );
+	$allowed_default_templates = array_intersect( $templates, $default_templates );
 
 	// user specified a custom template path, so it has priority.
 	if ( ! empty( $user_templates ) ) {
-		$templates = $user_templates;
+		array_merge($allowed_default_templates, $user_templates);
 	}
 
 	// last element included in the array is the most first one we try to load


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Custom templates were overriding any default templates when using `pmpro_{$type}_custom_template_path`. Now, instead of replacing $templates with $user_templates, we split $templates into an array of default templates and an array of custom templates, then merge them in that order. Custom templates are still loaded first, but now it will fall back to default template paths.

Closes Issue: #543

### How to test the changes in this Pull Request:

1. Install the code recipe from the following article: https://www.paidmembershipspro.com/new-method-load-custom-templates-pmpro-generated-pages-system-generated-emails/
2. Visit a PMPro page that *doesn't* have a custom template in pmpro-customizations/pages
3. Expected behavior before this fix: template doesn't load, page displayed but no content
4. Expected behavior after fix: template correctly loads from default paths

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

Tested on WP 5.2.2, PMPro v2.1, PHP 7.2.15-1

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUGFIX: fixed issue where default templates would fail to load if a custom template was specified