### PR TITLE
fix: Set start date to epoch on reports page

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -521,7 +521,7 @@ function pmpro_getSignups($period = false, $levels = 'all')
 	elseif( $period == 'this year')
 		$startdate = date_i18n( 'Y' ) . '-01-01';
 	else
-		$startdate = '';
+		$startdate = '1970-01-01';
 
 
 	//build query

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -520,7 +520,7 @@ function pmpro_get_prices_paid( $period, $count = NULL ) {
 	} elseif ( 'this year' === $period ) {
 		$startdate = date_i18n( 'Y', current_time( 'timestamp' ) ) . '-01-01';
 	} else {
-		$startdate = '';
+		$startdate = '1970-01-01';
 	}
 
 	$gateway_environment = pmpro_getOption( 'gateway_environment' );


### PR DESCRIPTION
This resolves an issue where the reports page was
failing with a 502 error on some sites.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

### How to test the changes in this Pull Request:

1. Open the reports page on an affected installation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Bug Fix: Fixed issue where the reports page was causing a 502 error on some sites.