### PR TITLE
Adding avatar as a valid field type for the [pmpro_member] shortcode.

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -105,6 +105,9 @@ function pmpro_member_shortcode($atts, $content=null, $code='')
 		//wp_users column
 		$user = get_userdata($user_id);
 		$r = $user->{$field};
+	} elseif( $field == 'avatar' ) {
+		// Get the user's avatar.
+		$r = get_avatar( $user_id );
 	} else {
 		//assume user meta
 		$r = get_user_meta($user_id, $field, true);


### PR DESCRIPTION
Many users have asked for a way to show a current user's avatar on the Membership Account page and in other places in their membership site.

This PR adds support for a "avatar" field type when using the [pmpro_member] shortcode. We are using the default size for an avatar display (96px square) in WordPress.