### PR TITLE
Moving content message to helper function; membership shortcode attribute to show noaccess message

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -347,45 +347,7 @@ function pmpro_membership_content_filter( $content, $skipcheck = false ) {
 			$content = "";
 		}
 
-		if( empty($post_membership_levels_ids ) ) {
-			$post_membership_levels_ids = array();
-		}
-
-		if( empty( $post_membership_levels_names ) ) {
-			$post_membership_levels_names = array();
-		}
-
-        //hide levels which don't allow signups by default
-        if( ! apply_filters("pmpro_membership_content_filter_disallowed_levels", false, $post_membership_levels_ids, $post_membership_levels_names ) ) {
-            foreach($post_membership_levels_ids as $key=>$id) {
-                //does this level allow registrations?
-                $level_obj = pmpro_getLevel( $id );
-                if( empty( $level_obj ) || empty( $level_obj->allow_signups ) ) {
-                    unset( $post_membership_levels_ids[$key] );
-                    unset( $post_membership_levels_names[$key] );
-                }
-            }
-        }
-
-		$pmpro_content_message_pre = '<div class="' . pmpro_get_element_class( 'pmpro_content_message' ) . '">';
-		$pmpro_content_message_post = '</div>';
-
-		$sr_search = array("!!levels!!", "!!referrer!!", "!!login_url!!", "!!login_page_url!!", "!!levels_url!!", "!!levels_page_url!!");
-		$sr_replace = array(pmpro_implodeToEnglish($post_membership_levels_names), urlencode(site_url($_SERVER['REQUEST_URI'])), esc_url( pmpro_login_url() ), esc_url( pmpro_login_url() ), esc_url( pmpro_url( 'levels' ) ), esc_url( pmpro_url( 'levels' ) ));
-		
-		//get the correct message to show at the bottom
-		if( is_feed() ) {
-			$newcontent = apply_filters("pmpro_rss_text_filter", stripslashes(pmpro_getOption("rsstext")));
-			$content .= $pmpro_content_message_pre . str_replace($sr_search, $sr_replace, $newcontent) . $pmpro_content_message_post;
-		} elseif( $current_user->ID ) {
-			//not a member
-			$newcontent = apply_filters("pmpro_non_member_text_filter", stripslashes(pmpro_getOption("nonmembertext")));
-			$content .= $pmpro_content_message_pre . str_replace($sr_search, $sr_replace, $newcontent) . $pmpro_content_message_post;
-		} else {
-			//not logged in!
-			$newcontent = apply_filters("pmpro_not_logged_in_text_filter", stripslashes(pmpro_getOption("notloggedintext")));
-			$content .= $pmpro_content_message_pre . str_replace($sr_search, $sr_replace, $newcontent) . $pmpro_content_message_post;
-		}
+		$content = pmpro_get_no_access_message( $content, $post_membership_levels_ids, $post_membership_levels_names );
 	}
 
 	return $content;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1787,7 +1787,66 @@ function pmpro_actions_nav_separator() {
 	$separator = apply_filters( 'pmpro_actions_nav_separator', ' | ' );
 
 	return $separator;
-} 
+}
+
+/**
+ * pmpro_get_no_access_message to return the appropriate content message for the protected content.
+ *
+ * @param array $level_ids The array of level IDs this post is protected for.
+ * @param array $level_names The array of names for the levels this post is protected for.
+ *
+ * @return string $content The appropriate content message for the given user/visitor and required levels.
+ *
+ */
+function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL ) {
+	global $current_user;
+
+	if ( empty( $level_ids ) ) {
+		$level_ids = array();
+	}
+
+	if ( empty( $level_names ) ) {
+		$level_names = array();
+		foreach ( $level_ids as $key => $id ) {
+			$level_obj = pmpro_getLevel( $id );
+			$level_names[] = $level_obj->name;
+		}
+	}
+
+	// Hide levels which don't allow signups by default.
+	if( ! apply_filters( 'pmpro_membership_content_filter_disallowed_levels', false, $level_ids, $level_names ) ) {
+		foreach ( $level_ids as $key => $id ) {
+			// Does this level allow registrations?
+			$level_obj = pmpro_getLevel( $id );
+			if ( empty( $level_obj ) || empty( $level_obj->allow_signups ) ) {
+				unset( $level_ids[$key] );
+				unset( $level_names[$key] );
+			}
+		}
+	}
+
+	$pmpro_content_message_pre = '<div class="' . pmpro_get_element_class( 'pmpro_content_message' ) . '">';
+	$pmpro_content_message_post = '</div>';
+
+	$sr_search = array( '!!levels!!', '!!referrer!!', '!!login_url!!', '!!login_page_url!!', '!!levels_url!!', '!!levels_page_url!!' );
+	$sr_replace = array( pmpro_implodeToEnglish( $level_names ), urlencode( site_url( $_SERVER['REQUEST_URI'] ) ), esc_url( pmpro_login_url() ), esc_url( pmpro_login_url() ), esc_url( pmpro_url( 'levels' ) ), esc_url( pmpro_url( 'levels' ) ) );
+
+	// Get the correct message to show at the bottom.
+	if ( is_feed() ) {
+		$newcontent = apply_filters( 'pmpro_rss_text_filter', stripslashes( pmpro_getOption( 'rsstext' ) ) );
+		$content .= $pmpro_content_message_pre . str_replace( $sr_search, $sr_replace, $newcontent ) . $pmpro_content_message_post;
+	} elseif ( $current_user->ID ) {
+		//not a member
+		$newcontent = apply_filters( 'pmpro_non_member_text_filter', stripslashes( pmpro_getOption( 'nonmembertext' ) ) );
+		$content .= $pmpro_content_message_pre . str_replace( $sr_search, $sr_replace, $newcontent ) . $pmpro_content_message_post;
+	} else {
+		//not logged in!
+		$newcontent = apply_filters( 'pmpro_not_logged_in_text_filter', stripslashes( pmpro_getOption( 'notloggedintext' ) ) );
+		$content .= $pmpro_content_message_pre . str_replace( $sr_search, $sr_replace, $newcontent ) . $pmpro_content_message_post;
+	}
+
+	return $content;
+}
 
 /*
  pmpro_getMembershipLevelForUser() returns the first active membership level for a user

--- a/shortcodes/membership.php
+++ b/shortcodes/membership.php
@@ -12,7 +12,8 @@ function pmpro_shortcode_membership($atts, $content=null, $code="")
 	extract(shortcode_atts(array(
 		'level' => NULL,
 		'levels' => NULL,
-		'delay' => NULL
+		'delay' => NULL,
+		'show_noaccess' => NULL
 	), $atts));
 
 	//if levels is used instead of level
@@ -85,7 +86,13 @@ function pmpro_shortcode_membership($atts, $content=null, $code="")
 	//to show or not to show
 	if($hasaccess)
 		return do_shortcode($content);	//show content
-	else
-		return "";	//just hide it
+	else {
+		if ( empty( $show_noaccess ) ) {
+			return '';
+		} else {
+			$content = '';
+			return pmpro_get_no_access_message( $content, $levels );
+		}
+	}
 }
 add_shortcode("membership", "pmpro_shortcode_membership");


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Creating new helper function to return the no access message for a protected piece of content. The function accepts the default content to return as well as the level IDs required for the content and optionally the level names if set.

The function is now used in the includes/content.php where messages are returned as well as with a new attribute "show_noaccess" on the [membership] shortcode in the format: [membership levels="1,2,3" show_noaccess="true"] ... [/membership]

### How to test the changes in this Pull Request:

1. Use the [membership] shortcode and set the show_noaccess attribute to true.
2. See the appropriate message based on level / logged in status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
