### PR TITLE
Send additional admin activity emails

### DIFF
--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -24,7 +24,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 	 *
 	 * @param string $frequency to send emails at. Determines length of time reported.
 	 */
-	public function sendAdminActivity( $frequency = '' ) {
+	public function sendAdminActivity( $frequency = '', $recipient = null ) {
 		global $wpdb, $pmpro_levels;
 
 		if ( ! in_array( $frequency, array( 'day', 'week', 'month', 'never' ), true ) ) {
@@ -400,7 +400,11 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 			$admin_activity_email_body .= $content;
 		}
 
-		$this->email    = get_bloginfo( 'admin_email' );
+		if ( empty( $recipient ) ) {
+			$recipient = get_bloginfo( 'admin_email' );
+		}
+		$this->email = $recipient;
+
 		$this->subject  = sprintf( __( '[%1$s] Paid Memberships Pro Activity for %2$s: %3$s', 'paid-memberships-pro' ), get_bloginfo( 'name' ), ucwords( $term ), $date_range );
 		$this->template = 'admin_activity_email';
 		$this->body     = $admin_activity_email_body;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds $recipient param to activity email function and `pmpro_after_admin_activity_email_cron` action to run additional code during the send admin activity email cron. Can be used to send additional admin activity emails to various recipients.

### How to test the changes in this Pull Request:
1. Add Gist here: https://gist.github.com/dparker1005/6bf650370a12aef44adf8c8c26d3e906/edit
2. Manually run the pmpro admin activity email cron
3. Verify that additional emails were sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.