### PR TITLE
Updating default template for billing failure notices to user and admin

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -621,7 +621,7 @@
 								"accountnumber" => hideCardNumber($invoice->accountnumber),
 								"expirationmonth" => $invoice->expirationmonth,
 								"expirationyear" => $invoice->expirationyear,
-								"login_link" => wp_login_url(pmpro_url("billing"))
+								"login_link" => wp_login_url( get_edit_user_link( $user->ID ) )
 							);
 			$this->data["billing_address"] = pmpro_formatAddress($invoice->billing->name,
 																 $invoice->billing->street,

--- a/email/billing_failure.html
+++ b/email/billing_failure.html
@@ -1,11 +1,3 @@
 <p>The current subscription payment for your !!sitename!! membership has failed. <strong>Please click the following link to log in and update your billing information to avoid account suspension. !!login_link!!</strong></p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>
-<p>The most recent account information we have on file is:</p>
-
-<p>!!billing_address!!</p>
-
-<p>
-	!!cardtype!!: !!accountnumber!!<br />
-	Expires: !!expirationmonth!!/!!expirationyear!!
-</p>

--- a/email/billing_failure_admin.html
+++ b/email/billing_failure_admin.html
@@ -1,11 +1,6 @@
-<p>Payment Failure</p>
+<p>The subscription payment for !!user_login!! at !!sitename!! has failed.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>
-<p>The most recent account information we have on file is:</p>
+<p>Membership Level: !!membership_level_name!!</p>
 
-<p>!!billing_address!!</p>
-
-<p>
-	!!cardtype!!: !!accountnumber!!<br />
-	Expires: !!expirationmonth!!/!!expirationyear!!
-</p>
+<p>Log in to your WordPress admin here: !!login_link!!</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Update the default formatting of the billing failure notice to be more cross-gateway compatible. Currently, users that check out with an offsite gateway would receive this billing_failure.html notice and it would look like a credit card failure with missing information for card number, type, expiration, and address. 

If a site owner wants to add this information back to these emails and is only using onsite credit card checkout, they can use the Email Templates Admin Editor to include this data.

Additionally, the admin version of the billing failure email had a link to the Membership Billing frontend page. This page is not useful to the admin. I have replaced the !!login_url!! variable to instead take the admin to the "Edit User" page for the account with failed payment.

### How to test the changes in this Pull Request:

1. Install the Email Templates Admin Editor
2. Trigger a test of the billing_failure.html notice
3. Trigger a test of the billing_failure_admin.html notice

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
ENHANCEMENT: Improving the cross-gateway compatible for default messages in the email notices sent to the user and admin when a recurring membership payment fails to process.
