### PR TITLE
PHP8: Deprecated Notices Fixed

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1379,7 +1379,7 @@ function pmpro_getMetavalues( $query ) {
 }
 
 // function to return the pagination string
-function pmpro_getPaginationString( $page = 1, $totalitems, $limit = 15, $adjacents = 1, $targetpage = '/', $pagestring = '&pn=' ) {
+function pmpro_getPaginationString( $page = 1, $totalitems = 0, $limit = 15, $adjacents = 1, $targetpage = '/', $pagestring = '&pn=' ) {
 	// defaults
 	if ( ! $adjacents ) {
 		$adjacents = 1;
@@ -2065,7 +2065,7 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
  * @param  int $user_id User ID to check for
  * @param  int $level_id Level ID to check for.
  */
-function pmpro_getSpecificMembershipLevelForUser( $user_id = null, $level_id ) {
+function pmpro_getSpecificMembershipLevelForUser( $user_id = null, $level_id = null ) {
 	if ( empty( $user_id ) ) {
 		global $current_user;
 		$user_id = $current_user->ID;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

PHP8 Deprecated Notices Fixed. It's frowned upon to have an optional variable in a function followed by a required variable. We should either switch them around (not doing this here), or give both variables a default value in the function.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

Errors that occurred upon activate:

```
[02-Dec-2020 10:15:24 UTC] PHP Deprecated:  Required parameter $totalitems follows optional parameter $page in /srv/users/phptesting/apps/php8/public/wp-content/plugins/paid-memberships-pro/includes/functions.php on line 1382

[02-Dec-2020 10:15:24 UTC] PHP Deprecated:  Required parameter $level_id follows optional parameter $user_id in /srv/users/phptesting/apps/php8/public/wp-content/plugins/paid-memberships-pro/includes/functions.php on line 2068
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Depreciated notices fixed for PHP8 compatibility.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
