### PR TITLE
Updating account profile edit, change password links to hide if dashboard is blocked.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -27,10 +27,25 @@ add_action( 'admin_init', 'pmpro_admin_init_redirect_to_dashboard' );
 /**
  * Block Subscibers from accessing the WordPress Dashboard.
  *
+ * @since 2.3.4
+ */
+function pmpro_block_dashboard_redirect() {
+	if ( pmpro_block_dashboard() ) {
+		wp_redirect( pmpro_url( 'account' ) );
+		exit;
+	}
+}
+add_action( 'admin_init', 'pmpro_block_dashboard_redirect', 9 );
+
+/**
+ * Is the current user blocked from the dashboard
+ * per the advanced setting.
+ *
  * @since 2.3
  */
 function pmpro_block_dashboard() {
 	global $current_user;
+
 	$block_dashboard = pmpro_getOption( 'block_dashboard' );
 
 	if ( ! wp_doing_ajax()
@@ -44,9 +59,6 @@ function pmpro_block_dashboard() {
 		$block = false;
 	}	
 	$block = apply_filters( 'pmpro_block_dashboard', $block );
-	if ( $block ) {
-		wp_redirect( pmpro_url( 'account' ) );
-		exit;
-	}
+
+	return $block;
 }
-add_action( 'admin_init', 'pmpro_block_dashboard', 9 );

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -517,35 +517,28 @@ function pmpro_member_profile_edit_form() {
 
 			<?php wp_nonce_field( 'update-user_' . $current_user->ID, 'update_user_nonce' ); ?>
 
+			<?php $user_fields = apply_filters( 'pmpro_member_profile_edit_user_object_fields', 
+				array(
+					'first_name'	=> __( 'First Name', 'paid-memberships-pro' ),
+					'last_name'		=> __( 'Last Name', 'paid-memberships-pro' ),
+					'display_name'	=> __( 'Display name publicly as', 'paid-memberships-pro' ),
+					'user_email'	=> __( 'Email', 'paid-memberships-pro' ),
+				)
+			); ?>
+
 			<div class="pmpro_checkout_box-user">
 				<div class="pmpro_member_profile_edit-fields">
-					<div class="pmpro_member_profile_edit-field pmpro_member_profile_edit-field-first_name">
-						<label for="first_name"><?php _e( 'First Name', 'paid-memberships-pro' ); ?></label>
-						<input type="text" name="first_name" id="first_name" value="<?php echo esc_attr( $user->first_name ); ?>" class="input <?php echo pmpro_getClassForField( 'first_name' );?>" />
+					<?php foreach ( $user_fields as $field_key => $label ) { ?>
+						<div class="pmpro_member_profile_edit-field pmpro_member_profile_edit-field-<?php esc_attr_e( $field_key ); ?>">
+							<label for="<?php esc_attr_e( $field_key ); ?>"><?php esc_html_e( $label ); ?></label>
+							<?php if ( current_user_can( 'manage_options' ) && $field_key === 'user_email' ) { ?>
+								<input type="text" readonly="readonly" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" class="input <?php echo pmpro_getClassForField( 'email' );?>" />
+								<p class="lite"><?php esc_html_e( 'Site administrators must use the WordPress dashboard to update their email address.', 'paid-memberships-pro' ); ?></p>
+							<?php } else { ?>
+								<input type="text" name="<?php esc_attr_e( $field_key ); ?>" id="<?php esc_attr_e( $field_key ); ?>" value="<?php echo esc_attr( $user->{$field_key} ); ?>" class="input <?php echo pmpro_getClassForField( esc_attr( $field_key ) ); ?>" />
+							<?php } ?>
 					</div> <!-- end pmpro_member_profile_edit-field-first_name -->
-
-					<div class="pmpro_member_profile_edit-field pmpro_member_profile_edit-field-last_name">
-						<label for="last_name"><?php _e( 'Last Name', 'paid-memberships-pro' ); ?></label>
-						<input type="text" name="last_name" id="last_name" value="<?php echo esc_attr( $user->last_name ); ?>" class="input <?php echo pmpro_getClassForField( 'last_name' );?>" />
-					</div> <!-- end pmpro_member_profile_edit-field-last_name -->
-
-					<div class="pmpro_member_profile_edit-field pmpro_member_profile_edit-field-display_name">
-						<label for="display_name"><?php _e( 'Display name publicly as', 'paid-memberships-pro' ); ?></label>
-						<input type="text" name="display_name" id="display_name" value="<?php echo esc_attr( $user->display_name ); ?>" class="input <?php echo pmpro_getClassForField( 'display_name' );?>" />
-						<span class="pmpro_asterisk"> <abbr title="<?php _e( 'Required Field', 'paid-memberships-pro' ); ?>">*</abbr></span>
-					</div> <!-- end pmpro_member_profile_edit-field-display_name -->
-
-					<div class="pmpro_member_profile_edit-field pmpro_member_profile_edit-field-email">
-						<label for="email"><?php _e( 'Email', 'paid-memberships-pro' ); ?></label>
-						
-						<?php if ( current_user_can( 'manage_options' ) ) { ?>
-						<input type="text" readonly="readonly" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" class="input <?php echo pmpro_getClassForField( 'email' );?>" />
-						<p class="lite"><?php esc_html_e( 'Site administrators must use the WordPress dashboard to update their email address.', 'paid-memberships-pro' ); ?></p>
-						<?php } else { ?>
-						<input type="email" name="email" id="email" value="<?php echo esc_attr( $user->user_email ); ?>" class="input <?php echo pmpro_getClassForField( 'email' );?>" />
-						<span class="pmpro_asterisk"> <abbr title="<?php _e( 'Required Field', 'paid-memberships-pro' ); ?>">*</abbr></span>
-						<?php } ?>
-					</div>					
+					<?php } ?>
 				</div> <!-- end pmpro_member_profile_edit-fields -->
 			</div> <!-- end pmpro_checkout_box-user -->
 

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -166,15 +166,22 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 						if ( ! empty( pmpro_getOption( 'member_profile_edit_page_id' ) ) ) {
 							$edit_profile_url = pmpro_url( 'member_profile_edit' );
 							$change_password_url = add_query_arg( 'view', 'change-password', pmpro_url( 'member_profile_edit' ) );
-						} else {
-							$edit_profile_url = admin_url( 'profile.php' );
-							$change_password_url = admin_url( 'profile.php' );
+						} elseif ( ! empty( pmpro_getOption( 'block_dashboard' ) ) ) {
+								$edit_profile_url = admin_url( 'profile.php' );
+								$change_password_url = admin_url( 'profile.php' );
+							}
 						}
 
 						// Build the links to return.
 						$pmpro_profile_action_links = array();
-						$pmpro_profile_action_links['edit-profile'] = sprintf( '<a id="pmpro_actionlink-profile" href="%s">%s</a>', esc_url( $edit_profile_url ), esc_html__( 'Edit Profile', 'paid-memberships-pro' ) );
-						$pmpro_profile_action_links['change-password'] = sprintf( '<a id="pmpro_actionlink-change-password" href="%s">%s</a>', esc_url( $change_password_url ), esc_html__( 'Change Password', 'paid-memberships-pro' ) );
+						if ( ! empty( $edit_profile_url) ) {
+							$pmpro_profile_action_links['edit-profile'] = sprintf( '<a id="pmpro_actionlink-profile" href="%s">%s</a>', esc_url( $edit_profile_url ), esc_html__( 'Edit Profile', 'paid-memberships-pro' ) );
+						}
+
+						if ( ! empty( $change_password_url ) ) {
+							$pmpro_profile_action_links['change-password'] = sprintf( '<a id="pmpro_actionlink-change-password" href="%s">%s</a>', esc_url( $change_password_url ), esc_html__( 'Change Password', 'paid-memberships-pro' ) );
+						}
+						
 						$pmpro_profile_action_links['logout'] = sprintf( '<a id="pmpro_actionlink-logout" href="%s">%s</a>', esc_url( wp_logout_url() ), esc_html__( 'Log Out', 'paid-memberships-pro' ) );
 
 						$pmpro_profile_action_links = apply_filters( 'pmpro_account_profile_action_links', $pmpro_profile_action_links );

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -166,10 +166,9 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 						if ( ! empty( pmpro_getOption( 'member_profile_edit_page_id' ) ) ) {
 							$edit_profile_url = pmpro_url( 'member_profile_edit' );
 							$change_password_url = add_query_arg( 'view', 'change-password', pmpro_url( 'member_profile_edit' ) );
-						} elseif ( ! empty( pmpro_getOption( 'block_dashboard' ) ) ) {
-								$edit_profile_url = admin_url( 'profile.php' );
-								$change_password_url = admin_url( 'profile.php' );
-							}
+						} elseif ( empty( pmpro_getOption( 'block_dashboard' ) ) ) {
+							$edit_profile_url = admin_url( 'profile.php' );
+							$change_password_url = admin_url( 'profile.php' );
 						}
 
 						// Build the links to return.
@@ -181,7 +180,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 						if ( ! empty( $change_password_url ) ) {
 							$pmpro_profile_action_links['change-password'] = sprintf( '<a id="pmpro_actionlink-change-password" href="%s">%s</a>', esc_url( $change_password_url ), esc_html__( 'Change Password', 'paid-memberships-pro' ) );
 						}
-						
+
 						$pmpro_profile_action_links['logout'] = sprintf( '<a id="pmpro_actionlink-logout" href="%s">%s</a>', esc_url( wp_logout_url() ), esc_html__( 'Log Out', 'paid-memberships-pro' ) );
 
 						$pmpro_profile_action_links = apply_filters( 'pmpro_account_profile_action_links', $pmpro_profile_action_links );

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -162,11 +162,11 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 				</ul>
 				<div class="pmpro_actionlinks">
 					<?php
-						// Get the edit profile and change password linkds if 'Member Profile Edit Page' is set.
+						// Get the edit profile and change password links if 'Member Profile Edit Page' is set.
 						if ( ! empty( pmpro_getOption( 'member_profile_edit_page_id' ) ) ) {
 							$edit_profile_url = pmpro_url( 'member_profile_edit' );
 							$change_password_url = add_query_arg( 'view', 'change-password', pmpro_url( 'member_profile_edit' ) );
-						} elseif ( empty( pmpro_getOption( 'block_dashboard' ) ) ) {
+						} elseif ( ! pmpro_block_dashboard() ) {
 							$edit_profile_url = admin_url( 'profile.php' );
 							$change_password_url = admin_url( 'profile.php' );
 						}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Users who are blocked from accessing the dashboard but are using a site that has not assigned a frontend profile edit page were being redirected to the homepage when clicking "Edit Profile" or "Change Password" from the Membership Account "Profile" page section.

This PR will hide those links if a frontend page is not selected and the PMPro option to hide the dashboard is on. This will not account for a case where the dashboard is blocked by another plugin like Theme My Login. Users with that setup must assign the TML profile page as the "Member Profile Edit Form" page under Memberships > Settings > Pages in the WordPress dashboard.

Users are also asking that the member profile edit form default fields can be adjusted to remove some of the default WP User Object fields OR add additional core WP user object fields. This PR introduces the filter `pmpro_member_profile_edit_user_object_fields` to set an array of field key => label pairs.

This PR will conflict with the open PR for the get-element-class cycle work so I will do that merge conflict before or after this is discussed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX/ENHANCEMENT: Hiding the Edit Profile or Change Password links if blocking dashboard access and a frontend page is not assigned.
* BUG FIX/ENHANCEMENT: Adding `pmpro_member_profile_edit_user_object_fields` filter hook to allow WP_User object fields to be added or hidden from the Member Profile Edit frontend page. 

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.