### PR TITLE
Fix: Cannot start session when headers already sent

### DIFF
--- a/includes/sessions.php
+++ b/includes/sessions.php
@@ -21,15 +21,19 @@ function pmpro_start_session() {
         if (defined('STDIN')) {
             //command line
         } else {
-            if (version_compare(phpversion(), '5.4.0', '>=')) {
-                if (session_status() == PHP_SESSION_NONE) {
-                    session_start();
+	    if (headers_sent() {
+		//someone already sent something
+	    }else{
+		if (version_compare(phpversion(), '5.4.0', '>=')) {
+		    if (session_status() == PHP_SESSION_NONE) {
+                        session_start();
+                    }
+                } else {
+                    if (!session_id()) {
+                        session_start();
+		    }
                 }
-            } else {
-                if (!session_id()) {
-                    session_start();
-                }
-            }
+	    }
         }
     }
 }


### PR DESCRIPTION
This one happens frequently. There are two ways to fix it. 
One is start the session waaaay before. The ore way, is properly check if already opened.

This one is the proper check.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1172.
Resolves #232.

### How to test the changes in this Pull Request:

1. Add these lines in functions.php (with warnings display set to true, to simplify the test)
```
add_action( "init", function () {
	trigger_error("towanda", E_USER_WARNING);
} );
```
2. You will see the headers already sent error in logs

```
PHP Warning:  towanda in /wp-content/themes/my-child/functions.php on line 42
PHP Warning:  session_start(): Cannot start session when headers already sent in /wp-content/plugins/paid-memberships-pro/includes/sessions.php on line 21
```
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
