### PR TITLE
Stubbing out the appearance of a general and an error style notifications.

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -155,6 +155,42 @@ tr.pmpro_settings_divider td {
     color: #CF8516;
 }
 
+/* notifications */
+#pmpro_notifications .pmpro_notification {
+    position: relative;
+}
+#pmpro_notifications .pmpro_notification .pmpro_notification-general {
+    background: #FFF;
+    border-left: 4px solid #77A02E;
+    box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
+    margin: 1em 0;
+    padding: 15px;
+}
+#pmpro_notifications .pmpro_notification .pmpro_notification-error {
+    background: #FFF;
+    border-left: 4px solid #DC3232;
+    box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
+    margin: 1em 0;
+    padding: 15px;
+}
+#pmpro_notifications .pmpro_notification h3 {
+    font-size: 24px;
+    font-weight: 400;
+    margin: 0;
+}
+#pmpro_notifications .pmpro_notification p {
+    margin: 1em 0 0 0;
+}
+#pmpro_notifications .pmpro_notification .button {
+    margin-right: 5px;
+}
+#pmpro_notifications .pmpro_notification .pmpro_notification-general h3 {
+    color: #77A02E;
+}
+#pmpro_notifications .pmpro_notification .pmpro_notification-error h3 {
+    color: #DC3232;
+}
+
 /* highlighted trs */
 tr.pmpro_message {background-image: none;}
 tr.pmpro_success {background-image: none;}

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -1,66 +1,54 @@
 <?php
-/*
-	This code calls the server at www.paidmembershipspro.com to see if there are any notifications to display to the user. Notifications are shown on the PMPro settings pages in the dashboard.
-*/
-function pmpro_notifications()
-{
-	if(current_user_can("manage_options"))
-	{
-		$pmpro_notification = get_transient("pmpro_notification_" . PMPRO_VERSION);
-		if(empty($pmpro_notification))
-		{
-			//set to NULL in case the below times out or fails, this way we only check once a day
-			set_transient("pmpro_notification_" . PMPRO_VERSION, 'NULL', 86400);
+/**
+ * This code calls the server at www.paidmembershipspro.com to see if there are any notifications to display to the user. Notifications are shown on the PMPro settings pages in the dashboard.
+ *
+ */
+function pmpro_notifications() {
+	if ( current_user_can( 'manage_options' ) ) {
+		$pmpro_notification = get_transient( 'pmpro_notification_' . PMPRO_VERSION );
+		if ( empty( $pmpro_notification ) ) {
+			// Set to NULL in case the below times out or fails, this way we only check once a day.
+			set_transient( 'pmpro_notification_' . PMPRO_VERSION, 'NULL', 86400 );
 
-			//figure out which server to get from
-			if(is_ssl())
-			{
-				$remote_notification = wp_remote_get("https://notifications.paidmembershipspro.com/?v=" . PMPRO_VERSION);
-			}
-			else
-			{
-				$remote_notification = wp_remote_get("http://notifications.paidmembershipspro.com/?v=" . PMPRO_VERSION);
+			// Figure out which server to get from.
+			if ( is_ssl() ) {
+				$remote_notification = wp_remote_get( 'https://notifications.paidmembershipspro.com/?v=' . PMPRO_VERSION );
+			} else {
+				$remote_notification = wp_remote_get( 'http://notifications.paidmembershipspro.com/?v=' . PMPRO_VERSION );
 			}
 
-			//get notification
-			$pmpro_notification = wp_remote_retrieve_body($remote_notification);
+			// Get notification.
+			$pmpro_notification = wp_remote_retrieve_body( $remote_notification );
 
-			//update transient if we got something
-			if(!empty($pmpro_notification))
-				set_transient("pmpro_notification_" . PMPRO_VERSION, $pmpro_notification, 86400);
+			// Update transient if we got something.
+			if ( ! empty( $pmpro_notification ) ) {
+				set_transient( 'pmpro_notification_' . PMPRO_VERSION, $pmpro_notification, 86400 );
+			}
 		}
 
-		if($pmpro_notification && $pmpro_notification != "NULL")
-		{
-		?>
-		<div id="pmpro_notifications">
-			<?php echo $pmpro_notification; ?>
-		</div>
-		<?php
-		}
+		if ( $pmpro_notification && $pmpro_notification != 'NULL') { ?>
+			<div id="pmpro_notifications">
+				<?php echo $pmpro_notification; ?>
+			</div>
+		<?php }
 	}
 
-	//exit so we just show this content
+	// Exit so we just show this content.
 	exit;
 }
-add_action('wp_ajax_pmpro_notifications', 'pmpro_notifications');
+add_action( 'wp_ajax_pmpro_notifications', 'pmpro_notifications' );
 
-/*
-	Show Powered by Paid Memberships Pro comment (only visible in source) in the footer.
+/**
+ * Show Powered by Paid Memberships Pro comment (only visible in source) in the footer.
+ *
 */
-function pmpro_link()
-{
-?>
-Memberships powered by Paid Memberships Pro v<?php echo PMPRO_VERSION?>.
-<?php
-}
-function pmpro_footer_link()
-{
-	if(!pmpro_getOption("hide_footer_link"))
-	{
-		?>
+function pmpro_link() { ?>
+Memberships powered by Paid Memberships Pro v<?php echo PMPRO_VERSION; ?>.
+<?php }
+
+function pmpro_footer_link() {
+	if ( ! pmpro_getOption( 'hide_footer_link' ) ) { ?>
 		<!-- <?php echo pmpro_link()?> -->
-		<?php
-	}
+	<?php }
 }
-add_action("wp_footer", "pmpro_footer_link");
+add_action( 'wp_footer', 'pmpro_footer_link' );

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -26,8 +26,15 @@ function pmpro_notifications() {
 			}
 		}
 
-		if ( $pmpro_notification && $pmpro_notification != 'NULL') { ?>
-			<div id="pmpro_notifications">
+		if ( $pmpro_notification == 'NULL' ){
+			// Set a default notification for testing purposes.
+			$pmpro_notification = '<div class="pmpro_notification-general"><h3><span class="dashicons dashicons-warning"></span> Title of the notification.</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor <a href="#">incididunt ut labore et</a> dolore magna aliqua.</p><p><a class="button button-primary" href="#">Install Now</a> <a class="button button-link" href="#">More Information</a></div>';
+			$pmpro_notification .= '<div class="pmpro_notification-error"><h3><span class="dashicons dashicons-flag"></span> Title of the notification.</h2><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor <a href="#">incididunt ut labore et</a> dolore magna aliqua.</p><p><a class="button button-primary" href="#">Install Now</a> <a class="button button-secondary" href="#">More Information</a></div>';
+		}
+
+		if ( ! empty( $pmpro_notification ) && $pmpro_notification != 'NULL') { ?>
+			<div class="pmpro_notification">
+				<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button>
 				<?php echo $pmpro_notification; ?>
 			</div>
 		<?php }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR provides two styles for notifications for the new server to send notifications to sites.

Notifications can be sent in a format like the following:

- Wrap the HTML in a DIV like: `<div class="pmpro_notification-general">...</div>` or `<div class="pmpro_notification-error">...</div>`
- The title of notification should be sent in the `<h3>` tag which can optionally include the HTML for a dash icon like https://developer.wordpress.org/resource/dashicons/.
- The text of the notification should be wrapped in the `<p>` tag. Notification text can include hyperlinks.
- Buttons, if applicable, can be included in their own line in a paragraph tag as well.


