### PR TITLE
Removing deprecated stripe-php function calls

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1937,8 +1937,7 @@ class PMProGateway_stripe extends PMProGateway {
 		$this->getCustomer( $order );
 
 		// Get open invoices.
-		$invoices = $this->customer->invoices();
-		$invoices = $invoices->all();
+		$invoices = Stripe_Invoice::all(['customer' => $this->customer->id, 'status' => 'open'])
 
 		// Found it, cancel it.
 		try {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change removed calls to a deprecated function in the Stripe-PHP library.

The deprecated call can be seen here:  https://github.com/strangerstudios/paid-memberships-pro/blob/00e7e8130ad667808c161f0c3964ae732798a3df/classes/gateways/class.pmprogateway_stripe.php#L1940

This function (i.e. Stripe\Customer::invoices()) was deprecated in the Stripe PHP Library in this commit: https://github.com/stripe/stripe-php/commit/8a046cfd119e50a048645f8d4249490a566379bc#diff-814438c52fc09aaad9ad47d5fa40351c

Having queries this with the Stripe support team, the recommended approach is now to use the list function on the Invoice object with the appropriate customer id and status (of open). This approach is documented at:  https://stripe.com/docs/api/invoices/list?lang=php

### How to test the changes in this Pull Request:

1. Create a new member & membership
2. Whilst logged in as that member, choose to cancel the membership
3. See error "There has been a critical error on your website." (prior to change, successful cancellation after change.)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Remove calls to deprecated stripe-php function Stripe\Customer::invoices() used during the cancellation of a membership.