### PR TITLE
Set epoch date to 1970-01-01

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -197,7 +197,7 @@ function pmpro_report_memberships_page()
 	}
 	elseif($period == "annual")
 	{
-		$startdate = '1960-01-01';	//all time
+		$startdate = '1970-01-01';	//all time
 		$enddate = strval(intval($year)+1) . '-01-01';
 		$date_function = 'YEAR';
 	}

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -165,7 +165,7 @@ function pmpro_report_sales_page()
 	}
 	else
 	{
-		$startdate = '1960-01-01';	//all time
+		$startdate = '1970-01-01';	//all time
 		$date_function = 'YEAR';
 		$currently_in_period = true;
 	}


### PR DESCRIPTION
Closes #1106

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The correct Epoch date is 1970-01-01. Some systems are able to handle dates that go beyond the epoch, while some are unable.

Closes Issue: #1106.

### How to test the changes in this Pull Request:

1. On an affected installation, try to access the PM Pro Dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Set epoch date to 1970-01-01 (previously 1960-01-01)