### PR TITLE
Adding note to login redirect function to use core WP filter, not ours which we have only left for posterity.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -27,6 +27,8 @@ function pmpro_login_redirect( $redirect_to, $request = NULL, $user = NULL ) {
 		}
 	}
 
+	// Custom redirect filters should use the core WordPress login_redirect filter instead of this one.
+	// This filter is left in place for PMPro versions dating back to 2014.
 	return apply_filters( 'pmpro_login_redirect_url', $redirect_to, $request, $user );
 }
 add_filter( 'login_redirect','pmpro_login_redirect', 10, 3 );


### PR DESCRIPTION
Just a simple code comment added here to advise custom code to use the login_redirect WP filter over the PMPro pmpro_login_redirect_url filter documented here: https://www.paidmembershipspro.com/hook/pmpro_login_redirect_url/.