### PR TITLE
Fixing 2checkout sandbox

### DIFF
--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -345,12 +345,7 @@
 			///echo str_replace("&", "&<br />", $ptpStr);
 			///exit;
 
-			//figure out gateway environment and URL to use
-			if($gateway_environment == "live")
-					$host = "www.2checkout.com";
-				else
-					$host = "sandbox.2checkout.com";
-			$tco_url = 'https://' . $host . '/checkout/purchase' . $ptpStr;
+			$tco_url = 'https://www.2checkout.com/checkout/purchase' . $ptpStr;
 
 			//redirect to 2checkout
 			wp_redirect( $tco_url );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
2Checkout recently deprecated their `sandbox.2checkout.com` service and moved the testing behavior over to their live accounts. More info on this here: https://knowledgecenter.2checkout.com/API-Integration/Transition_guides/Transition_Guide_for_2Checkout_Sandbox

This PR points both the sandbox and live payment requests directly to `https://www.2checkout.com/checkout/purchase`. These requests are differentiated by the `demo` `$tco_args` arg, which is set to `Y` for sandbox checkouts earlier in the code.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:
Setup 2Checkout alongside PMPro and ensure that both live and sandbox checkouts work as expected. Note: I have not yet explicitly tested that live checkouts still work, but this change shouldn't affect live checkouts whatsoever.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.