### PR TITLE
Moving PMPro License page to a tab under Memberships and under the Memberships Menu.

### DIFF
--- a/adminpages/addons.php
+++ b/adminpages/addons.php
@@ -205,7 +205,7 @@
 								elseif(empty($pmpro_license_key))
 								{
 									//no key
-									$actions['settings'] = '<span class="settings"><a href="' . admin_url('options-general.php?page=pmpro_license_settings') . '">' . __('Update License', 'paid-memberships-pro' ) . '</a></span>';
+									$actions['settings'] = '<span class="settings"><a href="' . admin_url('admin.php?page=pmpro-license') . '">' . __('Update License', 'paid-memberships-pro' ) . '</a></span>';
 									$actions['download'] = '<span class="download"><a target="_blank" href="' . $plugin_data['PluginURI'] . '">' . __('Download', 'paid-memberships-pro' ) . '</a></span>';
 								}
 								elseif(pmpro_license_isValid($pmpro_license_key, $plugin_data['License']))
@@ -217,7 +217,7 @@
 								else
 								{
 									//invalid key
-									$actions['settings'] = '<span class="settings"><a href="' . admin_url('options-general.php?page=pmpro_license_settings') . '">' . __('Update License', 'paid-memberships-pro' ) . '</a></span>';
+									$actions['settings'] = '<span class="settings"><a href="' . admin_url('admin.php?page=pmpro-license') . '">' . __('Update License', 'paid-memberships-pro' ) . '</a></span>';
 									$actions['download'] = '<span class="download"><a target="_blank" href="' . $plugin_data['PluginURI'] . '">' . __('Download', 'paid-memberships-pro' ) . '</a></span>';
 								}
 							}

--- a/adminpages/admin_header.php
+++ b/adminpages/admin_header.php
@@ -180,7 +180,8 @@
 			'pmpro-paymentsettings',
 			'pmpro-emailsettings',
 			'pmpro-advancedsettings',
-			'pmpro-addons'
+			'pmpro-addons',
+			'pmpro-license'
 		);
 		if( in_array( $view, $settings_tabs ) ) { ?>
 	<nav class="nav-tab-wrapper">
@@ -206,6 +207,10 @@
 
 		<?php if(current_user_can('pmpro_addons')) { ?>
 			<a href="<?php echo admin_url('admin.php?page=pmpro-addons');?>" class="nav-tab<?php if($view == 'pmpro-addons') { ?> nav-tab-active<?php } ?>"><?php _e('Add Ons', 'paid-memberships-pro' );?></a>
+		<?php } ?>
+
+		<?php if(current_user_can('manage_options')) { ?>
+			<a href="<?php echo admin_url('admin.php?page=pmpro-license');?>" class="nav-tab<?php if($view == 'pmpro-license') { ?> nav-tab-active<?php } ?>"><?php _e('License', 'paid-memberships-pro' );?></a>
 		<?php } ?>
 	</nav>
 

--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -167,7 +167,7 @@ function pmpro_dashboard_welcome_callback() { ?>
     		<?php if ( ! pmpro_license_isValid() && empty( $key ) ) { ?>
     			<p class="pmpro_message pmpro_error">
     				<strong><?php echo esc_html_e( 'No support license key found.', 'paid-memberships-pro' ); ?></strong><br />
-    				<?php printf(__( '<a href="%s">Enter your key here &raquo;</a>', 'paid-memberships-pro' ), admin_url( 'options-general.php?page=pmpro_license_settings' ) );?>
+    				<?php printf(__( '<a href="%s">Enter your key here &raquo;</a>', 'paid-memberships-pro' ), admin_url( 'admin.php?page=pmpro-license' ) );?>
     			</p>
     		<?php } elseif ( ! pmpro_license_isValid() ) { ?>
     			<p class="pmpro_message pmpro_alert">

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -53,6 +53,7 @@ function pmpro_add_pages() {
 	add_submenu_page( 'pmpro-dashboard', __( 'Reports', 'paid-memberships-pro' ), __( 'Reports', 'paid-memberships-pro' ), 'pmpro_reports', 'pmpro-reports', 'pmpro_reports' );
 	add_submenu_page( 'pmpro-dashboard', __( 'Settings', 'paid-memberships-pro' ), __( 'Settings', 'paid-memberships-pro' ), 'pmpro_membershiplevels', 'pmpro-membershiplevels', 'pmpro_membershiplevels' );
 	add_submenu_page( 'pmpro-dashboard', __( 'Add Ons', 'paid-memberships-pro' ), __( 'Add Ons', 'paid-memberships-pro' ), 'pmpro_addons', 'pmpro-addons', 'pmpro_addons' );
+	add_submenu_page( 'pmpro-dashboard', __( 'License', 'paid-memberships-pro' ), __( '<span style="color:#7FFF00">License</span>', 'paid-memberships-pro' ), 'manage_options', 'pmpro-license', 'pmpro_license_settings_page' );
 	
 	// Settings tabs
 	add_submenu_page( 'admin.php', __( 'Discount Codes', 'paid-memberships-pro' ), __( 'Discount Codes', 'paid-memberships-pro' ), 'pmpro_discountcodes', 'pmpro-discountcodes', 'pmpro_discountcodes' );
@@ -191,6 +192,18 @@ function pmpro_admin_bar_menu() {
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Add Ons', 'paid-memberships-pro' ),
 				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-addons' )
+			)
+		);
+	}
+
+	// Add menu item for License.
+	if ( current_user_can( 'manage_options' ) ) {
+		$wp_admin_bar->add_menu(
+			array(
+				'id' => 'pmpro-license',
+				'parent' => 'paid-memberships-pro',
+				'title' => __( 'License', 'paid-memberships-pro' ),
+				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-license' )
 			)
 		);
 	}

--- a/includes/license.php
+++ b/includes/license.php
@@ -17,7 +17,7 @@
 /*
 	Developers, add this line to your wp-config.php to remove PMPro license nags even if no license has been purchased.
 	
-	define('PMPRO_LICENSE_NAG', false);	//consider purchasing a license at https://www.paidmembershipspro.com/support-license/
+	define('PMPRO_LICENSE_NAG', false);	//consider purchasing a license at https://www.paidmembershipspro.com/pricing/
 */
 
 /*
@@ -80,7 +80,6 @@ function pmpro_license_settings_page() {
 	if(defined('PMPRO_DIR'))
 		require_once(PMPRO_DIR . "/adminpages/admin_header.php");
 	?>
-	<div class="wrap">
 		<h2><?php _e('Paid Memberships Pro Support License', 'paid-memberships-pro' );?></h2>
 		<p>Paid Memberships Pro and our add ons are distributed under the <a target="_blank" href='http://www.gnu.org/licenses/gpl-2.0.html'>GPLv2 license</a>. This means, among other things, that you may use the software on this site or any other site free of charge.</p>
 		<p><strong>An annual support license is recommended for websites running Paid Memberships Pro.</strong> <a href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=notifications&utm_campaign=pricing&utm_content=license-notice" target="_blank">View Support License Options &raquo;</a></p>			
@@ -111,15 +110,8 @@ function pmpro_license_settings_page() {
 				</div> <!-- end inside -->
 			</div> <!-- end post-box -->
 		</div> <!-- end metabox-holder -->		
-	</div> <!-- end wrap -->
 	<?php
 }
-
-function pmpro_license_admin_menu() {
-	//add license settings page
-	add_options_page('PMPro License', 'PMPro License', 'manage_options', 'pmpro_license_settings', 'pmpro_license_settings_page');
-}
-add_action('admin_menu', 'pmpro_license_admin_menu');
 
 /*
 	Check license.
@@ -265,7 +257,7 @@ function pmpro_license_nag() {
 		return;
 	
 	//don't load on the license page
-	if(!empty($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro_license_settings')
+	if(!empty($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-license')
 		return;
 	
 	//valid license?
@@ -299,7 +291,7 @@ function pmpro_license_nag() {
 				} 
 			?>
 			<?php _e("If you're running Paid Memberships Pro on a production website, we recommend an annual support license.", 'paid-memberships-pro' );?>
-			<a href="<?php echo admin_url('options-general.php?page=pmpro_license_settings');?>"><?php _e('More Info', 'paid-memberships-pro' );?></a>&nbsp;|&nbsp;<a href="<?php echo add_query_arg('pmpro_nag_paused', '1', $_SERVER['REQUEST_URI']);?>"><?php _e('Dismiss', 'paid-memberships-pro' );?></a>
+			<a href="<?php echo admin_url('admin.php?page=pmpro-license');?>"><?php _e('More Info', 'paid-memberships-pro' );?></a>&nbsp;|&nbsp;<a href="<?php echo add_query_arg('pmpro_nag_paused', '1', $_SERVER['REQUEST_URI']);?>"><?php _e('Dismiss', 'paid-memberships-pro' );?></a>
 		</p>
 	</div>
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR moves the PMPro License page from Settings > PMPro License to Memberships > License. There is a new tab in the plugin's admin page area for "License". Links within the plugin have been updated to point to this new location.

### Other information:
There may be old version of the Memberlite theme and certainly documentation and videos on the site pointing to the old URL / location.

Old url is: /wp-admin/options-general.php?page=pmpro_license_settings
New url is: /wp-admin/admin.php?page=pmpro-license
