### PR TITLE
Uses isset() instead of array_key_exists() to prevent a warning notice.

### DIFF
--- a/includes/sessions.php
+++ b/includes/sessions.php
@@ -75,8 +75,8 @@ function pmpro_set_session_var($key, $value) {
  */
 function pmpro_get_session_var( $key ) {
     pmpro_start_session();
-	if ( ! empty( $_SESSION ) && array_key_exists( $key, $_SESSION ) ) {
-		return  $_SESSION[$key] ;
+	if ( ! empty( $_SESSION ) && isset( $_SESSION[$key] ) ) {
+		return  $_SESSION[$key];
 	} else {
 		return false;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When calling `pmpro_get_session_var()`, the call to `array_key_exists()` can return a warning notice, if `$_SESSION` doesn't exist, is `NULL`, or isn't an array.

This change replaces `array_key_exists()` with `isset()`, which is more performant, and caters to the type casting, to sidestep the warning notice.

Closes Issue: #1117.

### How to test the changes in this Pull Request:

1. Checkout this branch on your local environment.
2. Call `pmpro_get_session_var()`, and functions which call `pmpro_get_session_var()`.
3. Ensure no warning notices as a result.
4. Please test around this issue.
