### PR TITLE
Adding Ghanian Cedi currency; Format update to Japanese Yen - JPY.

### DIFF
--- a/includes/currencies.php
+++ b/includes/currencies.php
@@ -40,6 +40,11 @@
 			'symbol' => 'DKK&nbsp;',
 			'position' => 'left',
 			),
+		'GHS' => array(
+			'name' => __('Ghanian Cedi (&#8373;)', 'paid-memberships-pro' ),
+			'symbol' => '&#8373;',
+			'position' => 'left',
+			),
 		'HKD' => __('Hong Kong Dollar (&#36;)', 'paid-memberships-pro' ),
 		'HUF' => __('Hungarian Forint', 'paid-memberships-pro' ),
 		'INR' => __('Indian Rupee', 'paid-memberships-pro' ),
@@ -48,7 +53,7 @@
 		'JPY' => array(
 			'name' => __('Japanese Yen (&yen;)', 'paid-memberships-pro' ),
 			'symbol' => '&yen;',
-			'position' => 'right',
+			'position' => 'left',
 			'decimals' => 0,
 			),
 		'KES' => __('Kenyan Shilling', 'paid-memberships-pro' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
A user requested Ghanian Cedi added to the list. In doing this, I also fixed a format with the JPY currency symbol position as noted in a .org support ticket and issue in this repository.
 
Closes Issue: 1055.

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* BUG FIX: Adjusted currency symbol position for JPY currency to 'left'. 
* ENHANCEMENT: Added Ghanian Cedi as a currency.
