### PR TITLE
Fixed issue where non-pretty permalinks may break frontend password reset

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -777,7 +777,15 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login, $user_d
 
 	$login_page_id = pmpro_getOption( 'login_page_id' );
     if ( ! empty ( $login_page_id ) ) {
-        $login_url = get_permalink( $login_page_id );
+		$login_url = get_permalink( $login_page_id );
+		if ( strpos( $login_url, '?' ) && ! strpos( $login_url, site_url( 'wp-login.php' ) ) ) {
+			// Login page permalink contains a '?', so we need to replace the '?' already in the login URL with '&'.
+			// Second condition in `if` above prevents infinite loop.
+			while ( strpos( $message, site_url( 'wp-login.php' ) . '?' ) ) {
+				$index_to_replace = strpos( $message, site_url( 'wp-login.php' ) . '?' ) + strlen( site_url( 'wp-login.php' ) );
+				$message = substr_replace( $message, '&#038;', $index_to_replace, 1 );
+			}
+		}
 		$message = str_replace( site_url( 'wp-login.php' ), $login_url, $message );
 	}
 

--- a/includes/login.php
+++ b/includes/login.php
@@ -778,13 +778,9 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login, $user_d
 	$login_page_id = pmpro_getOption( 'login_page_id' );
     if ( ! empty ( $login_page_id ) ) {
 		$login_url = get_permalink( $login_page_id );
-		if ( strpos( $login_url, '?' ) && ! strpos( $login_url, site_url( 'wp-login.php' ) ) ) {
+		if ( strpos( $login_url, '?' ) ) {
 			// Login page permalink contains a '?', so we need to replace the '?' already in the login URL with '&'.
-			// Second condition in `if` above prevents infinite loop.
-			while ( strpos( $message, site_url( 'wp-login.php' ) . '?' ) ) {
-				$index_to_replace = strpos( $message, site_url( 'wp-login.php' ) . '?' ) + strlen( site_url( 'wp-login.php' ) );
-				$message = substr_replace( $message, '&#038;', $index_to_replace, 1 );
-			}
+			$message = str_replace( site_url( 'wp-login.php' ) . '?', site_url( 'wp-login.php' ) . '&', $message );
 		}
 		$message = str_replace( site_url( 'wp-login.php' ), $login_url, $message );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolved issue where password reset link would send incorrectly when plain permalink are used.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1476.

### How to test the changes in this Pull Request:
See issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
