### PR TITLE
Adjust order delete prompt to support other locales.

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1343,8 +1343,8 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 								<a title="<?php esc_attr_e( 'Copy', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => '-1', 'copy' => $order->id ), admin_url('admin.php' ) ) ); ?>"><?php esc_html_e( 'Copy', 'paid-memberships-pro' ); ?></a>
 							</span> |
 							<span class="delete">
-								<a href="javascript:pmpro_askfirst('<?php echo esc_attr
-								( sprintf( __( 'Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?', 'paid-memberships-pro' ), str_replace( "'", '', $order->code ) ) ); ?>', 'admin.php?page=pmpro-orders&delete=<?php echo $order->id; ?>'); void(0);"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+							<?php $delete_prompt = sprintf( __( "Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?", 'paid-memberships-pro' ), str_replace( "'", '', $order->code ) ); ?>
+							<a href='javascript:pmpro_askfirst( "<?php echo esc_attr( $delete_prompt ); ?>"); void(0);'><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
 							</span> |
 							<span class="print">
 								<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'order' => $order->id ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1343,8 +1343,9 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 								<a title="<?php esc_attr_e( 'Copy', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => '-1', 'copy' => $order->id ), admin_url('admin.php' ) ) ); ?>"><?php esc_html_e( 'Copy', 'paid-memberships-pro' ); ?></a>
 							</span> |
 							<span class="delete">
-							<?php $delete_prompt = sprintf( __( "Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?", 'paid-memberships-pro' ), str_replace( "'", '', $order->code ) ); ?>
-							<a href='javascript:pmpro_askfirst( "<?php echo esc_attr( $delete_prompt ); ?>"); void(0);'><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+							<?php $delete_prompt = sprintf( __( 'Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?', 'paid-memberships-pro' ), str_replace( "'", '', $order->code ) ); ?>
+								<a href='javascript:pmpro_askfirst("<?php echo esc_attr
+								( $delete_prompt ) ?>", "admin.php?page=pmpro-orders&delete=<?php echo $order->id; ?>"); void(0);'><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
 							</span> |
 							<span class="print">
 								<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'order' => $order->id ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>


### PR DESCRIPTION
* ENHANCEMENT/BUG FIX: Fix an issue where locales like Italian caused JavaScript errors (due to single quotes being used inside the translation).

Moved the delete prompt wording outside of the HTML to make it easier to work with.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/paid-memberships-pro/issues/1357

### How to test the changes in this Pull Request:

1. Set locale to Italian.
2. Delete an order from inside the WordPress dashboard.
3. Ask Prompt should be in Italian and no JS errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
