### PR TITLE
Move row actions on orders.php from username to order_id - fixes #1126

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1334,18 +1334,8 @@ class="alternate"<?php } ?>>
 					<td>
 						<a href="admin.php?page=pmpro-orders&order=<?php echo $order->id; ?>"><?php echo $order->id; ?></a>
 					</td>
-					<td>
+					<td class="has-row-actions">
 						<a href="admin.php?page=pmpro-orders&order=<?php echo $order->id; ?>"><?php echo $order->code; ?></a>
-					</td>
-					<td class="username column-username has-row-actions">
-						<?php $order->getUser(); ?>
-						<?php if ( ! empty( $order->user ) ) { ?>
-							<a href="user-edit.php?user_id=<?php echo $order->user->ID; ?>"><?php echo $order->user->user_login; ?></a>
-						<?php } elseif ( $order->user_id > 0 ) { ?>
-							[<?php _e( 'deleted', 'paid-memberships-pro' ); ?>]
-						<?php } else { ?>
-							[<?php _e( 'none', 'paid-memberships-pro' ); ?>]
-						<?php } ?>
 						<br />
 						<div class="row-actions">
 							<span class="edit">
@@ -1380,6 +1370,16 @@ class="alternate"<?php } ?>>
 							}
 							?>
 						</div>
+					</td>
+					<td class="username column-username has-row-actions">
+						<?php $order->getUser(); ?>
+						<?php if ( ! empty( $order->user ) ) { ?>
+							<a href="user-edit.php?user_id=<?php echo $order->user->ID; ?>"><?php echo $order->user->user_login; ?></a>
+						<?php } elseif ( $order->user_id > 0 ) { ?>
+							[<?php _e( 'deleted', 'paid-memberships-pro' ); ?>]
+						<?php } else { ?>
+							[<?php _e( 'none', 'paid-memberships-pro' ); ?>]
+						<?php } ?>	
 					</td>
 					<?php do_action( 'pmpro_orders_extra_cols_body', $order ); ?>
 					<td><?php echo $order->membership_id; ?></td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Relocated the row_options on the order management page as they confused some admins - looks like they relate to the user, not the order.

Closes Issue: #1126 

### How to test the changes in this Pull Request:

1. go to orders page
2. hover over an order
3. related options appear under the order id - not the username

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: moved order options from username to order number on orders page