### PR TITLE
Updating invoice status to match format on the account page; removing enddate.

### DIFF
--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -24,9 +24,17 @@
 			<?php do_action("pmpro_invoice_bullets_top", $pmpro_invoice); ?>
 			<li><strong><?php _e('Account', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->user->display_name?> (<?php echo $pmpro_invoice->user->user_email?>)</li>
 			<li><strong><?php _e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->membership_level->name?></li>
-			<li><strong><?php _e('Status', 'paid-memberships-pro' ); ?>:</strong> <?php echo ! empty( $pmpro_invoice->status ) ? ucwords( $pmpro_invoice->status ) : __( 'Success', 'paid-memberships-pro' ); ?></li>
-			<?php if($pmpro_invoice->membership_level->enddate) { ?>
-				<li><strong><?php _e('Membership Expires', 'paid-memberships-pro' );?>:</strong> <?php echo date_i18n(get_option('date_format'), $pmpro_invoice->membership_level->enddate)?></li>
+			<?php if ( ! empty( $pmpro_invoice->status ) ) { ?>
+				<li><strong><?php _e('Status', 'paid-memberships-pro' ); ?>:</strong>
+				<?php
+					if ( in_array( $pmpro_invoice->status, array( '', 'success', 'cancelled' ) ) ) {
+						$display_status = __( 'Paid', 'paid-memberships-pro' );
+					} else {
+						$display_status = ucwords( $pmpro_invoice->status );
+					}
+					esc_html_e( $display_status );
+				?>
+				</li>
 			<?php } ?>
 			<?php if($pmpro_invoice->getDiscountCode()) { ?>
 				<li><strong><?php _e('Discount Code', 'paid-memberships-pro' );?>:</strong> <?php echo $pmpro_invoice->discount_code->code?></li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enddate on the single invoice had a notice for cases where the invoice was referencing orders for not the current user's membership. We reevaluated and decided "enddate" on the invoice really didn't make sense since it represents a payment at a point in time.

We also decided to have the status match that on the Membership Account "Invoices" section, where statuses like 'success', 'cancelled' and '' reflect "Paid" rather than the actual status which may be confusing since cancelled doesn't mean it wasn't paid successfully.
