### PR TITLE
Fixed issue where confirmation message wouldnt be sent in checkout email

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -641,6 +641,9 @@ if ( ! empty( $pmpro_confirmed ) ) {
 
 		if ( pmpro_changeMembershipLevel( $custom_level, $user_id, 'changed' ) ) {
 			//we're good
+			// Add confirmation message back into $pmpro_level.
+			$pmpro_level->confirmation = $wpdb->get_var( "SELECT confirmation FROM $wpdb->pmpro_membership_levels WHERE id = '" . esc_sql( $pmpro_level->id ) . "'" );
+
 			//blank order for free levels
 			if ( empty( $morder ) ) {
 				$morder                 = new MemberOrder();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We recently made a change to hide the confirmation message from the checkout level so that users couldn't possibly see confirmation message until they have that level. This caused an issue where the confirmation wouldn't be shown in the confirmation email.

This change adds the confirmation back into the level object after the user's membership level is successfully changed during checkout, fixing the email issue and potentially other issues with the confirmation message.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:
Check box on edit level page to send confirmation message in email, and then check out for that level with the default PMPro email templates. See that the confirmation is shown with this fix, but not without.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
