### PR TITLE
fixing missing else on Billing page

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -376,7 +376,7 @@
 		</script>
 	<?php } ?>
 
-<?php } // End for recurring level check.
+<?php } else { // End for recurring level check.
 	?>
 	<p><?php printf(__("Logged in as <strong>%s</strong>.", 'paid-memberships-pro' ), $current_user->user_login);?> <small><a href="<?php echo esc_url( wp_logout_url() );?>"><?php _e("logout", 'paid-memberships-pro' );?></a></small></p>
 	<?php
@@ -405,4 +405,5 @@
 		}
 	} else { ?>
 		<p><?php _e("This subscription is not recurring. So you don't need to update your billing information.", 'paid-memberships-pro' );?></p>
-	<?php } ?>
+	<?php }
+}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The conditional statement that starts on line 75 of billing.php with `if(pmpro_isLevelRecurring($level)) { ` lost its `else` statement when it was updated, so now the "Logged in as NAME" text displays twice and "This subscription is not recurring. So you don't need to update your billing information" message shows up if subscription is recurring.

### How to test the changes in this Pull Request:

1. on current version: go to Billing page while logged in as a member with a recurring Stripe subscription
2. After the billing info fields, at the bottom of the page see additional login details and "This subscription is not recurring. So you don't need to update your billing information".
3. install this commit, then repeat step 1
4. added bit after billing info fields now gone


### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed issue that caused Billing page to display non-recurring text for recurring subscriptions.