### PR TITLE
REST API Fatal Error Fix

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -473,6 +473,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 function pmpro_rest_api_get_permissions_check( $request ) {
 
 			$method = $request->get_method();
+			$route = $request->get_route();
 			
 			// default permissions to 'read' (subscriber)
 			$permissions = current_user_can('read');			
@@ -481,7 +482,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			// Is the request method allowed?
-			if ( ! in_array( $method, pmpro_get_rest_api_methods( $method ) ) ) {
+			if ( ! in_array( $method, pmpro_get_rest_api_methods( $route ) ) ) {
 				$permissions = false;
 			}
 
@@ -518,8 +519,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
  * To enable DELETE, hook into this filter.
  * @since 2.3
  */
-function pmpro_get_rest_api_methods( $endpoint = NULL ) {
+function pmpro_get_rest_api_methods( $route = NULL ) {
 	$methods = array( 'GET', 'POST', 'PUT', 'PATCH' );
-	$methods = apply_filters( 'pmpro_rest_api_methods', $methods, $endpoint );
+	$methods = apply_filters( 'pmpro_rest_api_methods', $methods, $route );
 	return $methods;
 }

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -470,10 +470,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 *
 		 * @since 2.3
 		 */
-		 function pmpro_rest_api_get_permissions_check($request) {
+		 function pmpro_rest_api_get_permissions_check( $request ) {
 
 			$method = $request->get_method();
-			$endpoint = $request->get_endpoint();
 			
 			// default permissions to 'read' (subscriber)
 			$permissions = current_user_can('read');			
@@ -482,7 +481,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			// Is the request method allowed?
-			if ( ! in_array( $method, pmpro_get_rest_api_methods( $endpoint ) ) ) {
+			if ( ! in_array( $method, pmpro_get_rest_api_methods( $method ) ) ) {
 				$permissions = false;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

* Removed undefined function and passed through $method to pmpro_get_rest_api_methods function.

