### PR TITLE
Now rounding amount sent with Stripe payment request button.

### DIFF
--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -110,7 +110,7 @@ jQuery( document ).ready( function( $ ) {
 						currency: pmproStripe.currency,
 						total: {
 							label: pmproStripe.siteName,
-							amount: data.initial_payment * 100,
+							amount: Math.round( data.initial_payment * 100 ),
 						},
 						requestPayerName: true,
 						requestPayerEmail: true,
@@ -144,7 +144,7 @@ jQuery( document ).ready( function( $ ) {
 						paymentRequest.update({
 							total: {
 								label: pmproStripe.siteName,
-								amount: data.initial_payment * 100,
+								amount: Math.round( data.initial_payment * 100 ),
 							},
 						});
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Stripe expects the `amount` passed to be an integer containing the number of cents (I think they call it sub-currency units or something) to show as the charge amount when a user clicks the Payment Request Button. Sometimes our API call would pass an initial payment that contains partial cents. I am using Math.Round here to ensure that the amount we pass is an integer and not a decimal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
