### PR TITLE
Forcing full width, block, not floated labels in Payment Information section.

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -113,6 +113,14 @@ form.pmpro_form label {
 	margin: 0;
 	text-align: left;
 }
+form.pmpro_form #pmpro_payment_information_fields .pmpro_checkout-fields label {
+	display: block;
+	float: none;
+	max-width: initial;
+	min-width: initial;
+	text-align: left;
+	width: auto;
+}
 form.pmpro_form .pmpro_checkout-field-checkbox label {
 	cursor: pointer;
 	display: inline-block;


### PR DESCRIPTION
Making the CSS for payment information section a little more bulletproof to support iframe input fields in Stripe Elements.