### PR TITLE
Redirect widget logins to referrer by default.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -249,6 +249,16 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 		if ( empty( $_GET['login'] ) || empty( $_GET['key'] ) ) {
 			$username = isset( $_REQUEST['username'] ) ? sanitize_text_field( $_REQUEST['username'] ) : NULL;
 			$redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url( $_REQUEST['redirect_to'] ) : NULL; ?>
+
+			<?php
+				// Redirect users back to their page that they logged-in from via the widget.  
+				if( $location === 'widget' && apply_filters( 'pmpro_login_widget_redirect_back', true ) ) {
+					if ( empty( $redirect_to ) ) {
+						$redirect_to = esc_url( site_url( $_SERVER['REQUEST_URI'] ) );
+					}
+				} 
+			?>
+
 			<div class="pmpro_login_wrap">
 				<?php echo $before_title . esc_html( 'Log In', 'paid-memberships-pro' ) . $after_title; ?>
 				<?php


### PR DESCRIPTION
* Redirect user's to referrer on login via widget by default.
* ENHANCEMENT:  filter added to disable the redirect for widget logins `pmpro_login_widget_redirect_back`