### PR TITLE
wasn't actually assigning merged custom templates to $templates

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -313,7 +313,7 @@ function pmpro_loadTemplate( $page_name = null, $where = 'local', $type = 'pages
 
 	// user specified a custom template path, so it has priority.
 	if ( ! empty( $user_templates ) ) {
-		array_merge($allowed_default_templates, $user_templates);
+		$templates = array_merge($allowed_default_templates, $user_templates);
 	}
 
 	// last element included in the array is the most first one we try to load


### PR DESCRIPTION
Related to PR #1046 - see that commit for details of the initial change. Missed the step of actually assigning the merged template array to `$templates`, so the fix wasn't being applied properly.