### PR TITLE
No longer converting order timestamps to local time on load

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -343,7 +343,7 @@ function pmpro_dashboard_report_recent_orders_callback() {
                                 echo '<br />(' . $order->status . ')'; 
                             } ?>
                         </td>
-                        <td><?php echo date_i18n( get_option( 'date_format' ), $order->timestamp ); ?></td>
+                        <td><?php echo date_i18n( get_option( 'date_format' ), $order->getTimestamp() ); ?></td>
         			</tr>
                     <?php
                 }

--- a/adminpages/orders-csv.php
+++ b/adminpages/orders-csv.php
@@ -498,7 +498,7 @@ for ( $ic = 1; $ic <= $iterations; $ic ++ ) {
 		}				
 
 		//timestamp
-		$ts = date_i18n( $dateformat, $order->timestamp );
+		$ts = date_i18n( $dateformat, $order->getTimestamp() );
 		array_push( $csvoutput, pmpro_enclose( $ts ) );
 
 		//any extra columns

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -815,11 +815,11 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 				<td>
 					<?php
 					if ( in_array( 'timestamp', $read_only_fields ) && $order_id > 0 ) {
-						echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $order->timestamp ) );
+						echo esc_html( date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $order->getTimestamp() ) );
 					} else {
 						// set up date vars
 						if ( ! empty( $order->timestamp ) ) {
-							$timestamp = $order->timestamp;
+							$timestamp = $order->getTimestamp();
 						} else {
 							$timestamp = current_time( 'timestamp' );
 						}
@@ -1452,8 +1452,8 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					</td>
 					<td><?php echo esc_html( $order->status ); ?></td>
 					<td>
-						<?php echo esc_html( date_i18n( get_option( 'date_format' ), $order->timestamp ) ); ?><br/>
-						<?php echo esc_html( date_i18n( get_option( 'time_format' ), $order->timestamp ) ); ?>
+						<?php echo esc_html( date_i18n( get_option( 'date_format' ), $order->getTimestamp() ) ); ?><br/>
+						<?php echo esc_html( date_i18n( get_option( 'time_format' ), $order->getTimestamp() ) ); ?>
 					</td>
 					<td>
 						<?php if ( $order->getDiscountCode() ) { ?>

--- a/adminpages/templates/orders-email.php
+++ b/adminpages/templates/orders-email.php
@@ -15,7 +15,7 @@
 	</tr>
 	<tr>
 		<td>
-			<?php echo __( 'Date:', 'paid-memberships-pro' ) . '&nbsp;' . date_i18n( 'Y-m-d', $order->timestamp ) ?>
+			<?php echo __( 'Date:', 'paid-memberships-pro' ) . '&nbsp;' . date_i18n( 'Y-m-d', $order->getTimestamp() ) ?>
 		</td>
 	</tr>
 	<?php if(!empty($order->billing->name)): ?>

--- a/adminpages/templates/orders-print.php
+++ b/adminpages/templates/orders-print.php
@@ -51,7 +51,7 @@
 				</tr>
 				<tr>
 					<td>
-						<?php echo __( 'Date:', 'paid-memberships-pro' ) . '&nbsp;' . date_i18n( get_option( 'date_format' ), $order->timestamp ); ?>
+						<?php echo __( 'Date:', 'paid-memberships-pro' ) . '&nbsp;' . date_i18n( get_option( 'date_format' ), $order->getTimestamp() ); ?>
 					</td>
 				</tr>
 			</table>

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -134,15 +134,12 @@
 				$this->gateway_environment = $dbobj->gateway_environment;
 				$this->payment_transaction_id = $dbobj->payment_transaction_id;
 				$this->subscription_transaction_id = $dbobj->subscription_transaction_id;
-				$this->timestamp = $dbobj->timestamp;
+				$this->timestamp = strtotime( $dbobj->timestamp );
 				$this->affiliate_id = $dbobj->affiliate_id;
 				$this->affiliate_subid = $dbobj->affiliate_subid;
 
 				$this->notes = $dbobj->notes;
 				$this->checkout_id = $dbobj->checkout_id;
-
-				// Fix the timestamp for local time
-				$this->timestamp = strtotime( get_date_from_gmt( $this->timestamp, 'Y-m-d H:i:s' ) );
 
 				//reset the gateway
 				if(empty($this->nogateway))
@@ -526,6 +523,16 @@
 		}
 
 		/**
+		 * Get the timestamp for this order.
+		 *
+		 * @param bool $gmt whether to return GMT time or local timestamp.
+		 * @return int timestamp.
+		 */
+		function getTimestamp( $gmt = false ) {
+			return $gmt ? $this->timestamp : strtotime( get_date_from_gmt( date( 'Y-m-d H:i:s', $this->timestamp ) ) );
+		}
+
+		/**
 		 * Change the timestamp of an order by passing in year, month, day, time.
 		 *
 		 * $time should be adjusted for local timezone.
@@ -545,10 +552,12 @@
 			global $wpdb;
 			$this->sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET timestamp = '" . $date . "' WHERE id = '" . $this->id . "' LIMIT 1";
 
-			if($wpdb->query($this->sqlQuery) !== "false")
+			if($wpdb->query($this->sqlQuery) !== "false") {
+				$this->timestamp = strtotime( $date );
 				return $this->getMemberOrderByID($this->id);
-			else
+			} else {
 				return false;
+			}
 		}
 
 		/**

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -288,7 +288,7 @@
 
 				$this->data["invoice_id"] = $invoice->code;
 				$this->data["invoice_total"] = pmpro_formatPrice($invoice->total);
-				$this->data["invoice_date"] = date_i18n(get_option('date_format'), $invoice->timestamp);
+				$this->data["invoice_date"] = date_i18n( get_option( 'date_format' ), $invoice->getTimestamp() );
 				$this->data["billing_name"] = $invoice->billing->name;
 				$this->data["billing_street"] = $invoice->billing->street;
 				$this->data["billing_city"] = $invoice->billing->city;
@@ -388,7 +388,7 @@
 
 				$this->data["invoice_id"] = $invoice->code;
 				$this->data["invoice_total"] = pmpro_formatPrice($invoice->total);
-				$this->data["invoice_date"] = date_i18n(get_option('date_format'), $invoice->timestamp);
+				$this->data["invoice_date"] = date_i18n(get_option('date_format'), $invoice->getTimestamp());
 				$this->data["billing_name"] = $invoice->billing->name;
 				$this->data["billing_street"] = $invoice->billing->street;
 				$this->data["billing_city"] = $invoice->billing->city;
@@ -711,7 +711,7 @@
 								"user_email" => $user->user_email,	
 								"invoice_id" => $invoice->code,
 								"invoice_total" => pmpro_formatPrice($invoice->total),
-								"invoice_date" => date_i18n(get_option('date_format'), $invoice->timestamp),
+								"invoice_date" => date_i18n(get_option('date_format'), $invoice->getTimestamp()),
 								"billing_name" => $invoice->billing->name,
 								"billing_street" => $invoice->billing->street,
 								"billing_city" => $invoice->billing->city,

--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -762,7 +762,7 @@
 				/** Initial payment **/
 				$nvpStr = "";
 				// STARTDATE is Required, even if useless here. Start from 24h before the order timestamp, to avoid timezone related issues.
-				$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->timestamp-DAY_IN_SECONDS ) . 'Z' );
+				$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->getTimestamp() - DAY_IN_SECONDS ) . 'Z' );
 				// filter results by a specific transaction id.
 				$nvpStr .= "&TRANSACTIONID=" . urlencode($order->subscription_transaction_id);
 

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -614,6 +614,7 @@
 				$order->status = "review";
 
 				//update order
+
 				$order->saveOrder();
 
 				return true;
@@ -844,7 +845,7 @@
 				/** Initial payment **/
 				$nvpStr = "";
 				// STARTDATE is Required, even if useless here. Start from 24h before the order timestamp, to avoid timezone related issues.
-				$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->timestamp-DAY_IN_SECONDS ) . 'Z' );
+				$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->getTimestamp() - DAY_IN_SECONDS ) . 'Z' );
 				// filter results by a specific transaction id.
 				$nvpStr .= "&TRANSACTIONID=" . urlencode($order->subscription_transaction_id);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -668,7 +668,7 @@ function pmpro_next_payment( $user_id = null, $order_status = 'success', $format
 
 		if ( ! empty( $order ) && ! empty( $order->id ) && ! empty( $level ) && ! empty( $level->id ) && ! empty( $level->cycle_number ) ) {
 			// next payment date
-			$nextdate = strtotime( '+' . $level->cycle_number . ' ' . $level->cycle_period, $order->timestamp );
+			$nextdate = strtotime( '+' . $level->cycle_number . ' ' . $level->cycle_period, $order->getTimestamp() );
 
 			$r = $nextdate;
 		} else {

--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -235,7 +235,7 @@ function pmpro_personal_data_exporter( $email_address, $page = 1 ) {
 				),
 				array(
 					'name' => __( 'Order Date', 'paid-memberships-pro' ),
-					'value' => date( get_option( 'date_format' ), $order->timestamp ),
+					'value' => date( get_option( 'date_format' ), $order->getTimestamp() ),
 				),
 				array(
 					'name' => __( 'Level', 'paid-memberships-pro' ),

--- a/includes/updates/upgrade_1_8_9_3.php
+++ b/includes/updates/upgrade_1_8_9_3.php
@@ -168,7 +168,7 @@ function pmpro_upgrade_1_8_9_3_ajax() {
 			//calculate and fix the end date
 			if(empty($user->membership_level->enddate)) {
 				if ( ! empty( $pmpro_level->expiration_number ) ) {
-					$enddate =  date_i18n( "Y-m-d", strtotime( "+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, $last_order->timestamp ) );
+					$enddate =  date_i18n( "Y-m-d", strtotime( "+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, $last_order->getTimestamp() ) );
 				} else {
 					$enddate = "NULL";
 				}

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -44,7 +44,7 @@
 		echo wp_kses_post( $confirmation_message );
 	?>
 	<h3>
-		<?php printf(__('Invoice #%s on %s', 'paid-memberships-pro' ), $pmpro_invoice->code, date_i18n(get_option('date_format'), $pmpro_invoice->timestamp));?>
+		<?php printf(__('Invoice #%s on %s', 'paid-memberships-pro' ), $pmpro_invoice->code, date_i18n(get_option('date_format'), $pmpro_invoice->getTimestamp()));?>
 	</h3>
 	<a class="<?php echo pmpro_get_element_class( 'pmpro_a-print' ); ?>" href="javascript:window.print()"><?php _e('Print', 'paid-memberships-pro' );?></a>
 	<ul>

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -18,7 +18,7 @@
 			$pmpro_invoice->getUser();
 			$pmpro_invoice->getMembershipLevel();
 		?>
-		<h3><?php printf(__('Invoice #%s on %s', 'paid-memberships-pro' ), $pmpro_invoice->code, date_i18n(get_option('date_format'), $pmpro_invoice->timestamp));?></h3>
+		<h3><?php printf(__('Invoice #%s on %s', 'paid-memberships-pro' ), $pmpro_invoice->code, date_i18n(get_option('date_format'), $pmpro_invoice->getTimestamp()));?></h3>
 		<a class="<?php echo pmpro_get_element_class( 'pmpro_a-print' ); ?>" href="javascript:window.print()"><?php _e('Print', 'paid-memberships-pro' ); ?></a>
 		<ul>
 			<?php do_action("pmpro_invoice_bullets_top", $pmpro_invoice); ?>
@@ -119,7 +119,7 @@
 				{
 					?>
 					<tr>
-						<td><a href="<?php echo pmpro_url("invoice", "?invoice=" . $invoice->code)?>"><?php echo date_i18n(get_option("date_format"), $invoice->timestamp)?></a></td>
+						<td><a href="<?php echo pmpro_url("invoice", "?invoice=" . $invoice->code)?>"><?php echo date_i18n(get_option("date_format"), $invoice->getTimestamp())?></a></td>
 						<td><a href="<?php echo pmpro_url("invoice", "?invoice=" . $invoice->code)?>"><?php echo $invoice->code; ?></a></td>
 						<td><?php echo $invoice->membership_level_name;?></td>
 						<td><?php echo pmpro_formatPrice($invoice->total);?></td>

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -237,7 +237,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 						}
 						?>
 						<tr id="pmpro_account-invoice-<?php echo $invoice->code; ?>">
-							<td><a href="<?php echo pmpro_url("invoice", "?invoice=" . $invoice->code)?>"><?php echo date_i18n(get_option("date_format"), $invoice->timestamp)?></td>
+							<td><a href="<?php echo pmpro_url("invoice", "?invoice=" . $invoice->code)?>"><?php echo date_i18n(get_option("date_format"), $invoice->getTimestamp())?></td>
 							<td><?php if(!empty($invoice->membership_level)) echo $invoice->membership_level->name; else echo __("N/A", 'paid-memberships-pro' );?></td>
 							<td><?php echo pmpro_formatPrice($invoice->total)?></td>
 							<td><?php echo $display_status; ?></td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- No longer converting order timestamp to local time when loading order data
- Added method `getTimestamp()` in order class

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1442 .

### How to test the changes in this Pull Request:
Perform test in issue #1442 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
