### PR TITLE
Adding WP 5.5 compatibility with core auto-updates.

### DIFF
--- a/includes/addons.php
+++ b/includes/addons.php
@@ -133,6 +133,8 @@ function pmpro_update_plugins_filter( $value ) {
 		if ( ! empty( $addon['License'] ) && version_compare( $plugin_data['Version'], $addon['Version'], '<' ) ) {
 			$value->response[ $plugin_file ] = pmpro_getPluginAPIObjectFromAddon( $addon );
 			$value->response[ $plugin_file ]->new_version = $addon['Version'];
+		} else {
+			$value->no_update[ $plugin_file ] = pmpro_getPluginAPIObjectFromAddon( $addon );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WP 5.5 RC-2 compatibility on the plugins screen with core auto-updates UI interface for third-party plugins/add-ons.

### How to test the changes in this Pull Request:

1. Install patch.
2. Install several add-ons.
3. Roll back these add-ons.
4. Use a tool like Easy Updates Manager and force updates in their Advanced->Force Updates interface. This will mimick core auto-updates. Alternatively, use cron, but this is more complicated as the cron needs to be run naturally rather than manually using something like WP Control.
5. Test with and without a license.
6. Possibly update non-licensed update errors with a link to some docs or the license tab with an upsell.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Compatibility with WP 5.5 Core Automatic Updates.