### PR TITLE
Fixing warning on Dashboard and Orders 

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -318,12 +318,16 @@ function pmpro_dashboard_report_recent_orders_callback() {
                             <?php } ?>
         				</td>
                         <td>
-                            <?php
-                                $level = pmpro_getLevel( $order->membership_id );
-                                if ( ! empty( $level ) ) {
-                                    echo $level->name;
-                                }
-                            ?>
+							<?php
+								$level = pmpro_getLevel( $order->membership_id );
+								if ( ! empty( $level ) ) {
+									echo $level->name;
+								} elseif ( $order->membership_id > 0 ) { ?>
+									[<?php _e( 'deleted', 'paid-memberships-pro' ); ?>]
+								<?php } else { ?>
+									[<?php _e( 'none', 'paid-memberships-pro' ); ?>]
+								<?php }
+							?>
                         </td>
         				<td><?php echo pmpro_formatPrice( $order->total ); ?></td>
         				<td>

--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -320,7 +320,9 @@ function pmpro_dashboard_report_recent_orders_callback() {
                         <td>
                             <?php
                                 $level = pmpro_getLevel( $order->membership_id );
-                                echo $level->name;
+                                if ( ! empty( $level ) ) {
+                                    echo $level->name;
+                                }
                             ?>
                         </td>
         				<td><?php echo pmpro_formatPrice( $order->total ); ?></td>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1385,7 +1385,11 @@ class="alternate"<?php } ?>>
 							$level = pmpro_getLevel( $order->membership_id );
 							if ( ! empty( $level ) ) {
 								echo $level->name;
-							}
+							} elseif ( $order->membership_id > 0 ) { ?>
+								[<?php _e( 'deleted', 'paid-memberships-pro' ); ?>]
+							<?php } else { ?>
+								[<?php _e( 'none', 'paid-memberships-pro' ); ?>]
+							<?php }
 						?>
 					</td>
 					<td><?php echo pmpro_formatPrice( $order->total ); ?></td>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1383,7 +1383,9 @@ class="alternate"<?php } ?>>
 					<td>
 						<?php
 							$level = pmpro_getLevel( $order->membership_id );
-							echo $level->name;
+							if ( ! empty( $level ) ) {
+								echo $level->name;
+							}
 						?>
 					</td>
 					<td><?php echo pmpro_formatPrice( $order->total ); ?></td>


### PR DESCRIPTION
Warning for empty level->name is now caught in two places. "deleted" or "none" in place of level name using logic similar to how we do a deleted user.