### PR TITLE
Fixed losing a day on membership renewal

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -22,8 +22,8 @@ function pmpro_checkout_level_extend_memberships( $level ) {
 		}
 
 		// calculate days left
-		$todays_date = current_time( 'timestamp' );
-		$expiration_date = $user_level->enddate;
+		$todays_date = strtotime( current_time( 'Y-m-d' ) );
+		$expiration_date = strtotime( date( 'Y-m-d', $user_level->enddate ) );
 		$time_left = $expiration_date - $todays_date;
 
 		// time left?


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves #1406 

Now ignoring the checkout time when compensating user for un-used time during membership renewal. This prevents off-by-one errors when a user checks out after the time of day of their original checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.