### PR TITLE
Adding array check when retrieving user meta.

### DIFF
--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -487,7 +487,10 @@ function pmpro_notifications_pause() {
 		return true;
 	}
 	
-	$archived_notifications = get_user_meta( $current_user->ID, 'pmpro_archived_notifications', true );			
+	$archived_notifications = get_user_meta( $current_user->ID, 'pmpro_archived_notifications', true );
+	if ( ! is_array( $archived_notifications ) ) {
+		return false;
+	}			
 	$archived_notifications = array_values( $archived_notifications );
 	$num = count($archived_notifications);
 	$now = current_time( 'timestamp' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Wrap an `is_array` check 

### Changelog entry

> PHP 7.4 compatibility with array check.