### PR TITLE
Fix fatal error for is_main_query

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -202,8 +202,12 @@ function pmpro_login_the_title( $title, $id = NULL ) {
 	if ( is_admin() ) {
 		return $title;
 	}
-	
-	if ( ! is_main_query() || ! is_page( $id ) ) {
+
+	if ( ! is_page( $id ) ) {
+		return $title;
+	}
+
+	if ( in_the_loop() && ! is_main_query() ) {
 		return $title;
 	}
 


### PR DESCRIPTION
* Bug Fix: fatal error for is_main_query in some cases.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Steps to recreate the fatal error:

1. Install https://wordpress.org/plugins/themeisle-companion/ and enable Social Sharing Modules.
2. Navigate to front-end.
3. Pull PR and refresh (Be sure to clear cache).