### PR TITLE
Check if session is available

### DIFF
--- a/includes/sessions.php
+++ b/includes/sessions.php
@@ -80,8 +80,8 @@ function pmpro_set_session_var($key, $value)
  * TODO: Update docblock.
  */
 function pmpro_get_session_var( $key ) {
-	pmpro_start_session();
-	if ( array_key_exists( $key, $_SESSION ) ) {
+    pmpro_start_session();
+	if ( ! empty( $_SESSION ) && array_key_exists( $key, $_SESSION ) ) {
 		return  $_SESSION[$key] ;
 	} else {
 		return false;


### PR DESCRIPTION
BUG FIX: Check if session is set, stops a warning from happening when sessions aren't set.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: N/A

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX: Session variable not set causing warning in array_exists check.