### PR TITLE
Adding Advanced Setting to Hide Admin Bar.

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -44,6 +44,9 @@
 		//tos
 		pmpro_setOption("tospage");
 
+		//toolbar
+		pmpro_setOption( 'hide_toolbar' );
+
 		//footer link
 		pmpro_setOption("hide_footer_link");
 
@@ -80,6 +83,8 @@
 	$recaptcha_privatekey = pmpro_getOption("recaptcha_privatekey");
 
 	$tospage = pmpro_getOption("tospage");
+
+	$hide_toolbar = pmpro_getOption( 'hide_toolbar' );
 
 	$hide_footer_link = pmpro_getOption("hide_footer_link");
 
@@ -313,6 +318,14 @@ if ( pmpro_displayAds() ) {
 					?>
 					<br />
 					<p class="description"><?php _e('If yes, create a WordPress page containing your TOS agreement and assign it using the dropdown above.', 'paid-memberships-pro' );?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row" valign="top">
+					<label for="hide_toolbar"><?php _e('WordPress Toolbar', 'paid-memberships-pro' );?></label>
+				</th>
+				<td>
+					<input id="hide_toolbar" name="hide_toolbar" type="checkbox" value="yes" <?php checked( $hide_toolbar, 'yes' ); ?> /> <label for="hide_toolbar"><?php _e('Hide the Toolbar from non-Administrator users.', 'paid-memberships-pro' );?></label>
 				</td>
 			</tr>
 

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -2,6 +2,7 @@
 /**
  * Custom menu functions for Paid Memberships Pro
  *
+ * @since 2.3
  */
 function pmpro_register_menus() {
 	// Register PMPro menu areas.
@@ -12,3 +13,20 @@ function pmpro_register_menus() {
 	);
 }
 add_action( 'after_setup_theme', 'pmpro_register_menus' );
+
+/**
+ * Hide the WordPress Toolbar from Non-Admins.
+ *
+ * @since 2.3
+ */
+function pmpro_hide_toolbar_from_non_admins() {
+
+	// Get the Advanced Setting for toolbar display.
+	$hide_toolbar = pmpro_getOption( 'hide_toolbar' );
+
+	if ( ! current_user_can( 'administrator' ) && ! empty( $hide_toolbar ) ) {
+		add_filter( 'show_admin_bar', '__return_false' );
+		//add_action( 'admin_print_scripts-profile.php', 'habfna_hide_admin_bar_settings' );
+	}	
+}
+add_action( 'init', 'pmpro_hide_toolbar_from_non_admins', 9 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds new setting to hide admin bar from non-administrator users. Users can still access this setting on the "Edit Profile" admin page. We may want to consider adding the CSS to hide that row.

### Changelog entry
ENHANCEMENT: Adding an Advanced Setting to "Hide the Toolbar from non-Administrator users.".
