### PR TITLE
Logged in member view of login shortcode/block/function fixes

### DIFF
--- a/blocks/login/block.php
+++ b/blocks/login/block.php
@@ -58,5 +58,5 @@ function render_dynamic_block( $attributes ) {
 	$attributes['show_menu']            = filter_var( $attributes['show_menu'], FILTER_VALIDATE_BOOLEAN );
 	$attributes['show_logout_link']     = filter_var( $attributes['show_logout_link'], FILTER_VALIDATE_BOOLEAN );
 
-	return( pmpro_login_forms_handler( $attributes['display_if_logged_in'], $attributes['show_menu'], $attributes['show_logout_link'], '', false ) );
+	return( pmpro_login_forms_handler( $attributes['show_menu'], $attributes['show_logout_link'], $attributes['display_if_logged_in'], '', false ) );
 }

--- a/includes/login.php
+++ b/includes/login.php
@@ -741,7 +741,7 @@ function pmpro_logged_in_welcome( $show_menu = true, $show_logout_link = true ) 
 		 * The menu can be customized per level using the Nav Menus Add On for Paid Memberships Pro.
 		 *
 		 */
-		if ( $show_menu != 'false' ) {
+		if ( ! empty( $show_menu ) ) {
 			$pmpro_login_widget_menu_defaults = array(
 				'theme_location'  => 'pmpro-login-widget',
 				'container'       => 'nav',

--- a/shortcodes/pmpro_login.php
+++ b/shortcodes/pmpro_login.php
@@ -18,6 +18,25 @@ function pmpro_shortcode_login( $atts, $content=null, $code='' ) {
 		'location' => 'shortcode'
 	), $atts ) );
 
+	// Turn 0's into falses.
+	if ( $display_if_logged_in === '0' || $display_if_logged_in === 'false' || $display_if_logged_in === 'no' ) {
+		$display_if_logged_in = false;
+	} else {
+		$display_if_logged_in = true;
+	}
+
+	if ( $show_menu === '0' || $show_menu === 'false' || $show_menu === 'no' ){
+		$show_menu = false;
+	} else {
+		$show_menu = true;
+	}
+
+	if ( $show_logout_link === '0' || $show_logout_link === 'false' || $show_logout_link === 'no' ) {
+		$show_logout_link = false;
+	} else {
+		$show_logout_link = true;
+	}
+
 	// Display the login form using shortcode attributes.
 	return pmpro_login_forms_handler( $show_menu, $show_logout_link, $display_if_logged_in, $location, false );	
 }


### PR DESCRIPTION
Some bugs around the block order of parameters, fixing shortcode attributes that weren't validating as bool, changing the show_menu check to a bool (! empty ) rather than an exact string check.