### PR TITLE
Extend order code possibilities to base-36 (0-9A-Z)

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -837,9 +837,15 @@
 			$count++;
 
 			while( empty( $code ) ) {
+				// create a unique scramble which uses a base-36 representation
 				$scramble = md5( AUTH_KEY . microtime() . SECURE_AUTH_KEY . $count );
+				$scramble = base_convert( $scramble, 16, 36 );
+
+				// create the code stripping out the extra chars
 				$code = substr( $scramble, 0, 10 );
 				$code = apply_filters( 'pmpro_random_code', $code, $this );	//filter
+
+				// ensure the uniqueness
 				$check = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE code = '$code' LIMIT 1" );
 				if( $check || is_numeric( $code ) ) {
 					$code = NULL;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Extend order code possibilities to base-36 (0-9A-Z), to add even more entropy and less collisions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
