### PR TITLE
Adding "has-row-actions" CSS class to td element in orders admin

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1337,7 +1337,7 @@ class="alternate"<?php } ?>>
 					<td>
 						<a href="admin.php?page=pmpro-orders&order=<?php echo $order->id; ?>"><?php echo $order->code; ?></a>
 					</td>
-					<td class="username column-username">
+					<td class="username column-username has-row-actions">
 						<?php $order->getUser(); ?>
 						<?php if ( ! empty( $order->user ) ) { ?>
 							<a href="user-edit.php?user_id=<?php echo $order->user->ID; ?>"><?php echo $order->user->user_login; ?></a>


### PR DESCRIPTION
After moving the order row's "buttons" into row actions, the elements did not display when using the tab method to toggle through links on page. This is particularly important for accessibility and UX cases.

The WP admin has a class `has-row-actions` that should be added to any table <td> element when the element has row actions so that they appear when the element is in focus. 