### PR TITLE
Fixed issues where orders could lose an hour when saved.

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -142,8 +142,7 @@
 				$this->checkout_id = $dbobj->checkout_id;
 
 				// Fix the timestamp for local time
-				$gmt_offset = get_option( 'gmt_offset' );
-				$this->timestamp = strtotime( $this->timestamp ) + ( (int)$gmt_offset * HOUR_IN_SECONDS );
+				$this->timestamp = strtotime( get_date_from_gmt( $this->timestamp, 'Y-m-d H:i:s' ) );
 
 				//reset the gateway
 				if(empty($this->nogateway))
@@ -376,9 +375,8 @@
 			$this->user = $wpdb->get_row("SELECT * FROM $wpdb->users WHERE ID = '" . $this->user_id . "' LIMIT 1");
 			
 			// Fix the timestamp for local time 
-			$gmt_offset = get_option('gmt_offset');
 			if ( ! empty( $this->user ) && ! empty( $this->user->user_registered ) ) {
-				$this->user->user_registered = strtotime( $this->user->user_registered ) + ( (int)$gmt_offset * HOUR_IN_SECONDS );
+				$this->user->user_registered = strtotime( get_date_from_gmt( $this->user->user_registered, 'Y-m-d H:i:s' ) );
 			}
 
 			return $this->user;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now using `get_date_from_gmt()` to convert timestamps to local time.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: XXX.

### How to test the changes in this Pull Request:

Pre-fix:
1. Change timezone to Melbourne, Australia
2. Save order on Mar 15
3. See that it loses an hour when saved

Post-fix:
1. Change timezone to Melbourne, Australia
2. Save order on Mar 15
3. See that time saves correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.