### PR TITLE
Updating for bug with !!login_page_url!! in content message description text

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -172,7 +172,7 @@
 					</th>
 					<td>
 						<textarea name="notloggedintext" rows="3" cols="50" class="large-text"><?php echo stripslashes($notloggedintext)?></textarea>
-						<p class="description"><?php _e('This message replaces the post content for logged-out visitors.', 'paid-memberships-pro' );?> <?php _e('Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code> <code>!!referrer!!</code> <code>!!login_page_url!!</code> <code>!!levels_page_url!!</code></p>
+						<p class="description"><?php _e('This message replaces the post content for logged-out visitors.', 'paid-memberships-pro' );?> <?php _e('Available variables', 'paid-memberships-pro' );?>: <code>!!levels!!</code> <code>!!referrer!!</code> <code>!!login_url!!</code> <code>!!levels_page_url!!</code></p>
 					</td>
 				</tr>
 				<tr>

--- a/includes/content.php
+++ b/includes/content.php
@@ -359,9 +359,8 @@ function pmpro_membership_content_filter($content, $skipcheck = false)
 		$pmpro_content_message_pre = '<div class="pmpro_content_message">';
 		$pmpro_content_message_post = '</div>';
 
-		$sr_search = array("!!levels!!", "!!referrer!!", "!!login_url!!", "!!levels_page_url!!");
-		$sr_replace = array(pmpro_implodeToEnglish($post_membership_levels_names), urlencode(site_url($_SERVER['REQUEST_URI'])), esc_url( pmpro_login_url() ), esc_url( pmpro_url( 'levels' ) ) );
-
+		$sr_search = array("!!levels!!", "!!referrer!!", "!!login_url!!", "!!login_page_url!!", "!!levels_url!!", "!!levels_page_url!!");
+		$sr_replace = array(pmpro_implodeToEnglish($post_membership_levels_names), urlencode(site_url($_SERVER['REQUEST_URI'])), esc_url( pmpro_login_url() ), esc_url( pmpro_login_url() ), esc_url( pmpro_url( 'levels' ) ), esc_url( pmpro_url( 'levels' ) ));
 		
 		//get the correct message to show at the bottom
 		if(is_feed())


### PR DESCRIPTION
Updated replacement suggestion for login_page_url to use login_url. 

Now supporting login_page_url, login_url, levels_page_url, and levels_url in the replacements for these variables.