### PR TITLE
PayPal Express: implement getTransactionStatus

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -821,6 +821,99 @@
 				return false;
 			}
 		}
+		
+		function getTransactionStatus(&$order) {
+			$transaction_details = $order->Gateway->getTransactionDetailsByOrder( $order );
+			if( false === $transaction_details ){
+				return false;
+			}
+
+			if( ! isset( $transaction_details['PAYMENTSTATUS'] ) ){
+				return false;
+			}
+
+			return $transaction_details['PAYMENTSTATUS'];
+		}
+
+		function getTransactionDetailsByOrder(&$order)
+		{
+			if(empty($order->payment_transaction_id))
+				return false;
+
+			if( $order->payment_transaction_id == $order->subscription_transaction_id ){
+				/** Initial payment **/
+				$nvpStr = "";
+				// STARTDATE is Required, even if useless here. Start from 24h before the order timestamp, to avoid timezone related issues.
+				$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->timestamp-DAY_IN_SECONDS ) . 'Z' );
+				// filter results by a specific transaction id.
+				$nvpStr .= "&TRANSACTIONID=" . urlencode($order->subscription_transaction_id);
+
+				$this->httpParsedResponseAr = $this->PPHttpPost('TransactionSearch', $nvpStr);
+
+				if( ! in_array( strtoupper( $this->httpParsedResponseAr["ACK"] ), [ 'SUCCESS', 'SUCCESSWITHWARNING' ] ) ){
+					// since we are using TRANSACTIONID=I-... which is NOT a transaction id,
+                    			// paypal is returning an error. but the results are actually filtered by that transaction id, usually.
+
+					// let's double check it.
+					if( ! isset( $this->httpParsedResponseAr['L_TRANSACTIONID0'] ) ){
+						// really no results? it's a real error.
+						return false;
+					}
+				}
+
+				$transaction_ids = [];
+				for( $i = 0; $i < PHP_INT_MAX; $i++ ){
+	    				// loop until we have results
+					if( ! isset( $this->httpParsedResponseAr["L_TRANSACTIONID$i"] ) ){
+						break;
+					}
+
+					// ignore I-... results
+					if( "I-" === substr( $this->httpParsedResponseAr["L_TRANSACTIONID$i"], 0 ,2 ) ){
+						if( $order->subscription_transaction_id != $this->httpParsedResponseAr["L_TRANSACTIONID$i"] ){
+							// if we got a result from another I- subscription transaction id,
+							// then something changed into paypal responses.
+							// var_dump( $this->httpParsedResponseAr, $this->httpParsedResponseAr["L_TRANSACTIONID$i"] );
+							throw new Exception();
+						}
+
+						continue;
+					}
+
+					$transaction_ids[] = $this->httpParsedResponseAr["L_TRANSACTIONID$i"];
+				}
+
+				// no payment_transaction_ids in results
+				if( empty( $transaction_ids ) ){
+					return false;
+				}
+
+				// found the payment transaction id, it's the last one (the oldest)
+				$payment_transaction_id = end( $transaction_ids );
+				return $this->getTransactionDetails( $payment_transaction_id );
+			}else{
+				/** Recurring payment **/
+				return $this->getTransactionDetails( $order->payment_transaction_id );
+			}
+		}
+		
+		function getTransactionDetails($payment_transaction_id)
+        	{
+			$nvpStr = "";
+			$nvpStr .= "&TRANSACTIONID=" . urlencode($payment_transaction_id);
+
+			$this->httpParsedResponseAr = $this->PPHttpPost('GetTransactionDetails', $nvpStr);
+
+			if("SUCCESS" == strtoupper($this->httpParsedResponseAr["ACK"]) || "SUCCESSWITHWARNING" == strtoupper($this->httpParsedResponseAr["ACK"]))
+			{
+				return $this->httpParsedResponseAr;
+			}
+			else
+			{
+				// var_dump( $this->httpParsedResponseAr, $this->httpParsedResponseAr["L_TRANSACTIONID$i"] );
+				return false;
+			}
+		}
 
 		/**
 		 * Filter pmpro_next_payment to get date via API if possible


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

It would be really easy (1 api call) to get the Gateway Status for a Payment if we had the transaction_id even for initial payments. By the way, we don't have initial payment transaction_id (payment_transaction_id == subscription_transaction_id for initial payment orders). Because of that I need to use multiple api call (and triple safe checks) to be sure to collect the correct payment_transaction_id for initial payments. This sucks, but it works.

### How to test the changes in this Pull Request:

1. Take any initial payment order
2. Run this code:
```
<?php
$order = new MemberOrder();
$order->getMemberOrderByCode( $order_code );

$status = $order->Gateway->getTransactionStatus( $order );
var_dump( $status );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
