### PR TITLE
Adding Edit User and Edit Order links to the Error Canceling admin email

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -855,10 +855,14 @@
 					$pmproemail->template = "subscription_cancel_error";
 					$pmproemail->data = array("body"=>"<p>" . sprintf(__("There was an error canceling the subscription for user with ID=%s. You will want to check your payment gateway to see if their subscription is still active.", 'paid-memberships-pro' ), strval($this->user_id)) . "</p><p>Error: " . $this->error . "</p>");
 					$pmproemail->data["body"] .= '<p>' . __('User Email', 'paid-memberships-pro') . ': ' . $order_user->user_email . '</p>';
+					$pmproemail->data["body"] .= '<p>' . __('Username', 'paid-memberships-pro') . ': ' . $order_user->user_login . '</p>';
 					$pmproemail->data["body"] .= '<p>' . __('User Display Name', 'paid-memberships-pro') . ': ' . $order_user->display_name . '</p>';
 					$pmproemail->data["body"] .= '<p>' . __('Order', 'paid-memberships-pro') . ': ' . $this->code . '</p>';
 					$pmproemail->data["body"] .= '<p>' . __('Gateway', 'paid-memberships-pro') . ': ' . $this->gateway . '</p>';
 					$pmproemail->data["body"] .= '<p>' . __('Subscription Transaction ID', 'paid-memberships-pro') . ': ' . $this->subscription_transaction_id . '</p>';
+					$pmproemail->data["body"] .= '<hr />';
+					$pmproemail->data["body"] .= '<p>' . __('Edit User', 'paid-memberships-pro') . ': ' . get_edit_user_link( $this->user_id ) . '</p>';
+					$pmproemail->data["body"] .= '<p>' . __('Edit Order', 'paid-memberships-pro') . ': ' . add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $this->id ), admin_url('admin.php' ) ) . '</p>';
 					$pmproemail->sendEmail(get_bloginfo("admin_email"));
 				} else {
 					//Note: status would have been set to cancelled by the gateway class. So we don't have to update it here.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds Edit User and Edit Order links to the email when a gateway subscription fails to cancel. This email is only sent to the blog admin who has access to these edit links.

When managing error canceling emails, I am constantly searching my site for the user edit link in question in this email message. This will reduce the time admins must spend searching a members list for the specific user the email was generated for.

The email already includes the Order ID and User ID, so this code is leveraging that existing data to display more information to speed up membership site management.

### Changelog entry

ENHANCEMENT: Adding Order Edit and User Edit links to the Error Canceling email sent to the blog admin.