### PR TITLE
fix for fpassthru disabled error

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -553,10 +553,18 @@
 				ini_set('zlib.output_compression', 'Off');
 			}
 
-			// open and send the file contents to the remote location
-			$fh = fopen( $filename, 'rb' );
-			fpassthru($fh);
-			fclose($fh);
+			if( function_exists('fpassthru') )
+			{
+				// open and send the file contents to the remote location
+				$fh = fopen( $filename, 'rb' );
+				fpassthru($fh);
+				fclose($fh);
+			}
+			else
+			{
+				// use readfile() if fpassthru() is disabled (like on Flywheel Hosted)
+				readfile($fh);
+			}
 
 			// remove the temp file
 			unlink($filename);

--- a/adminpages/orders-csv.php
+++ b/adminpages/orders-csv.php
@@ -588,10 +588,18 @@ function pmpro_transmit_order_content( $csv_fh, $filename, $headers = array() ) 
 			ini_set( 'zlib.output_compression', 'Off' );
 		}
 
-		// open and send the file contents to the remote location
-		$fh = fopen( $filename, 'rb' );
-		fpassthru( $fh );
-		fclose( $fh );
+		if( function_exists('fpassthru') )
+		{
+			// open and send the file contents to the remote location
+			$fh = fopen( $filename, 'rb' );
+			fpassthru($fh);
+			fclose($fh);
+		}
+		else
+		{
+			// use readfile() if fpassthru() is disabled (like on Flywheel Hosted)
+			readfile($fh);
+		}
 
 		// remove the temp file
 		unlink( $filename );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Conditionally use readfile() if fpassthru() is disabled on this Wordpress installation. This has mostly been affecting Flywheel Hosted users (see https://getflywheel.com/wordpress-support/what-php-functions-are-disabled/) -

Closes Issue: #1071

### How to test the changes in this Pull Request:

1. Disable the fpassthru function in php.ini (https://www.php.net/manual/en/ini.core.php#ini.disable-functions)
2. Go to Memberships > Members and export members list csv
3. 503 or other server error, if generated .csv is downloaded it will be blank
4. Install this commit then repeat step 2
5. csv generated correctly, no server error

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUGFIX: Fixed an issue that caused member/order list exports to give a 503 error on hosting setups where fpassthru is disabled (like Flywheel Hosted)