### PR TITLE
Now clearing activity email cron on deactivation

### DIFF
--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -207,6 +207,7 @@ function pmpro_deactivation() {
 	wp_clear_scheduled_hook( 'pmpro_cron_trial_ending_warnings' );
 	wp_clear_scheduled_hook( 'pmpro_cron_expire_memberships' );
 	wp_clear_scheduled_hook( 'pmpro_cron_credit_card_expiring_warnings' );
+	wp_clear_scheduled_hook( 'pmpro_cron_admin_activity_email' );
 
 	// remove caps from admin role
 	pmpro_set_capabilities_for_role( 'administrator', 'disable' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Bug fix: clear activity email cron when PMPro is deactivated

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1. Enable PMPro
2. Disable PMPro
3. Ensure that 'pmpro_cron_admin_activity_email' is not present

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.