### PR TITLE
Enhancement: Support Elementor Widgets Require Membership Settings

### DIFF
--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -34,6 +34,8 @@ function pmpro_elementor_get_all_levels() {
 		$levels_array[ $level->id ] = $level->name;
 	}
 
+	$levels_array = apply_filters( 'pmpro_elementor_levels_array', $levels_array );
+
 	return $levels_array;
 }
 

--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -1,4 +1,8 @@
-<?php 
+<?php
+
+// Include custom settings to restrict Elementor widgets.
+require_once( 'elementor/class-elementor.php' );
+
 /**
  * Elementor Compatibility
  */
@@ -14,4 +18,22 @@ function pmpro_elementor_compatibility() {
 	add_filter('the_content', 'pmpro_membership_content_filter', 15);
 }
 add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
+
+/**
+ * Get all available levels for elementor widget setting.
+ * @return array Associative array of level ID and name.
+ * @since 2.2.6
+ */
+function pmpro_elementor_get_all_levels() {
+	$all_levels = pmpro_getAllLevels( true, false );
+
+	$levels_array = array();
+
+	$levels_array[0] = __( 'Non-members', 'paid-memberships-pro' );
+	foreach( $all_levels as $level ) {
+		$levels_array[ $level->id ] = $level->name;
+	}
+
+	return $levels_array;
+}
 

--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -1,14 +1,8 @@
 <?php
 
-// Only run code if Elementor enabled.
-if ( defined( 'ELEMENTOR_VERSION' ) ) {
-	// Include custom settings to restrict Elementor widgets.
-	require_once( 'elementor/class-elementor.php' );
+// Include custom settings to restrict Elementor widgets.
+require_once( 'elementor/class-elementor.php' );
 
-	add_action( 'pmpro_save_membership_level', 'pmpro_elementor_clear_level_cache' );
-	add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
-
-}
 
 /**
  * Elementor Compatibility
@@ -51,8 +45,11 @@ function pmpro_elementor_get_all_levels() {
 
 	return $levels_array;
 }
+add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
+
 
 
 function pmpro_elementor_clear_level_cache( $level_id ) {
 	delete_transient( 'pmpro_elementor_levels_cache' );
 }
+add_action( 'pmpro_save_membership_level', 'pmpro_elementor_clear_level_cache' );

--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -1,7 +1,9 @@
 <?php
 
-// Include custom settings to restrict Elementor widgets.
-require_once( 'elementor/class-elementor.php' );
+if ( defined( 'ELEMENTOR_VERSION' ) ) {
+	// Include custom settings to restrict Elementor widgets.
+	require_once( 'elementor/class-elementor.php' );
+}
 
 /**
  * Elementor Compatibility

--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -1,8 +1,13 @@
 <?php
 
+// Only run code if Elementor enabled.
 if ( defined( 'ELEMENTOR_VERSION' ) ) {
 	// Include custom settings to restrict Elementor widgets.
 	require_once( 'elementor/class-elementor.php' );
+
+	add_action( 'pmpro_save_membership_level', 'pmpro_elementor_clear_level_cache' );
+	add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
+
 }
 
 /**
@@ -19,7 +24,6 @@ function pmpro_elementor_compatibility() {
 	remove_filter('the_content', 'pmpro_membership_content_filter', 5);
 	add_filter('the_content', 'pmpro_membership_content_filter', 15);
 }
-add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
 
 /**
  * Get all available levels for elementor widget setting.
@@ -27,17 +31,28 @@ add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
  * @since 2.2.6
  */
 function pmpro_elementor_get_all_levels() {
-	$all_levels = pmpro_getAllLevels( true, false );
 
-	$levels_array = array();
+	$levels_array = get_transient( 'pmpro_elementor_levels_cache' );
 
-	$levels_array[0] = __( 'Non-members', 'paid-memberships-pro' );
-	foreach( $all_levels as $level ) {
-		$levels_array[ $level->id ] = $level->name;
+	if ( empty( $levels_array ) ) {
+		$all_levels = pmpro_getAllLevels( true, false );
+
+		$levels_array = array();
+
+		$levels_array[0] = __( 'Non-members', 'paid-memberships-pro' );
+		foreach( $all_levels as $level ) {
+			$levels_array[ $level->id ] = $level->name;
+		}
+
+		set_transient( 'pmpro_elementor_levels_cache', $levels_array, 1 * DAY_IN_SECONDS );
 	}
-
+	
 	$levels_array = apply_filters( 'pmpro_elementor_levels_array', $levels_array );
 
 	return $levels_array;
 }
 
+
+function pmpro_elementor_clear_level_cache( $level_id ) {
+	delete_transient( 'pmpro_elementor_levels_cache' );
+}

--- a/includes/compatibility/elementor/class-elementor-restriction.php
+++ b/includes/compatibility/elementor/class-elementor-restriction.php
@@ -1,0 +1,70 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+use Elementor\Controls_Manager;
+
+class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
+	protected function content_restriction() {
+		// Setup controls
+		$this->register_controls();
+
+		// Filter elementor render_content hook
+		add_action( 'elementor/widget/render_content', array( $this, 'pmpro_elementor_filter_content' ), 20, 2 );
+	}
+
+	// Register controls to sections and widgets
+	protected function register_controls() {
+		foreach( $this->locations as $where )
+			add_action('elementor/element/'.$where['element'].'/'.$this->section_name.'/before_section_end', array( $this, 'add_controls' ), 10, 2 );
+	}
+
+	// Define controls
+	public function add_controls( $element, $args ) {
+		$element_type = $element->get_type();
+
+		$element->add_control(
+			'pmpro_require_membership_heading', array(
+				'label'     => __( 'Require Membership Level', 'paid-memberships-pro' ),
+				'type'      => Controls_Manager::HEADING,
+                'separator' => 'before',
+			)
+		);
+
+		$element->add_control(
+            'pmpro_require_membership', array(
+                'type'        => Controls_Manager::SELECT2,
+                'options'     => pmpro_elementor_get_all_levels(),
+                'multiple'    => 'true',
+				'label_block' => 'true',
+				'description' => __( 'Require membership level to see this content.', 'paid-memberships-pro' ),
+            )
+        );
+
+	}
+
+	public function pmpro_elementor_filter_content( $content, $widget ){
+
+        // Don't hide content in editor mode.
+        if ( \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
+            return $content;
+        }
+
+        $widget_settings = $widget->get_active_settings();
+
+        $restricted_levels = $widget_settings['pmpro_require_membership'];
+        
+        // Just return content if no setting is set for the current widget.
+        if ( ! $restricted_levels ) {
+            return $content;
+        }
+
+        if ( ! pmpro_hasMembershipLevel( $restricted_levels ) ) {
+           $content = '';
+        }
+        
+        return $content;
+	}
+}
+
+new PMPro_Elementor_Content_Restriction;

--- a/includes/compatibility/elementor/class-elementor-restriction.php
+++ b/includes/compatibility/elementor/class-elementor-restriction.php
@@ -10,19 +10,18 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 		$this->register_controls();
 
 		// Filter elementor render_content hook
-		add_action( 'elementor/widget/render_content', array( $this, 'pmpro_elementor_filter_content' ), 20, 2 );
+		add_action( 'elementor/widget/render_content', array( $this, 'pmpro_elementor_filter_content' ), 10, 2 );
 	}
 
 	// Register controls to sections and widgets
 	protected function register_controls() {
-		foreach( $this->locations as $where )
-			add_action('elementor/element/'.$where['element'].'/'.$this->section_name.'/before_section_end', array( $this, 'add_controls' ), 10, 2 );
+		foreach( $this->locations as $where ) {
+				add_action('elementor/element/'.$where['element'].'/'.$this->section_name.'/before_section_end', array( $this, 'add_controls' ), 10, 2 );
+		}
 	}
 
 	// Define controls
 	public function add_controls( $element, $args ) {
-		$element_type = $element->get_type();
-
 		$element->add_control(
 			'pmpro_require_membership_heading', array(
 				'label'     => __( 'Require Membership Level', 'paid-memberships-pro' ),
@@ -53,7 +52,7 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
         $widget_settings = $widget->get_active_settings();
 
         $restricted_levels = $widget_settings['pmpro_require_membership'];
-        
+
         // Just return content if no setting is set for the current widget.
         if ( ! $restricted_levels ) {
             return $content;

--- a/includes/compatibility/elementor/class-elementor.php
+++ b/includes/compatibility/elementor/class-elementor.php
@@ -14,10 +14,6 @@ class PMPro_Elementor {
         array(
             'element' => 'common',
             'action'  => '_section_style',
-        ),
-        array(
-            'element' => 'section',
-            'action'  => 'section_advanced',
         )
     );
     public $section_name = 'pmpro_elementor_section';

--- a/includes/compatibility/elementor/class-elementor.php
+++ b/includes/compatibility/elementor/class-elementor.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Add restriction options to Elementor Widgets For Paid Memberships Pro.
+ * @since 2.2.6
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+use Elementor\Controls_Manager;
+
+class PMPro_Elementor {
+    private static $_instance = null;
+
+    public $locations = array(
+        array(
+            'element' => 'common',
+            'action'  => '_section_style',
+        ),
+        array(
+            'element' => 'section',
+            'action'  => 'section_advanced',
+        )
+    );
+    public $section_name = 'pmpro_elementor_section';
+
+	/**
+	 * Register new section for PMPro Required Membership Levels.
+	 */
+	public function __construct() {
+        
+        require_once( __DIR__ . '/class-elementor-restriction.php' );
+        // Register new section to display restriction controls
+        $this->register_sections();
+
+        $this->content_restriction();
+	}
+
+    /**
+     *
+     * Ensures only one instance of the class is loaded or can be loaded.
+     *
+     * @return PMPro_Elementor An instance of the class.
+     */
+    public static function instance() {
+        if ( is_null( self::$_instance ) )
+            self::$_instance = new self();
+
+        return self::$_instance;
+    }
+
+    private function register_sections() {
+        foreach( $this->locations as $where ) {
+            add_action( 'elementor/element/'.$where['element'].'/'.$where['action'].'/after_section_end', array( $this, 'add_section' ), 10, 2 );
+        }
+    }
+
+    public function add_section( $element, $args ) {
+        $exists = \Elementor\Plugin::instance()->controls_manager->get_control_from_stack( $element->get_unique_name(), $this->section_name );
+
+        if( !is_wp_error( $exists ) )
+            return false;
+
+        $element->start_controls_section(
+            $this->section_name, array(
+                'tab'   => \Elementor\Controls_Manager::TAB_ADVANCED,
+                'label' => __( 'Paid Memberships Pro', 'paid-memberships-pro' ),
+            )
+        );
+
+        $element->end_controls_section();
+    }
+
+    protected function content_restriction(){}
+}
+
+// Instantiate Plugin Class
+PMPro_Elementor::instance();


### PR DESCRIPTION
Enhancement: Create Elementor widget settings for Paid Memberships Pro. This allows to hide widgets based on user's membership level/show to non-members.

TODO: Support columns better. Currently you will need to select each widget and not set the main 'parent' column to show/hide for members.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enhancement: Create Elementor widget settings for Paid Memberships Pro. This allows to hide widgets based on user's membership level/show to non-members.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1. Setup Elementor, create a page using Elementor.
2. Navigate to the selected Widget (i.e. Text) and choose "Advanced" tab.
3. In the Advanced Tab, go to "Paid Memberships Pro" and select what levels should access that widget.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Enhancement: Create Elementor widget settings for Paid Memberships Pro. This allows to hide widgets based on user's membership level/show to non-members.