### PR TITLE
Fixed issue where empty dates would show current date in memberslist

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -570,6 +570,9 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function column_joindate( $item ) {
 		$joindate = $item[ 'joindate' ];
+		if ( empty( $joindate ) ) {
+			return;
+		}
 		return date_i18n( get_option('date_format'), $joindate );
 	}
 
@@ -581,6 +584,9 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function column_startdate( $item ) {
 		$startdate = $item[ 'startdate' ];
+		if ( empty( $startdate ) ) {
+			return;
+		}
 		return date_i18n( get_option('date_format'), $startdate );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Checking for empty start and join dates in Members List
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:
Customer ticket here (admins only): https://www.paidmembershipspro.com/forums/topic/membership-start-date-showing-as-today/
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.