### PR TITLE
Fixes notices and undefined variables when using Braintree

### DIFF
--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -990,18 +990,17 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 			
 				try {
 					$webhookNotification = Braintree_WebhookNotification::parse( $_POST['bt_signature'], $_POST['bt_payload'] );
+					if ( Braintree_WebhookNotification::SUBSCRIPTION_CANCELED === $webhookNotification->kind ) {
+					    // Return, we're already processing the cancellation
+					    return true;
+		            }
 				} catch ( \Exception $e ) {
 				    // Don't do anything
 				}
 			}
 			
 			// Always cancel, even if Braintree fails
-			$order->updateStatus("cancelled" );
-			
-			if ( Braintree_WebhookNotification::SUBSCRIPTION_CANCELED === $webhookNotification->kind ) {
-			    // Return, we're already processing the cancellation
-			    return true;
-            }
+			$order->updateStatus("cancelled" );			
             
 			//require a subscription id
 			if(empty($order->subscription_transaction_id))

--- a/includes/lib/Braintree/lib/Braintree/Util.php
+++ b/includes/lib/Braintree/lib/Braintree/Util.php
@@ -99,7 +99,7 @@ class Util
 
             switch($error["extensions"]["errorClass"]) {
             case "VALIDATION":
-                continue;
+                continue 2;
             case "AUTHENTICATION":
                 throw new Exception\Authentication();
                 break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

These changes resolve errors that occurred during checkout when using the Braintree gateway

### How to test the changes in this Pull Request:

1. Have an existing membership (untested if this occurred because of another gateway being used before)
2. Sign up for a new membership 
3. Errors will show up and prevent you from being redirected to the confirmation page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Errors resolved that would show during checkout from the Braintree payment gateway
