### PR TITLE
Fixed bug where option to pay with PayPal wouldn't show if paid disco…

### DIFF
--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -212,7 +212,7 @@
 			global $gateway, $gateway_environment, $pmpro_level;
 			$default_gateway = pmpro_getOption("gateway");
 
-			if(($gateway == "paypal" || $default_gateway == "paypal") && !pmpro_isLevelFree($pmpro_level)) {
+			if ( $gateway == 'paypal' || $default_gateway == 'paypal' ) {
 				$dependencies = array( 'jquery' );
 				$paypal_enable_3dsecure = pmpro_getOption( 'paypal_enable_3dsecure' );
 				$data = array();	

--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -130,6 +130,14 @@
 				<?php
 			}
 
+			if ( pmpro_getGateway() == "paypal" && true == apply_filters('pmpro_include_payment_option_for_paypal', true ) ) {
+				if ( pmpro_isLevelFree($code_level) ) {
+					?> jQuery('#pmpro_payment_method').hide(); <?php
+				} else {
+					?> jQuery('#pmpro_payment_method').show(); <?php
+				}
+			}
+
 			//hide/show paypal button
 			if(pmpro_getGateway() == "paypalexpress" || pmpro_getGateway() == "paypalstandard")
 			{


### PR DESCRIPTION
Fixed bug where option to pay with PayPal wouldn't show if paid discount code was applied to free level

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed bug where option to pay with PayPal wouldn't show if paid discount code was applied to free level

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set gateway to Website Payments Pro
2. Create free level and paid discount code for that free level
3. Go to checkout for that free level
4. Enter paid discount code
5. Verify that the option to pay with PayPal is present

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.