### PR TITLE
Update to process cancellation for the recurring_subscription_failed txn_type

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -763,7 +763,8 @@
 			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
 			if (
 				( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
-				( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id )
+				( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id ) || 
+				( $_POST['txn_type'] != 'recurring_payment_failed' )
 			) {
 				return true;
 			}

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -760,13 +760,13 @@
 			// Always cancel the order locally even if PayPal might fail
 			$order->updateStatus("cancelled");
 
-			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
-			if (
-				( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
-				( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id ) || 
-				( $_POST['txn_type'] != 'recurring_payment_failed' )
-			) {
-				return true;
+			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.			
+			if ( ( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
+				 ( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id ) ) {
+				// recurring_payment_failed transaction still need to be cancelled
+				if ( $_POST['txn_type'] !== 'recurring_payment_failed' ) {
+					return true;	
+				}
 			}
 
 			// Build the nvp string for PayPal API

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -235,8 +235,8 @@ if ( $txn_type == "recurring_payment_suspended_due_to_max_failed_payment" && 'su
 	pmpro_ipnExit();
 }
 
-//Recurring Payment Profile Cancelled (PayPal Express)
-if ( $txn_type == "recurring_payment_profile_cancel" ) {
+// Recurring Payment Profile Cancelled or Failed (PayPal Express)
+if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_payment_failed' ) {
 	//find last order
 	$last_subscription_order = new MemberOrder();
 	if ( $last_subscription_order->getLastMemberOrderBySubscriptionTransactionID( $recurring_payment_id ) == false ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The change updates the IPN handler and PayPal Express class to support the recurring_subscription_failed. This change fixes issue https://github.com/strangerstudios/paid-memberships-pro/issues/1080.

### How to test the changes in this Pull Request:

1. Use the gist like https://gist.github.com/ideadude/8e05f2429914ca2869319c68cebb50aa but update txn_type to recurring_subscription_failed. Ask Kim for a real IPN record from the live site that you can test with.
2. Run the fake IPN. 
3. The user will cancel membership.

### Changelog entry
* BUG FIX: Updated to support the `recurring_subscription_failed` IPN transaction type where PayPal will fail to collect the recurring payment but keep the profile open. We now cancel the profile and membership.