### PR TITLE
BUG FIX: Moved pmpro_personal_options_update

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -405,13 +405,12 @@ function pmpro_member_profile_edit_form() {
 		return;
 	}
 
-	do_action( 'pmpro_personal_options_update', $current_user->ID );
-
 	// Saving profile updates.
 	if ( isset( $_POST['action'] ) && $_POST['action'] == 'update-profile' && $current_user->ID == $_POST['user_id'] && wp_verify_nonce( $_POST['update_user_nonce'], 'update-user_' . $current_user->ID ) ) {
 		$update           = true;
 		$user     		  = new stdClass;
 		$user->ID         = $_POST[ 'user_id' ];
+		do_action( 'pmpro_personal_options_update', $user->ID );
 	} else {
 		$update = false;
 	}


### PR DESCRIPTION
BUG FIX: Fixed an issue where pmpro_personal_options_update would run on page load. This now only runs when updating a user's profile.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->