### PR TITLE
Removing hyphen in email label

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -133,7 +133,7 @@ function pmpro_login_form( $show_menu = true, $show_logout_link = true, $display
 				$msgt = 'pmpro_error';
 				break;
 			case 'recovered':
-				$message = __( 'Check your e-mail for the confirmation link.', 'paid-memberships-pro' );
+				$message = __( 'Check your email for the confirmation link.', 'paid-memberships-pro' );
 				break;
 		}
 	}

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -246,11 +246,11 @@
 							$bconfirmemail = $current_user->user_email;
 					?>
 					<div class="pmpro_checkout-field pmpro_checkout-field-bemail">
-						<label for="bemail"><?php _e('E-mail Address', 'paid-memberships-pro' );?></label>
+						<label for="bemail"><?php _e('Email Address', 'paid-memberships-pro' );?></label>
 						<input id="bemail" name="bemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="input <?php echo pmpro_getClassForField("bemail");?>" size="30" value="<?php echo esc_attr($bemail)?>" />
 					</div> <!-- end pmpro_checkout-field-bemail -->
 					<div class="pmpro_checkout-field pmpro_checkout-field-bconfirmemail">
-						<label for="bconfirmemail"><?php _e('Confirm E-mail', 'paid-memberships-pro' );?></label>
+						<label for="bconfirmemail"><?php _e('Confirm Email', 'paid-memberships-pro' );?></label>
 						<input id="bconfirmemail" name="bconfirmemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="input <?php echo pmpro_getClassForField("bconfirmemail");?>" size="30" value="<?php echo esc_attr($bconfirmemail)?>" />
 					</div> <!-- end pmpro_checkout-field-bconfirmemail -->
 					<?php } ?>

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -145,7 +145,7 @@
 			?>
 
 			<div class="pmpro_checkout-field pmpro_checkout-field-bemail">
-				<label for="bemail"><?php _e('E-mail Address', 'paid-memberships-pro' );?></label>
+				<label for="bemail"><?php _e('Email Address', 'paid-memberships-pro' );?></label>
 				<input id="bemail" name="bemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="input <?php echo pmpro_getClassForField("bemail");?>" size="30" value="<?php echo esc_attr($bemail); ?>" />
 			</div> <!-- end pmpro_checkout-field-bemail -->
 
@@ -153,7 +153,7 @@
 				$pmpro_checkout_confirm_email = apply_filters("pmpro_checkout_confirm_email", true);
 				if($pmpro_checkout_confirm_email) { ?>
 					<div class="pmpro_checkout-field pmpro_checkout-field-bconfirmemail">
-						<label for="bconfirmemail"><?php _e('Confirm E-mail Address', 'paid-memberships-pro' );?></label>
+						<label for="bconfirmemail"><?php _e('Confirm Email Address', 'paid-memberships-pro' );?></label>
 						<input id="bconfirmemail" name="bconfirmemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="input <?php echo pmpro_getClassForField("bconfirmemail");?>" size="30" value="<?php echo esc_attr($bconfirmemail); ?>" />
 					</div> <!-- end pmpro_checkout-field-bconfirmemail -->
 				<?php } else { ?>
@@ -327,14 +327,14 @@
 				}
 			?>
 			<div class="pmpro_checkout-field pmpro_checkout-field-bemail">
-				<label for="bemail"><?php _e('E-mail Address', 'paid-memberships-pro' );?></label>
+				<label for="bemail"><?php _e('Email Address', 'paid-memberships-pro' );?></label>
 				<input id="bemail" name="bemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="input <?php echo pmpro_getClassForField("bemail");?>" size="30" value="<?php echo esc_attr($bemail); ?>" />
 			</div> <!-- end pmpro_checkout-field-bemail -->
 			<?php
 				$pmpro_checkout_confirm_email = apply_filters("pmpro_checkout_confirm_email", true);
 				if($pmpro_checkout_confirm_email) { ?>
 					<div class="pmpro_checkout-field pmpro_checkout-field-bconfirmemail">
-						<label for="bconfirmemail"><?php _e('Confirm E-mail', 'paid-memberships-pro' );?></label>
+						<label for="bconfirmemail"><?php _e('Confirm Email', 'paid-memberships-pro' );?></label>
 						<input id="bconfirmemail" name="bconfirmemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="input <?php echo pmpro_getClassForField("bconfirmemail");?>" size="30" value="<?php echo esc_attr($bconfirmemail); ?>" />
 					</div> <!-- end pmpro_checkout-field-bconfirmemail -->
 				<?php } else { ?>

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -733,7 +733,7 @@ if ( ! empty( $pmpro_confirmed ) ) {
 
 			$sendemails = apply_filters( "pmpro_send_checkout_emails", true);
 	
-			if($sendemails) { // Send the e-mails only if the flag is set to true
+			if($sendemails) { // Send the emails only if the flag is set to true
 
 				//setup some values for the emails
 				if ( ! empty( $morder ) ) {


### PR DESCRIPTION
Fixing all places we use the term "Email" to remove hyphen. I have not removed them in the language files but I can if needed.