### PR TITLE
Separate cancel/cancelGateway logic in PayPal Express

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -768,7 +768,11 @@
 					return true;	
 				}
 			}
-
+			
+			// Cancel at gateway
+			$this->cancelGateway($order);
+		}
+		function cancelGateway(&$order) {
 			// Build the nvp string for PayPal API
 			$nvpStr = "";
 			$nvpStr .= "&PROFILEID=" . urlencode($order->subscription_transaction_id) . "&ACTION=Cancel&NOTE=" . urlencode("User requested cancel.");


### PR DESCRIPTION
Separate cancelGateway logic, useful when you want to cancel at gateway without changing the order status (i.e. order status = error but not cancelled at gateway for any reason and still trying to get the money)

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

