### PR TITLE
Adding i18n for JS functionality.

### DIFF
--- a/blocks/blocks.php
+++ b/blocks/blocks.php
@@ -58,5 +58,10 @@ function pmpro_block_editor_scripts() {
 		array(),
 		PMPRO_VERSION
 	);
+
+	// Adding translation functionality to Gutenberg blocks/JS.
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		wp_set_script_translations( 'pmpro-blocks-editor-js', 'paid-memberships-pro' );
+	}
 }
 add_action( 'enqueue_block_editor_assets', 'pmpro_block_editor_scripts' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [ x Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding `wp_set_script_translations` so JS can be translated.

### How to test the changes in this Pull Request:

This will be difficult to test because the translators must translate the Gutenberg strings, then a JSON language pack is generated, and we'd have to switch to that language to ensure everything is translated correctly.

### Changelog entry

> JavaScript files are now translatable.