### PR TITLE
Now using CONVERT_TZ for start and enddates

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1836,8 +1836,8 @@ function pmpro_getMembershipLevelForUser( $user_id = null, $force = false ) {
 				mu.trial_amount,
 				mu.trial_limit,
 				mu.code_id as code_id,
-				UNIX_TIMESTAMP(startdate) as startdate,
-				UNIX_TIMESTAMP(enddate) as enddate
+				UNIX_TIMESTAMP( CONVERT_TZ(startdate, '+00:00', @@global.time_zone) ) as startdate,
+				UNIX_TIMESTAMP( CONVERT_TZ(enddate, '+00:00', @@global.time_zone) ) as enddate
 			FROM {$wpdb->pmpro_membership_levels} AS l
 			JOIN {$wpdb->pmpro_memberships_users} AS mu ON (l.id = mu.membership_id)
 			WHERE mu.user_id = $user_id AND mu.status = 'active'

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -7,15 +7,6 @@ function pmpro_membership_level_profile_fields($user)
 {
 	global $current_user;
 
-	$server_tz = date_default_timezone_get();
-	$wp_tz =  get_option( 'timezone_string' );
-
-	//option "timezone_string" is empty if set to UTC+0
-	if(empty($wp_tz))
-		$wp_tz = 'UTC';
-
-	date_default_timezone_set($wp_tz);
-
 	$membership_level_capability = apply_filters("pmpro_edit_member_capability", "manage_options");
 	if(!current_user_can($membership_level_capability))
 		return false;
@@ -82,27 +73,14 @@ function pmpro_membership_level_profile_fields($user)
 
 		$show_expiration = true;
 		$show_expiration = apply_filters("pmpro_profile_show_expiration", $show_expiration, $user);
-		if($show_expiration)
-		{
-
+		if ( $show_expiration ) {
 			//is there an end date?
 			$user->membership_level = pmpro_getMembershipLevelForUser($user->ID);
 			$end_date = (!empty($user->membership_level) && !empty($user->membership_level->enddate)); // Returned as UTC timestamp
 
-			//some vars for the dates
-			if( $end_date && 'UTC' === $wp_tz ) {
-				$selected_expires_day =  date( 'j', $user->membership_level->enddate );
-				$selected_expires_month =  date( 'm', $user->membership_level->enddate );
-				$selected_expires_year =  date( 'Y', $user->membership_level->enddate );
-			} elseif( $end_date ) {
-				$selected_expires_day = get_gmt_from_date( date( 'Y-m-d H:i:s', $user->membership_level->enddate ), 'j' );
-				$selected_expires_month = get_gmt_from_date( date( 'Y-m-d H:i:s', $user->membership_level->enddate ), 'm' );
-				$selected_expires_year = get_gmt_from_date( date( 'Y-m-d H:i:s', $user->membership_level->enddate ), 'Y' );
-			} else {
-				$selected_expires_day = date( 'j', current_time('timestamp') );
-				$selected_expires_month = date( 'm', current_time('timestamp') );
-				$selected_expires_year = date( 'Y', current_time('timestamp') ) + 1;
-			}
+			$selected_expires_day =  date( 'j', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
+			$selected_expires_month =  date( 'm', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
+			$selected_expires_year =  date( 'Y', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
 		?>
 		<tr>
 			<th><label for="expiration"><?php _e("Expires", 'paid-memberships-pro' ); ?></label></th>
@@ -268,8 +246,6 @@ function pmpro_membership_level_profile_fields($user)
     </script>
 <?php
 	do_action("pmpro_after_membership_level_profile_fields", $user);
-
-	date_default_timezone_set( $server_tz );
 }
 
 /*


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Now using CONVERT_TZ SQL function when getting `startdate` and `enddate` from database. Query should now get the time from the DB in local time, meaning that no additional conversions are required. Fixes issues were SQL time settings could cause off-by-one error when showing enddate on profile page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.