### PR TITLE
Bug Fix: CVV not passing through to API

### DIFF
--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -26,8 +26,24 @@
 			//add fields to payment settings
 			add_filter('pmpro_payment_options', array('PMProGateway_authorizenet', 'pmpro_payment_options'));
 			add_filter('pmpro_payment_option_fields', array('PMProGateway_authorizenet', 'pmpro_payment_option_fields'), 10, 2);
+
+			add_filter('pmpro_checkout_order', array('PMProGateway_authorizenet', 'pmpro_checkout_order'));
+			add_filter('pmpro_billing_order', array('PMProGateway_authorizenet', 'pmpro_checkout_order'));
+
 		}
 
+		static function pmpro_checkout_order( $morder ) {
+
+			if ( isset( $_REQUEST['CVV'] ) ) {
+				$authorizenet_cvv = sanitize_text_field( $_REQUEST['CVV'] );
+			} else {
+				$authorizenet_cvv = '';
+			}
+
+			$morder->CVV2 = $authorizenet_cvv;
+			return $morder;
+		}
+		
 		/**
 		 * Make sure this gateway is in the gateways list
 		 *
@@ -507,8 +523,10 @@
 				// guide at: http://developer.authorize.net
 			);
 
-			if(!empty($order->CVV2))
+
+			if(!empty($order->CVV2) ) {
 				$post_values["x_card_code"] = $order->CVV2;
+			}
 
 			// This section takes the input fields and converts them to the proper format
 			// for an http post.  For example: "x_login=username&x_tran_key=a1B2c3D4"


### PR DESCRIPTION
Bug Fix: CVV value wasn't being passed through to Authorize.net API.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Bug Fix: CVV not passing to Authorize.net API

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Bug Fix: CVV not passing to Authorize.net API