### PR TITLE
Pagination now works when filtering orders by discount code

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -23,6 +23,8 @@ if ( isset( $_REQUEST['l'] ) ) {
 
 if ( isset( $_REQUEST['discount_code'] ) ) {
 	$discount_code = intval( $_REQUEST['discount_code'] );
+} elseif ( isset( $_REQUEST['discount-code'] ) ) {
+	$discount_code = intval( $_REQUEST['discount-code'] );
 } else {
 	$discount_code = false;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Allow PMPro Orders page to get discount code filter from `discount-code` in addition to `discount_code`. Originally, only `discount_code` was allowed, but pagination passed code through `discount-code`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:
Filter orders by discount code and confirm that pagination now works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
