### PR TITLE
Removing curly braces. PHP 7.4 compatibility.

### DIFF
--- a/includes/lib/name-parser.php
+++ b/includes/lib/name-parser.php
@@ -25,7 +25,7 @@ if(!function_exists("pnp_split_full_name"))
 		$name_parts = array();
 		// completely ignore any words in parentheses
 		foreach ($unfiltered_name_parts as $word) {
-			if (!empty($word) && $word{0} != "(")
+			if (!empty($word) && $word[0] != "(")
 				$name_parts[] = $word;
 		}
 		$num_words = sizeof($name_parts);
@@ -131,7 +131,7 @@ if(!function_exists("pnp_split_full_name"))
 
 	// single letter, possibly followed by a period
 	function pnp_is_initial($word) {
-		return ((strlen($word) == 1) || (strlen($word) == 2 && $word{1} == "."));
+		return ((strlen($word) == 1) || (strlen($word) == 2 && $word[1] == "."));
 	}
 
 	// detect mixed case words like "McDonald"


### PR DESCRIPTION
Closes #1252 

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes PHP 7.4 deprecation notices that are shown to the user.

### How to test the changes in this Pull Request:

1. Install PHP 7.4
2. Have WP_DEBUG set to true.
3. Visit any page on the site and you'll receive a deprecation notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix PHP 7.4 deprecation notice regarding curly braces when pulling in array values.