### PR TITLE
Membership profile: fix month calculation in expiry dropdown #1174

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -131,8 +131,10 @@ function pmpro_membership_level_profile_fields($user)
 						<?php
 							for($i = 1; $i < 13; $i++)
 							{
+								$first_of_month = date_create($i . "/1/" . $current_year, wp_timezone());
+                                				$option_month = wp_date( "M",  $first_of_month->getTimestamp());
 							?>
-							<option value="<?php echo $i?>" <?php if($i == $selected_expires_month) { ?>selected="selected"<?php } ?>><?php echo date_i18n("M", strtotime($i . "/15/" . $current_year, current_time("timestamp")))?></option>
+							<option value="<?php echo $i?>" <?php if($i == $selected_expires_month) { ?>selected="selected"<?php } ?>><?php echo $option_month; ?></option>
 							<?php
 							}
 						?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This commit uses the in WordPress 5.3 newly introduced wp_timezone and wp_date functions, to calculate the timestamp for the first of the month while respecting the timezone from WordPress' settings.

The main difference is, that the timestamp created is fed with the wp_timezone, and thus the timezone isn't subtracted or added later on. 

Furthermore, this removes the – now legacy from 5.3 on – `date_i18n()` call.

Closes Issue: 1174.

### How to test the changes in this Pull Request:

1. Set WP timezone to somewhere in Europe (this causes the issue on my personal setup)
2. Ensure that months when setting an expiration date begin with January

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Membership profile: fix month calculation in expiry dropdown