### PR TITLE
Add custom filters for orders (adminpages)

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -152,6 +152,8 @@ if ( empty( $filter ) || $filter === 'all' ) {
 	$condition = "o.total = 0";
 }
 
+$condition = apply_filters( 'pmpro_admin_orders_query_condition', $condition, $filter );
+
 // deleting?
 if ( ! empty( $_REQUEST['delete'] ) ) {
 	$dorder = new MemberOrder( intval( $_REQUEST['delete'] ) );
@@ -999,6 +1001,12 @@ selected="selected"<?php } ?>><?php echo date( 'M', $now ); ?></option>
 						value="only-paid" <?php selected( $filter, 'only-paid' ); ?>><?php _e( 'Only Paid Orders', 'paid-memberships-pro' ); ?></option>
 					<option 
 						value="only-free" <?php selected( $filter, 'only-free' ); ?>><?php _e( 'Only Free Orders', 'paid-memberships-pro' ); ?></option>
+
+					<?php $custom_filters = apply_filters( 'pmpro_admin_orders_filters', array() ); ?>
+					<?php foreach( $custom_filters as $custom_filter ) { ?>
+						<option 
+							value="<?php $custom_filter['name'] ?>" <?php selected( $filter, <?php $custom_filter['name'] ?> ); ?>><?php $custom_filter['title'] ?></option>
+					<?php } ?>
 				</select>
 
 				<span id="from"><?php _e( 'From', 'paid-memberships-pro' ); ?></span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added custom filters capability for osers admin page. This is because in many cases we might need to filter the orders list on specific conditions.

### How to test the changes in this Pull Request:

1. Add a WordPress' filter that adds a custom filter to the order admin page
2. Add a WordPress' filter to check if the orders admin page is loaded with that filter and apply a condition

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
