### PR TITLE
Now resetting memberslist page number when changing shown level

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -621,7 +621,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				$l = false;
 			}
 			_e('Show', 'paid-memberships-pro' );?>
-			<select name="l" onchange="jQuery('#member-list-form').submit();">
+			<select name="l" onchange="jQuery('#current-page-selector').val('1'); jQuery('#member-list-form').submit();">
 				<option value="" <?php if(!$l) { ?>selected="selected"<?php } ?>><?php _e('All Levels', 'paid-memberships-pro' );?></option>
 				<?php
 					$levels = $wpdb->get_results("SELECT id, name FROM $wpdb->pmpro_membership_levels ORDER BY name");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Reset the current page number in the Members List when the shown level is changed. This can avoid situations where you switch from "All Levels" page x to a level with only one page of users, but see none displayed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. View your Members List
2. Change which page you are viewing
3. Change the level you are viewing
4. See that the page number goes back to 1 when the page loads

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
