### PR TITLE
Recurring order tax fixes

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -158,7 +158,7 @@
 
 			global $wpdb;
 			//double check for a user_id, gateway and gateway environment
-			$sql = "SELECT * FROM $wpdb->pmpro_membership_orders WHERE `subscription_transaction_id` = $subscription_id ORDER BY id ASC "; //Gets the first one. Should be active/success?
+			$sql = "SELECT * FROM $wpdb->pmpro_membership_orders WHERE `subscription_transaction_id` = '$subscription_id' ORDER BY id ASC "; //Gets the first one. Should be active/success?
 
 			$result = $wpdb->get_row( $sql );
 

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -152,6 +152,21 @@
 		}
 
 		/**
+		 * Returns an object containing the order data or false if it doesn't exist
+		 */
+		function get_original_subscription_order( $subscription_id ){
+
+			global $wpdb;
+			//double check for a user_id, gateway and gateway environment
+			$sql = "SELECT * FROM $wpdb->pmpro_membership_orders WHERE `subscription_transaction_id` = $subscription_id ORDER BY id ASC "; //Gets the first one. Should be active/success?
+
+			$result = $wpdb->get_row( $sql );
+
+			return $result;
+
+		}
+
+		/**
 		 * Set up the Gateway class to use with this order.
 		 *
 		 * @param string $gateway Name/label for the gateway to set.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3389,3 +3389,24 @@ function pmpro_insert_or_replace( $table, $data, $format, $primary_key = 'id' ) 
 		return $wpdb->replace( $table, $data, $format );
 	}
 }
+
+/**
+ * Checks if a webhook is running
+ */
+function pmpro_doing_webhook( $gateway = null ){
+
+	if( defined( 'PMPRO_DOING_WEBHOOK' ) && !empty ( PMPRO_DOING_WEBHOOK ) ){
+		if( $gateway !== null ){
+			if( PMPRO_DOING_WEBHOOK == $gateway ){
+				return true;
+			} else {
+				return false;	
+			}
+		} else {
+			return true;
+		}
+	} else {
+		return false;
+	}
+	
+}

--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -14,6 +14,8 @@
 
 	global $wpdb;
 
+	define( 'PMPRO_DOING_WEBHOOK', 'authnet' );
+
 	//some code taken from http://www.merchant-account-services.org/blog/handling-authorizenet-arb-subscription-failures/
 	// Flag if this is an ARB transaction. Set to false by default.
 	$arb = false;

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -20,6 +20,8 @@ if ( ! defined( "ABSPATH" ) ) {
 //globals
 global $wpdb;
 
+define( 'PMPRO_DOING_WEBHOOK', 'braintree' );
+
 // Debug log
 global $logstr;
 $logstr = array( "Logged On: " . date_i18n( "m/d/Y H:i:s", current_time( 'timestamp' ) ) );

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -15,6 +15,8 @@ if ( ! defined( "ABSPATH" ) ) {
 global $wpdb, $gateway_environment, $logstr;
 $logstr = "";    //will put debug info here and write to ipnlog.txt
 
+define( 'PMPRO_DOING_WEBHOOK', 'paypal' );
+
 //validate?
 if ( ! pmpro_ipnValidate() ) {
 	//validation failed

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -14,6 +14,8 @@
 	global $logstr;
 	$logstr = "";
 
+	define( 'PMPRO_DOING_WEBHOOK', 'stripe' );
+
 	//you can define a different # of seconds (define PMPRO_STRIPE_WEBHOOK_DELAY in your wp-config.php) if you need this webhook to delay more or less
 	if(!defined('PMPRO_STRIPE_WEBHOOK_DELAY'))
 		define('PMPRO_STRIPE_WEBHOOK_DELAY', 2);

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -20,6 +20,8 @@
 	global $wpdb, $gateway_environment, $logstr;
 	$logstr = "";	//will put debug info here and write to inslog.txt
 
+	define( 'PMPRO_DOING_WEBHOOK', 'twocheckout' );
+
 	//validate?
 	if( ! pmpro_twocheckoutValidate() ) {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Contains part of the fixes needed to ensure that tax is calculated correctly on renewal orders.

Resolves XXX.

### How to test the changes in this Pull Request:

1. The PMPro Vat Tax Add On should be active
2. Proceed through checkout for a recurring membership
3. Tax should be correct. The this fix should ensure that the tax rates and values show correctly on renewals too

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Tax rates are now recorded correctly on renewal orders
