### PR TITLE
Paypal ipn cancel once

### DIFF
--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -678,11 +678,11 @@
 		{
 			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
 			if (
-					( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
-					( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
-				) {
-					$order->updateStatus("cancelled");
-					return true;
+				( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
+				( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
+			) {
+				$order->updateStatus("cancelled");
+				return true;
 			}
 
 			//paypal profile stuff

--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -676,6 +676,15 @@
 
 		function cancel(&$order)
 		{
+			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
+			if (
+					( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
+					( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
+				) {
+					$order->updateStatus("cancelled");
+					return true;
+			}
+
 			//paypal profile stuff
 			$nvpStr = "";
 			$nvpStr .= "&PROFILEID=" . urlencode($order->subscription_transaction_id) . "&ACTION=Cancel&NOTE=" . urlencode("User requested cancel.");

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -762,9 +762,9 @@
 
 			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
 			if (
-					( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
-					( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
-				) {
+				( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
+				( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
+			) {
 				return true;
 			}
 

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -760,8 +760,11 @@
 			// Always cancel the order locally even if PayPal might fail
 			$order->updateStatus("cancelled");
 
-			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal
-			if( !empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) {
+			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
+			if (
+					( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
+					( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
+				) {
 				return true;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Prevent trying to cancel subscription at gateway if processing an IPN cancellation (double cancel)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1208

### How to test the changes in this Pull Request:
Still needs testing on a development site which can receive IPN messages, but the general steps are as follows:
1. Have user check out for subscription via PayPal
2. Cancel subscription at PayPal gateway
3. Ensure that no email was received by site admin saying that there was an error canceling the subscription at the gateway

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.