### PR TITLE
Adding hook before member profile update errors are returned to add errors for required fields or other validation

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -457,6 +457,15 @@ function pmpro_member_profile_edit_form() {
 			}
 		}
 
+		/**
+		 * Fires before member profile update errors are returned.
+		 *
+		 * @param $errors WP_Error object (passed by reference).
+		 * @param $update Whether this is a user update.
+		 * @param $user   User object (passed by reference).
+		 */
+		do_action_ref_array( 'pmpro_user_profile_update_errors', array( &$errors, $update, &$user ) );
+
 		// Show error messages.
 		if ( ! empty( $errors ) ) { ?>
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_message pmpro_error', 'pmpro_error' ); ?>">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

This recipe will "require" First Name on the member profile edit page: https://gist.github.com/kimcoleman/288fa1d647044cbe67e80a98b411e328. 
 
### Changelog entry

* ENHANCEMENT: Adding hook `pmpro_user_profile_update_errors` to allow custom code to validate or require fields before saving the user data on the Member Profile Edit frontend page.
