### PR TITLE
First steps toward frontend login

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -498,6 +498,21 @@ function pmpro_hide_pages_redirect()
 add_action('wp', 'pmpro_hide_pages_redirect');
 
 /**
+ * Filter the entire content of the Membership Account page if no user.
+ *
+ */
+function pmpro_membership_account_filter( $content ) {
+	global $pmpro_pages;
+
+	// If no user, swap entire Membership Account page content.
+	if ( is_page( $pmpro_pages[ 'account' ] ) && ! is_user_logged_in() ) {
+		$content = pmpro_login_form( );
+	}
+	return $content;
+}
+add_filter( 'the_content', 'pmpro_membership_account_filter', 10 );
+
+/**
  * Adds custom classes to the array of post classes.
  *
  * pmpro-level-required = this post requires at least one level

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -44,7 +44,7 @@ pmpro_setDBTables();
 
 // from: http://stackoverflow.com/questions/5266945/wordpress-how-detect-if-current-page-is-the-login-page/5892694#5892694
 function pmpro_is_login_page() {
-	return ( in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ) ) || is_page( 'login' ) );
+	return ( in_array( $GLOBALS['pagenow'], array( 'wp-login.php', 'wp-register.php' ) ) || is_page( 'login' ) || is_page( pmpro_getOption( 'account_page_id' ) ) );
 }
 
 // thanks: http://wordpress.org/support/topic/is_plugin_active

--- a/preheaders/account.php
+++ b/preheaders/account.php
@@ -16,22 +16,16 @@ if (isset($_REQUEST['msg'])) {
     $pmpro_msg = false;
 }
 
-//if no user, redirect to levels page
-if (empty($current_user->ID)) {
-    $redirect = apply_filters("pmpro_account_preheader_no_user_redirect", pmpro_url("levels"));
-    if ($redirect) {
-        wp_redirect($redirect);
-        exit;
-    }
-}
-
-//if no membership level, redirect to levels page
-if (empty($current_user->membership_level->ID)) {
-    $redirect = apply_filters("pmpro_account_preheader_redirect", pmpro_url("levels"));
-    if ($redirect) {
-        wp_redirect($redirect);
-        exit;
-    }
+/**
+ * Check if the current logged in user has a membership level.
+ * If not, redirect to levels page.
+ */
+if ( ! empty( $current_user->ID && empty( $current_user->membership_level->ID ) ) ) {
+	$redirect = apply_filters( 'pmpro_account_preheader_redirect', pmpro_url( 'levels' ) );
+	if ( $redirect ) {
+		wp_redirect( $redirect );
+		exit;
+	}
 }
 
 global $pmpro_levels;


### PR DESCRIPTION
- Filters the_content of membership account page to insert pmpro_login_form().
- Remove admin redirect to wp-admin and treat like other users.
- Login via membership account page now redirects non-members to levels page (filter available for overriding this)
- Login via membership account page now redirects members back to referrer (membership account page, other) or passed in redirect_to attribute.
- Redirecting wp-login.php to Membership Account page for login.