### PR TITLE
Warning user if stripe billing period longer than 1 year

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -617,7 +617,9 @@
 									<p class="description"><?php _e('The amount to be billed one cycle after the initial payment.', 'paid-memberships-pro' );?></p>
 									<?php if($gateway == "braintree") { ?>
 										<strong <?php if(!empty($pmpro_braintree_error)) { ?>class="pmpro_red"<?php } ?>><?php _e('Braintree integration currently only supports billing periods of "Month" or "Year".', 'paid-memberships-pro' );?></strong>
-									<?php } ?>
+									<?php } elseif($gateway == "stripe") { ?>
+										<p class="description"><strong <?php if(!empty($pmpro_stripe_error)) { ?>class="pmpro_red"<?php } ?>><?php _e('Stripe integration does not allow billing periods longer than 1 year.', 'paid-memberships-pro' );?></strong></p>
+									<?php }?>
 								</td>
 							</tr>
 

--- a/adminpages/functions.php
+++ b/adminpages/functions.php
@@ -51,8 +51,18 @@ function pmpro_checkLevelForStripeCompatibility($level = NULL)
 			if(is_numeric($level))
 				$level = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = %d LIMIT 1" , $level ) );
 
-			//check this level
+			// Check if this level uses billing limits.
 			if ( ( $level->billing_limit > 0 ) && ! function_exists( 'pmprosbl_plugin_row_meta' ) ) {
+				return false;
+			}
+
+			// Check if this level has a billing period longer than 1 year.
+			if ( 
+				( $level->cycle_period === 'Year' && $level->cycle_number > 1 ) ||
+				( $level->cycle_period === 'Month' && $level->cycle_number > 12 ) ||
+				( $level->cycle_period === 'Week' && $level->cycle_number > 52 ) ||
+				( $level->cycle_period === 'Day' && $level->cycle_number > 365 )
+			) {
 				return false;
 			}
 		}
@@ -231,7 +241,19 @@ function pmpro_check_discount_code_level_for_gateway_compatibility( $discount_co
 
 		// Check this discount code level for gateway compatibility
 		if ( $gateway == 'stripe' ) {
-			if ( ( $discount_code_level->billing_limit > 0 ) && ! function_exists( 'pmprosbl_plugin_row_meta' ) ) {
+			// Check if this code level has a billing limit.
+			if ( ( intval( $discount_code_level->billing_limit ) > 0 ) && ! function_exists( 'pmprosbl_plugin_row_meta' ) ) {
+				global $pmpro_stripe_error;
+				$pmpro_stripe_error = true;
+				return false;
+			}
+			// Check if this code level has a billing period longer than 1 year.
+			if ( 
+				( $discount_code_level->cycle_period === 'Year' && intval( $discount_code_level->cycle_number ) > 1 ) ||
+				( $discount_code_level->cycle_period === 'Month' && intval( $discount_code_level->cycle_number ) > 12 ) ||
+				( $discount_code_level->cycle_period === 'Week' && intval( $discount_code_level->cycle_number ) > 52 ) ||
+				( $discount_code_level->cycle_period === 'Day' && intval( $discount_code_level->cycle_number ) > 365 )
+			) {
 				global $pmpro_stripe_error;
 				$pmpro_stripe_error = true;
 				return false;

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -446,7 +446,9 @@
 							<?php _e('The amount to be billed one cycle after the initial payment.', 'paid-memberships-pro' );?>
 							<?php if($gateway == "braintree") { ?>
 								<strong <?php if(!empty($pmpro_braintree_error)) { ?>class="pmpro_red"<?php } ?>><?php _e('Braintree integration currently only supports billing periods of "Month" or "Year".', 'paid-memberships-pro' );?></strong>
-							<?php } ?>
+							<?php } elseif($gateway == "stripe") { ?>
+								<p class="description"><strong <?php if(!empty($pmpro_stripe_error)) { ?>class="pmpro_red"<?php } ?>><?php _e('Stripe integration does not allow billing periods longer than 1 year.', 'paid-memberships-pro' );?></strong></p>
+							<?php }?>
 						</p>
 						<?php if($gateway == "braintree" && $edit < 0) { ?>
 							<p class="pmpro_message"><strong><?php _e('Note', 'paid-memberships-pro' );?>:</strong> <?php _e('After saving this level, make note of the ID and create a "Plan" in your Braintree dashboard with the same settings and the "Plan ID" set to <em>pmpro_#</em>, where # is the level ID.', 'paid-memberships-pro' );?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Show warning to user if membership levels/discount codes have recurring payment periods longer than 1 year while Stripe is set as gateway. Recurring payment periods longer than 1 year are not supported by the Stripe API:
https://stripe.com/docs/api/plans/create#create_plan-interval_count

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a membership level with a billing period longer than 1 year
2. Save the level and see that a warning is shown on levels page/while editing level

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
