### PR TITLE
No longer pulling array value directly from funciton call in memberslist

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -407,7 +407,8 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			do_action( 'pmpro_memberslist_extra_cols_body', $user_object );
 			$extra_cols = ob_get_clean();
 			preg_match_all( '/<td>(.*?)<\/td>/s', $extra_cols, $matches );
-			$custom_field_num = explode( 'custom_field_', $column_name )[1];
+			$custom_field_num_arr = explode( 'custom_field_', $column_name );
+			$custom_field_num     = $custom_field_num_arr[1];
 			if ( is_numeric( $custom_field_num ) && isset( $matches[1][ intval( $custom_field_num ) ] ) ) {
 				echo( $matches[1][ intval( $custom_field_num ) ] );
 			}


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolved parse error that could occur: `*Parse error*: syntax error, unexpected ‘[’ in
*/htdocs/wp-content/plugins/paid-memberships-pro/classes/class-pmpro-members-list-table.php*
on line *410*`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.