### PR TITLE
Handling case where membership billing order gateway is not the same as primary site gateway.

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -1,6 +1,6 @@
 <div class="<?php echo pmpro_get_element_class( 'pmpro_billing_wrap' ); ?>">
 <?php
-	global $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $show_check_payment_instructions, $show_paypal_link;
+	global $wpdb, $current_user, $gateway, $pmpro_msg, $pmpro_msgt, $show_check_payment_instructions, $show_paypal_link;
 	global $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
 
 	/**
@@ -12,7 +12,8 @@
 	 */
 	$pmpro_email_field_type = apply_filters('pmpro_email_field_type', true);
 
-	$gateway = pmpro_getOption("gateway");
+	// Get the default gateway for the site.
+	$default_gateway = pmpro_getOption( 'gateway' );
 
 	// Set the wrapping class for the checkout div based on the default gateway;
 	if ( empty( $gateway ) ) {
@@ -79,7 +80,7 @@
 			<?php
 				$pmpro_billing_show_payment_method = apply_filters( 'pmpro_billing_show_payment_method'
 					, true);
-				if ( $pmpro_billing_show_payment_method && ! empty( $CardType ) ) { ?>
+				if ( $pmpro_billing_show_payment_method && ! empty( $CardType ) && $has_recurring_levels ) { ?>
 					<li><strong><?php _e( 'Payment Method', 'paid-memberships-pro' ); ?>: </strong>
 						<?php echo esc_html( ucwords( $CardType ) ); ?>
 						<?php _e('ending in', 'paid-memberships-pro' ); ?>
@@ -117,7 +118,13 @@
 		<p class="<?php echo pmpro_get_element_class( 'pmpro_actions_nav' ); ?>">
 			<span class="<?php echo pmpro_get_element_class( 'pmpro_actions_nav-right' ); ?>"><a href="<?php echo pmpro_url( 'account' )?>"><?php _e('View Your Membership Account &rarr;', 'paid-memberships-pro' );?></a></span>
 		</p> <!-- end pmpro_actions_nav -->
-	<?php } else { ?>
+	<?php } elseif ( $gateway != $default_gateway ) {
+		// This membership's gateway is not the default site gateway, Pay by Check, or PayPal Express.
+		?>
+		<p><?php _e( 'Your billing information cannot be updated at this time.', 'paid-memberships-pro' ); ?></p>
+	<?php } else {
+		// Show the default gateway form and allow billing information update.
+		?>
 		<div id="pmpro_level-<?php echo $level->id; ?>" class="<?php echo pmpro_get_element_class( $pmpro_billing_gateway_class, 'pmpro_level-' . $level->id ); ?>">
 		<form id="pmpro_form" class="<?php echo pmpro_get_element_class( 'pmpro_form' ); ?>" action="<?php echo pmpro_url("billing", "", "https")?>" method="post">
 

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -39,7 +39,11 @@ if (empty($user_order->gateway)) {
 $pmpro_requirebilling = true;
 
 // Set the gateway, ideally using the gateway used to pay for the last order (if it exists)
-$gateway = !empty( $user_order->gateway ) ? $user_order->gateway : pmpro_getOption("gateway");
+if ( ! empty( $user_order->gateway ) ) {
+    $gateway = $user_order->gateway;
+} else {
+    $gateway = NULL;
+}
 
 //enqueue some scripts
 wp_enqueue_script( 'jquery.creditCardValidator', plugins_url( '/js/jquery.creditCardValidator.js', dirname( __FILE__ ) ), array( 'jquery' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If a site changes its primary gateway, there are cases where a previous member may have their membership managed by the previous primary gateway. We currently just show the Billing Information update form for the new gateway, however that form would not do anything to update an active membership with another gateway.

There are more approaches we could take to resolve this, such as sending the $gateway for the user's active subscription through to the filters on billing page used to swap in other gateway classes including `pmpro_include_billing_address_fields` and `pmpro_include_payment_information_fields` but that has broader implications for sites using those filters already, and for each gateway class and the checkout pages.

This update takes a more straightforward approach to resolve the current bug: if the gateway attached to the recurring payment is not the primary site gateway, pay by check, or PayPal Express, we hide all payment information and address fields and show a notice that the information cannot be updated at this time.

We could alternatively consider allowing the site owner to filter this message and show a link like "to change your billing information you must complete a new checkout for your level" and link to checkout for their same level. Many people already ask "how do I change my payment method for membership?" in the case that they want to change from credit card to PayPal. So it may be an option to add this as a filter message below the entire form regardless of gateway.  This filter could be used by Add PayPal Express or Pay by Check Add Ons to show a "would you rather pay by check? would you rather pay by PayPal?" type message.
 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: https://github.com/strangerstudios/paid-memberships-pro/issues/1392

### Changelog entry

* BUG FIX: Fixing case where members could not update a recurring payment's Billing Information for subscriptions managed by the inactive gateway. 