### PR TITLE
Added checkout_level API call

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -147,6 +147,19 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			),
 		));
 
+		/**
+		 * Get membership level after checkout options are applied.
+		 * @since 2.4
+		 * Example: https://example.com/wp-json/pmpro/v1/checkout_level
+		 */
+		register_rest_route( $pmpro_namespace, '/checkout_level', 
+		array(
+			array(
+				'methods' => WP_REST_Server::READABLE,
+				'callback' => array( $this, 'pmpro_rest_api_get_checkout_level' ),
+			),
+		));
+
 		}
 		
 		/**
@@ -461,6 +474,24 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$discount_code->save();
 
 			return new WP_REST_Response( $discount_code, 200 );
+		}
+
+		/**
+		 * Get a membership level at checkout.
+		 * @since 2.4
+		 * Example: https://example.com/wp-json/pmpro/v1/checkout_level
+		 */
+		function pmpro_rest_api_get_checkout_level( $request ) {
+			$params = $request->get_params();
+
+			$level_id = isset( $params['level_id'] ) ? $params['level_id'] : null;
+			if ( empty( $level_id ) ) {
+				return new WP_REST_Response( 'No level_id found.', 400 );
+			}
+
+			$discount_code = isset( $params['discount_code'] ) ? $params['discount_code'] : null;
+			$checkout_level = pmpro_getLevelAtCheckout( $level_id, $discount_code );
+			return new WP_REST_Response( $checkout_level );
 		}
 
 		/**

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -478,15 +478,16 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 		/**
 		 * Get a membership level at checkout.
+		 * Note: Not compatible with MMPU.
 		 * @since 2.4
 		 * Example: https://example.com/wp-json/pmpro/v1/checkout_level
 		 */
 		function pmpro_rest_api_get_checkout_level( $request ) {
 			$params = $request->get_params();
 
-			$level_id = isset( $params['level_id'] ) ? $params['level_id'] : null;
+			$level_id = isset( $params['level'] ) ? $params['level'] : null;
 			if ( empty( $level_id ) ) {
-				return new WP_REST_Response( 'No level_id found.', 400 );
+				return new WP_REST_Response( 'No level found.', 400 );
 			}
 
 			$discount_code = isset( $params['discount_code'] ) ? $params['discount_code'] : null;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding API function to get Checkout Level given the current fields set at checkout.

### How to test the changes in this Pull Request:

1. Add Gist: https://gist.github.com/dparker1005/399266c69f5351abb60ef4706c74d3a4
2. Can click "Test API" button on checkout page to see what the checkout level will be given the current checkout fields

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.