### PR TITLE
Adjusts the default type for $this->attachments to be an empty array

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -44,7 +44,7 @@
 						
 			$this->headers = array("Content-Type: text/html");
 			
-			$this->attachments = NULL;
+			$this->attachments = array();
 			
 			//load the template			
 			$locale = apply_filters("plugin_locale", get_locale(), "paid-memberships-pro");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`wp_mail()` has a default value of `array()` for the `attachments` parameter. This PR sets the default value inside the PMPro email class to match what is expected by `wp_mail()`, to play nicely with email logging plugins such as Email Log.

Closes Issue: #1131.

### How to test the changes in this Pull Request:

1. Install the Email Log plugin. `wp plugin install email-log`
2. Trigger an email in PMPro.
3. View the email in Email Log.
4. Visit your local error_log file, and see no warning notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->