### PR TITLE
Temporary method to getRealPaymentTransactionId

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -846,60 +846,76 @@
 				return false;
 
 			if( $order->payment_transaction_id == $order->subscription_transaction_id ){
-				/** Initial payment **/
-				$nvpStr = "";
-				// STARTDATE is Required, even if useless here. Start from 24h before the order timestamp, to avoid timezone related issues.
-				$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->getTimestamp() - DAY_IN_SECONDS ) . 'Z' );
-				// filter results by a specific transaction id.
-				$nvpStr .= "&TRANSACTIONID=" . urlencode($order->subscription_transaction_id);
-
-				$this->httpParsedResponseAr = $this->PPHttpPost('TransactionSearch', $nvpStr);
-
-				if( ! in_array( strtoupper( $this->httpParsedResponseAr["ACK"] ), [ 'SUCCESS', 'SUCCESSWITHWARNING' ] ) ){
-					// since we are using TRANSACTIONID=I-... which is NOT a transaction id,
-                    			// paypal is returning an error. but the results are actually filtered by that transaction id, usually.
-
-					// let's double check it.
-					if( ! isset( $this->httpParsedResponseAr['L_TRANSACTIONID0'] ) ){
-						// really no results? it's a real error.
-						return false;
-					}
-				}
-
-				$transaction_ids = [];
-				for( $i = 0; $i < PHP_INT_MAX; $i++ ){
-	    				// loop until we have results
-					if( ! isset( $this->httpParsedResponseAr["L_TRANSACTIONID$i"] ) ){
-						break;
-					}
-
-					// ignore I-... results
-					if( "I-" === substr( $this->httpParsedResponseAr["L_TRANSACTIONID$i"], 0 ,2 ) ){
-						if( $order->subscription_transaction_id != $this->httpParsedResponseAr["L_TRANSACTIONID$i"] ){
-							// if we got a result from another I- subscription transaction id,
-							// then something changed into paypal responses.
-							// var_dump( $this->httpParsedResponseAr, $this->httpParsedResponseAr["L_TRANSACTIONID$i"] );
-							throw new Exception();
-						}
-
-						continue;
-					}
-
-					$transaction_ids[] = $this->httpParsedResponseAr["L_TRANSACTIONID$i"];
-				}
-
-				// no payment_transaction_ids in results
-				if( empty( $transaction_ids ) ){
+				$payment_transaction_id = $this->getRealPaymentTransactionId();
+				if( ! $payment_transaction_id ){
 					return false;
 				}
 
-				// found the payment transaction id, it's the last one (the oldest)
-				$payment_transaction_id = end( $transaction_ids );
 				return $this->getTransactionDetails( $payment_transaction_id );
 			}else{
 				/** Recurring payment **/
 				return $this->getTransactionDetails( $order->payment_transaction_id );
 			}
+		}
+		
+		/**
+		 * Try to recover the real payment_transaction_id when payment_transaction_id === subscription_transaction_id === I-xxxxxxxx.
+		 *
+		 * @since 1.8.5
+		*/
+		function getRealPaymentTransactionId()
+		{
+			/** Initial payment **/
+			$nvpStr = "";
+			// STARTDATE is Required, even if useless here. Start from 24h before the order timestamp, to avoid timezone related issues.
+			$nvpStr .= "&STARTDATE=" . urlencode( gmdate( DATE_W3C, $order->getTimestamp() - DAY_IN_SECONDS ) . 'Z' );
+			// filter results by a specific transaction id.
+			$nvpStr .= "&TRANSACTIONID=" . urlencode($order->subscription_transaction_id);
+
+			$this->httpParsedResponseAr = $this->PPHttpPost('TransactionSearch', $nvpStr);
+
+			if( ! in_array( strtoupper( $this->httpParsedResponseAr["ACK"] ), [ 'SUCCESS', 'SUCCESSWITHWARNING' ] ) ){
+				// since we are using TRANSACTIONID=I-... which is NOT a transaction id,
+				// paypal is returning an error. but the results are actually filtered by that transaction id, usually.
+
+				// let's double check it.
+				if( ! isset( $this->httpParsedResponseAr['L_TRANSACTIONID0'] ) ){
+					// really no results? it's a real error.
+					return false;
+				}
+			}
+
+			$transaction_ids = [];
+			for( $i = 0; $i < PHP_INT_MAX; $i++ ){
+				// loop until we have results
+				if( ! isset( $this->httpParsedResponseAr["L_TRANSACTIONID$i"] ) ){
+					break;
+				}
+
+				// ignore I-... results
+				if( "I-" === substr( $this->httpParsedResponseAr["L_TRANSACTIONID$i"], 0 ,2 ) ){
+					if( $order->subscription_transaction_id != $this->httpParsedResponseAr["L_TRANSACTIONID$i"] ){
+						// if we got a result from another I- subscription transaction id,
+						// then something changed into paypal responses.
+						// var_dump( $this->httpParsedResponseAr, $this->httpParsedResponseAr["L_TRANSACTIONID$i"] );
+						throw new Exception();
+					}
+
+					continue;
+				}
+
+				$transaction_ids[] = $this->httpParsedResponseAr["L_TRANSACTIONID$i"];
+			}
+
+			// no payment_transaction_ids in results
+			if( empty( $transaction_ids ) ){
+				return false;
+			}
+
+			// found the payment transaction id, it's the last one (the oldest)
+			$payment_transaction_id = end( $transaction_ids );
+			
+			return $payment_transaction_id;
 		}
 		
 		function getTransactionDetails($payment_transaction_id)

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -846,7 +846,7 @@
 				return false;
 
 			if( $order->payment_transaction_id == $order->subscription_transaction_id ){
-				$payment_transaction_id = $this->getRealPaymentTransactionId();
+				$payment_transaction_id = $this->getRealPaymentTransactionId( $order );
 				if( ! $payment_transaction_id ){
 					return false;
 				}
@@ -863,7 +863,7 @@
 		 *
 		 * @since 1.8.5
 		*/
-		function getRealPaymentTransactionId()
+		function getRealPaymentTransactionId(&$order)
 		{
 			/** Initial payment **/
 			$nvpStr = "";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Separate the temporary hack to recover a missing transaction id for PayPal Express Gateway, to have a method to call directly when the missing transaction id is needed to do debug, refund automation...

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
