### PR TITLE
Adding a hook to the member profile edit form tag.

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -480,7 +480,16 @@ function pmpro_member_profile_edit_form() {
 	}
 	?>
 	<div class="<?php echo pmpro_get_element_class( 'pmpro_member_profile_edit_wrap' ); ?>">
-		<form id="member-profile-edit" class="<?php echo pmpro_get_element_class( 'pmpro_form' ); ?>" action="" method="post">
+		<form id="member-profile-edit" class="<?php echo pmpro_get_element_class( 'pmpro_form' ); ?>" action="" method="post"
+			<?php
+				/**
+				 * Fires inside the member-profile-edit form tag in the pmpro_member_profile_edit_form function.
+				 *
+				 * @since 2.4.1
+				 */
+				do_action( 'pmpro_member_profile_edit_form_tag' );
+			?>
+		>
 
 			<?php wp_nonce_field( 'update-user_' . $current_user->ID, 'update_user_nonce' ); ?>
 


### PR DESCRIPTION
New hook pmpro_member_profile_edit_form_tag replicates the core WP hook here: https://developer.wordpress.org/reference/hooks/user_edit_form_tag/

This hook is used by Register Helper here: https://github.com/strangerstudios/pmpro-register-helper/blob/b35bb8b2e87acab6d0276e4c1a7f743703613f2f/pmpro-register-helper.php#L1064-L1071

We should test file uploads in pmpro without that form type on the file upload - they may work as is. Most avatar upload systems need this encoding on the form so that we can support a plugin like Simple Local Avatars on our frontend form.