### PR TITLE
Fixed issue where checkout_levels endpoint could return wrong initial payment

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -596,7 +596,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			foreach ( $level_ids as $level_id ) {
 				$r[ $level_id ] = pmpro_getLevelAtCheckout( $level_id, $discount_code );
 				if ( ! empty( $r[ $level_id ]->initial_payment ) ) {
-					$r['initial_payment'] += intval( $r[ $level_id ]->initial_payment );
+					$r['initial_payment'] += floatval( $r[ $level_id ]->initial_payment );
 				}
 			}
 			$r['initial_payment_formatted'] = pmpro_formatPrice( $r['initial_payment'] );


### PR DESCRIPTION
This could cause the incorrect amount to be shown in Apple Pay/Google Pay, even though the correct amount is charged.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Using `floatval()` instead of `intval()` around initial payment prices.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
