### PR TITLE
Show link to "generate" member profile edit page only

### DIFF
--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -86,7 +86,18 @@ if (!empty($_REQUEST['createpages'])) {
         $pages['invoice'] = __('Membership Invoice', 'paid-memberships-pro' );
         $pages['levels'] = __('Membership Levels', 'paid-memberships-pro' );
 		$pages['member_profile_edit'] = __('Your Profile', 'paid-memberships-pro' );
-
+	} elseif ( $_REQUEST['page_name'] == 'member_profile_edit' ) {
+		if ( ! empty( pmpro_getOption( 'member_profile_edit_page_generated' ) ) ) {
+			// Don't generate again.
+			unset( $pages['member_profile_edit'] );
+		} else {
+			// Generate the new Your Profile page and save an option that it was created.
+			$pages['member_profile_edit'] = array(
+				'title' => __('Your Profile', 'paid-memberships-pro' ),
+				'content' => '[pmpro_member_profile_edit]',
+			);
+			pmpro_setOption( 'member_profile_edit_page_generated', '1' );
+		}
     } else {
         //generate extra pages one at a time
         $pmpro_page_name = sanitize_text_field($_REQUEST['page_name']);
@@ -300,7 +311,10 @@ require_once(dirname(__FILE__) . "/admin_header.php");
 			            &nbsp;
 			            <a target="_blank" href="<?php echo get_permalink($pmpro_pages['member_profile_edit']); ?>"
 			               class="button button-secondary pmpro_page_view"><?php _e('view page', 'paid-memberships-pro' ); ?></a>
-			        <?php } ?>
+			        <?php } elseif ( empty( pmpro_getOption( 'member_profile_edit_page_generated' ) ) ) { ?>
+						&nbsp;
+						<a href="<?php echo wp_nonce_url( add_query_arg( array( 'page' => 'pmpro-pagesettings', 'createpages' => 1, 'page_name' => esc_attr( 'member_profile_edit' )   ), admin_url('admin.php') ), 'createpages', 'pmpro_pagesettings_nonce' ); ?>"><?php _e('Generate Page', 'paid-memberships-pro' ); ?></a>
+                    <?php } ?>
 					<p class="description"><?php _e('Include the shortcode', 'paid-memberships-pro' ); ?> [pmpro_member_profile_edit].</p>
 
 					<?php if ( ! class_exists( 'PMProRH_Field' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Showing a link to "Generate" only the new Member Profile Edit page. This will help people upgrading to 2.3 easily create the appropriate and shortcode.

Once you have used the "generate" button to create this page we do not show it again (do not want duplicate pages generated).

### How to test the changes in this Pull Request:

1. Unset your member profile edit page, if set, under Memberships > Settings > Page Settings.
2. Click the "generate" link for the page.
3. The page is created.
4. Unset the page for member profile edit.
5. The generate link should not return.