### PR TITLE
Pay by check formatting updates

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -27,11 +27,12 @@
 		$pmpro_invoice->getMembershipLevel();			
 				
 		$confirmation_message .= "<p>" . sprintf(__('Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s.', 'paid-memberships-pro' ), $pmpro_invoice->user->user_email) . "</p>";
-		
-		//check instructions
-		if($pmpro_invoice->gateway == "check" && !pmpro_isLevelFree($pmpro_invoice->membership_level))
-			$confirmation_message .= wpautop(wp_unslash( pmpro_getOption("instructions") ) );
-		
+
+		// Check instructions
+		if ( $pmpro_invoice->gateway == "check" && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+			$confirmation_message .= '<div class="pmpro_payment_instructions">' . wpautop( wp_unslash( pmpro_getOption("instructions") ) ) . '</div>';
+		}
+
 		/**
 		 * All devs to filter the confirmation message.
 		 * We also have a function in includes/filters.php that applies the the_content filters to this message.

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -73,16 +73,18 @@
 			</div> <!-- end pmpro_invoice-billing-address -->
 		<?php } ?>
 		
-		<?php if($pmpro_invoice->accountnumber) { ?>
+		<?php if ( ! empty( $pmpro_invoice->accountnumber ) || ! empty( $pmpro_invoice->payment_type ) ) { ?>
 			<div class="pmpro_invoice-payment-method">
 				<strong><?php _e('Payment Method', 'paid-memberships-pro' );?></strong>
-				<p><?php echo $pmpro_invoice->cardtype?> <?php _e('ending in', 'paid-memberships-pro' );?> <?php echo last4($pmpro_invoice->accountnumber)?></p>
-				<p><?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo $pmpro_invoice->expirationmonth?>/<?php echo $pmpro_invoice->expirationyear?></p>
+				<?php if($pmpro_invoice->accountnumber) { ?>
+					<p><?php echo ucwords( $pmpro_invoice->cardtype ); ?> <?php _e('ending in', 'paid-memberships-pro' );?> <?php echo last4($pmpro_invoice->accountnumber)?></p>
+					<p><?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo $pmpro_invoice->expirationmonth?>/<?php echo $pmpro_invoice->expirationyear?></p>
+				<?php } else { ?>
+					<p><?php echo $pmpro_invoice->payment_type; ?></p>
+				<?php } ?>
 			</div> <!-- end pmpro_invoice-payment-method -->
-		<?php } elseif($pmpro_invoice->payment_type) { ?>
-			<?php echo $pmpro_invoice->payment_type?>
 		<?php } ?>
-		
+
 		<div class="pmpro_invoice-total">
 			<strong><?php _e('Total Billed', 'paid-memberships-pro' );?></strong>
 			<p><?php if($pmpro_invoice->total != '0.00') { ?>

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -35,9 +35,10 @@
 		</ul>
 
 		<?php
-			//check instructions
-			if($pmpro_invoice->gateway == "check" && !pmpro_isLevelFree($pmpro_invoice->membership_level))
-				echo wpautop(pmpro_getOption("instructions"));
+			// Check instructions
+			if ( $pmpro_invoice->gateway == "check" && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+				echo '<div class="pmpro_payment_instructions">' . wpautop( wp_unslash( pmpro_getOption("instructions") ) ) . '</div>';
+			}
 		?>
 
 		<hr />

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -55,14 +55,16 @@
 				</div> <!-- end pmpro_invoice-billing-address -->
 			<?php } ?>
 
-			<?php if($pmpro_invoice->accountnumber) { ?>
+			<?php if ( ! empty( $pmpro_invoice->accountnumber ) || ! empty( $pmpro_invoice->payment_type ) ) { ?>
 				<div class="pmpro_invoice-payment-method">
 					<strong><?php _e('Payment Method', 'paid-memberships-pro' );?></strong>
-					<p><?php echo ucwords( $pmpro_invoice->cardtype ); ?> <?php _e('ending in', 'paid-memberships-pro' );?> <?php echo last4($pmpro_invoice->accountnumber)?></p>
-					<p><?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo $pmpro_invoice->expirationmonth?>/<?php echo $pmpro_invoice->expirationyear?></p>
+					<?php if($pmpro_invoice->accountnumber) { ?>
+						<p><?php echo ucwords( $pmpro_invoice->cardtype ); ?> <?php _e('ending in', 'paid-memberships-pro' );?> <?php echo last4($pmpro_invoice->accountnumber)?></p>
+						<p><?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo $pmpro_invoice->expirationmonth?>/<?php echo $pmpro_invoice->expirationyear?></p>
+					<?php } else { ?>
+						<p><?php echo $pmpro_invoice->payment_type; ?></p>
+					<?php } ?>
 				</div> <!-- end pmpro_invoice-payment-method -->
-			<?php } elseif($pmpro_invoice->payment_type) { ?>
-				<?php echo $pmpro_invoice->payment_type?>
 			<?php } ?>
 
 			<div class="pmpro_invoice-total">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The payment details section on the Membership Confirmation page and Membership Invoice single pages had bad formatting when the payment gateway on the order was "Check". This PR includes a few updates to improve the formatting.

I've also added a new div with class name "pmpro_payment_instructions" to wrap the payment instructions when output on the confirmation or invoice pages.