### PR TITLE
Added "Uninstall PMPro on Deletion" advanced setting

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -51,6 +51,7 @@
 		pmpro_setOption("hideads");
 		pmpro_setOption("hideadslevels");
 		pmpro_setOption("redirecttosubscription");
+		pmpro_setOption("uninstall");
 
         /**
          * Filter to add custom settings to the advanced settings page.
@@ -97,6 +98,7 @@
 	if( is_multisite() ) {
 		$redirecttosubscription = pmpro_getOption("redirecttosubscription");
 	}
+	$uninstall = pmpro_getOption('uninstall');
 
 	// Default settings.
 	if(!$nonmembertext)
@@ -460,6 +462,17 @@ if ( function_exists( 'pmpro_displayAds' ) && pmpro_displayAds() ) {
 		            }
 		        } 
 		        ?>
+						<tr>
+							<th scope="row" valign="top">
+								<label for="showexcerpts"><?php _e('Uninstall PMPro on deletion?', 'paid-memberships-pro' );?></label>
+									</th>
+									<td>
+											<select id="uninstall" name="uninstall">
+													<option value="0" <?php if ( ! $uninstall ) { ?>selected="selected"<?php } ?>><?php _e( 'No', 'paid-memberships-pro' );?></option>
+													<option value="1" <?php if ( $uninstall == 1 ) { ?>selected="selected"<?php } ?>><?php _e( 'Yes - Delete all PMPro Data.', 'paid-memberships-pro' );?></option>
+											</select>
+									</td>
+									</tr>
 	        </tbody>
 			</table>
 			<script>

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,55 +8,57 @@
 if (!defined('ABSPATH') && !defined('WP_UNINSTALL_PLUGIN'))
     exit();
 
-// otherwise remove pages
-$pmpro_pages = array(
-	'account' => get_option( 'pmpro_account_page_id' ),
-	'billing' => get_option( 'pmpro_billing_page_id' ),
-	'cancel' =>get_option( 'pmpro_cancel_page_id' ),
-	'checkout' => get_option( 'pmpro_checkout_page_id' ),
-	'confirmation' => get_option( 'pmpro_confirmation_page_id' ),
-	'invoice' => get_option( 'pmpro_invoice_page_id' ),
-	'levels' => get_option( 'pmpro_levels_page_id' ),
-  'login' => get_option( 'pmpro_login_page_id' ),
-  'member_profile_edit' => get_option( 'pmpro_member_profile_edit_page_id' )
-);
+if ( get_option( 'pmpro_uninstall', 0 ) ) {
+	// otherwise remove pages
+	$pmpro_pages = array(
+		'account' => get_option( 'pmpro_account_page_id' ),
+		'billing' => get_option( 'pmpro_billing_page_id' ),
+		'cancel' =>get_option( 'pmpro_cancel_page_id' ),
+		'checkout' => get_option( 'pmpro_checkout_page_id' ),
+		'confirmation' => get_option( 'pmpro_confirmation_page_id' ),
+		'invoice' => get_option( 'pmpro_invoice_page_id' ),
+		'levels' => get_option( 'pmpro_levels_page_id' ),
+	  'login' => get_option( 'pmpro_login_page_id' ),
+	  'member_profile_edit' => get_option( 'pmpro_member_profile_edit_page_id' )
+	);
 
-foreach ( $pmpro_pages as $pmpro_page_id => $pmpro_page ) {
-	$shortcode_prefix = 'pmpro_';
-	$shortcode = '[' . $shortcode_prefix . $pmpro_page_id . ']';
-	$post = get_post( $pmpro_page );
+	foreach ( $pmpro_pages as $pmpro_page_id => $pmpro_page ) {
+		$shortcode_prefix = 'pmpro_';
+		$shortcode = '[' . $shortcode_prefix . $pmpro_page_id . ']';
+		$post = get_post( $pmpro_page );
 
-	// If shortcode is found at the beginning of the page content and it is the only content that exists, remove the page
-	if ( strpos( $post->post_content, $shortcode ) === 0 && strcmp( $post->post_content, $shortcode ) === 0 )
-		wp_delete_post( $post->ID, true ); // Force delete (no trash)
+		// If shortcode is found at the beginning of the page content and it is the only content that exists, remove the page
+		if ( strpos( $post->post_content, $shortcode ) === 0 && strcmp( $post->post_content, $shortcode ) === 0 )
+			wp_delete_post( $post->ID, true ); // Force delete (no trash)
+	}
+
+	// otherwise remove db tables
+	global $wpdb;
+
+	$tables = array(
+	    'pmpro_discount_codes',
+	    'pmpro_discount_codes_levels',
+	    'pmpro_discount_codes_uses',
+	    'pmpro_memberships_categories',
+	    'pmpro_memberships_pages',
+	    'pmpro_memberships_users',
+	    'pmpro_membership_levels',
+	    'pmpro_membership_orders'
+	);
+
+	foreach($tables as $table){
+	    $delete_table = $wpdb->prefix . $table;
+	    // setup sql query
+	    $sql = "DROP TABLE `$delete_table`";
+	    // run the query
+	    $wpdb->query($sql);
+	}
+
+	require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+	dbDelta($sql);
+
+	//delete options
+	global $wpdb;
+	$sqlQuery = "DELETE FROM $wpdb->options WHERE option_name LIKE 'pmpro_%'";
+	$wpdb->query($sqlQuery);
 }
-
-// otherwise remove db tables
-global $wpdb;
-
-$tables = array(
-    'pmpro_discount_codes',
-    'pmpro_discount_codes_levels',
-    'pmpro_discount_codes_uses',
-    'pmpro_memberships_categories',
-    'pmpro_memberships_pages',
-    'pmpro_memberships_users',
-    'pmpro_membership_levels',
-    'pmpro_membership_orders'
-);
-
-foreach($tables as $table){
-    $delete_table = $wpdb->prefix . $table;
-    // setup sql query
-    $sql = "DROP TABLE `$delete_table`";
-    // run the query
-    $wpdb->query($sql);
-}
-
-require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
-dbDelta($sql);
-
-//delete options
-global $wpdb;
-$sqlQuery = "DELETE FROM $wpdb->options WHERE option_name LIKE 'pmpro_%'";
-$wpdb->query($sqlQuery);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added advanced setting to control whether PMPro should be uninstall when the plugin is deleted.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.