### PR TITLE
V2.3 Admin email design, renaming menu and widget, widget menus for non-members, 

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -129,367 +129,379 @@
 		
 		<h1 class="wp-heading-inline"><?php esc_html_e( 'Advanced Settings', 'paid-memberships-pro' ); ?></h1>
 		<hr class="wp-header-end">
-		<h2 class="title"><?php esc_html_e( 'Restrict Dashboard Access', 'paid-memberships-pro' ); ?></h2>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="block_dashboard"><?php _e('WordPress Dashboard', 'paid-memberships-pro' );?></label>
-				</th>
-				<td>
-					<input id="block_dashboard" name="block_dashboard" type="checkbox" value="yes" <?php checked( $block_dashboard, 'yes' ); ?> /> <label for="block_dashboard"><?php _e('Block all users with the Subscriber role from accessing the Dashboard.', 'paid-memberships-pro' );?></label>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="hide_toolbar"><?php _e('WordPress Toolbar', 'paid-memberships-pro' );?></label>
-				</th>
-				<td>
-					<input id="hide_toolbar" name="hide_toolbar" type="checkbox" value="yes" <?php checked( $hide_toolbar, 'yes' ); ?> /> <label for="hide_toolbar"><?php _e('Hide the Toolbar from all users with the Subscriber role.', 'paid-memberships-pro' );?></label>
-				</td>
-			</tr>
-		</tbody>
-		</table>
+		<div class="pmpro_admin_section pmpro_admin_section-restrict-dashboard">
+			<h2 class="title"><?php esc_html_e( 'Restrict Dashboard Access', 'paid-memberships-pro' ); ?></h2>
+			<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="block_dashboard"><?php _e('WordPress Dashboard', 'paid-memberships-pro' );?></label>
+					</th>
+					<td>
+						<input id="block_dashboard" name="block_dashboard" type="checkbox" value="yes" <?php checked( $block_dashboard, 'yes' ); ?> /> <label for="block_dashboard"><?php _e('Block all users with the Subscriber role from accessing the Dashboard.', 'paid-memberships-pro' );?></label>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="hide_toolbar"><?php _e('WordPress Toolbar', 'paid-memberships-pro' );?></label>
+					</th>
+					<td>
+						<input id="hide_toolbar" name="hide_toolbar" type="checkbox" value="yes" <?php checked( $hide_toolbar, 'yes' ); ?> /> <label for="hide_toolbar"><?php _e('Hide the Toolbar from all users with the Subscriber role.', 'paid-memberships-pro' );?></label>
+					</td>
+				</tr>
+			</tbody>
+			</table>
+		</div> <!-- end pmpro_admin_section-restrict-dashboard -->
 		<hr />
-		<h2 class="title"><?php esc_html_e( 'Message Settings', 'paid-memberships-pro' ); ?></h2>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="nonmembertext"><?php _e('Message for Logged-in Non-members', 'paid-memberships-pro' );?>:</label>
-				</th>
-				<td>
-					<textarea name="nonmembertext" rows="3" cols="50" class="large-text"><?php echo stripslashes($nonmembertext)?></textarea>
-					<p class="description"><?php _e('This message replaces the post content for non-members. Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code> <code>!!referrer!!</code> <code>!!levels_page_url!!</code></p>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="notloggedintext"><?php _e('Message for Logged-out Users', 'paid-memberships-pro' );?>:</label>
-				</th>
-				<td>
-					<textarea name="notloggedintext" rows="3" cols="50" class="large-text"><?php echo stripslashes($notloggedintext)?></textarea>
-					<p class="description"><?php _e('This message replaces the post content for logged-out visitors.', 'paid-memberships-pro' );?> <?php _e('Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code> <code>!!referrer!!</code> <code>!!login_page_url!!</code> <code>!!levels_page_url!!</code></p>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="rsstext"><?php _e('Message for RSS Feed', 'paid-memberships-pro' );?>:</label>
-				</th>
-				<td>
-					<textarea name="rsstext" rows="3" cols="50" class="large-text"><?php echo stripslashes($rsstext)?></textarea>
-					<p class="description"><?php _e('This message replaces the post content in RSS feeds.', 'paid-memberships-pro' );?> <?php _e('Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code></p>
-				</td>
-			</tr>
-		</tbody>
-		</table>
+		<div class="pmpro_admin_section pmpro_admin_section-message-settings">
+			<h2 class="title"><?php esc_html_e( 'Message Settings', 'paid-memberships-pro' ); ?></h2>
+			<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="nonmembertext"><?php _e('Message for Logged-in Non-members', 'paid-memberships-pro' );?>:</label>
+					</th>
+					<td>
+						<textarea name="nonmembertext" rows="3" cols="50" class="large-text"><?php echo stripslashes($nonmembertext)?></textarea>
+						<p class="description"><?php _e('This message replaces the post content for non-members. Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code> <code>!!referrer!!</code> <code>!!levels_page_url!!</code></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="notloggedintext"><?php _e('Message for Logged-out Users', 'paid-memberships-pro' );?>:</label>
+					</th>
+					<td>
+						<textarea name="notloggedintext" rows="3" cols="50" class="large-text"><?php echo stripslashes($notloggedintext)?></textarea>
+						<p class="description"><?php _e('This message replaces the post content for logged-out visitors.', 'paid-memberships-pro' );?> <?php _e('Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code> <code>!!referrer!!</code> <code>!!login_page_url!!</code> <code>!!levels_page_url!!</code></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="rsstext"><?php _e('Message for RSS Feed', 'paid-memberships-pro' );?>:</label>
+					</th>
+					<td>
+						<textarea name="rsstext" rows="3" cols="50" class="large-text"><?php echo stripslashes($rsstext)?></textarea>
+						<p class="description"><?php _e('This message replaces the post content in RSS feeds.', 'paid-memberships-pro' );?> <?php _e('Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code></p>
+					</td>
+				</tr>
+			</tbody>
+			</table>
+		</div> <!-- end pmpro_admin_section-message-settings -->
 		<hr />
-		<h2 class="title"><?php esc_html_e( 'Content Settings', 'paid-memberships-pro' ); ?></h2>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="filterqueries"><?php _e("Filter searches and archives?", 'paid-memberships-pro' );?></label>
-				</th>
-				<td>
-					<select id="filterqueries" name="filterqueries">
-						<option value="0" <?php if(!$filterqueries) { ?>selected="selected"<?php } ?>><?php _e('No - Non-members will see restricted posts/pages in searches and archives.', 'paid-memberships-pro' );?></option>
-						<option value="1" <?php if($filterqueries == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Only members will see restricted posts/pages in searches and archives.', 'paid-memberships-pro' );?></option>
-					</select>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="showexcerpts"><?php _e('Show Excerpts to Non-Members?', 'paid-memberships-pro' );?></label>
-            </th>
-            <td>
-                <select id="showexcerpts" name="showexcerpts">
-                    <option value="0" <?php if(!$showexcerpts) { ?>selected="selected"<?php } ?>><?php _e('No - Hide excerpts.', 'paid-memberships-pro' );?></option>
-                    <option value="1" <?php if($showexcerpts == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Show excerpts.', 'paid-memberships-pro' );?></option>
-                </select>
-            </td>
-            </tr>
-		</tbody>
-		</table>
-		<hr />
-		<h2 class="title"><?php esc_html_e( 'Checkout Settings', 'paid-memberships-pro' ); ?></h2>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="tospage"><?php _e('Require Terms of Service on signups?', 'paid-memberships-pro' );?></label>
-				</th>
-				<td>
-					<?php
-						wp_dropdown_pages(array("name"=>"tospage", "show_option_none"=>"No", "selected"=>$tospage));
-					?>
-					<br />
-					<p class="description"><?php _e('If yes, create a WordPress page containing your TOS agreement and assign it using the dropdown above.', 'paid-memberships-pro' );?></p>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="recaptcha"><?php _e('Use reCAPTCHA?', 'paid-memberships-pro' );?>:</label>
-				</th>
-				<td>
-					<select id="recaptcha" name="recaptcha" onchange="pmpro_updateRecaptchaTRs();">
-						<option value="0" <?php if(!$recaptcha) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
-						<option value="1" <?php if($recaptcha == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Free memberships only.', 'paid-memberships-pro' );?></option>
-						<option value="2" <?php if($recaptcha == 2) { ?>selected="selected"<?php } ?>><?php _e('Yes - All memberships.', 'paid-memberships-pro' );?></option>
-					</select>
-					<p class="description"><?php _e('A free reCAPTCHA key is required.', 'paid-memberships-pro' );?> <a href="https://www.google.com/recaptcha/admin/create"><?php _e('Click here to signup for reCAPTCHA', 'paid-memberships-pro' );?></a>.</p>
-				</td>
-			</tr>
-		</tbody>
-		</table>
-		<table class="form-table" id="recaptcha_settings" <?php if(!$recaptcha) { ?>style="display: none;"<?php } ?>>
-		<tbody>
-			<tr>
-				<th scope="row" valign="top"><label for="recaptcha_version"><?php _e( 'reCAPTCHA Version', 'paid-memberships-pro' );?>:</label></th>
-				<td>					
-					<select id="recaptcha_version" name="recaptcha_version">
-						<option value="2_checkbox" <?php selected( '2_checkbox', $recaptcha_version ); ?>><?php _e( ' v2 - Checkbox', 'paid-memberships-pro' ); ?></option>
-						<option value="3_invisible" <?php selected( '3_invisible', $recaptcha_version ); ?>><?php _e( 'v3 - Invisible', 'paid-memberships-pro' ); ?></option>
-					</select>
-					<p class="description"><?php _e( 'Changing your version will require new API keys.', 'paid-memberships-pro' ); ?></p>
-				</td>
-			</tr>
-			<tr>
-				<th scope="row"><label for="recaptcha_publickey"><?php _e('reCAPTCHA Site Key', 'paid-memberships-pro' );?>:</label></th>
-				<td>
-					<input type="text" id="recaptcha_publickey" name="recaptcha_publickey" value="<?php echo esc_attr($recaptcha_publickey);?>" class="regular-text code" />
-				</td>
-			</tr>
-			<tr>
-				<th scope="row"><label for="recaptcha_privatekey"><?php _e('reCAPTCHA Secret Key', 'paid-memberships-pro' );?>:</label></th>
-				<td>
-					<input type="text" id="recaptcha_privatekey" name="recaptcha_privatekey" value="<?php echo esc_attr($recaptcha_privatekey);?>" class="regular-text code" />
-				</td>
-			</tr>
-		</tbody>
-		</table>
-		<hr />
-		<h2 class="title"><?php esc_html_e( 'Communication Settings', 'paid-memberships-pro' ); ?></h2>
-		<table class="form-table">
-			<tr>
-				<th><?php _e( 'Notifications', 'paid-memberships-pro' ); ?></th>
-				<td>
-					<select name="maxnotificationpriority">
-						<option value="5" <?php selected( $maxnotificationpriority, 5 ); ?>>
-							<?php _e( 'Show all notifications.', 'paid-memberships-pro' ); ?>
-						</option>
-						<option value="1" <?php selected( $maxnotificationpriority, 1 ); ?>>
-							<?php _e( 'Show only security notifications.', 'paid-memberships-pro' ); ?>
-						</option>
-					</select>
-					<br />
-					<p class="description"><?php _e('Notifications are occasionally shown on the Paid Memberships Pro settings pages.', 'paid-memberships-pro' );?></p>
-				</td>
-			</tr>
-			<tr>
-				<th>
-					<label for="activity_email_frequency"><?php _e('Activity Email Frequency', 'paid-memberships-pro' );?></label>
-				</th>
-				<td>
-					<select name="activity_email_frequency">
-						<option value="day" <?php selected( $activity_email_frequency, 'day' ); ?>>
-							<?php _e( 'Daily', 'paid-memberships-pro' ); ?>
-						</option>
-						<option value="week" <?php selected( $activity_email_frequency, 'week' ); ?>>
-							<?php _e( 'Weekly', 'paid-memberships-pro' ); ?>
-						</option>
-						<option value="month" <?php selected( $activity_email_frequency, 'month' ); ?>>
-							<?php _e( 'Monthly', 'paid-memberships-pro' ); ?>
-						</option>
-						<option value="never" <?php selected( $activity_email_frequency, 'never' ); ?>>
-							<?php _e( 'Never', 'paid-memberships-pro' ); ?>
-						</option>
-					</select>
-					<br />
-					<p class="description"><?php _e( 'Send periodic sales and revenue updates from this site to the administration email address.', 'paid-memberships-pro' );?></p>
-				</td>
-			</tr>
-		</tbody>
-		</table>	
-		<hr />
-		<h2 clas="title"><?php esc_html_e( 'Other Settings', 'paid-memberships-pro' ); ?></h2>
-		<table class="form-table">
-		<tbody>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="hideads"><?php _e("Hide Ads From Members?", 'paid-memberships-pro' );?></label>
-				</th>
-				<td>
-					<select id="hideads" name="hideads" onchange="pmpro_updateHideAdsTRs();">
-						<option value="0" <?php if(!$hideads) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
-						<option value="1" <?php if($hideads == 1) { ?>selected="selected"<?php } ?>><?php _e('Hide Ads From All Members', 'paid-memberships-pro' );?></option>
-						<option value="2" <?php if($hideads == 2) { ?>selected="selected"<?php } ?>><?php _e('Hide Ads From Certain Members', 'paid-memberships-pro' );?></option>
-					</select>
-				</td>
-			</tr>
-			<tr id="hideads_explanation" <?php if($hideads < 2) { ?>style="display: none;"<?php } ?>>
-				<th scope="row" valign="top">&nbsp;</th>
-				<td>
-					<p><?php _e('Ads from the following plugins will be automatically turned off', 'paid-memberships-pro' );?>: <em>Easy Adsense</em>, ...</p>
-					<p><?php _e('To hide ads in your template code, use code like the following', 'paid-memberships-pro' );?>:</p>
-				<pre lang="PHP">
-if ( pmpro_displayAds() ) {
-	//insert ad code here
-}</pre>
-				</td>
-			</tr>			
-			<tr id="hideadslevels_tr" <?php if($hideads != 2) { ?>style="display: none;"<?php } ?>>
-				<th scope="row" valign="top">
-					<label for="hideadslevels"><?php _e('Choose Levels to Hide Ads From', 'paid-memberships-pro' );?>:</label>
-				</th>
-				<td>
-					<div class="checkbox_box" <?php if(count($levels) > 5) { ?>style="height: 100px; overflow: auto;"<?php } ?>>
-						<?php
-							$hideadslevels = pmpro_getOption("hideadslevels");
-							if(!is_array($hideadslevels))
-								$hideadslevels = explode(",", $hideadslevels);
-
-							$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels ";
-							$levels = $wpdb->get_results($sqlQuery, OBJECT);
-							foreach($levels as $level)
-							{
-						?>
-							<div class="clickable"><input type="checkbox" id="hideadslevels_<?php echo $level->id?>" name="hideadslevels[]" value="<?php echo $level->id?>" <?php if(in_array($level->id, $hideadslevels)) { ?>checked="checked"<?php } ?>> <?php echo $level->name?></div>
-						<?php
-							}
-						?>
-					</div>
-					<script>
-						jQuery('.checkbox_box input').click(function(event) {
-							event.stopPropagation()
-						});
-
-						jQuery('.checkbox_box div.clickable').click(function() {
-							var checkbox = jQuery(this).find(':checkbox');
-							checkbox.attr('checked', !checkbox.attr('checked'));
-						});
-					</script>
-				</td>
-			</tr>
-			<?php if(is_multisite()) { ?>
-			<tr>
-				<th scope="row" valign="top">
-					<label for="redirecttosubscription"><?php _e('Redirect all traffic from registration page to /susbcription/?', 'paid-memberships-pro' );?>: <em>(<?php _e('multisite only', 'paid-memberships-pro' );?>)</em></label>
-				</th>
-				<td>
-					<select id="redirecttosubscription" name="redirecttosubscription">
-						<option value="0" <?php if(!$redirecttosubscription) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
-						<option value="1" <?php if($redirecttosubscription == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes', 'paid-memberships-pro' );?></option>
-					</select>
-				</td>
-			</tr>
-			<?php } ?>			
-			<?php
-            // Filter to Add More Advanced Settings for Misc Plugin Options, etc.
-            if (has_action('pmpro_custom_advanced_settings')) {
-	            $custom_fields = apply_filters('pmpro_custom_advanced_settings', array());
-	            foreach ($custom_fields as $field) {
-	            ?>
-	            <tr>
-	                <th valign="top" scope="row">
-	                    <label
-	                        for="<?php echo esc_attr( $field['field_name'] ); ?>"><?php echo esc_textarea( $field['label'] ); ?></label>
-	                </th>
-	                <td>
-	                    <?php
-	                    switch ($field['field_type']) {
-	                        case 'select':
-	                            ?>
-	                            <select id="<?php echo esc_attr( $field['field_name'] ); ?>"
-	                                    name="<?php echo esc_attr( $field['field_name'] ); ?>">
-	                                <?php 
-	                                	//For associative arrays, we use the array keys as values. For numerically indexed arrays, we use the array values.
-	                                	$is_associative = (bool)count(array_filter(array_keys($field['options']), 'is_string'));
-	                                	foreach ($field['options'] as $key => $option) {
-	                                    	if(!$is_associative) $key = $option;
-	                                    	?>
-	                                    	<option value="<?php echo esc_attr($key); ?>" <?php selected($key, pmpro_getOption($field['field_name']));?>>
-	                                    		<?php echo esc_textarea($option); ?>
-	                                    	</option>
-	                               			<?php
-	                                	} 
-	                                ?>
-	                            </select>
-	                            <?php
-	                            break;
-	                        case 'text':
-	                            ?>
-	                            <input id="<?php echo esc_attr( $field['field_name'] ); ?>"
-	                                   name="<?php echo esc_attr( $field['field_name'] ); ?>"
-	                                   type="<?php echo esc_attr( $field['field_type'] ); ?>"
-	                                   value="<?php echo esc_attr(pmpro_getOption($field['field_name'])); ?> "
-	                                   class="regular-text">
-	                            <?php
-	                            break;
-	                        case 'textarea':
-	                            ?>
-	                            <textarea id="<?php echo esc_attr( $field['field_name'] ); ?>"
-	                                      name="<?php echo esc_attr( $field['field_name'] ); ?>"
-	                                      class="large-text">
-	                                <?php echo esc_textarea(pmpro_getOption($field['field_name'])); ?>
-	                            </textarea>
-	                            <?php
-	                            break;
-	                        default:
-	                            break;
-	                    }
-	                    if (!empty($field['description'])) {
-	                        ?>
-	                        <p class="description"><?php echo esc_textarea( $field['description'] ); ?></p>
-	                    <?php
-	                    }
-	                    ?>
-	                </td>
+		<div class="pmpro_admin_section pmpro_admin_section-content-settings">
+			<h2 class="title"><?php esc_html_e( 'Content Settings', 'paid-memberships-pro' ); ?></h2>
+			<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="filterqueries"><?php _e("Filter searches and archives?", 'paid-memberships-pro' );?></label>
+					</th>
+					<td>
+						<select id="filterqueries" name="filterqueries">
+							<option value="0" <?php if(!$filterqueries) { ?>selected="selected"<?php } ?>><?php _e('No - Non-members will see restricted posts/pages in searches and archives.', 'paid-memberships-pro' );?></option>
+							<option value="1" <?php if($filterqueries == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Only members will see restricted posts/pages in searches and archives.', 'paid-memberships-pro' );?></option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="showexcerpts"><?php _e('Show Excerpts to Non-Members?', 'paid-memberships-pro' );?></label>
+	            </th>
+	            <td>
+	                <select id="showexcerpts" name="showexcerpts">
+	                    <option value="0" <?php if(!$showexcerpts) { ?>selected="selected"<?php } ?>><?php _e('No - Hide excerpts.', 'paid-memberships-pro' );?></option>
+	                    <option value="1" <?php if($showexcerpts == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Show excerpts.', 'paid-memberships-pro' );?></option>
+	                </select>
+	            </td>
 	            </tr>
-	            <?php
-	            }
-	        } 
-	        ?>
-        </tbody>
-		</table>
-		<script>
-			function pmpro_updateHideAdsTRs()
-			{
-				var hideads = jQuery('#hideads').val();
-				if(hideads == 2)
-				{
-					jQuery('#hideadslevels_tr').show();
-				}
-				else
-				{
-					jQuery('#hideadslevels_tr').hide();
-				}
+			</tbody>
+			</table>
+		</div> <!-- end pmpro_admin_section-content-settings -->
+		<hr />
+		<div class="pmpro_admin_section pmpro_admin_section-checkout-settings">
+			<h2 class="title"><?php esc_html_e( 'Checkout Settings', 'paid-memberships-pro' ); ?></h2>
+			<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="tospage"><?php _e('Require Terms of Service on signups?', 'paid-memberships-pro' );?></label>
+					</th>
+					<td>
+						<?php
+							wp_dropdown_pages(array("name"=>"tospage", "show_option_none"=>"No", "selected"=>$tospage));
+						?>
+						<br />
+						<p class="description"><?php _e('If yes, create a WordPress page containing your TOS agreement and assign it using the dropdown above.', 'paid-memberships-pro' );?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="recaptcha"><?php _e('Use reCAPTCHA?', 'paid-memberships-pro' );?>:</label>
+					</th>
+					<td>
+						<select id="recaptcha" name="recaptcha" onchange="pmpro_updateRecaptchaTRs();">
+							<option value="0" <?php if(!$recaptcha) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
+							<option value="1" <?php if($recaptcha == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Free memberships only.', 'paid-memberships-pro' );?></option>
+							<option value="2" <?php if($recaptcha == 2) { ?>selected="selected"<?php } ?>><?php _e('Yes - All memberships.', 'paid-memberships-pro' );?></option>
+						</select>
+						<p class="description"><?php _e('A free reCAPTCHA key is required.', 'paid-memberships-pro' );?> <a href="https://www.google.com/recaptcha/admin/create"><?php _e('Click here to signup for reCAPTCHA', 'paid-memberships-pro' );?></a>.</p>
+					</td>
+				</tr>
+			</tbody>
+			</table>
+			<table class="form-table" id="recaptcha_settings" <?php if(!$recaptcha) { ?>style="display: none;"<?php } ?>>
+			<tbody>
+				<tr>
+					<th scope="row" valign="top"><label for="recaptcha_version"><?php _e( 'reCAPTCHA Version', 'paid-memberships-pro' );?>:</label></th>
+					<td>					
+						<select id="recaptcha_version" name="recaptcha_version">
+							<option value="2_checkbox" <?php selected( '2_checkbox', $recaptcha_version ); ?>><?php _e( ' v2 - Checkbox', 'paid-memberships-pro' ); ?></option>
+							<option value="3_invisible" <?php selected( '3_invisible', $recaptcha_version ); ?>><?php _e( 'v3 - Invisible', 'paid-memberships-pro' ); ?></option>
+						</select>
+						<p class="description"><?php _e( 'Changing your version will require new API keys.', 'paid-memberships-pro' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="recaptcha_publickey"><?php _e('reCAPTCHA Site Key', 'paid-memberships-pro' );?>:</label></th>
+					<td>
+						<input type="text" id="recaptcha_publickey" name="recaptcha_publickey" value="<?php echo esc_attr($recaptcha_publickey);?>" class="regular-text code" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="recaptcha_privatekey"><?php _e('reCAPTCHA Secret Key', 'paid-memberships-pro' );?>:</label></th>
+					<td>
+						<input type="text" id="recaptcha_privatekey" name="recaptcha_privatekey" value="<?php echo esc_attr($recaptcha_privatekey);?>" class="regular-text code" />
+					</td>
+				</tr>
+			</tbody>
+			</table>
+		</div> <!-- end pmpro_admin_section-checkout-settings -->
+		<hr />
+		<div class="pmpro_admin_section pmpro_admin_section-communication-settings">
+			<h2 class="title"><?php esc_html_e( 'Communication Settings', 'paid-memberships-pro' ); ?></h2>
+			<table class="form-table">
+				<tr>
+					<th><?php _e( 'Notifications', 'paid-memberships-pro' ); ?></th>
+					<td>
+						<select name="maxnotificationpriority">
+							<option value="5" <?php selected( $maxnotificationpriority, 5 ); ?>>
+								<?php _e( 'Show all notifications.', 'paid-memberships-pro' ); ?>
+							</option>
+							<option value="1" <?php selected( $maxnotificationpriority, 1 ); ?>>
+								<?php _e( 'Show only security notifications.', 'paid-memberships-pro' ); ?>
+							</option>
+						</select>
+						<br />
+						<p class="description"><?php _e('Notifications are occasionally shown on the Paid Memberships Pro settings pages.', 'paid-memberships-pro' );?></p>
+					</td>
+				</tr>
+				<tr>
+					<th>
+						<label for="activity_email_frequency"><?php _e('Activity Email Frequency', 'paid-memberships-pro' );?></label>
+					</th>
+					<td>
+						<select name="activity_email_frequency">
+							<option value="day" <?php selected( $activity_email_frequency, 'day' ); ?>>
+								<?php _e( 'Daily', 'paid-memberships-pro' ); ?>
+							</option>
+							<option value="week" <?php selected( $activity_email_frequency, 'week' ); ?>>
+								<?php _e( 'Weekly', 'paid-memberships-pro' ); ?>
+							</option>
+							<option value="month" <?php selected( $activity_email_frequency, 'month' ); ?>>
+								<?php _e( 'Monthly', 'paid-memberships-pro' ); ?>
+							</option>
+							<option value="never" <?php selected( $activity_email_frequency, 'never' ); ?>>
+								<?php _e( 'Never', 'paid-memberships-pro' ); ?>
+							</option>
+						</select>
+						<br />
+						<p class="description"><?php _e( 'Send periodic sales and revenue updates from this site to the administration email address.', 'paid-memberships-pro' );?></p>
+					</td>
+				</tr>
+			</tbody>
+			</table>
+		</div> <!-- end pmpro_admin_section-communication-settings -->
+		<hr />
+		<div class="pmpro_admin_section pmpro_admin_section-other-settings">
+			<h2 class="title"><?php esc_html_e( 'Other Settings', 'paid-memberships-pro' ); ?></h2>
+			<table class="form-table">
+			<tbody>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="hideads"><?php _e("Hide Ads From Members?", 'paid-memberships-pro' );?></label>
+					</th>
+					<td>
+						<select id="hideads" name="hideads" onchange="pmpro_updateHideAdsTRs();">
+							<option value="0" <?php if(!$hideads) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
+							<option value="1" <?php if($hideads == 1) { ?>selected="selected"<?php } ?>><?php _e('Hide Ads From All Members', 'paid-memberships-pro' );?></option>
+							<option value="2" <?php if($hideads == 2) { ?>selected="selected"<?php } ?>><?php _e('Hide Ads From Certain Members', 'paid-memberships-pro' );?></option>
+						</select>
+					</td>
+				</tr>
+				<tr id="hideads_explanation" <?php if($hideads < 2) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top">&nbsp;</th>
+					<td>
+						<p><?php _e('Ads from the following plugins will be automatically turned off', 'paid-memberships-pro' );?>: <em>Easy Adsense</em>, ...</p>
+						<p><?php _e('To hide ads in your template code, use code like the following', 'paid-memberships-pro' );?>:</p>
+					<pre lang="PHP">
+	if ( pmpro_displayAds() ) {
+		//insert ad code here
+	}</pre>
+					</td>
+				</tr>			
+				<tr id="hideadslevels_tr" <?php if($hideads != 2) { ?>style="display: none;"<?php } ?>>
+					<th scope="row" valign="top">
+						<label for="hideadslevels"><?php _e('Choose Levels to Hide Ads From', 'paid-memberships-pro' );?>:</label>
+					</th>
+					<td>
+						<div class="checkbox_box" <?php if(count($levels) > 5) { ?>style="height: 100px; overflow: auto;"<?php } ?>>
+							<?php
+								$hideadslevels = pmpro_getOption("hideadslevels");
+								if(!is_array($hideadslevels))
+									$hideadslevels = explode(",", $hideadslevels);
 
-				if(hideads > 0)
-				{
-					jQuery('#hideads_explanation').show();
-				}
-				else
-				{
-					jQuery('#hideads_explanation').hide();
-				}
-			}
-			pmpro_updateHideAdsTRs();
+								$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels ";
+								$levels = $wpdb->get_results($sqlQuery, OBJECT);
+								foreach($levels as $level)
+								{
+							?>
+								<div class="clickable"><input type="checkbox" id="hideadslevels_<?php echo $level->id?>" name="hideadslevels[]" value="<?php echo $level->id?>" <?php if(in_array($level->id, $hideadslevels)) { ?>checked="checked"<?php } ?>> <?php echo $level->name?></div>
+							<?php
+								}
+							?>
+						</div>
+						<script>
+							jQuery('.checkbox_box input').click(function(event) {
+								event.stopPropagation()
+							});
 
-			function pmpro_updateRecaptchaTRs()
-			{
-				var recaptcha = jQuery('#recaptcha').val();
-				if(recaptcha > 0)
+							jQuery('.checkbox_box div.clickable').click(function() {
+								var checkbox = jQuery(this).find(':checkbox');
+								checkbox.attr('checked', !checkbox.attr('checked'));
+							});
+						</script>
+					</td>
+				</tr>
+				<?php if(is_multisite()) { ?>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="redirecttosubscription"><?php _e('Redirect all traffic from registration page to /susbcription/?', 'paid-memberships-pro' );?>: <em>(<?php _e('multisite only', 'paid-memberships-pro' );?>)</em></label>
+					</th>
+					<td>
+						<select id="redirecttosubscription" name="redirecttosubscription">
+							<option value="0" <?php if(!$redirecttosubscription) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
+							<option value="1" <?php if($redirecttosubscription == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes', 'paid-memberships-pro' );?></option>
+						</select>
+					</td>
+				</tr>
+				<?php } ?>			
+				<?php
+	            // Filter to Add More Advanced Settings for Misc Plugin Options, etc.
+	            if (has_action('pmpro_custom_advanced_settings')) {
+		            $custom_fields = apply_filters('pmpro_custom_advanced_settings', array());
+		            foreach ($custom_fields as $field) {
+		            ?>
+		            <tr>
+		                <th valign="top" scope="row">
+		                    <label
+		                        for="<?php echo esc_attr( $field['field_name'] ); ?>"><?php echo esc_textarea( $field['label'] ); ?></label>
+		                </th>
+		                <td>
+		                    <?php
+		                    switch ($field['field_type']) {
+		                        case 'select':
+		                            ?>
+		                            <select id="<?php echo esc_attr( $field['field_name'] ); ?>"
+		                                    name="<?php echo esc_attr( $field['field_name'] ); ?>">
+		                                <?php 
+		                                	//For associative arrays, we use the array keys as values. For numerically indexed arrays, we use the array values.
+		                                	$is_associative = (bool)count(array_filter(array_keys($field['options']), 'is_string'));
+		                                	foreach ($field['options'] as $key => $option) {
+		                                    	if(!$is_associative) $key = $option;
+		                                    	?>
+		                                    	<option value="<?php echo esc_attr($key); ?>" <?php selected($key, pmpro_getOption($field['field_name']));?>>
+		                                    		<?php echo esc_textarea($option); ?>
+		                                    	</option>
+		                               			<?php
+		                                	} 
+		                                ?>
+		                            </select>
+		                            <?php
+		                            break;
+		                        case 'text':
+		                            ?>
+		                            <input id="<?php echo esc_attr( $field['field_name'] ); ?>"
+		                                   name="<?php echo esc_attr( $field['field_name'] ); ?>"
+		                                   type="<?php echo esc_attr( $field['field_type'] ); ?>"
+		                                   value="<?php echo esc_attr(pmpro_getOption($field['field_name'])); ?> "
+		                                   class="regular-text">
+		                            <?php
+		                            break;
+		                        case 'textarea':
+		                            ?>
+		                            <textarea id="<?php echo esc_attr( $field['field_name'] ); ?>"
+		                                      name="<?php echo esc_attr( $field['field_name'] ); ?>"
+		                                      class="large-text">
+		                                <?php echo esc_textarea(pmpro_getOption($field['field_name'])); ?>
+		                            </textarea>
+		                            <?php
+		                            break;
+		                        default:
+		                            break;
+		                    }
+		                    if (!empty($field['description'])) {
+		                        ?>
+		                        <p class="description"><?php echo esc_textarea( $field['description'] ); ?></p>
+		                    <?php
+		                    }
+		                    ?>
+		                </td>
+		            </tr>
+		            <?php
+		            }
+		        } 
+		        ?>
+	        </tbody>
+			</table>
+			<script>
+				function pmpro_updateHideAdsTRs()
 				{
-					jQuery('#recaptcha_settings').show();
+					var hideads = jQuery('#hideads').val();
+					if(hideads == 2)
+					{
+						jQuery('#hideadslevels_tr').show();
+					}
+					else
+					{
+						jQuery('#hideadslevels_tr').hide();
+					}
+
+					if(hideads > 0)
+					{
+						jQuery('#hideads_explanation').show();
+					}
+					else
+					{
+						jQuery('#hideads_explanation').hide();
+					}
 				}
-				else
+				pmpro_updateHideAdsTRs();
+
+				function pmpro_updateRecaptchaTRs()
 				{
-					jQuery('#recaptcha_settings').hide();
+					var recaptcha = jQuery('#recaptcha').val();
+					if(recaptcha > 0)
+					{
+						jQuery('#recaptcha_settings').show();
+					}
+					else
+					{
+						jQuery('#recaptcha_settings').hide();
+					}
 				}
-			}
-			pmpro_updateRecaptchaTRs();
-		</script>
+				pmpro_updateRecaptchaTRs();
+			</script>
+		</div> <!-- end pmpro_admin_section-other-settings -->
 
 		<p class="submit">
 			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save Settings', 'paid-memberships-pro' );?>" />

--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -172,7 +172,7 @@ function pmpro_dashboard_welcome_callback() { ?>
     		<?php } elseif ( ! pmpro_license_isValid() ) { ?>
     			<p class="pmpro_message pmpro_alert">
     				<strong><?php echo esc_html_e( 'Your license is invalid or expired.', 'paid-memberships-pro' ); ?></strong><br />
-    				<?php printf(__( '<a href="%s">View your membership account</a> to verify your license key.', 'paid-memberships-pro' ), 'https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-dashboard%26utm_campaign%3Dmembership-account%26utm_content%3Dverify-license-key' );?>
+    				<?php printf(__( '<a href="%s">View your membership account</a> to verify your license key.', 'paid-memberships-pro' ), 'https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-dashboard%26utm_campaign%3Dmembership-account%26utm_content%3Dverify-license-key' );?>
     		<?php } else { ?>
     			<p class="pmpro_message pmpro_success"><?php printf(__( '<strong>Thank you!</strong> A valid <strong>%s</strong> license key has been used to activate your support license on this site.', 'paid-memberships-pro' ), ucwords($pmpro_license_check['license']));?></p>
     		<?php } ?>

--- a/adminpages/license.php
+++ b/adminpages/license.php
@@ -44,9 +44,9 @@ if ( defined( 'PMPRO_DIR' ) ) {
 
 		<div class="about-text">
 			<?php if(!pmpro_license_isValid() && empty($key)) { ?>
-				<p class="pmpro_message pmpro_error"><strong><?php _e('Enter your support license key.</strong> Your license key can be found in your membership email receipt or in your <a href="https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dno-key" target="_blank">Membership Account</a>.', 'paid-memberships-pro' );?></p>
+				<p class="pmpro_message pmpro_error"><strong><?php _e('Enter your support license key.</strong> Your license key can be found in your membership email receipt or in your <a href="https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dno-key" target="_blank">Membership Account</a>.', 'paid-memberships-pro' );?></p>
 			<?php } elseif(!pmpro_license_isValid()) { ?>
-				<p class="pmpro_message pmpro_error"><strong><?php _e('Your license is invalid or expired.', 'paid-memberships-pro' );?></strong> <?php _e('Visit the PMPro <a href="https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dkey-not-valid" target="_blank">Membership Account</a> page to confirm that your account is active and to find your license key.', 'paid-memberships-pro' );?></p>
+				<p class="pmpro_message pmpro_error"><strong><?php _e('Your license is invalid or expired.', 'paid-memberships-pro' );?></strong> <?php _e('Visit the PMPro <a href="https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dkey-not-valid" target="_blank">Membership Account</a> page to confirm that your account is active and to find your license key.', 'paid-memberships-pro' );?></p>
 			<?php } else { ?>													
 				<p class="pmpro_message pmpro_success"><?php printf(__('<strong>Thank you!</strong> A valid <strong>%s</strong> license key has been used to activate your support license on this site.', 'paid-memberships-pro' ), ucwords($pmpro_license_check['license']));?></p>
 			<?php } ?>
@@ -70,8 +70,8 @@ if ( defined( 'PMPRO_DIR' ) ) {
 					<a class="button button-primary button-hero" href="https://www.paidmembershipspro.com/membership-checkout/?level=20&utm_source=plugin&utm_medium=pmpro-license&utm_campaign=plus-checkout&utm_content=buy-plus" target="_blank"><?php echo esc_html( 'Buy Plus License', 'paid-memberships-pro' ); ?></a>
 					<a class="button button-hero" href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=pmpro-license&utm_campaign=pricing&utm_content=view-license-options" target="_blank"><?php echo esc_html( 'View Support License Options', 'paid-memberships-pro' ); ?></a>
 				<?php } else { ?>
-					<a class="button button-primary button-hero" href="https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dview-account" target="_blank"><?php echo esc_html( 'Manage My Account', 'paid-memberships-pro' ); ?></a>
-					<a class="button button-hero" href="https://www.paidmembershipspro.com/login/?redirect_to=%2Fnew-topic%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dsupport%26utm_content%3Dnew-support-ticket" target="_blank"><?php echo esc_html( 'Open Support Ticket', 'paid-memberships-pro' ); ?></a>
+					<a class="button button-primary button-hero" href="https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dview-account" target="_blank"><?php echo esc_html( 'Manage My Account', 'paid-memberships-pro' ); ?></a>
+					<a class="button button-hero" href="https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fnew-topic%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dsupport%26utm_content%3Dnew-support-ticket" target="_blank"><?php echo esc_html( 'Open Support Ticket', 'paid-memberships-pro' ); ?></a>
 				<?php } ?>
 			</p>
 

--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -149,8 +149,8 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					</tr>
 					<tr>
 						<td valign="top" style="background: #FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:left;">
-							<div style="border: 8px dashed #EFEFEF;padding:30px;margin: 0px 0px 30px 0px;text-align:center;">
-								<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Discount Code Usage', 'paid-memberships-pro' ); ?></h3>
+							<div style="border: 8px dashed #EFEFEF;padding:30px;margin:0px;text-align:center;">
+								<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Discount Code Usage', 'paid-memberships-pro' ); ?></h3>
 								<?php
 								$num_orders_with_discount_code  = $wpdb->get_var( "SELECT COUNT( * ) FROM {$wpdb->pmpro_discount_codes_uses} WHERE timestamp >= '" . esc_sql( $report_start_date ) . " 00:00:00' AND timestamp <= '" . esc_sql( $report_end_date ) . " 00:00:00'" );
 								if ( $num_orders_with_discount_code > 0 ) {
@@ -167,7 +167,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										"
 									);
 									?>
-									<p style="margin:0px 0px 15px 0px;padding:0;"><?php printf( __( '<strong>%1$d orders</strong> used a <a %2$s>Discount Code</a> at checkout. Here is a breakdown of your most used codes:', 'paid-memberships-pro' ), esc_html( $num_orders_with_discount_code ), 'style="color:#2997c8;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"' ); ?></p>
+									<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( '<strong>%1$d orders</strong> used a <a %2$s>Discount Code</a> at checkout. Here is a breakdown of your most used codes:', 'paid-memberships-pro' ), esc_html( $num_orders_with_discount_code ), 'style="color:#2997c8;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"' ); ?></p>
 										<?php
 										$codes_left_to_show = 5;
 										foreach ( $orders_per_discount_code as $orders_per_discount_code_element ) {
@@ -179,7 +179,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										}
 								} else {
 									?>
-									<p style="margin:0px 0px 15px 0px;padding:0;"><?php printf( __( 'No <a %1$s>Discount Codes</a> were used %2$s.', 'paid-memberships-pro' ), 'style="color:#2997c8;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"', esc_html( $term ) ); ?></p>
+									<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( 'No <a %1$s>Discount Codes</a> were used %2$s.', 'paid-memberships-pro' ), 'style="color:#2997c8;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"', esc_html( $term ) ); ?></p>
 									<?php
 								}
 								?>
@@ -187,9 +187,9 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 						</td>
 					</tr>
 					<tr>
-						<td valign="top" style="background: #EFEFEF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:center;">
-							<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Active Add Ons', 'paid-memberships-pro' ); ?></h3>
-							<table align="center" border="0" cellpadding="0" cellspacing="15" width="100%" style="border:0;background-color:#EFEFEF;text-align: center;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height: 25px;color:#444444;">
+						<td valign="top" style="background: #EFEFEF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding:30px;text-align:center;">
+							<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Active Add Ons', 'paid-memberships-pro' ); ?></h3>
+							<table align="center" border="0" cellpadding="0" cellspacing="15" width="100%" style="border:0;background-color:#EFEFEF;text-align: center;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;">
 								<tr>
 									<?php
 									// Get addon statistics.

--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -67,7 +67,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 
 		ob_start();
 		?>
-		<div style="margin:0;padding:30px;width:100%;background-color:#333333;">
+		<div style="margin:0;padding:0px 30px 0px 30px;width:100%;background-color:#999999;">
 		<center>
 			<table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;border:0;max-width:600px!important;background-color:#FFFFFF;">
 				<tbody>
@@ -76,14 +76,14 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:center;">
-							<h2 style="color:#2997c8;font-size: 30px;margin:0px 0px 20px 0px;padding:0px;"><?php get_bloginfo( 'name' ); ?></h2>
-							<p style="font-size: 20px;line-height: 30px;margin:0px;padding:0px;"><?php printf( __( "Here's a summary of what happened in your Paid Memberships Pro site %s.", 'paid-memberships-pro' ), esc_html( $term ) ); ?></p>
+						<td valign="top" style="background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:30px;text-align:center;">
+							<h2 style="color:#2997c8;font-size:30px;margin:0px 0px 20px 0px;padding:0px;"><?php get_bloginfo( 'name' ); ?></h2>
+							<p style="font-size:20px;line-height:30px;margin:0px;padding:0px;"><?php printf( __( "Here's a summary of what happened in your Paid Memberships Pro site %s.", 'paid-memberships-pro' ), esc_html( $term ) ); ?></p>
 						</td>
 					</tr>
 					<tr>
-						<td valign="top" style="background: #EFEFEF;font-family:Helvetica,Arial,sans-serif;font-size: 20px;line-height: 30px;color:#444444;padding: 15px;text-align:center;">
-							<p style="margin:0px;padding:0px;"><strong><?php echo( esc_html( $date_range ) ); ?></strong></p> <!--Show date range this covers here in their site's date format-->
+						<td valign="top" style="background:#F1F1F1;font-family:Helvetica,Arial,sans-serif;font-size:20px;line-height:30px;color:#222222;padding:15px;text-align:center;">
+							<p style="margin:0px;padding:0px;"><strong><?php echo( esc_html( $date_range ) ); ?></strong></p>
 						</td>
 					</tr>
 					<?php
@@ -91,17 +91,17 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:center;">
+						<td valign="top" style="background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:30px;text-align:center;">
 							<?php
 							$revenue = pmpro_get_revenue_between_dates( $report_start_date, $report_end_date );
 							if ( $revenue > 0 ) {
 								?>
-								<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Sales and Revenue', 'paid-memberships-pro' ); ?></h3>
+								<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Sales and Revenue', 'paid-memberships-pro' ); ?></h3>
 								<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( 'Your membership site made <strong>%1$s</strong> in revenue %2$s.', 'paid-memberships-pro' ), esc_html( pmpro_formatPrice( $revenue ) ), esc_html( $term ) ); ?></p>
 							<?php } else { ?>
-								<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Signups and Cancellations', 'paid-memberships-pro' ); ?></h3>
+								<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Signups and Cancellations', 'paid-memberships-pro' ); ?></h3>
 							<?php } ?>
-							<table align="center" border="0" cellpadding="0" cellspacing="5" width="100%" style="border:0;background-color:#FFFFFF;text-align: center;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height: 25px;color:#444444;">
+							<table align="center" border="0" cellpadding="0" cellspacing="5" width="100%" style="border:0;background-color:#FFFFFF;text-align:center;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;">
 								<tr>
 									<?php
 									$num_joined    = $wpdb->get_var( "SELECT COUNT( DISTINCT user_id ) FROM {$wpdb->pmpro_memberships_users} WHERE startdate >= '" . esc_sql( $report_start_date ) . " 00:00:00' AND startdate <= '" . esc_sql( $report_end_date ) . " 00:00:00'" );
@@ -112,9 +112,9 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 									$num_expired_link   = admin_url( 'admin.php?page=pmpro-memberslist&l=expired' );
 									$num_cancelled_link = admin_url( 'admin.php?page=pmpro-memberslist&l=cancelled' );
 									?>
-									<td width="33%" style="border: 8px solid #dff0d8;color:#3c763d;padding:10px;"><a style="color:#3c763d;display:block;text-decoration: none;" href="<?php echo( esc_url( $num_joined_link ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $num_joined ) ); ?></div>Joined</a></td>
-									<td width="33%" style="border: 8px solid #fcf8e3;color:#8a6d3b;padding:10px;"><a style="color:#8a6d3b;display:block;text-decoration: none;" href="<?php echo( esc_url( $num_expired_link ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $num_expired ) ); ?></div>Expired</a></td>
-									<td width="33%" style="border: 8px solid #f2dede;color:#a94442;padding:10px;"><a style="color:#a94442;display:block;text-decoration: none;" href="<?php echo( esc_url( $num_cancelled_link ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $num_cancelled ) ); ?></div>Cancelled</a></td>
+									<td width="33%" style="border:8px solid #dff0d8;color:#3c763d;padding:10px;"><a style="color:#3c763d;display:block;text-decoration:none;" href="<?php echo( esc_url( $num_joined_link ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $num_joined ) ); ?></div>Joined</a></td>
+									<td width="33%" style="border:8px solid #fcf8e3;color:#8a6d3b;padding:10px;"><a style="color:#8a6d3b;display:block;text-decoration:none;" href="<?php echo( esc_url( $num_expired_link ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $num_expired ) ); ?></div>Expired</a></td>
+									<td width="33%" style="border:8px solid #f2dede;color:#a94442;padding:10px;"><a style="color:#a94442;display:block;text-decoration:none;" href="<?php echo( esc_url( $num_cancelled_link ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $num_cancelled ) ); ?></div>Cancelled</a></td>
 								</tr>
 							</table>
 						</td>
@@ -124,11 +124,11 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #EFEFEF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:left;">
+						<td valign="top" style="background:#F1F1F1;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:30px;text-align:left;">
 							<?php
 							$total_members = $wpdb->get_var( "SELECT COUNT( DISTINCT user_id ) FROM {$wpdb->pmpro_memberships_users} WHERE status IN ('active')" );
 							?>
-							<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px;padding:0px;"><span style="background: #2997c8;color:#FFFFFF;padding:10px;"><?php echo( esc_html( $total_members ) ); ?></span><?php esc_html_e( ' Total Members&mdash;great work!', 'paid-memberships-pro' ); ?></h3>
+							<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px;padding:0px;"><span style="background:#2997c8;color:#FFFFFF;padding:10px;"><?php echo( esc_html( $total_members ) ); ?></span><?php esc_html_e( ' Total Members&mdash;great work!', 'paid-memberships-pro' ); ?></h3>
 							<?php
 							$members_per_level = $wpdb->get_results(
 								"
@@ -166,8 +166,8 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:left;">
-							<div style="border: 8px dashed #EFEFEF;padding:30px;margin:0px;text-align:center;">
+						<td valign="top" style="background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:30px;text-align:left;">
+							<div style="border:8px dashed #F1F1F1;padding:30px;margin:0px;text-align:center;">
 								<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Discount Code Usage', 'paid-memberships-pro' ); ?></h3>
 								<?php
 								$num_orders_with_discount_code  = $wpdb->get_var( "SELECT COUNT( * ) FROM {$wpdb->pmpro_discount_codes_uses} WHERE timestamp >= '" . esc_sql( $report_start_date ) . " 00:00:00' AND timestamp <= '" . esc_sql( $report_end_date ) . " 00:00:00'" );
@@ -209,9 +209,9 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #EFEFEF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding:30px;text-align:center;">
+						<td valign="top" style="background:#F1F1F1;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:30px;text-align:center;">
 							<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Active Add Ons', 'paid-memberships-pro' ); ?></h3>
-							<table align="center" border="0" cellpadding="0" cellspacing="15" width="100%" style="border:0;background-color:#EFEFEF;text-align: center;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;">
+							<table align="center" border="0" cellpadding="0" cellspacing="15" width="100%" style="border:0;background-color:#F1F1F1;text-align:center;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;">
 								<tr>
 									<?php
 									// Get addon statistics.
@@ -237,14 +237,14 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										}
 									}
 									$addon_updates_box_color      = $update_addons ? '#f2dede' : '#FFFFFF';
-									$addon_updates_text_color = $update_addons ? '#a94442' : '#444444';
+									$addon_updates_text_color = $update_addons ? '#a94442' : '#:';
 									?>
 									<td width="33%" style="background:#FFFFFF;padding:10px;"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $free_addons ) ); ?></div><?php esc_html_e( 'Free Add Ons', 'paid-memberships-pro' ); ?></td>
 									<td width="33%" style="background:#FFFFFF;padding:10px;"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $plus_addons ) ); ?></div><?php esc_html_e( 'Plus Add Ons', 'paid-memberships-pro' ); ?></td>
-									<td width="33%" style="background:<?php echo( $addon_updates_box_color ); ?>;padding:10px;"><a style="color:<?php echo( $addon_updates_text_color ); ?>;display:block;text-decoration: none;" href="<?php echo( esc_url( admin_url( 'admin.php?page=pmpro-addons&plugin_status=update' ) ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $update_addons ) ); ?></div><?php esc_html_e( 'Required Updates', 'paid-memberships-pro' ); ?></a></td>
+									<td width="33%" style="background:<?php echo( $addon_updates_box_color ); ?>;padding:10px;"><a style="color:<?php echo( $addon_updates_text_color ); ?>;display:block;text-decoration:none;" href="<?php echo( esc_url( admin_url( 'admin.php?page=pmpro-addons&plugin_status=update' ) ) ); ?>" target="_blank"><div style="font-size:50px;font-weight:900;line-height:65px;"><?php echo( esc_html( $update_addons ) ); ?></div><?php esc_html_e( 'Required Updates', 'paid-memberships-pro' ); ?></a></td>
 								</tr>
 							</table>
-							<p style="margin:0px;padding:0px;"><?php printf( __( 'It is important to keep all Add Ons up to date to take advantage of security improvements, bug fixes, and expanded features. Add On updates can be made <a href="%s" target="_blank">via the WordPress Dashboard</a>.', 'paid-memberships-pro' ), esc_url( admin_url( 'update-core.php' ) ) ); ?></p>
+							<p style="margin:0px;padding:0px;"><?php printf( __( 'It is important to keep all Add Ons up to date to take advantage of security improvements, bug fixes, and expanded features. Add On updates can be made <a href="%s" style="color:#2997c8;" target="_blank">via the WordPress Dashboard</a>.', 'paid-memberships-pro' ), esc_url( admin_url( 'update-core.php' ) ) ); ?></p>
 						</td>
 					</tr>
 					<?php
@@ -252,8 +252,8 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding: 30px;text-align:left;">
-							<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Membership Site Administration', 'paid-memberships-pro' ); ?></h3>
+						<td valign="top" style="background:#FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:30px;text-align:left;">
+							<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Membership Site Administration', 'paid-memberships-pro' ); ?></h3>
 							<ul>
 								<?php
 								$roles_to_list = array(
@@ -270,7 +270,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										echo( '<li>' . count( $users_with_role ) . ' ' . esc_html( $role_name ) . ': ' );
 										$users_with_role_formatted = array();
 										foreach ( $users_with_role as $user_with_role ) {
-											$users_with_role_formatted[] = '<a target="_blank" href="' . admin_url( 'user-edit.php?user_id=' . $user_with_role->ID ) . '">' . $user_with_role->data->user_login . '</a>';
+											$users_with_role_formatted[] = '<a target="_blank" style="color:#2997c8;" href="' . admin_url( 'user-edit.php?user_id=' . $user_with_role->ID ) . '">' . $user_with_role->data->user_login . '</a>';
 										}
 										echo( implode( ', ', $users_with_role_formatted ) );
 									}
@@ -283,9 +283,8 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 							$key = get_option( 'pmpro_license_key', '' );
 							if ( ! pmpro_license_isValid( $key, null ) ) {
 								?>
-							<hr style="background-color: #EFEFEF;border: 0;height: 4px;margin: 30px 0px 30px 0px;" />
-							<!--Show section below only if there is no license key. -->
-							<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'License Status: None', 'paid-memberships-pro' ); ?></h3> 
+							<hr style="background-color:#F1F1F1;border:0;height:4px;margin:30px 0px 30px 0px;" />
+							<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'License Status: None', 'paid-memberships-pro' ); ?></h3> 
 							<p style="margin:0px;padding:0px;"><?php printf( __( '...and that is perfectly OK! PMPro is free to use for as long as you want for membership sites of all sizes. Interested in unlimited support, access to over 70 featured-enhancing Add Ons and instant installs and updates? <a %s>Check out our paid plans to learn more</a>.', 'paid-memberships-pro' ), ' style="color:#2997c8;" href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=pmpro-admin-activity-email&utm_campaign=pricing&utm_content=license-section" target="_blank"' ); ?></p>
 								<?php
 							}
@@ -297,14 +296,11 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background-color:#FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#444444;padding:0;text-align:left;">
-							<table align="center" border="0" cellpadding="0" cellspacing="10" width="100%" style="border:0;background-color:#FFFFFF;text-align:left;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height: 25px;color:#444444;">
+						<td valign="top" style="background-color:#FFFFFF;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;padding:0;text-align:left;">
+							<table align="center" border="0" cellpadding="0" cellspacing="10" width="100%" style="border:0;background-color:#FFFFFF;text-align:left;font-family:Helvetica,Arial,sans-serif;font-size:16px;line-height:25px;color:#222222;">
 								<tr valign="top">
-									<td width="60%" style="background-color:#EFEFEF;padding:15px;">
-										<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;">Recent Articles</h3>
-										<!-- look to this for example: https://github.com/strangerstudios/paid-memberships-pro/blob/dev/adminpages/dashboard.php#L351-L354; show max 1 time per week? if daily, exclude it? show one? needs discussion -->
-										<!-- Sample links had href="#/?utm_source=plugin&utm_medium=pmpro-admin-activity-email&utm_campaign=blog&utm_content=recent-articles-section", are these params important? -->
-										<!--Pull in via RSS Feed from specific category on our blog. Last 3? How do we make sure there isn’t the same thing sent twice? Could this be dynamic and we choose to occasionally send something different? -->
+									<td width="60%" style="background-color:#F1F1F1;padding:15px;">
+										<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;">Recent Articles</h3>
 									<?php
 									// Get RSS Feed(s).
 									include_once ABSPATH . WPINC . '/feed.php';
@@ -327,14 +323,11 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 									}
 									?>
 									</td>
-									<td width="40%" style="background-color:#EFEFEF;padding:15px;"> 
-										<h3 style="color:#2997c8;font-size: 20px;line-height: 30px;margin:0px 0px 15px 0px;padding:0px;"><?php _e( 'PMPro Stats', 'paid-memberships-pro' ); ?></h3>
-										<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( '%s Sites Use PMPro', 'paid-memberships-pro' ), '<strong>80,000</strong>' ); ?></p>
-										<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( '%s Years in Development', 'paid-memberships-pro' ), '<strong>8+</strong>' ); ?></p>
+									<td width="40%" style="background-color:#F1F1F1;padding:15px;"> 
+										<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php _e( 'PMPro Stats', 'paid-memberships-pro' ); ?></h3>
 										<p style="margin:0px 0px 15px 0px;padding:0px;"><a style="color:#2997c8;" href="https://twitter.com/pmproplugin" target="_blank"><?php esc_html_e( 'Follow @pmproplugin on Twitter', 'paid-memberships-pro' ); ?></a></p>
 										<p style="margin:0px 0px 15px 0px;padding:0px;"><a style="color:#2997c8;" href="https://www.facebook.com/PaidMembershipsPro/" target="_blank"><?php esc_html_e( 'Like Us on Facebook', 'paid-memberships-pro' ); ?></p></p>
 										<p style="margin:0px 0px 15px 0px;padding:0px;"><a style="color:#2997c8;" href="https://www.youtube.com/user/strangerstudiostv" target="_blank"><?php esc_html_e( 'Subscribe to Our YouTube Channel', 'paid-memberships-pro' ); ?></a></p>
-										<!-- Show Plus signups count? Rating? -->
 									</td>
 								</tr>
 							</table>
@@ -345,7 +338,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 					ob_clean();
 					?>
 					<tr>
-						<td valign="top" style="background: #333333;font-family:Helvetica,Arial,sans-serif;font-size:20px;line-height:30px;color:#FFFFFF;padding: 30px;text-align:center;">
+						<td valign="top" style="background:#333333;font-family:Helvetica,Arial,sans-serif;font-size:20px;line-height:30px;color:#FFFFFF;padding:30px;text-align:center;">
 							<p style="margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'This email is automatically generated by your WordPress site and sent to your Administration Email Address set under Settings > General in your WordPress dashboard.', 'paid-memberships-pro' ); ?></p>
 							<p style="margin:0px;padding:0px;"><?php printf( __( 'To adjust the frequency of this message or disable these emails completely, you can <a %s>update the "Activity Email Frequency" setting here</a>.', 'paid-memberships-pro' ), ' style="color:#FFFFFF;" href="' . admin_url( 'admin.php?page=pmpro-advancedsettings' ) . '" target="_blank"' ); ?></p>
 						</td>

--- a/includes/login.php
+++ b/includes/login.php
@@ -673,7 +673,7 @@ function pmpro_logged_in_welcome( $show_menu = true, $show_logout_link = true ) 
 		 * The menu can be customized per level using the Nav Menus Add On for Paid Memberships Pro.
 		 *
 		 */
-		if ( ! empty ( $show_menu ) ) {
+		if ( $show_menu != 'false' ) {
 			$pmpro_login_widget_menu_defaults = array(
 				'theme_location'  => 'pmpro-login-widget',
 				'container'       => 'nav',

--- a/includes/login.php
+++ b/includes/login.php
@@ -458,16 +458,16 @@ function pmpro_reset_password_form() {
 
 function pmpro_login_forms_handler_nav( $pmpro_form ) { ?>
 	<hr />
-	<p class="pmpro_form_nav">
+	<p class="pmpro_actions_nav">
 		<?php
 			/**
-			 * Filters the separator used between login form navigation links.
+			 * Filters the separator used between action navigation links.
 			 *
 			 * @since 2.3
 			 *
-			 * @param string $pmpro_form_nav_separator The separator used between form navigation links.
+			 * @param string $pmpro_actions_nav_separator The separator used between action links.
 			 */
-			$pmpro_form_nav_separator = apply_filters( 'pmpro_form_nav_separator', ' | ' );
+			$pmpro_actions_nav_separator = apply_filters( 'pmpro_actions_nav_separator', ' | ' );
 
 			// Build the links to return.
 			$links = array();
@@ -494,9 +494,9 @@ function pmpro_login_forms_handler_nav( $pmpro_form ) { ?>
 				$links['lost_password'] = apply_filters( 'pmpro_lost_password_url', $pmpro_lost_password_url );
 			}
 
-			echo implode( $pmpro_form_nav_separator, $links );
+			echo implode( esc_html( $pmpro_actions_nav_separator ), $links );
 		?>
-	</p>
+	</p> <!-- end pmpro_actions_nav -->
 	<?php
 }
 

--- a/includes/login.php
+++ b/includes/login.php
@@ -642,7 +642,7 @@ function pmpro_login_failed( $username ) {
 add_action( 'wp_login_failed', 'pmpro_login_failed', 10, 2 );
 
 /**
- * Show welcome content for a "Logged In" member with Display Name, Log Out link and a "PMPro Member" menu area.
+ * Show welcome content for a "Logged In" member with Display Name, Log Out link and a "Log In Widget" menu area.
  *
  * @since 2.3
  *
@@ -651,7 +651,7 @@ function pmpro_logged_in_welcome( $show_menu = true, $show_logout_link = true ) 
 	if ( is_user_logged_in( ) ) {
 		// Set the location the user's display_name will link to based on level status.
 		global $current_user, $pmpro_pages;
-		if ( ! empty( $pmpro_pages ) && pmpro_hasMembershipLevel() ) {
+		if ( ! empty( $pmpro_pages ) && ! empty( $pmpro_pages['account'] ) ) {
 			$account_page      = get_post( $pmpro_pages['account'] );
 			$user_account_link = '<a href="' . esc_url( pmpro_url( 'account' ) ) . '">' . esc_html( preg_replace( '/\@.*/', '', $current_user->display_name ) ) . '</a>';
 		} else {
@@ -669,20 +669,20 @@ function pmpro_logged_in_welcome( $show_menu = true, $show_logout_link = true ) 
 
 		<?php
 		/**
-		 * Show the "Member Form" menu to users with an active membership level.
-		 * The menu can be customized per-level using the Nav Menus Add On for Paid Memberships Pro.
+		 * Show the "Log In Widget" menu to users.
+		 * The menu can be customized per level using the Nav Menus Add On for Paid Memberships Pro.
 		 *
 		 */
-		if ( ! empty ( $show_menu ) && pmpro_hasMembershipLevel() ) {
-			$pmpro_member_menu_defaults = array(
-				'theme_location'  => 'pmpro-login-forms',
+		if ( ! empty ( $show_menu ) ) {
+			$pmpro_login_widget_menu_defaults = array(
+				'theme_location'  => 'pmpro-login-widget',
 				'container'       => 'nav',
 				'container_id'    => 'pmpro-member-navigation',
 				'container_class' => 'pmpro-member-navigation',
 				'fallback_cb'	  => false,
 				'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 			);
-			wp_nav_menu( $pmpro_member_menu_defaults );
+			wp_nav_menu( $pmpro_login_widget_menu_defaults );
 		}
 		?>
 

--- a/includes/menus.php
+++ b/includes/menus.php
@@ -228,7 +228,7 @@ function pmpro_register_menus() {
 	// Register PMPro menu areas.
 	register_nav_menus(
 		array(
-			'pmpro-login-forms' => __( 'Member Form Widget - Paid Memberships Pro', 'paid-memberships-pro' ),
+			'pmpro-login-widget' => __( 'Log In Widget - PMPro', 'paid-memberships-pro' ),
 		)
 	);
 }

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -16,7 +16,7 @@ class PMPro_Widget_Member_Login extends WP_Widget {
 			'classname'   => 'widget_pmpro_member_login',
 			'description' => __( 'Display a login form and optional "Logged In" member content.', 'paid-memberships-pro' ),
 		);
-		parent::__construct( 'pmpro-member-login', esc_html__( 'Member Login/Log Out - Paid Memberships Pro', 'paid-memberships-pro' ), $widget_ops );
+		parent::__construct( 'pmpro-member-login', esc_html__( 'Log In - PMPro', 'paid-memberships-pro' ), $widget_ops );
 		$this->alt_option_name = 'widget_pmpro_member_login';
 
 		add_action( 'save_post', array( $this, 'flush_widget_cache' ) );
@@ -108,11 +108,17 @@ class PMPro_Widget_Member_Login extends WP_Widget {
 
 		<p>
 			<input class="checkbox" type="checkbox" <?php checked( $show_menu ); ?> id="<?php echo $this->get_field_id( 'show_menu' ); ?>" name="<?php echo $this->get_field_name( 'show_menu' ); ?>" />
-			<label for="<?php echo $this->get_field_id( 'show_menu' ); ?>"><?php esc_html_e( 'Display the "Member Form" menu.', 'paid-memberships-pro' ); ?></label>
-			<p class="description"><?php esc_html_e( 'Menu will be hidden to non-members. Assign the menu under Appearance > Menus.', 'paid-memberships-pro' ); ?></p>
+			<label for="<?php echo $this->get_field_id( 'show_menu' ); ?>"><?php esc_html_e( 'Display the "Log In Widget" menu.', 'paid-memberships-pro' ); ?></label>
 		</p>
-
-<?php
+		<?php
+			$allowed_nav_menus_link_html = array (
+				'a' => array (
+					'href' => array(),
+					'target' => array(),
+					'title' => array(),
+				),
+			);
+			echo '<p class="description">' . sprintf( wp_kses( __( 'Customize this menu per level using the <a href="%s" title="Paid Memberships Pro - Nav Menus Add On" target="_blank">Nav Menus Add On</a>. Assign the menu under Appearance > Menus.', 'paid-memberships-pro' ), $allowed_nav_menus_link_html ), 'https://www.paidmembershipspro.com/add-ons/pmpro-nav-menus/?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=nav-menus' ) . '</p>';
 	}
 }
 /* End Member Login Widget */


### PR DESCRIPTION
Renamed menu to make better sense in terms of who sees it.

Renamed widget per discussion with Jason

Renamed the form nav action separator filter as this may eventually be used in other places down the road.

Fixed widget logic where show menu was set to "false" but still showing because false is a string (not empty).

Now showing the Log In Widget menu to both members and non-members. This can be adjusted using the nav menus add on.