### PR TITLE
Now checking if headers sent before starting session

### DIFF
--- a/includes/sessions.php
+++ b/includes/sessions.php
@@ -11,6 +11,11 @@
  * @since 1.9.2
  */
 function pmpro_start_session() {
+    // If headers were already sent, we can't use sessions.
+	if ( headers_sent() ) {
+		return;
+    }
+
     //if the session hasn't been started yet, start it (ignore if running from command line)
     if (!defined('PMPRO_USE_SESSIONS') || PMPRO_USE_SESSIONS == true) {
         if (defined('STDIN')) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now checking if headers sent before starting session. Should avoid `PHP Warning: session_start(): Cannot start session when headers already sent in /site/wp-content/plugins/paid-memberships-pro/includes/sessions.php on line 21` warning from being logged.

NOTE: This PR still needs to be tested to ensure that sessions still work as expected when we need them to. Would also be nice to not fail silently if headers already sent, not sure if there is a better error message that we could show.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Use a customizations plugin to send headers before the `pmpro_checkout_preheader_before_get_level_at_checkout` action is run
2. Verify that without this patch a warning is shown, and with this patch it is not

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.