### PR TITLE
Added Braintree functions to get next payment date

### DIFF
--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -1071,4 +1071,44 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 			*/
 			return apply_filters( 'pmpro_braintree_plan_id', 'pmpro_' . $level_id, $level_id );
 	}
+
+	function get_subscription( &$order ) {
+		// Does order have a subscription?
+		if ( empty( $order ) || empty( $order->subscription_transaction_id ) ) {
+			return false;
+		}
+
+		try {
+			$subscription = Braintree_Subscription::find( $order->subscription_transaction_id );
+		} catch ( Exception $e ) {
+			$order->error      = __( "Error getting subscription with Braintree:", 'paid-memberships-pro' ) . $e->getMessage();
+			$order->shorterror = $order->error;
+			return false;
+		}
+
+		return $subscription;
+	}
+
+	/**
+	 * Filter pmpro_next_payment to get date via API if possible
+	 */
+	static function pmpro_next_payment( $timestamp, $user_id, $order_status ) {
+		// Check that we have a user ID...
+		if ( ! empty( $user_id ) ) {
+			// Get last order...
+			$order = new MemberOrder();
+			$order->getLastMemberOrder( $user_id, $order_status );
+
+			// Check if this is a Braintree order with a subscription transaction id...
+			if ( ! empty( $order->id ) && ! empty( $order->subscription_transaction_id ) && $order->gateway == "braintree" ) {
+				// Get the subscription and return the next billing date.
+				$subscription = $order->Gateway->get_subscription( $order );
+				if ( ! empty( $subscription ) ) {
+					$timestamp = $subscription->nextBillingDate->getTimestamp();
+				}
+			}
+		}
+
+		return $timestamp;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added method to get a subscription's next payment date to the Braintree gateway. This function can be run every time that the next payment date is calculated by adding the following PHP to your site:
`add_filter('pmpro_next_payment', array('PMProGateway_braintree', 'pmpro_next_payment'), 10, 3);`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
