### PR TITLE
resolve broken logic blocking membership changes

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -934,7 +934,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	// if it's a custom level, they're changing
 	if ( ! is_array( $level ) ) {
 		// are they even changing?
-		if ( pmpro_hasMembershipLevel( $level, $user_id ) ) {
+		if ( !pmpro_hasMembershipLevel( $level, $user_id ) ) {
 			$pmpro_error = __( 'not changing?', 'paid-memberships-pro' );
 			return false; // not changing
 		}


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: 1120.

The fix is small, but resolves a critically blocking bug preventing essential behaviour.

### How to test the changes in this Pull Request:

1. Attempt to change a user's membership through the admin panel "edit profile"
2. User's membership will update accordingly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Correct logical error within pmpro_changeMembershipLevel. If user DOES NOT have membership being modified, abort early.