### PR TITLE
Force order status to "error" when Initial Payment fails (paypalexpress)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1074,6 +1074,10 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 
 			if ( ! empty( $c_order->error ) ) {
 				$pmpro_error = $c_order->error;
+			} else {
+				if( $old_level_status == 'error' ) {
+					$c_order->updateStatus("error");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As discussed with Jason, it's better to force the order status to "error" when Initial Payment fails, instead of cancelled (which creates confusion and makes reports dirty).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
