### PR TITLE
Expiration Date Input On readonly fix

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -685,7 +685,17 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 			</tr>
 			<?php
 			if ( in_array( 'ExpirationDate', $read_only_fields ) && $order_id > 0 ) {
-				echo esc_html( $order->ExpirationDate );
+				?>
+
+				<tr>
+				    <th scope="row" valign="top"><label
+						for="expirationmonth"><?php esc_html_e( 'Expiration Month', 'paid-memberships-pro' ); ?>:</label></th>
+				    <td>
+					<?php echo esc_html( $order->expirationmonth . '/' . $order->expirationyear ); ?>
+				    </td>
+				</tr>
+
+				<?php
 			} else {
 						?>
 							<tr>


### PR DESCRIPTION
This commit fixes the Expiration Date Input when This input is readonly.

### All Submissions:

* [ ] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Bug fix: When you have the Expiration Date as readonly on Orders admin view, it is not visible, this fix, makes it visible again.

### How to test the changes in this Pull Request:

1. Add ExpirationDate to array inside **pmpro_orders_read_only_fields** filter (adminpages/orders.php line 172)
2. Go to Orders page inside Paid Memeberships pro -> Edit
3. Now Expiration Date is visible

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> The expiration date is visible even when the input is marked read-only inside ordrers admin view.