### PR TITLE
Changing license key field to text type and unmasked.

### DIFF
--- a/adminpages/license.php
+++ b/adminpages/license.php
@@ -56,7 +56,7 @@ if ( defined( 'PMPRO_DIR' ) ) {
 				<tbody>
 					<tr id="pmpro-settings-key-box">
 						<td>
-							<input type="password" name="pmpro-license-key" id="pmpro-license-key" value="<?php echo esc_attr($key);?>" placeholder="<?php _e('Enter license key here...', 'paid-memberships-pro' );?>" size="40"  />
+							<input type="text" name="pmpro-license-key" id="pmpro-license-key" value="<?php echo esc_attr($key);?>" placeholder="<?php _e('Enter license key here...', 'paid-memberships-pro' );?>" size="40" />
 							<?php wp_nonce_field( 'pmpro-key-nonce', 'pmpro-key-nonce' ); ?>
 							<?php submit_button( __( 'Validate Key', 'paid-memberships-pro' ), 'primary', 'pmpro-verify-submit', false ); ?>
 						</td>


### PR DESCRIPTION
The License Key field in the WordPress admin was previously a masked "password" type field, however this field was not actually masked in the page source or hashed in the database at all. Having this appear as a masked field implied it was a secure field. Additionally, we did some spot check for other plugin and license key handling to find that these fields are not commonly masked.

This should also reduce support for people who are trying to find what account is linked to their key. 