### PR TITLE
Redirects for frontend login

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -2,11 +2,14 @@
 
 global $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear, $pmpro_requirebilling;
 
-if (! is_user_logged_in()) {	
-	wp_redirect(pmpro_url('levels'));
-	exit();
+// Redirect non-user to the login page; pass the Billing page as the redirect_to query arg.
+if ( ! is_user_logged_in() ) {
+	$billing_url = pmpro_url( 'billing' );
+    wp_redirect( add_query_arg( 'redirect_to', urlencode( $billing_url ), pmpro_login_url() ) );
+    exit;
 } else {
-	$current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
+    // Get the current user's membership level. 
+    $current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );
 }
 
 //need to be secure?

--- a/preheaders/confirmation.php
+++ b/preheaders/confirmation.php
@@ -2,16 +2,22 @@
 
 global $current_user, $pmpro_invoice;
 
-// Get the membership level for the current user.
-if($current_user->ID)
-    $current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
-
-// Redirect to login if logged out.
+// Redirect non-user to the login page; pass the Confirmation page as the redirect_to query arg.
 if ( ! is_user_logged_in() ) {
-    $redirect_url = pmpro_login_url();
-    wp_redirect( $redirect_url );
-    exit;
-} 
+	// Get level ID from URL parameter.
+	if ( ! empty( $_REQUEST['level'] ) ) {
+		$confirmation_url = add_query_arg( 'level', sanitize_text_field( $_REQUEST['level'] ), pmpro_url( 'confirmation' ) );
+	} else {
+		$confirmation_url = pmpro_url( 'confirmation' );
+	}
+	wp_redirect( add_query_arg( 'redirect_to', urlencode( $confirmation_url ), pmpro_login_url() ) );
+	exit;
+}
+
+// Get the membership level for the current user.
+if ( $current_user->ID ) {
+	$current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
+}
 
 /*
 	Use the filter to add your gateway here if you want to show them a message on the confirmation page while their checkout is pending.
@@ -20,7 +26,7 @@ if ( ! is_user_logged_in() ) {
 */
 $gateways_with_pending_status = apply_filters('pmpro_gateways_with_pending_status', array('paypalstandard', 'twocheckout', 'gourl'));
 if ( ! pmpro_hasMembershipLevel() && ! in_array( pmpro_getGateway(), $gateways_with_pending_status ) ) {
-    // Logged in, but doesn't have a leve
+    // Logged in, but doesn't have a level
     $redirect_url = pmpro_url( 'account' );
     wp_redirect( $redirect_url );
     exit;

--- a/preheaders/invoice.php
+++ b/preheaders/invoice.php
@@ -2,32 +2,40 @@
 
 global $current_user, $pmpro_invoice;
 
-if($current_user->ID)
-    $current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
-
-if (!is_user_logged_in()) {
-    wp_redirect(pmpro_url("account"));
-    exit;
+if ( $current_user->ID ) {
+	$current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );
 }
 
 //get invoice from DB
-if (!empty($_REQUEST['invoice']))
-    $invoice_code = sanitize_text_field($_REQUEST['invoice']);
-else
-    $invoice_code = NULL;
+if ( ! empty( $_REQUEST['invoice'] ) ) {
+	$invoice_code = sanitize_text_field( $_REQUEST['invoice'] );
+} else {
+	$invoice_code = NULL;
+}
 
-if (!empty($invoice_code)) {
-    $pmpro_invoice = new MemberOrder($invoice_code);
+// Redirect non-user to the login page; pass the Invoice page as the redirect_to query arg.
+if ( ! is_user_logged_in() ) {
+	if ( ! empty( $invoice_code ) ) {
+		$invoice_url = add_query_arg( 'invoice', $invoice_code, pmpro_url( 'invoice' ) );
+	} else {
+		$invoice_url = pmpro_url( 'invoice' );
+	}
+	wp_redirect( add_query_arg( 'redirect_to', urlencode( $invoice_url ), pmpro_login_url() ) );
+	exit;
+}
 
-    //var_dump($pmpro_invoice);
-    if (!$pmpro_invoice->id) {
-        wp_redirect(pmpro_url("account")); //no match
-        exit;
-    }
+if ( ! empty( $invoice_code ) ) {
+	$pmpro_invoice = new MemberOrder( $invoice_code );
 
-    //make sure they have permission to view this
-    if (!current_user_can("administrator") && $current_user->ID != $pmpro_invoice->user_id) {
-        wp_redirect(pmpro_url("account")); //no permission
-        exit;
-    }
+	if ( ! $pmpro_invoice->id ) {
+		// Redirect user to the account page if no invoice found.
+		wp_redirect( pmpro_url( 'account' ) );
+		exit;
+	}
+
+	// Make sure they have permission to view this.
+	if ( ! current_user_can( 'administrator' ) && $current_user->ID != $pmpro_invoice->user_id ) {
+		wp_redirect( pmpro_url( 'account' ) ); //no permission
+		exit;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Redirecting core pmpro pages if not logged in: invoice, cancel, confirmation, and billing should redirect to `pmpro_login_url()` (default redirect is is account page).

Now passing the `redirect_to` query arg for the page you were on, including url parameters.

Redirecting core pmpro pages if no level once logged in:
- cancel page returns you to membership account page.
- confirmation page redirects to account page, not homepage.
- invoice page: show your past invoices if you have any. show that you have none if you have none.
- billing page: had logic there for non-member users.
- checkout: goes to "a first found" level checkout