### PR TITLE
Added checkout_levels REST API call

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -527,11 +527,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$discount_code = isset( $params['discount_code'] ) ? $params['discount_code'] : null;
 
 			$r = array();
-			$r['inital_payment'] = 0.00;
+			$r['initial_payment'] = 0.00;
 			foreach ( $level_ids as $level_id ) {
 				$r[ $level_id ] = pmpro_getLevelAtCheckout( $level_id, $discount_code );
 				if ( ! empty( $r[ $level_id ]->initial_payment ) ) {
-					$r['inital_payment'] += intval( $r[ $level_id ]->initial_payment );
+					$r['initial_payment'] += intval( $r[ $level_id ]->initial_payment );
 				}
 			}
 			return new WP_REST_Response( $r );

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -534,6 +534,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 					$r['initial_payment'] += intval( $r[ $level_id ]->initial_payment );
 				}
 			}
+			$r['initial_payment_formatted'] = pmpro_formatPrice( $r['initial_payment'] );
 			return new WP_REST_Response( $r );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added MMPU-Compatible `/pmpro/v1/checkout_levels` API call. Includes information about each level being checked out for along with the total initial payment that will be charged. Necessary for MMPU compatibility for Stripe Payment Methods.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.