### PR TITLE
Remove sanitize_text_field on password fields

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -273,7 +273,7 @@
 				else
 					$username = "";
 				if(isset($_REQUEST['password']))
-					$password = sanitize_text_field($_REQUEST['password']);
+					$password = $_REQUEST['password'];
 				else
 					$password = "";
 				if(isset($_REQUEST['bemail']))

--- a/includes/login.php
+++ b/includes/login.php
@@ -377,7 +377,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 	}
 
 	if ( isset( $_GET['password'] ) ) {
-		switch( sanitize_text_field( $_GET['password'] ) ) {
+		switch( $_GET['password'] ) {
 			case 'changed':
 				$message = __( 'Your password has successfully been updated.', 'paid-memberships-pro' );
 				$msgt = 'pmpro_success';

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -238,14 +238,14 @@ if ( isset( $_REQUEST['username'] ) ) {
 	$username = "";
 }
 if ( isset( $_REQUEST['password'] ) ) {
-	$password = sanitize_text_field($_REQUEST['password']);
+	$password = $_REQUEST['password'];
 } else {
 	$password = "";
 }
 if ( isset( $_REQUEST['password2_copy'] ) ) {
 	$password2 = $password;
 } elseif ( isset( $_REQUEST['password2'] ) ) {
-	$password2 = sanitize_text_field($_REQUEST['password2']);
+	$password2 = $_REQUEST['password2'];
 } else {
 	$password2 = "";
 }


### PR DESCRIPTION
* BUG FIX: Removed sanitize_text_field calls for password fields as it was stripping characters in some cases.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

calling `sanitize_text_field` on passwords would remove certain characters from the password. For example "my<pass>" would result in the password being saved as "my".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* BUG FIX: Removed sanitize_text_field calls for password fields as it was stripping characters in some cases.
