### PR TITLE
Send name/email to payments pro, even if there is no address

### DIFF
--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -344,10 +344,15 @@
 			if(!empty($order->StartDate))
 				$nvpStr .= "&STARTDATE=" . $order->StartDate . "&ISSUENUMBER=" . $order->IssueNumber;
 
+			// Name and email info
+			if ( ! empty( $order->FirstName ) && ! empty( $order->LastName ) && ! empty( $order->Email ) ) {
+				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName;
+			}
+
 			//billing address, etc
 			if(!empty($order->Address1))
 			{
-				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName . "&STREET=" . $order->Address1;
+				$nvpStr .= "&STREET=" . $order->Address1;
 
 				if($order->Address2)
 					$nvpStr .= "&STREET2=" . $order->Address2;
@@ -451,10 +456,15 @@
 			if(!empty($order->StartDate))
 				$nvpStr .= "&STARTDATE=" . $order->StartDate . "&ISSUENUMBER=" . $order->IssueNumber;
 
+			// Name and email info
+			if ( $order->FirstName && $order->LastName && $order->Email ) {
+				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName;
+			}
+
 			//billing address, etc
 			if($order->Address1)
 			{
-				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName . "&STREET=" . $order->Address1;
+				$nvpStr .= "&STREET=" . $order->Address1;
 
 				if($order->Address2)
 					$nvpStr .= "&STREET2=" . $order->Address2;
@@ -532,10 +542,15 @@
 			if(!empty($order->StartDate))
 				$nvpStr .= "&STARTDATE=" . $order->StartDate . "&ISSUENUMBER=" . $order->IssueNumber;
 
+			// Name and email info
+			if ( $order->FirstName && $order->LastName && $order->Email ) {
+				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName;
+			}
+
 			//billing address, etc
 			if($order->Address1)
 			{
-				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName . "&STREET=" . $order->Address1;
+				$nvpStr .= "&STREET=" . $order->Address1;
 
 				if($order->Address2)
 					$nvpStr .= "&STREET2=" . $order->Address2;
@@ -583,16 +598,21 @@
 			if($order->StartDate)
 				$nvpStr .= "&STARTDATE=" . $order->StartDate . "&ISSUENUMBER=" . $order->IssueNumber;
 
-			//billing address, etc
-			if($order->Address1)
-			{
-				$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName . "&STREET=" . $order->Address1;
+				// Name and email info
+				if ( $order->FirstName && $order->LastName && $order->Email ) {
+					$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName;
+				}
 
-				if($order->Address2)
-					$nvpStr .= "&STREET2=" . $order->Address2;
+				//billing address, etc
+				if($order->Address1)
+				{
+					$nvpStr .= "&STREET=" . $order->Address1;
 
-				$nvpStr .= "&CITY=" . $order->billing->city . "&STATE=" . $order->billing->state . "&COUNTRYCODE=" . $order->billing->country . "&ZIP=" . $order->billing->zip;
-			}
+					if($order->Address2)
+						$nvpStr .= "&STREET2=" . $order->Address2;
+
+					$nvpStr .= "&CITY=" . $order->billing->city . "&STATE=" . $order->billing->state . "&COUNTRYCODE=" . $order->billing->country . "&ZIP=" . $order->billing->zip . "&SHIPTOPHONENUM=" . $order->billing->phone;
+				}
 
 			$this->httpParsedResponseAr = $this->PPHttpPost('UpdateRecurringPaymentsProfile', $nvpStr);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There is a user who wanted first name, last name, and email to be sent to Payments Pro, but didn't want to require the user to give a billing address. This PR removes the requirement for an address to be present in order for name/email information to be sent.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set gateway to Payments Pro with valid credentials
2. Make billing fields not required for payment
3. Check out with giving first name, last name, and email