### PR TITLE
Adding the current user's payment method used for subscription to Billing Information page

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -79,12 +79,12 @@
 			<?php
 				$pmpro_billing_show_payment_method = apply_filters( 'pmpro_billing_show_payment_method'
 					, true);
-				if ( $pmpro_billing_show_payment_method ) { ?>
+				if ( $pmpro_billing_show_payment_method && ! empty( $CardType ) ) { ?>
 					<li><strong><?php _e( 'Payment Method', 'paid-memberships-pro' ); ?>: </strong>
-						<?php echo ucwords( get_user_meta( $current_user->ID, 'pmpro_CardType', true ) ); ?> 
+						<?php echo ucwords( $CardType ); ?> 
 						<?php _e('ending in', 'paid-memberships-pro' ); ?>
 						<?php echo last4( get_user_meta( $current_user->ID, 'pmpro_AccountNumber', true ) ); ?>.
-						<?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo get_user_meta( $current_user->ID, 'pmpro_ExpirationMonth', true ); ?>/<?php echo get_user_meta( $current_user->ID, 'pmpro_ExpirationYear', true ); ?>
+						<?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo $ExpirationMonth; ?>/<?php echo $ExpirationYear; ?>
 					</li>
 					<?php
 				}

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -75,6 +75,21 @@
 			<?php if($level->billing_limit) { ?>
 				<li><strong><?php _e("Duration", 'paid-memberships-pro' );?>:</strong> <?php echo $level->billing_limit.' '.sornot($level->cycle_period,$level->billing_limit)?></li>
 			<?php } ?>
+
+			<?php
+				$pmpro_billing_show_payment_method = apply_filters( 'pmpro_billing_show_payment_method'
+					, true);
+				if ( $pmpro_billing_show_payment_method ) { ?>
+					<li><strong><?php _e( 'Payment Method', 'paid-memberships-pro' ); ?>: </strong>
+						<?php echo ucwords( get_user_meta( $current_user->ID, 'pmpro_CardType', true ) ); ?> 
+						<?php _e('ending in', 'paid-memberships-pro' ); ?>
+						<?php echo last4( get_user_meta( $current_user->ID, 'pmpro_AccountNumber', true ) ); ?>.
+						<?php _e('Expiration', 'paid-memberships-pro' );?>: <?php echo get_user_meta( $current_user->ID, 'pmpro_ExpirationMonth', true ); ?>/<?php echo get_user_meta( $current_user->ID, 'pmpro_ExpirationYear', true ); ?>
+					</li>
+					<?php
+				}
+			?>
+
 			<?php
 			 /**
 			 * pmpro_billing_bullets_top hook allows you to add information to the billing list (at the bottom).


### PR DESCRIPTION
Now showing the payment method to be used or just updated so the users know that their payment method update was successful.

There is a filter `pmpro_billing_show_payment_method` to disable the display for sites using a service like Churnbuster that can get out of sync with the user's usermeta values for card type, account number, and expiration date.

Users previously had no way to see what card they were paying with or whether the update was successful after update.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUG FIX/ENHANCEMENT: Added a notice of the payment method being used for subscription on the Membership Billing page.