### PR TITLE
Updating the advanced settings page to remove message about "EasyAdsense"

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -341,12 +341,11 @@
 				<tr id="hideads_explanation" <?php if($hideads < 2) { ?>style="display: none;"<?php } ?>>
 					<th scope="row" valign="top">&nbsp;</th>
 					<td>
-						<p><?php _e('Ads from the following plugins will be automatically turned off', 'paid-memberships-pro' );?>: <em>Easy Adsense</em>, ...</p>
 						<p><?php _e('To hide ads in your template code, use code like the following', 'paid-memberships-pro' );?>:</p>
 					<pre lang="PHP">
-	if ( pmpro_displayAds() ) {
-		//insert ad code here
-	}</pre>
+if ( pmpro_displayAds() ) {
+	//insert ad code here
+}</pre>
 					</td>
 				</tr>			
 				<tr id="hideadslevels_tr" <?php if($hideads != 2) { ?>style="display: none;"<?php } ?>>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR removes the line "Ads from the following plugins will be automatically turned off: Easy Adsense" since this is no longer an active plugin and may be misleading as there are newer plugins that we do not integrate with that are called "Easy Google Adsense" and "Easy Peasey Adsense".

The function itself still checks for the presence of the `EzAdSense` class. We should look to deprecate this integration and consider other new ad plugins we can have built-in filters for.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Removed text on Advanced Settings for "Hide Ads" section where it may be misleading that we integrate with newer Adsense plugins (Easy Adsense is no longer in development).
 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.