### PR TITLE
Added second space after PRIMARY KEY in pmpro_db_delta()

### DIFF
--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -272,7 +272,7 @@ function pmpro_db_delta()
 		  `allow_signups` tinyint(4) NOT NULL DEFAULT '1',
 		  `expiration_number` int(10) unsigned NOT NULL,
 		  `expiration_period` enum('Day','Week','Month','Year') NOT NULL,
-		  PRIMARY KEY (`id`),
+		  PRIMARY KEY  (`id`),
 		  KEY `allow_signups` (`allow_signups`),
 		  KEY `initial_payment` (`initial_payment`),
 		  KEY `name` (`name`)
@@ -317,7 +317,7 @@ function pmpro_db_delta()
 		  `affiliate_id` varchar(32) NOT NULL,
 		  `affiliate_subid` varchar(32) NOT NULL,
 		  `notes` TEXT NOT NULL,
-		  PRIMARY KEY (`id`),
+		  PRIMARY KEY  (`id`),
 		  UNIQUE KEY `code` (`code`),
 		  KEY `session_id` (`session_id`),
 		  KEY `user_id` (`user_id`),
@@ -377,7 +377,7 @@ function pmpro_db_delta()
 		   `startdate` datetime NOT NULL,
 		   `enddate` datetime DEFAULT NULL,
 		   `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-		   PRIMARY KEY (`id`),
+		   PRIMARY KEY  (`id`),
 		   KEY `membership_id` (`membership_id`),
 		   KEY `modified` (`modified`),
 		   KEY `code_id` (`code_id`),
@@ -396,7 +396,7 @@ function pmpro_db_delta()
 		  `starts` date NOT NULL,
 		  `expires` date NOT NULL,
 		  `uses` int(11) NOT NULL,
-		  PRIMARY KEY (`id`),
+		  PRIMARY KEY  (`id`),
 		  UNIQUE KEY `code` (`code`),
 		  KEY `starts` (`starts`),
 		  KEY `expires` (`expires`)
@@ -418,7 +418,7 @@ function pmpro_db_delta()
 		  `trial_limit` int(11) NOT NULL DEFAULT '0',
 		  `expiration_number` int(10) unsigned NOT NULL,
 		  `expiration_period` enum('Day','Week','Month','Year') NOT NULL,
-		  PRIMARY KEY (`code_id`,`level_id`),
+		  PRIMARY KEY  (`code_id`,`level_id`),
 		  KEY `initial_payment` (`initial_payment`)
 		);
 	";
@@ -432,7 +432,7 @@ function pmpro_db_delta()
 		  `user_id` int(10) unsigned NOT NULL,
 		  `order_id` int(10) unsigned NOT NULL,
 		  `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-		  PRIMARY KEY (`id`),
+		  PRIMARY KEY  (`id`),
 		  KEY `user_id` (`user_id`),
 		  KEY `timestamp` (`timestamp`)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Now following rule to have two spaces after `PRIMARY KEY` when using `db_delta()` function.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.