### PR TITLE
Fix PHP Notice: Trying to access array offset on value of type null

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1325,7 +1325,7 @@ function pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values, $prev_values
 	}
 
 	for ( $i = 0; $i < count( $meta_values ); $i++ ) {
-		if ( $prev_values[ $i ] ) {
+		if ( isset( $prev_values[ $i ] ) ) {
 			update_user_meta( $user_id, $meta_keys[ $i ], $meta_values[ $i ], $prev_values[ $i ] );
 		} else {
 			$old_value = get_user_meta( $user_id, $meta_keys[ $i ], true );


### PR DESCRIPTION
Fix PHP Notice: Trying to access array offset on value of type null
Issue: https://github.com/strangerstudios/paid-memberships-pro/issues/1401

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue:https://github.com/strangerstudios/paid-memberships-pro/issues/1401.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
PHP Notice: Trying to access array offset on value of type null in /…/wp-content/plugins/paid-memberships-pro/includes/functions.php on line 1329

The line should be:
if ( isset( $prev_values[ $i ] ) ) {

instead of:
if ( $prev_values[ $i ] ) {