### PR TITLE
Incorrect naming convention for pmpro_require_billing

### DIFF
--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -1,14 +1,11 @@
 // Wire up the form for Stripe.
 jQuery( document ).ready( function( $ ) {
 
-	var stripe, elements, pmpro_require_billing, cardNumber, cardExpiry, cardCvc;
+	var stripe, elements, cardNumber, cardExpiry, cardCvc;
 
 	// Identify with Stripe.
 	stripe = Stripe( pmproStripe.publishableKey );
 	elements = stripe.elements();
-
-	// Used by plugns that hide/show the billing fields.
-	pmpro_require_billing = true;
 
 	// Create Elements.
 	cardNumber = elements.create('cardNumber');
@@ -50,7 +47,7 @@ jQuery( document ).ready( function( $ ) {
 		event.preventDefault();
 
 		// Double check in case a discount code made the level free.
-		if ( pmpro_require_billing ) {
+		if ( typeof pmpro_require_billing === 'undefined' || pmpro_require_billing ) {
 
 			if ( pmproStripe.verifyAddress ) {
 				address = {
@@ -101,8 +98,6 @@ jQuery( document ).ready( function( $ ) {
 
 			$( '#pmpro_message' ).addClass( 'pmpro_error' ).show();
 			$('.pmpro_error').text(response.error.message);
-
-			pmpro_require_billing = true;
 
 			// TODO Delete any incomplete subscriptions if 3DS auth failed.
 			// data = {

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -1,14 +1,14 @@
 // Wire up the form for Stripe.
 jQuery( document ).ready( function( $ ) {
 
-	var stripe, elements, pmproRequireBilling, cardNumber, cardExpiry, cardCvc;
+	var stripe, elements, pmpro_require_billing, cardNumber, cardExpiry, cardCvc;
 
 	// Identify with Stripe.
 	stripe = Stripe( pmproStripe.publishableKey );
 	elements = stripe.elements();
 
 	// Used by plugns that hide/show the billing fields.
-	pmproRequireBilling = true;
+	pmpro_require_billing = true;
 
 	// Create Elements.
 	cardNumber = elements.create('cardNumber');
@@ -50,7 +50,7 @@ jQuery( document ).ready( function( $ ) {
 		event.preventDefault();
 
 		// Double check in case a discount code made the level free.
-		if ( pmproRequireBilling ) {
+		if ( pmpro_require_billing ) {
 
 			if ( pmproStripe.verifyAddress ) {
 				address = {
@@ -102,7 +102,7 @@ jQuery( document ).ready( function( $ ) {
 			$( '#pmpro_message' ).addClass( 'pmpro_error' ).show();
 			$('.pmpro_error').text(response.error.message);
 
-			pmproRequireBilling = true;
+			pmpro_require_billing = true;
 
 			// TODO Delete any incomplete subscriptions if 3DS auth failed.
 			// data = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes Issue: #1065 

Corrected the naming convection for pmpro_require_billing to match the convention used in plugins. Removed the declaration to prevent ending up with two versions of pmpro_require_billing with different scopes, and instead check for typeof undefined.