### PR TITLE
Fixed some timezones having first month be December in month dropdown

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -132,7 +132,7 @@ function pmpro_membership_level_profile_fields($user)
 							for($i = 1; $i < 13; $i++)
 							{
 							?>
-							<option value="<?php echo $i?>" <?php if($i == $selected_expires_month) { ?>selected="selected"<?php } ?>><?php echo date_i18n("M", strtotime($i . "/1/" . $current_year, current_time("timestamp")))?></option>
+							<option value="<?php echo $i?>" <?php if($i == $selected_expires_month) { ?>selected="selected"<?php } ?>><?php echo date_i18n("M", strtotime($i . "/15/" . $current_year, current_time("timestamp")))?></option>
 							<?php
 							}
 						?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed some timezones having first month be December in month dropdown, which would save the incorrect month when updating user expiration date.

Should also check for this bug elsewhere in the plugin.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: 1174.

### How to test the changes in this Pull Request:

1. Set WP timezone to somewhere in Europe (this causes the issue on my personal setup)
2. Ensure that months when setting an expiration date begin with January

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.