### PR TITLE
Showing admin notice on Delete User Form if any users for deletion have membership.

### DIFF
--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -21,6 +21,36 @@ function pmpro_delete_user($user_id = NULL)
 add_action('delete_user', 'pmpro_delete_user');
 add_action('wpmu_delete_user', 'pmpro_delete_user');
 
+/**
+ * Show a notice on the Delete User form so admin knows that membership and subscriptions will be cancelled.
+ *
+ * @param WP_User $current_user WP_User object for the current user.
+ * @param int[]   $userids      Array of IDs for users being deleted.
+ */
+function pmpro_delete_user_form_notice( $current_user, $userids ) {
+	// Check if any users for deletion have an an active membership level.
+	foreach ( $userids as $user_id ) {
+		$userids_have_levels = pmpro_hasMembershipLevel( null, $user_id );
+		if ( ! empty( $userids_have_levels ) ) {
+			break;
+		}
+	}
+
+	// Show a notice if users for deletion have an an active membership level.
+	if ( ! empty( $userids_have_levels ) ) { ?>
+		<div class="notice notice-error inline">
+			<?php if ( count( $userids ) > 1 ) {
+				_e( '<p><strong>Warning:</strong> One or more users for deletion have an active membership level. Deleting a user will also cancel their membership and recurring subscription.</p>', 'paid-memberships-pro' );
+			} else {
+				_e( '<p><strong>Warning:</strong> This user has an active membership level. Deleting a user will also cancel their membership and recurring subscription.</p>', 'paid-memberships-pro' );
+			}
+		?>
+		</div>
+	<?php
+	}
+}
+add_action( 'delete_user_form', 'pmpro_delete_user_form_notice', 10, 2 );
+
 //deleting a category? remove any level associations
 function pmpro_delete_category($cat_id = NULL)
 {
@@ -33,7 +63,7 @@ add_action('delete_category', 'pmpro_delete_category');
 //deleting a post? remove any level associations
 function pmpro_delete_post($post_id = NULL)
 {
-	global $wpdb;		
+	global $wpdb;
 	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '" . $post_id . "'";
 	$wpdb->query($sqlQuery);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds a notice when admin tries to delete users. It checks if any users for deletion have membership and shows an appropriate message for a single or multiple user deletion informing admin that membership and active subscriptions will be terminated after deletion.

### How to test the changes in this Pull Request:

1. Go to Users admin page.
2. Select a single user with no level for deletion. No message should be shown. 
3. Select a single user with a level for deletion. A message should be shown. 
4. Select multiple users, some with a level, for deletion. A different message should be shown. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
* ENHANCEMENT: Showing a notice on the Delete User form so admin knows that membership and subscriptions will be cancelled.