### PR TITLE
Fixed level change issues during 2Checkout checkout

### DIFF
--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -266,24 +266,37 @@
 	*/
 	function pmpro_insChangeMembershipLevel($txn_id, &$morder)
 	{
+		global $wpdb;
 		$recurring = pmpro_getParam( 'recurring', 'POST' );
+
+		// Get discount code.
+		$morder->getDiscountCode();
+		if ( ! empty( $morder->discount_code ) ) {
+			// Update membership level
+			$morder->getMembershipLevel(true);
+			$discount_code_id = $morder->discount_code->id;
+		} else {
+			$discount_code_id = "";
+		}
+
+		// If this is an initial payment...
+		if ( empty( pmpro_getParam( 'message_type', 'REQUEST' ) ) || pmpro_getParam( 'message_type', 'REQUEST' ) === 'ORDER_CREATED' ) {
+			// Apply discount code level changes.
+			if ( ! empty( $discount_code_id ) ) {
+				$sqlQuery                 = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups, l.confirmation FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.id = '" . $discount_code_id . "' AND cl.level_id = '" . $morder->membership_level->level_id . "' LIMIT 1";
+				$morder->membership_level = $wpdb->get_row( $sqlQuery );
+			}
+	
+			// Extend membership if renewal.
+			// Added manually because pmpro_checkout_level filter is not run.
+			$morder->membership_level = pmpro_checkout_level_extend_memberships( $morder->membership_level );
+		}
 
 		//filter for level
 		$morder->membership_level = apply_filters("pmpro_inshandler_level", $morder->membership_level, $morder->user_id);
 
 		//set the start date to current_time('mysql') but allow filters (documented in preheaders/checkout.php)
 		$startdate = apply_filters("pmpro_checkout_start_date", "'" . current_time('mysql') . "'", $morder->user_id, $morder->membership_level);
-
-		//get discount code
-		$morder->getDiscountCode();
-		if(!empty($morder->discount_code))
-		{
-			//update membership level
-			$morder->getMembershipLevel(true);
-			$discount_code_id = $morder->discount_code->id;
-		}
-		else
-			$discount_code_id = "";
 		
 		//fix expiration date
 		if(!empty($morder->membership_level->expiration_number))


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes the following issues when checking out using 2Checkout:
- Discount code not affecting membership level when changed (specifically when calculating expiration date)
- Membership renewals resetting expiration date instead of extending them

Note that changes being made via the `pmpro_checkout_level` filter still ARE NOT applied during the membership level change. This specifically affects custom code which modifies the expiration date of a membership. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1531

### How to test the changes in this Pull Request:

1. Create a discount code with a different expiry time than the level it is discounting
2. Set gateway to 2Checkout
3. Check out for membership level using discount code
4. Verify that expiration date is set correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
