### PR TITLE
Fixing error where one unset PMPro page was hiding entire form in adm…

### DIFF
--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -107,8 +107,20 @@ require_once(dirname(__FILE__) . "/admin_header.php");
         <?php wp_nonce_field('savesettings', 'pmpro_pagesettings_nonce');?>
         <h2><?php _e( 'Page Settings', 'paid-memberships-pro' ); ?></h2>
         <?php
-        global $pmpro_pages_ready;
-        if ( $pmpro_pages_ready ) { ?>
+		// check if we have all pages
+		if ( $pmpro_pages['account'] ||
+			$pmpro_pages['billing'] ||
+			$pmpro_pages['cancel'] ||
+			$pmpro_pages['checkout'] ||
+			$pmpro_pages['confirmation'] ||
+			$pmpro_pages['invoice'] ||
+			$pmpro_pages['levels'] ) {
+			$pmpro_some_pages_ready = true;
+		} else {
+			$pmpro_some_pages_ready = false;
+		}
+
+        if ( $pmpro_some_pages_ready ) { ?>
             <p><?php _e('Manage the WordPress pages assigned to each required Paid Memberships Pro page.', 'paid-memberships-pro' ); ?></p>
         <?php } elseif( ! empty( $_REQUEST['manualpages'] ) ) { ?>
             <p><?php _e('Assign the WordPress pages for each required Paid Memberships Pro page or', 'paid-memberships-pro' ); ?> <a
@@ -123,7 +135,7 @@ require_once(dirname(__FILE__) . "/admin_header.php");
             </div> <!-- end pmpro-new-install -->
         <?php } ?>
 
-        <?php if ( ! empty( $pmpro_pages_ready ) || ! empty( $_REQUEST['manualpages'] ) ) { ?>
+        <?php if ( ! empty( $pmpro_some_pages_ready ) || ! empty( $_REQUEST['manualpages'] ) ) { ?>
         <table class="form-table">
             <tbody>
             <tr>


### PR DESCRIPTION
…in Memberships > Settings > Page Settings.

### Changes proposed in this Pull Request:
Fixing the logic of when to show the "Generate Pages" button on the Page Settings Page. Now the button only shows if you have none of the pages set. If any single page is already set up, the standard manual form shows.

Closes Issue: https://github.com/strangerstudios/paid-memberships-pro/issues/1104

### Changelog entry
BUG FIX: Now only showing the default "Generate Pages" button if there are NO pages set at all.
