### PR TITLE
Add missing space between "Paid" and price on the profile page

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -55,7 +55,7 @@ function pmpro_membership_level_profile_fields($user)
 				if(empty($membership_values) || pmpro_isLevelFree($membership_values))
                 {
 					if(!empty($membership_values->original_initial_payment) && $membership_values->original_initial_payment > 0)
-						echo __('Paid', 'paid-memberships-pro' ) . pmpro_formatPrice($membership_values->original_initial_payment) . ".";
+						echo __('Paid', 'paid-memberships-pro' ) . " " . pmpro_formatPrice($membership_values->original_initial_payment) . ".";
 					else
 						_e('Not paying.', 'paid-memberships-pro' );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, there's no space between "Paid" and the amount:

![Screenshot 2020-09-11 at 08 24 49](https://user-images.githubusercontent.com/958800/92874556-6fc02300-f408-11ea-86f7-ac7505cc1b65.png)

The change adds a space between "Paid" and the amount.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Add a space between "Paid" and price on the profile page