### PR TITLE
Fixing 2Checkout Discount Codes User Count and Custom Expiration Date (enddate) Settings

### DIFF
--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -217,7 +217,7 @@
 		 */
 		static function pmpro_checkout_before_change_membership_level($user_id, $morder)
 		{
-			global $wpdb, $discount_code_id;
+			global $wpdb;
 
 			//if no order, no need to pay
 			if(empty($morder))
@@ -227,9 +227,11 @@
 			$morder->saveOrder();
 
 			//save discount code use
-			if(!empty($discount_code_id))
+			if(isset($morder->membership_level) && !empty($morder->membership_level->code_id))
+			{
+				$discount_code_id = (int)$morder->membership_level->code_id;
 				$wpdb->query("INSERT INTO $wpdb->pmpro_discount_codes_uses (code_id, user_id, order_id, timestamp) VALUES('" . $discount_code_id . "', '" . $user_id . "', '" . $morder->id . "', now())");
-
+			}
 			do_action("pmpro_before_send_to_twocheckout", $user_id, $morder);
 
 			$morder->Gateway->sendToTwocheckout($morder);

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -274,6 +274,17 @@
 		//set the start date to current_time('mysql') but allow filters (documented in preheaders/checkout.php)
 		$startdate = apply_filters("pmpro_checkout_start_date", "'" . current_time('mysql') . "'", $morder->user_id, $morder->membership_level);
 
+		//get discount code
+		$morder->getDiscountCode();
+		if(!empty($morder->discount_code))
+		{
+			//update membership level
+			$morder->getMembershipLevel(true);
+			$discount_code_id = $morder->discount_code->id;
+		}
+		else
+			$discount_code_id = "";
+		
 		//fix expiration date
 		if(!empty($morder->membership_level->expiration_number))
 		{
@@ -286,19 +297,6 @@
 
 		//filter the enddate (documented in preheaders/checkout.php)
 		$enddate = apply_filters("pmpro_checkout_end_date", $enddate, $morder->user_id, $morder->membership_level, $startdate);
-
-		//get discount code
-		$morder->getDiscountCode();
-		if(!empty($morder->discount_code))
-		{
-			//update membership level
-			$morder->getMembershipLevel(true);
-			$discount_code_id = $morder->discount_code->id;
-		}
-		else
-			$discount_code_id = "";
-
-		
 
 		//custom level to change user to
 		$custom_level = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves The following problems regarding discount codes and 2checkout :
1- Increase user count when discount code is used
2- Reads the new enddate after the discount code is applied

### How to test the changes in this Pull Request:

1. You need to have a Live fully functional 2checkout account integrated with pmpro
2. Create a Discount Code, edit the expiry date to a custom value different from the original membership
3. Test the Discount Code and you should see the increase of the user count that used this coupon and the custom expiry date should be applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
