### PR TITLE
Fixed issue where memberslist may show incorrect count and enddate

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -318,7 +318,7 @@
 				mu.initial_payment,
 				mu.billing_amount,
 				mu.cycle_period,
-				UNIX_TIMESTAMP(mu.enddate) as enddate,
+				UNIX_TIMESTAMP(max(mu.enddate)) as enddate,
 				m.name as membership
 			FROM {$wpdb->users} u
 			LEFT JOIN {$wpdb->usermeta} um ON u.ID = um.user_id
@@ -326,7 +326,7 @@
 			LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id
 			{$former_member_join}
 			WHERE u.ID BETWEEN %d AND %d AND mu.membership_id > 0 {$filter} {$search}
-			-- GROUP BY u.ID
+			GROUP BY u.ID
 			ORDER BY u.ID",
 				$first_uid,
 				$last_uid

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -314,14 +314,14 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		$start = $end - $limit;
 
 		if ( $count ) {
-			$sqlQuery = "SELECT COUNT(*) ";
+			$sqlQuery = "SELECT COUNT( DISTINCT u.ID ) ";
 		} else {
 			$sqlQuery =
 				"
 				SELECT u.ID, u.user_login, u.user_email, u.display_name,
 				UNIX_TIMESTAMP(u.user_registered) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, SUM(mu.initial_payment+ mu.billing_amount) as fee, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit,
 				UNIX_TIMESTAMP(mu.startdate) as startdate,
-				UNIX_TIMESTAMP(mu.enddate) as enddate, m.name as membership
+				UNIX_TIMESTAMP(max(mu.enddate)) as enddate, m.name as membership
 				";
 		}
 			


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed issue where memberslist may show incorrect count and enddate

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1207 

### How to test the changes in this Pull Request:

1. Find a user who has had multiple memberships in the past, but is now an old user
2. Navigate to Memberships > Members and change the "Show" dropdown to "Old Members"
3. Count the number of members shown and ensure that it is equal to the number shown next to the search bar
4. Find your user from step 1 and see that their enddate is the most recent of all their memberships 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.