### PR TITLE
Frontend CSS adjustment; Removed duplicate message from Membership Billing page

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -145,6 +145,10 @@ form.pmpro_form select {
 	display: inline-block;
 	max-width: 90%;
 }
+form.pmpro_form .pmpro_checkout-field-bcity_state_zip .input,
+form.pmpro_form .pmpro_checkout-field-bcity_state_zip select {
+	max-width: 30%;
+}
 form.pmpro_form .pmpro_payment-cvv .input,
 form.pmpro_form .pmpro_payment-discount-code .input,
 form.pmpro_form #other_discount_code.input {

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -386,9 +386,6 @@
 	<?php } ?>
 
 <?php } else { // End for recurring level check.
-	?>
-	<p><?php printf(__("Logged in as <strong>%s</strong>.", 'paid-memberships-pro' ), $current_user->user_login);?> <small><a href="<?php echo esc_url( wp_logout_url() );?>"><?php _e("logout", 'paid-memberships-pro' );?></a></small></p>
-	<?php
 	// Check to see if the user has a cancelled order
 	$order = new MemberOrder();
 	$order->getLastMemberOrder( $current_user->ID, array( 'cancelled', 'expired', 'admin_cancelled' ) );


### PR DESCRIPTION
## Changelog entry
* BUG FIX: Fixing potential duplicate "logged in as" message on Membership Billing page for members with a non-recurring level.
* BUG FIX/ENHANCEMENT: Improving appearance of "City, State Zip Code" fields in Billing Address areas where the theme may force a width of 100% on input elements. 