### PR TITLE
Adjusting the grid layout of the Stripe checkout fields where double spacing was being added.

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -297,7 +297,7 @@ select.pmpro_error {
 	display: grid;
 	-ms-grid-columns: 3fr 1em 1fr;
 	grid-template-columns: 3fr 1fr;
-	grid-gap: 1em;
+	grid-column-gap: 1em;
 }
 #pmpro_license {
 	background: #FFF;
@@ -319,7 +319,7 @@ select.pmpro_error {
 		"AccountNumber AccountNumber"
 		"Expiry CVV"
 		"DiscountCode DiscountCode";
-	grid-gap: 1em;
+	grid-column-gap: 1em;
 	-ms-grid-columns: 1fr 1em 1fr;
 	grid-template-columns: 1fr 1fr;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->



### Other information:
This is just a small CSS fix for the Stripe grid layout billing information section - it was adding double the spacing needed.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.