### PR TITLE
Bug fixes for Stripe implementation (v2.1-Beta1)

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1962,13 +1962,8 @@ class PMProGateway_stripe extends PMProGateway
 
         try {
 	    $this->source->attach( ['customer' => $this->customer->id] );
-	
-	    Stripe_Customer::update(
-		$this->customer->id,
-		[
-		    'invoice_settings' => ['default_payment_method' => $order->payment_method_id],
-	        ]
-	    );
+	    $this->customer->invoice_settings->default_payment_method = $this->source->id;
+	    $this->customer->save();
         } catch ( \Stripe\Error $e ) {
             $order->error = $e->message;
             return false;

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2299,13 +2299,7 @@ class PMProGateway_stripe extends PMProGateway
         }
 
         try {
-            $params = array(
-                'expand' => array(
-                    'source',
-                    'customer',
-                ),
-            );
-            $this->payment_intent->confirm( $params );
+            $this->payment_intent->confirm();
         } catch ( \Stripe\Error $e ) {
             $order->error = $e->message;
             return false;

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -350,10 +350,7 @@ class PMProGateway_stripe extends PMProGateway
                 );
 
                 if ( ! empty( $order ) ) {
-		    if ( ! empty( $order->Gateway->source ) ) {
-                        $localize_vars['source'] = $order->Gateway->source;	// Access last4 etc.
-                    }
-                    if ( ! empty( $order->Gateway->payment_intent ) ) {
+		    if ( ! empty( $order->Gateway->payment_intent ) ) {
                         $localize_vars['paymentIntent'] = $order->Gateway->payment_intent;
                     }
                     if ( ! empty( $order->Gateway->setup_intent ) ) {
@@ -2214,7 +2211,7 @@ class PMProGateway_stripe extends PMProGateway
                 ),
                 'trial_period_days' => $order->TrialPeriodDays,
                 'expand' => array(
-                    'pending_setup_intent',
+                    'pending_setup_intent.payment_method',
                 ),
             );
             $order->subscription = Stripe_Subscription::create( $params );
@@ -2299,7 +2296,12 @@ class PMProGateway_stripe extends PMProGateway
         }
 
         try {
-            $this->payment_intent->confirm();
+	    $params = array(
+                'expand' => array(
+                    'payment_method',
+                ),
+            );
+            $this->payment_intent->confirm( $params );	
         } catch ( \Stripe\Error $e ) {
             $order->error = $e->message;
             return false;

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1961,8 +1961,7 @@ class PMProGateway_stripe extends PMProGateway
         }
 
         try {
-	    $payment_method = Stripe_PaymentMethod::retrieve( $order->payment_method_id );
-	    $payment_method->attach( ['customer' => $this->customer->id] );
+	    $this->source->attach( ['customer' => $this->customer->id] );
 	
 	    Stripe_Customer::update(
 		$this->customer->id,

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2301,7 +2301,7 @@ class PMProGateway_stripe extends PMProGateway
                     'payment_method',
                 ),
             );
-            $this->payment_intent->confirm( $params );	
+            $this->payment_intent->confirm( $params );
         } catch ( \Stripe\Error $e ) {
             $order->error = $e->message;
             return false;

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -116,11 +116,9 @@ jQuery( document ).ready( function( $ ) {
 			// TODO Get card info for order and user meta after checkout instead.
 			//	We need this for now to make sure user meta gets updated.
 			// insert fields for other card fields
-			if( $( '#CardType[name=CardType]' ).length ) {
-				
+			if( $( '#CardType[name=CardType]' ).length ) {				
 				$( '#CardType' ).val( card.brand );
-			} else {
-				
+			} else {				
 				form.append( '<input type="hidden" name="CardType" value="' + card.brand + '"/>' );
 			}
 			

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -162,10 +162,11 @@ jQuery( document ).ready( function( $ ) {
 			// TODO Get card info for order and user meta after checkout instead.
 			//	We need this for now to make sure user meta gets updated.
 			// insert fields for other card fields
-			if( $( '#CardType[name=CardType]' ).length )
+			if( $( '#CardType[name=CardType]' ).length ) {
 				$( '#CardType' ).val( card.brand );
-			else
+			} else {
 				form.append( '<input type="hidden" name="CardType" value="' + card.brand + '"/>' );
+			}
 
 			form.append( '<input type="hidden" name="AccountNumber" value="XXXXXXXXXXXX' + card.last4 + '"/>' );
 			form.append( '<input type="hidden" name="ExpirationMonth" value="' + ( '0' + card.exp_month ).slice( -2 ) + '"/>' );

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -116,9 +116,9 @@ jQuery( document ).ready( function( $ ) {
 			// TODO Get card info for order and user meta after checkout instead.
 			//	We need this for now to make sure user meta gets updated.
 			// insert fields for other card fields
-			if( $( '#CardType[name=CardType]' ).length ) {				
+			if( $( '#CardType[name=CardType]' ).length ) {
 				$( '#CardType' ).val( card.brand );
-			} else {				
+			} else {
 				form.append( '<input type="hidden" name="CardType" value="' + card.brand + '"/>' );
 			}
 			

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -65,7 +65,7 @@ jQuery( document ).ready( function( $ ) {
 				name = $.trim( $( '#bfirstname' ).val() + ' ' + $( '#blastname' ).val() );
 			}
 			
-			stripe.createPaymentMethod(	'card',	cardNumber, {
+			stripe.createPaymentMethod( 'card', cardNumber, {
 				billing_details: {
 					address: address,
 					name: name,
@@ -83,7 +83,7 @@ jQuery( document ).ready( function( $ ) {
 	// Handle the response from Stripe.
 	function stripeResponseHandler( response ) {
 
-		var form, data, card, source, paymentMethod, customerId;
+		var form, data, card, paymentMethod, customerId;
 
 		form = $('#pmpro_form, .pmpro_form');
 

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -135,7 +135,7 @@ jQuery( document ).ready( function( $ ) {
 
 		    // TODO Refactor
 			if ( pmproStripe.paymentIntent ) {
-				customerId = pmproStripe.paymentIntent.customer.id;
+				customerId = pmproStripe.paymentIntent.customer;
 				paymentMethod = pmproStripe.paymentIntent.payment_method;
 				form.append( '<input type="hidden" name="payment_intent_id" value="' + pmproStripe.paymentIntent.id + '" />' );
 			}

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -83,7 +83,7 @@ jQuery( document ).ready( function( $ ) {
 	// Handle the response from Stripe.
 	function stripeResponseHandler( response ) {
 
-		var form, data, card, paymentMethod, customerId;
+		var form, data, card, paymentMethodId, customerId;
 
 		form = $('#pmpro_form, .pmpro_form');
 
@@ -132,31 +132,32 @@ jQuery( document ).ready( function( $ ) {
 			form.get(0).submit();			
 			
 		} else if ( response.paymentIntent || response.setupIntent ) {
+			
+			customerId = pmproStripe.paymentIntent 
+				? pmproStripe.paymentIntent.customer
+				: pmproStripe.setupIntent.customer;
+			
+			paymentMethodId = pmproStripe.paymentIntent
+				? pmproStripe.paymentIntent.payment_method.id
+				: pmproStripe.setupIntent.payment_method.id;
+				
+			card = pmproStripe.paymentIntent
+				? pmproStripe.paymentIntent.payment_method.card
+				: pmproStripe.setupIntent.payment_method.card;
 
-		    // TODO Refactor
-			if ( pmproStripe.paymentIntent ) {
-				customerId = pmproStripe.paymentIntent.customer;
-				paymentMethod = pmproStripe.paymentIntent.payment_method;
+		    	if ( pmproStripe.paymentIntent ) {
 				form.append( '<input type="hidden" name="payment_intent_id" value="' + pmproStripe.paymentIntent.id + '" />' );
 			}
 			if ( pmproStripe.setupIntent ) {
-				if ( ! customerId ) {
-					customerId = pmproStripe.setupIntent.customer;
-				}
-				if ( ! paymentMethod ) {
-					paymentMethod = pmproStripe.setupIntent.payment_method;
-				}
 				form.append( '<input type="hidden" name="setup_intent_id" value="' + pmproStripe.setupIntent.id + '" />' );
 				form.append( '<input type="hidden" name="subscription_id" value="' + pmproStripe.subscription.id + '" />' );
 			}
-
-			card = pmproStripe.source.card;
 
 			// insert the Customer ID into the form so it gets submitted to the server
 			form.append( '<input type="hidden" name="customer_id" value="' + customerId + '" />' );
 
 			// insert the PaymentMethod ID into the form so it gets submitted to the server
-			form.append( '<input type="hidden" name="payment_method_id" value="' + paymentMethod + '" />' );
+			form.append( '<input type="hidden" name="payment_method_id" value="' + paymentMethodId + '" />' );
 
 			// TODO Get card info for order and user meta after checkout instead.
 			//	We need this for now to make sure user meta gets updated.

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -71,7 +71,7 @@ jQuery( document ).ready( function( $ ) {
 					name: name,
 				}
 			}).then( stripeResponseHandler );
-			
+
 			// Prevent the form from submitting with the default action.
 			return false;
 		} else {
@@ -112,7 +112,7 @@ jQuery( document ).ready( function( $ ) {
 			
 			// insert the Source ID into the form so it gets submitted to the server
 			form.append( '<input type="hidden" name="payment_method_id" value="' + paymentMethodId + '" />' );
-			
+
 			// TODO Get card info for order and user meta after checkout instead.
 			//	We need this for now to make sure user meta gets updated.
 			// insert fields for other card fields
@@ -132,7 +132,7 @@ jQuery( document ).ready( function( $ ) {
 			form.get(0).submit();			
 			
 		} else if ( response.paymentIntent || response.setupIntent ) {
-			
+
 		    // TODO Refactor
 			if ( pmproStripe.paymentIntent ) {
 				customerId = pmproStripe.paymentIntent.customer.id;
@@ -151,7 +151,7 @@ jQuery( document ).ready( function( $ ) {
 			}
 
 			card = pmproStripe.source.card;
-			
+
 			// insert the Customer ID into the form so it gets submitted to the server
 			form.append( '<input type="hidden" name="customer_id" value="' + customerId + '" />' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #1063 
Closes #1064 
Closes #1065 

Changes to class.pmprogateway_stripe.php:

Migrated to PaymentMethod API from Sources API. This was needed to close #1063 . Can now set `'setup_future_usage' => 'off_session'`, to prevent asking for two authentications (one for initial payment and one for subscription).

Uses PaymentMethod API to retrieve payment method and attach to customer.

Uses `payment_method` instead of `source` in PaymentIntent and sets `setup_future_usage`.

Uses `default_payment_method` instead of `default_source` in SetupIntent.

Modified expand in `create_subscription()` to correctly expand `payment_method`. Closes #1064.

Removed `customer` from `expand` in `confirm_payment_intent2`. This isn't needed and was inconsistent between PaymentIntent and SetupIntent.

Changes to pmpro-stripe.js:

Removed `pmpro_require_billing` declaration. As this code is now inside the document.ready block, this resulted in two variables with different scopes (one declared here, and one declared outside of the block by plugins). Instead now checks for `typeof pmpro_require_billing === 'undefined'`. Closes #1065 .

Uses PaymentMethod API instead of Sources API to create payment method. Closes #1063. 

Re-factored response handler. Previously, `pmproStripe.setupIntent.customer` was customer id and `pmproStripe.paymentIntent.customer` was customer object. This was due to customer being expanded in PaymentIntent but not SetupIntent (see above). Now they are both customer id.

`card` is now accessible from `pmproStripe.setupIntent.payment_method`. Closes #1064.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
