### PR TITLE
Updating the billing page for check payment gateway notes. Adding "back" link to account.

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -90,11 +90,18 @@
 
 <?php if ( $has_recurring_levels ) {
 	if ( $show_check_payment_instructions ) {
-		$instructions = pmpro_getOption("instructions");
-		echo '<div class="pmpro_check_instructions">' . wpautop(wp_unslash( $instructions )) . '</div>';
-	} elseif ( $show_paypal_link ) { ?>
+		$instructions = pmpro_getOption("instructions"); ?>
+		<div class="pmpro_check_instructions"><?php echo wpautop( wp_unslash( $instructions ) ); ?></div>
+		<hr />
+		<p class="pmpro_actions_nav">
+			<span class="pmpro_actions_nav-right"><a href="<?php echo pmpro_url( 'account' )?>"><?php _e('View Your Membership Account &rarr;', 'paid-memberships-pro' );?></a></span>
+		</p> <!-- end pmpro_actions_nav -->
+	<?php } elseif ( $show_paypal_link ) { ?>
 		<p><?php  _e('Your payment subscription is managed by PayPal. Please <a href="http://www.paypal.com">login to PayPal here</a> to update your billing information.', 'paid-memberships-pro' );?></p>
-
+		<hr />
+		<p class="pmpro_actions_nav">
+			<span class="pmpro_actions_nav-right"><a href="<?php echo pmpro_url( 'account' )?>"><?php _e('View Your Membership Account &rarr;', 'paid-memberships-pro' );?></a></span>
+		</p> <!-- end pmpro_actions_nav -->
 	<?php } else { ?>
 		<div id="pmpro_level-<?php echo $level->id; ?>" class="<?php echo $pmpro_billing_gateway_class; ?>">
 		<form id="pmpro_form" class="pmpro_form" action="<?php echo pmpro_url("billing", "", "https")?>" method="post">

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -1,6 +1,6 @@
 <div class="pmpro_billing_wrap">
 <?php
-	global $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $show_paypal_link;
+	global $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $show_check_payment_instructions, $show_paypal_link;
 	global $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
 
 	/**
@@ -88,9 +88,11 @@
 	}
 ?>
 
-<?php if( $has_recurring_levels ) { ?>
-	<?php if($show_paypal_link) { ?>
-
+<?php if ( $has_recurring_levels ) {
+	if ( $show_check_payment_instructions ) {
+		$instructions = pmpro_getOption("instructions");
+		echo '<div class="pmpro_check_instructions">' . wpautop(wp_unslash( $instructions )) . '</div>';
+	} elseif ( $show_paypal_link ) { ?>
 		<p><?php  _e('Your payment subscription is managed by PayPal. Please <a href="http://www.paypal.com">login to PayPal here</a> to update your billing information.', 'paid-memberships-pro' );?></p>
 
 	<?php } else { ?>

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -13,7 +13,7 @@ if ( ! is_user_logged_in() ) {
 }
 
 //need to be secure?
-global $besecure, $gateway, $show_paypal_link;
+global $besecure, $gateway, $show_paypal_link, $show_check_payment_instructions;
 $user_order = new MemberOrder();
 $user_order->getLastMemberOrder( null, array( 'success', 'pending' ) );
 if (empty($user_order->gateway)) {
@@ -28,6 +28,8 @@ if (empty($user_order->gateway)) {
         //$besecure = false;
         $show_paypal_link = true;
     }
+} elseif( $user_order->gateway == 'check' ) {
+    $show_check_payment_instructions = true;
 } else {
     //$besecure = true;
     $besecure = pmpro_getOption("use_ssl");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This update will show the "Check Payment Instructions" on the Billing Information page. It also adds a "View your membership account" back link for both PayPal and check payment members that view this page.

### How to test the changes in this Pull Request:

1. Complete checkout for a recurring order using a check payment gateway.
2. Visit the billing information page to see payment instructions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Billing Information page updated to show check payment instructions.
