### PR TITLE
Oxford comma levels string

### DIFF
--- a/includes/currencies.php
+++ b/includes/currencies.php
@@ -40,6 +40,11 @@
 			'symbol' => 'DKK&nbsp;',
 			'position' => 'left',
 			),
+		'GHS' => array(
+			'name' => __('Ghanaian Cedi (&#8373;)', 'paid-memberships-pro' ),
+			'symbol' => '&#8373;',
+			'position' => 'left',
+			),
 		'HKD' => __('Hong Kong Dollar (&#36;)', 'paid-memberships-pro' ),
 		'HUF' => __('Hungarian Forint', 'paid-memberships-pro' ),
 		'INR' => __('Indian Rupee', 'paid-memberships-pro' ),
@@ -48,7 +53,7 @@
 		'JPY' => array(
 			'name' => __('Japanese Yen (&yen;)', 'paid-memberships-pro' ),
 			'symbol' => '&yen;',
-			'position' => 'right',
+			'position' => 'left',
 			'decimals' => 0,
 			),
 		'KES' => __('Kenyan Shilling', 'paid-memberships-pro' ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1755,7 +1755,16 @@ function pmpro_implodeToEnglish( $array, $conjunction = 'and' ) {
 		$conjunction = __( 'and', 'paid-memberships-pro' );
 	}
 
-	return implode( ', ', $array ) . ' ' . $conjunction . ' ' . $last;
+	// List the elements in a comma-separated list.
+	$start = implode( ', ', $array );
+
+	// Add the Oxford comma if needed.
+	if ( count( $array ) > 1 ) {
+		$start .= ',';
+	}
+
+	// Output the elements.
+	return $start . ' ' . $conjunction . ' ' . $last;
 }
 
 // from yoast wordpress seo


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR revisits the `pmpro_implodeToEnglish` function to add the Oxford comma in the comma-separated lists, specifically how this is output when using the !!levels!! string replacement in a non-member text .

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Assign three or more levels to a post or page.
2. View the post or page as a non-member.
3. The multiple levels output in the non-member text should read as follows:
`This content is for Free, Enhanced, and Premium members only.`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Updating the 'pmpro_implodeToEnglish' function to use an Oxford comma.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.