### PR TITLE
Wrapping checkout button shortcode output and block in a span so it can be targeted with CSS.

### DIFF
--- a/blocks/checkout-button/block.php
+++ b/blocks/checkout-button/block.php
@@ -60,5 +60,5 @@ function render_dynamic_block( $attributes ) {
 		$css_class = null;
 	}
 
-	return( pmpro_getCheckoutButton( $level, $text, $css_class ) );
+	return( "<span class=\"" . pmpro_get_element_class( 'span_pmpro_checkout_button' ) . "\">" . pmpro_getCheckoutButton( $level, $text, $css_class ) . "</span>" );
 }

--- a/shortcodes/checkout_button.php
+++ b/shortcodes/checkout_button.php
@@ -15,7 +15,12 @@ function pmpro_checkout_button_shortcode($atts, $content=null, $code="")
 		'class' => NULL
 	), $atts));
 	
-	return pmpro_getCheckoutButton($level, $text, $class);
+	ob_start(); ?>
+ 	<span class="<?php pmpro_get_element_class( 'span_pmpro_checkout_button' ); ?>">
+ 		<?php echo pmpro_getCheckoutButton($level, $text, $class); ?>
+ 	</span>
+ 	<?php
+ 	return ob_get_clean();
 }
 add_shortcode("pmpro_button", "pmpro_checkout_button_shortcode");
 add_shortcode("pmpro_checkout_button", "pmpro_checkout_button_shortcode");


### PR DESCRIPTION
Another PR requested this feature a long while ago - I am revisiting some PRs now and think this is a good update. This PR adds a wrapping <span class="span_pmpro_checkout_button">...</span> for the output of the [pmpro_checkout_button] shortcode or Checkout Button Block.