### PR TITLE
Fixing pagination and export issues with a discount code filter on the Orders admin page.

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -814,7 +814,7 @@
 									</span>
 									<?php if ( (int)$uses > 0 ) { ?>
 										| <span class="orders">
-											<a title="<?php _e(' View Orders', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-orders', 'discount_code' => $code->id, 'filter' => 'with-discount-code' ), admin_url('admin.php' ) ); ?>"><?php _e( 'Orders', 'paid-memberships-pro' ); ?></a>
+											<a title="<?php _e(' View Orders', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $code->id, 'filter' => 'with-discount-code' ), admin_url('admin.php' ) ); ?>"><?php _e( 'Orders', 'paid-memberships-pro' ); ?></a>
 										</span>
 									<?php } ?>
 								</div>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -21,8 +21,8 @@ if ( isset( $_REQUEST['l'] ) ) {
 	$l = false;
 }
 
-if ( isset( $_REQUEST['discount_code'] ) ) {
-	$discount_code = intval( $_REQUEST['discount_code'] );
+if ( isset( $_REQUEST['discount-code'] ) ) {
+	$discount_code = intval( $_REQUEST['discount-code'] );
 } else {
 	$discount_code = false;
 }
@@ -1083,7 +1083,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 				$sqlQuery .= "ORDER BY id DESC ";
 				$codes = $wpdb->get_results($sqlQuery, OBJECT);
 				if ( ! empty( $codes ) ) { ?>
-				<select id="discount_code" name="discount_code">
+				<select id="discount-code" name="discount-code">
 					<?php foreach ( $codes as $code ) { ?>
 						<option
 							value="<?php echo esc_attr( $code->id ); ?>" <?php selected( $discount_code, $code->id ); ?>><?php echo esc_html( $code->code ); ?></option>
@@ -1125,7 +1125,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').hide();
 					jQuery('#status').hide();
 					jQuery('#l').hide();
-					jQuery('#discount_code').hide();
+					jQuery('#discount-code').hide();
 					jQuery('#from').hide();
 					jQuery('#to').hide();
 					jQuery('#submit').show();
@@ -1141,7 +1141,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').hide();
 					jQuery('#status').hide();
 					jQuery('#l').hide();
-					jQuery('#discount_code').hide();
+					jQuery('#discount-code').hide();
 					jQuery('#submit').show();
 					jQuery('#from').show();
 					jQuery('#to').show();
@@ -1157,7 +1157,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').show();
 					jQuery('#status').hide();
 					jQuery('#l').hide();
-					jQuery('#discount_code').hide();
+					jQuery('#discount-code').hide();
 					jQuery('#submit').show();
 					jQuery('#from').hide();
 					jQuery('#to').hide();
@@ -1173,7 +1173,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').hide();
 					jQuery('#status').hide();
 					jQuery('#l').show();
-					jQuery('#discount_code').hide();
+					jQuery('#discount-code').hide();
 					jQuery('#submit').show();
 					jQuery('#from').hide();
 					jQuery('#to').hide();
@@ -1189,7 +1189,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').hide();
 					jQuery('#status').hide();
 					jQuery('#l').hide();
-					jQuery('#discount_code').show();
+					jQuery('#discount-code').show();
 					jQuery('#submit').show();
 					jQuery('#from').hide();
 					jQuery('#to').hide();
@@ -1205,7 +1205,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').hide();
 					jQuery('#status').show();
 					jQuery('#l').hide();
-					jQuery('#discount_code').hide();
+					jQuery('#discount-code').hide();
 					jQuery('#submit').show();
 					jQuery('#from').hide();
 					jQuery('#to').hide();
@@ -1221,7 +1221,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					jQuery('#predefined-date').hide();
 					jQuery('#status').hide();
 					jQuery('#l').hide();
-					jQuery('#discount_code').hide();
+					jQuery('#discount-code').hide();
 					jQuery('#submit').show();
 					jQuery('#from').hide();
 					jQuery('#to').hide();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There was an issue with pagination of the Orders admin page if you selected to filter by a discount code. Page 2 of the view, even if there were orders that fit the filter, would be blank. This PR resolves the error.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Fixed pagination of the Order admin page when filtering by a discount code used.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
