### PR TITLE
Adjust register link for front-end login.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2084,8 +2084,24 @@ function pmpro_getAllLevels( $include_hidden = false, $force = false ) {
 	} else {
 		$pmpro_visible_levels = $pmpro_levels;
 	}
-
 	return $pmpro_levels;
+}
+
+/**
+ * Check if any level(s) are available for signup.
+ * @return bool
+ * @since 2.3
+ */
+function pmpro_are_any_visible_levels() {
+	$levels = pmpro_getAllLevels( false, true );
+
+	if ( ! empty( $levels ) ) {
+		$r = true;
+	} else {
+		$r = false;
+	}
+
+	return $r;
 }
 
 /**

--- a/includes/login.php
+++ b/includes/login.php
@@ -251,7 +251,7 @@ function pmpro_login_form( $show_menu = true, $show_logout_link = true, $display
 					if ( apply_filters( 'pmpro_show_register_link', get_option( 'users_can_register' ) ) ) {
 						$levels_page_id = pmpro_getOption( 'levels_page_id' );
 						
-						if ( $levels_page_id && pmpro_are_visible_levels() ) {
+						if ( $levels_page_id && pmpro_are_any_visible_levels() ) {
 							$pmpro_registration_url = sprintf( '<a href="%s">%s</a>', esc_url( pmpro_url( 'levels' ) ), __( 'Join Now', 'paid-memberships-pro' ) );
 						} else {
 							$pmpro_registration_url = sprintf( '<a href="%s">%s</a>', wp_registration_url() , __( 'Register', 'paid-memberships-pro' ) );
@@ -625,23 +625,10 @@ function pmpro_logged_in_welcome( $show_menu = true, $show_logout_link = true ) 
 function pmpro_no_level_page_register_redirect( $url ) {
 	$level = pmpro_url( 'levels' );
 
-	if ( empty( pmpro_url( 'levels' ) ) && get_option( 'users_can_register' ) && ! pmpro_are_visible_levels() ) {
+	if ( empty( pmpro_url( 'levels' ) ) && get_option( 'users_can_register' ) && ! pmpro_are_any_visible_levels() ) {
 		return false;
 	}
 
 	return $url;
 }
 add_action( 'pmpro_register_redirect', 'pmpro_no_level_page_register_redirect' );
-
-
-function pmpro_are_visible_levels() {
-	$levels = pmpro_getAllLevels();
-
-	if ( ! empty( $levels ) ) {
-		$r = true;
-	} else {
-		$r = false;
-	}
-
-	return $r;
-}

--- a/includes/login.php
+++ b/includes/login.php
@@ -249,8 +249,14 @@ function pmpro_login_form( $show_menu = true, $show_logout_link = true, $display
 					$pmpro_form_nav_separator = apply_filters( 'pmpro_form_nav_separator', ' | ' );
 
 					if ( get_option( 'users_can_register' ) ) {
-						$pmpro_registration_url = sprintf( '<a href="%s">%s</a>', esc_url( pmpro_url( 'levels' ) ), __( 'Register', 'paid-memberships-pro' ) );
-
+						$levels_page_id = pmpro_getOption( 'levels_page_id' );
+						
+						if ( $levels_page_id && pmpro_are_visible_levels() ) {
+							$pmpro_registration_url = sprintf( '<a href="%s">%s</a>', esc_url( pmpro_url( 'levels' ) ), __( 'Join Now', 'paid-memberships-pro' ) );
+						} else {
+							$pmpro_registration_url = sprintf( '<a href="%s">%s</a>', wp_registration_url() , __( 'Register', 'paid-memberships-pro' ) );
+						}
+						
 						echo apply_filters( 'pmpro_registration_url', $pmpro_registration_url );
 
 						echo esc_html( $pmpro_form_nav_separator );
@@ -610,4 +616,32 @@ function pmpro_logged_in_welcome( $show_menu = true, $show_logout_link = true ) 
 		<?php
 		}
 	}
+}
+
+/**
+ * Allow default WordPress registration page if no level page is set and registrations are open for a site.
+ * @since 2.3
+ */
+function pmpro_no_level_page_register_redirect( $url ) {
+	$level = pmpro_url( 'levels' );
+
+	if ( empty( pmpro_url( 'levels' ) ) && get_option( 'users_can_register' ) && ! pmpro_are_visible_levels() ) {
+		return false;
+	}
+
+	return $url;
+}
+add_action( 'pmpro_register_redirect', 'pmpro_no_level_page_register_redirect' );
+
+
+function pmpro_are_visible_levels() {
+	$levels = pmpro_getAllLevels();
+
+	if ( ! empty( $levels ) ) {
+		$r = true;
+	} else {
+		$r = false;
+	}
+
+	return $r;
 }

--- a/includes/login.php
+++ b/includes/login.php
@@ -248,7 +248,7 @@ function pmpro_login_form( $show_menu = true, $show_logout_link = true, $display
 					 */
 					$pmpro_form_nav_separator = apply_filters( 'pmpro_form_nav_separator', ' | ' );
 
-					if ( get_option( 'users_can_register' ) ) {
+					if ( apply_filters( 'pmpro_show_register_link', get_option( 'users_can_register' ) ) ) {
 						$levels_page_id = pmpro_getOption( 'levels_page_id' );
 						
 						if ( $levels_page_id && pmpro_are_visible_levels() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

* Function added "pmpro_are_any_visible_levels". This returns true/false if levels are available for signup.
* Adjust the register link to show Join Now if levels page is set and levels are available, otherwise redirect to default wp-login.php?action=register link.