### PR TITLE
Continued wireframes code for user fields admin page post-call notes.

### DIFF
--- a/adminpages/userfields.php
+++ b/adminpages/userfields.php
@@ -4,6 +4,16 @@
 		die( __( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 	}
 
+	/**
+	 * Get all levels regardless of visibility.
+	 *
+	 */
+	$levels = pmpro_getAllLevels( false, true );
+
+	/**
+	 * Load the common header for admin pages.
+	 *
+	 */
 	require_once( dirname(__FILE__) . '/admin_header.php' );
 
 	/**
@@ -17,6 +27,13 @@
 		'memberships_page_pmpro-userfields',
 		'side'
 	);
+	add_meta_box(
+		'pmpro_userfields_help',
+		esc_html( 'User Fields Help', 'paid-memberships-pro' ),
+		'pmpro_userfields_help_widget',
+		'memberships_page_pmpro-userfields',
+		'side'
+	);
 
 	/**
 	 * Meta box to show a save button and other data.
@@ -26,6 +43,16 @@
 		<p class="submit">
 			<input name="savesettings" type="submit" class="button-primary" value="<?php esc_attr_e( 'Save All Settings', 'paid-memberships-pro' ); ?>" />
 		</p>
+		<?php
+	}
+
+	/**
+	 * Meta box to show help information.
+	 *
+	 */
+	function pmpro_userfields_help_widget() { ?>
+		<p><?php esc_html_e( 'User fields can be added to the membership checkout form, the frontend user profile edit page, and for admins only on the Edit Users Screen in the WordPress admin.', 'paid-memberships-pro' ); ?></p>
+		<p><?php esc_html_e( 'Groups are used to define a collection of fields that should be displayed together under a common heading. Group settings control field locations and membership level visibility.', 'paid-memberships-pro' ); ?></p>
 		<?php
 	}
 
@@ -46,9 +73,22 @@
 						<div class="pmpro_userfield-group pmpro_userfield-group-collapse">
 							<?php /* this is just a sample view of a collapsed group */ ?> 
 							<div class="pmpro_userfield-group-header">
-								<button type="button" class="pmpro_userfield-action pmpro_userfield-show"><span class="screen-reader-text"><?php esc_html_e( 'Edit Group', 'paid-memberships-pro' ); ?></span></button>
+								<div class="pmpro_userfield-group-buttons">
+									<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-1" id="pmpro_userfield-group-buttons-button-move-up" aria-disabled="true" disabled="disabled" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move up', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-up-alt2"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-1" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Group Up', 'paid-memberships-pro' ); ?></span>
+
+									<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-2" id="pmpro_userfield-group-buttons-button-move-down" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move down', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-down-alt2"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-2" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Group Down', 'paid-memberships-pro' ); ?></span>
+								</div> <!-- end pmpro_userfield-group-buttons -->
 								<h3>More Information</h3>
-								<button type="button" class="pmpro_userfield-action pmpro_userfield-pinned"><span class="screen-reader-text"><?php esc_html_e( 'Move Group', 'paid-memberships-pro' ); ?></span></button>
+								<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-3" id="pmpro_userfield-group-buttons-button-expand-group" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Expand and Edit Group', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-right"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-3" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Expand and Edit Group', 'paid-memberships-pro' ); ?></span>
 							</div> <!-- end pmpro_userfield-group-header -->
 							<div class="pmpro_userfield-inside">
 								blah blah blah this is hidden.
@@ -57,12 +97,25 @@
 
 						<div class="pmpro_userfield-group">
 							<div class="pmpro_userfield-group-header">
-								<button type="button" class="pmpro_userfield-action pmpro_userfield-hide"><span class="screen-reader-text"><?php esc_html_e( 'Close Group', 'paid-memberships-pro' ); ?></span></button>
+								<div class="pmpro_userfield-group-buttons">
+									<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-1" id="pmpro_userfield-group-buttons-button-move-up" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move up', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-up-alt2"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-1" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Group Up', 'paid-memberships-pro' ); ?></span>
+
+									<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-2" id="pmpro_userfield-group-buttons-button-move-down" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move down', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-down-alt2"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-2" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Group Down', 'paid-memberships-pro' ); ?></span>
+								</div> <!-- end pmpro_userfield-group-buttons -->
 								<h3>
 									<label for="pmpro_userfields_group_name"><?php esc_html_e( 'Group Name', 'paid-memberships-pro' ); ?></label>
 									<input type="text" name="pmpro_userfields_group_name" placeholder="Group Name" value="About My Cat" />
 								</h3>
-								<button type="button" class="pmpro_userfield-action pmpro_userfield-move"><span class="screen-reader-text"><?php esc_html_e( 'Move Group', 'paid-memberships-pro' ); ?></span></button>
+								<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-3" id="pmpro_userfield-group-buttons-button-expand-group" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Expand and Edit Group', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-down"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-3" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Expand and Edit Group', 'paid-memberships-pro' ); ?></span>
 							</div> <!-- end pmpro_userfield-group-header -->
 							
 							<div class="pmpro_userfield-inside">
@@ -93,14 +146,11 @@
 									
 									<div class="pmpro_userfield-field-setting">
 										<label for="pmpro_userfields_group_membership"><?php esc_html_e( 'Restrict Group for Membership Levels', 'paid-memberships-pro' ); ?></label>
-										<select multiple="multiple" name="pmpro_userfields_group_membership">
-											<option>Beginner</option>
-											<option>Enhanced</option>
-											<option>Supporter</option>
-											<option>Platinum</option>
-											<option>Ultimate</option>
-											<option>World Domination</option>
-										</select>
+										<div class="checkbox_box" <?php if ( count( $levels ) > 3 ) { ?>style="height: 90px; overflow: auto;"<?php } ?>>
+											<?php foreach( $levels as $level ) { ?>
+												<div class="clickable"><input type="checkbox" id="pmpro_userfields_group_membership_<?php echo $level->id?>" name="pmpro_userfields_group_membership[]"> <?php echo $level->name; ?></div>
+											<?php } ?>
+										</div>
 									</div> <!-- end pmpro_userfield-field-setting -->
 								
 								</div> <!-- end pmpro_userfield-field-settings -->
@@ -112,64 +162,91 @@
 									<li class="pmpro_userfield-group-column-label"><?php esc_html_e( 'Label', 'paid-memberships-pro'); ?></li>
 									<li class="pmpro_userfield-group-column-name"><?php esc_html_e( 'Name', 'paid-memberships-pro'); ?></li>
 									<li class="pmpro_userfield-group-column-type"><?php esc_html_e( 'Type', 'paid-memberships-pro'); ?></li>
-									<li class="pmpro_userfield-group-column-options"></li>
 								</ul>
 								
 								<div class="pmpro_userfield-group-fields">
 
 									<div class="pmpro_userfield-group-field pmpro_userfield-group-field-collapse">
 										<ul class="pmpro_userfield-group-tbody">
-											<li class="pmpro_userfield-group-column-order">1</li>
-											<li class="pmpro_userfield-group-column-label">Cat's Name</li>
+											<li class="pmpro_userfield-group-column-order">
+												<div class="pmpro_userfield-group-buttons">
+													<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-1" id="pmpro_userfield-group-buttons-button-move-up" aria-disabled="true" disabled="disabled" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move up', 'paid-memberships-pro' ); ?>">
+														<span class="dashicons dashicons-arrow-up-alt2"></span>
+													</button>
+													<span id="pmpro_userfield-group-buttons-description-1" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Field Up', 'paid-memberships-pro' ); ?></span>
+
+													<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-2" id="pmpro_userfield-group-buttons-button-move-down" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move down', 'paid-memberships-pro' ); ?>">
+														<span class="dashicons dashicons-arrow-down-alt2"></span>
+													</button>
+													<span id="pmpro_userfield-group-buttons-description-2" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Field Down', 'paid-memberships-pro' ); ?></span>
+												</div> <!-- end pmpro_userfield-group-buttons -->
+											</li>
+											<li class="pmpro_userfield-group-column-label">
+												<span class="pmpro_userfield-label">Cat's Name</span>
+												<div class="pmpro_userfield-group-options">
+													<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a> |
+													<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a> |
+													<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+												</div> <!-- end pmpro_userfield-group-options -->
+											</li>
 											<li class="pmpro_userfield-group-column-name">cat_name</li>
 											<li class="pmpro_userfield-group-column-type">Text</li>
-											<li class="pmpro_userfield-group-column-options">
-												<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a>
-												<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a>
-												<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
-											</li>
 										</ul>
 									</div> <!-- end pmpro_userfield-group-field -->
 
 									<div class="pmpro_userfield-group-field pmpro_userfield-group-field-collapse">
 										<ul class="pmpro_userfield-group-tbody">
-											<li class="pmpro_userfield-group-column-order">2</li>
-											<li class="pmpro_userfield-group-column-label">Cat's Breed</li>
+											<li class="pmpro_userfield-group-column-order">
+												<div class="pmpro_userfield-group-buttons">
+													<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-1" id="pmpro_userfield-group-buttons-button-move-up" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move up', 'paid-memberships-pro' ); ?>">
+														<span class="dashicons dashicons-arrow-up-alt2"></span>
+													</button>
+													<span id="pmpro_userfield-group-buttons-description-1" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Field Up', 'paid-memberships-pro' ); ?></span>
+
+													<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-2" id="pmpro_userfield-group-buttons-button-move-down" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move down', 'paid-memberships-pro' ); ?>">
+														<span class="dashicons dashicons-arrow-down-alt2"></span>
+													</button>
+													<span id="pmpro_userfield-group-buttons-description-2" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Field Down', 'paid-memberships-pro' ); ?></span>
+												</div> <!-- end pmpro_userfield-group-buttons -->
+											</li>
+											<li class="pmpro_userfield-group-column-label">
+												<span class="pmpro_userfield-label">Cat's Breed</span>
+												<div class="pmpro_userfield-group-options">
+													<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a> |
+													<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a> |
+													<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+												</div> <!-- end pmpro_userfield-group-options -->
+											</li>
 											<li class="pmpro_userfield-group-column-name">cat_breed</li>
 											<li class="pmpro_userfield-group-column-type">Select</li>
-											<li class="pmpro_userfield-group-column-options">
-												<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a>
-												<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a>
-												<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
-											</li>
-										</ul>
-									</div> <!-- end pmpro_userfield-group-field -->
-
-									<div class="pmpro_userfield-group-field pmpro_userfield-group-field-collapse">
-										<ul class="pmpro_userfield-group-tbody">
-											<li class="pmpro_userfield-group-column-order">3</li>
-											<li class="pmpro_userfield-group-column-label">Cat's Sex</li>
-											<li class="pmpro_userfield-group-column-name">cat_sex</li>
-											<li class="pmpro_userfield-group-column-type">Radio</li>
-											<li class="pmpro_userfield-group-column-options">
-												<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a>
-												<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a>
-												<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
-											</li>
 										</ul>
 									</div> <!-- end pmpro_userfield-group-field -->
 
 									<div class="pmpro_userfield-group-field pmpro_userfield-group-field-expand">
 										<ul class="pmpro_userfield-group-tbody">
-											<li class="pmpro_userfield-group-column-order">4</li>
-											<li class="pmpro_userfield-group-column-label">Favorite Food</li>
+											<li class="pmpro_userfield-group-column-order">
+												<div class="pmpro_userfield-group-buttons">
+													<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-1" id="pmpro_userfield-group-buttons-button-move-up" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move up', 'paid-memberships-pro' ); ?>">
+														<span class="dashicons dashicons-arrow-up-alt2"></span>
+													</button>
+													<span id="pmpro_userfield-group-buttons-description-1" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Field Up', 'paid-memberships-pro' ); ?></span>
+
+													<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-2" id="pmpro_userfield-group-buttons-button-move-down" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move down', 'paid-memberships-pro' ); ?>">
+														<span class="dashicons dashicons-arrow-down-alt2"></span>
+													</button>
+													<span id="pmpro_userfield-group-buttons-description-2" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Field Down', 'paid-memberships-pro' ); ?></span>
+												</div> <!-- end pmpro_userfield-group-buttons -->
+											</li>
+											<li class="pmpro_userfield-group-column-label">
+												<span class="pmpro_userfield-label">Favorite Food</span>
+												<div class="pmpro_userfield-group-options">
+													<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a> |
+													<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a> |
+													<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+												</div> <!-- end pmpro_userfield-group-options -->
+											</li>
 											<li class="pmpro_userfield-group-column-name">cat_food</li>
 											<li class="pmpro_userfield-group-column-type">Text</li>
-											<li class="pmpro_userfield-group-column-options">
-												<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a>
-												<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a>
-												<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
-											</li>
 										</ul>
 
 										<div class="pmpro_userfield-field-settings">
@@ -177,13 +254,13 @@
 											<div class="pmpro_userfield-field-setting">
 												<label for="pmpro_userfields_field-label"><?php esc_html_e( 'Label', 'paid-memberships-pro' ); ?></label>
 												<input type="text" name="pmpro_userfields-field-label" value="Favorite Food" />
-												<span class="description"><?php esc_html_e( 'Brief descriptive text for the field, shown on user forms.', 'paid-memberships-pro' ); ?></span>
+												<span class="description"><?php esc_html_e( 'Brief descriptive text for the field. Shown on user forms.', 'paid-memberships-pro' ); ?></span>
 											</div> <!-- end pmpro_userfield-field-setting -->
 
 											<div class="pmpro_userfield-field-setting">
 												<label for="pmpro_userfields_field-name"><?php esc_html_e( 'Name', 'paid-memberships-pro' ); ?></label>
 												<input type="text" name="pmpro_userfields-field-name" value="cat_food" />
-												<span class="description"><?php esc_html_e( 'Single word, no spaces. Underscores and dashes allowed', 'paid-memberships-pro' ); ?></span>
+												<span class="description"><?php esc_html_e( 'Single word with no spaces. Underscores are allowed.', 'paid-memberships-pro' ); ?></span>
 											</div> <!-- end pmpro_userfield-field-setting -->
 
 											<div class="pmpro_userfield-field-setting">
@@ -203,23 +280,23 @@
 												</select>												
 											</div> <!-- end pmpro_userfield-field-setting -->
 
-											<div class="pmpro_userfield-field-setting pmpro_userfield-field-setting-radio">
-												<label for="pmpro_userfields_field-required"><?php esc_html_e( 'Required?', 'paid-memberships-pro' ); ?></label>
-												<span><input name="pmpro_userfields_field-required" type="radio" value="1" /> <?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></span>
-												<span><input name="pmpro_userfields_field-required" type="radio" value="0" /> <?php esc_html_e( 'No', 'paid-memberships-pro' ); ?></span>
-											</div> <!-- end pmpro_userfield-field-setting -->
+											<div class="pmpro_userfield-field-setting pmpro_userfield-field-setting-dual">
+												<div class="pmpro_userfield-field-setting">
+													<label for="pmpro_userfields_field-required"><?php esc_html_e( 'Required?', 'paid-memberships-pro' ); ?></label>
+													<select name="pmpro_userfields_field-required">
+														<option value="no" selected="selected"><?php esc_html_e( 'No', 'paid-memberships-pro' ); ?></option>
+														<option value="yes"><?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></option>
+													</select>
+												</div> <!-- end pmpro_userfield-field-setting -->
 
-											<div class="pmpro_userfield-field-setting pmpro_userfield-field-setting-radio">
-												<label for="pmpro_userfields_field-readonly"><?php esc_html_e( 'Read Only?', 'paid-memberships-pro' ); ?></label>
-												<span><input name="pmpro_userfields_field-readonly" type="radio" value="1" /> <?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></span>
-												<span><input name="pmpro_userfields_field-readonly" type="radio" value="0" /> <?php esc_html_e( 'No', 'paid-memberships-pro' ); ?></span>
-											</div> <!-- end pmpro_userfield-field-setting -->
-
-											<div class="pmpro_userfield-field-setting pmpro_userfield-field-setting-radio">
-												<label for="pmpro_userfields_field-conditional"><?php esc_html_e( 'Conditional Logic', 'paid-memberships-pro' ); ?></label>
-												<span><input name="pmpro_userfields_field-conditional" type="radio" value="1" /> <?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></span>
-												<span><input name="pmpro_userfields_field-conditional" type="radio" value="0" /> <?php esc_html_e( 'No', 'paid-memberships-pro' ); ?></span>
-											</div> <!-- end pmpro_userfield-field-setting -->
+												<div class="pmpro_userfield-field-setting">
+													<label for="pmpro_userfields_field-readonly"><?php esc_html_e( 'Read Only?', 'paid-memberships-pro' ); ?></label>
+												<select name="pmpro_userfields_field-readonly">
+														<option value="no" selected="selected"><?php esc_html_e( 'No', 'paid-memberships-pro' ); ?></option>
+														<option value="yes"><?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></option>
+													</select>
+												</div> <!-- end pmpro_userfield-field-setting -->
+											</div> <!-- end pmpro_userfield-field-setting-dual -->
 
 											<div class="pmpro_userfield-field-setting">
 												<label for="pmpro_userfields_field-membership"><?php esc_html_e( 'Membership Levels', 'paid-memberships-pro' ); ?></label>
@@ -252,26 +329,42 @@
 
 											<div class="pmpro_userfield-field-setting">
 												<label for="pmpro_userfields_field-hint"><?php esc_html_e( 'Hint', 'paid-memberships-pro' ); ?></label>
-												<input type="text" name="pmpro_userfields-field-hint" />
+												<textarea name="pmpro_userfields-field-hint" /></textarea>
 												<span class="description"><?php esc_html_e( 'Descriptive text for users or admins submitting the field.', 'paid-memberships-pro' ); ?></span>
 											</div> <!-- end pmpro_userfield-field-setting -->
 										</div> <!-- end pmpro_userfield-field-settings -->
-										<p class="text-center">
+										<div class="pmpro_userfield-field-actions">
 											<button name="pmpro_userfields_add_field" class="button button-secondary">
 												<?php esc_html_e( 'Close Field', 'paid-memberships-pro' ); ?>
 											</button>
-										</p>
+										</div> <!-- end pmpro_userfield-field-actions -->
+									</div> <!-- end pmpro_userfield-group-field -->
+
+									<div class="pmpro_userfield-group-field pmpro_userfield-group-field-collapse">
+										<ul class="pmpro_userfield-group-tbody">
+											<li class="pmpro_userfield-group-column-order">4</li>
+											<li class="pmpro_userfield-group-column-label">
+												<span class="pmpro_userfield-label">Cat's Age</span>
+												<div class="pmpro_userfield-group-options">
+													<a class="edit-field" title="<?php esc_html_e( 'Edit field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a> |
+													<a class="duplicate-field" title="<?php esc_html_e( 'Duplicate field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Duplicate', 'paid-memberships-pro' ); ?></a> |
+													<a class="delete-field" title="<?php esc_html_e( 'Delete field', 'paid-memberships-pro' ); ?>" href="#"><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+												</div> <!-- end pmpro_userfield-group-options -->
+											</li>
+											<li class="pmpro_userfield-group-column-name">cat_breed</li>
+											<li class="pmpro_userfield-group-column-type">Select</li>
+										</ul>
 									</div> <!-- end pmpro_userfield-group-field -->
 
 								</div> <!-- end pmpro_userfield-group-fields -->
 
-								<p class="text-center">
+								<div class="pmpro_userfield-group-actions">
 									<button name="pmpro_userfields_add_field" class="button button-secondary button-hero">
 										<?php
 											/* translators: a plus sign dashicon */
 											printf( esc_html__( '%s Add Field', 'paid-memberships-pro' ), '<span class="dashicons dashicons-plus"></span>' ); ?>
 									</button>
-								</p>
+								</div> <!-- end pmpro_userfield-group-actions -->
 
 							</div> <!-- end pmpro_userfield-inside -->
 
@@ -279,11 +372,24 @@
 
 						<div class="pmpro_userfield-group pmpro_userfield-group-collapse">
 							<div class="pmpro_userfield-group-header">
-								<?php /* this is just a sample view of a collapsed group */ ?> 
-								<button type="button" class="pmpro_userfield-action pmpro_userfield-show"><span class="screen-reader-text"><?php esc_html_e( 'Edit Group', 'paid-memberships-pro' ); ?></span></button>
+								<div class="pmpro_userfield-group-buttons">
+									<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-1" id="pmpro_userfield-group-buttons-button-move-up" aria-disabled="true" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move up', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-up-alt2"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-1" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Group Up', 'paid-memberships-pro' ); ?></span>
+
+									<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-2" id="pmpro_userfield-group-buttons-button-move-down" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Move down', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-down-alt2"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-2" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Move Group Down', 'paid-memberships-pro' ); ?></span>
+								</div> <!-- end pmpro_userfield-group-buttons -->
 								<h3>About My Dog</h3>
-								<button type="button" class="pmpro_userfield-action pmpro_userfield-move"><span class="screen-reader-text"><?php esc_html_e( 'Move Group', 'paid-memberships-pro' ); ?></span></button>
+								<button type="button" aria-describedby="pmpro_userfield-group-buttons-description-3" id="pmpro_userfield-group-buttons-button-expand-group" aria-disabled="false" class="pmpro_userfield-group-buttons-button" aria-label="<?php esc_html_e( 'Expand and Edit Group', 'paid-memberships-pro' ); ?>">
+										<span class="dashicons dashicons-arrow-right"></span>
+									</button>
+									<span id="pmpro_userfield-group-buttons-description-3" class="pmpro_userfield-group-buttons-description"><?php esc_html_e( 'Expand and Edit Group', 'paid-memberships-pro' ); ?></span>
 							</div> <!-- end pmpro_userfield-group-header -->
+
 							<div class="pmpro_userfield-inside">
 							blah blah blah this is hidden.
 							</div> <!-- end pmpro_userfield-inside -->	

--- a/css/admin.css
+++ b/css/admin.css
@@ -78,10 +78,26 @@
 }
 
 /* checkboxes */
-.checkbox_box {width: 300px; background: #FFFFFF; border: 1px solid #CCC;}
-.checkbox_box div {border-bottom: 1px solid #CCC; padding: 3px;}
-.checkbox_box .clickable {cursor: pointer;}
-.checkbox_box .clickable:hover {background: #FFC;}
+.checkbox_box {
+	background: #FFFFFF;
+	border: 1px solid #7e8993;
+	border-radius: 4px;
+	color:#32373c;
+	width: 300px;
+}
+.checkbox_box div {
+	border-bottom: 1px solid #CCC;
+	padding: 4px;
+}
+.checkbox_box div:last-child {
+	border-bottom: none;
+}
+.checkbox_box .clickable {
+	cursor: pointer;
+}
+.checkbox_box .clickable:hover {
+	background: rgba( 255, 185, 0, 0.1 );
+}
 
 /* consent log */
 .pmpro_consent_log.pmpro_scrollable {
@@ -123,52 +139,35 @@
     max-width: none;
 }
 
-/* user field settings */
+/* Field Group Actions */
 .admin_page_pmpro-userfields button .dashicons {
 	vertical-align: middle;
 }
-/* Field Group Actions */
-.admin_page_pmpro-userfields .pmpro_userfield-action {
+.admin_page_pmpro-userfields .pmpro_userfield-group-buttons-button {
 	background: 0 0;
 	border: 0;
 	cursor: pointer;
 	flex-shrink: 0;
-	height: 36px;
 	margin: 0;
 	padding: 0;
-	width: 36px;
 }
-.admin_page_pmpro-userfields .pmpro_userfield-action:before {
-	font-family: dashicons;
-	color: #999;
-	display: inline-block;
-	line-height: 1;
-	font-weight: 400;
-	font-style: normal;
-	speak: never;
-	text-decoration: inherit;
-	text-transform: none;
-	text-rendering: auto;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	width: 20px;
-	height: 20px;
-	font-size: 20px;
-	vertical-align: top;
-	text-align: center;
+.admin_page_pmpro-userfields .pmpro_userfield-group-buttons-button:disabled {
+	color: #AAA;
 }
-.admin_page_pmpro-userfields .pmpro_userfield-pinned:before {
-	content: "\f109"; /* Pin/Thumbtack */
+.admin_page_pmpro-userfields .pmpro_userfield-group-buttons-description {
+	display: none;
 }
-.admin_page_pmpro-userfields .pmpro_userfield-move:before {
-	content: "\f545"; /* Multi-directional arrow */
+.admin_page_pmpro-userfields .pmpro_userfield-group-buttons-button.dashicons {
+	vertical-align: middle;
 }
-.admin_page_pmpro-userfields .pmpro_userfield-show:before {
-	content: "\f139";
+.admin_page_pmpro-userfields .pmpro_userfield-group-field-expand .pmpro_userfield-group-buttons-button {
+	color: #FFF;
 }
-.admin_page_pmpro-userfields .pmpro_userfield-hide:before {
-	content: "\f140";
+.admin_page_pmpro-userfields .pmpro_userfield-group-field-expand .pmpro_userfield-group-buttons-button:disabled {
+	color: #0071a1;
 }
+
+/* General User Fields Page Styles */
 .admin_page_pmpro-userfields .pmpro_userfield-inside label,
 .admin_page_pmpro-userfields .pmpro_userfield-inside .description {
 	display: block;
@@ -181,6 +180,13 @@
 .admin_page_pmpro-userfields .pmpro_userfield-inside select,
 .admin_page_pmpro-userfields .pmpro_userfield-inside textarea {
 	width: 90%;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-inside textarea {
+	height: 90px;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-inside h3 {
+	margin: 0;
+	padding: 8px 12px;
 }
 .admin_page_pmpro-userfields .pmpro_userfield-group {
 	background: #FFF;
@@ -200,35 +206,61 @@
 	background: #f5f5f5;
 	border-top: 3px solid #ccd0d4;
 }
-
 .admin_page_pmpro-userfields .pmpro_userfield-group-field-expand .pmpro_userfield-group-tbody {
 	background: #007cba;
 	color: #FFF;
 }
-
-.admin_page_pmpro-userfields .pmpro_userfield-group-thead li,
-.admin_page_pmpro-userfields .pmpro_userfield-group-tbody li {
-	flex: 1;
-	padding: 8px;
-}
 .admin_page_pmpro-userfields .pmpro_userfield-group-thead li {
 	font-weight: bold;
+	padding: 8px 12px;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-tbody li {
+	padding: 8px 12px;
+}
+.admin_page_pmpro-userfields li.pmpro_userfield-group-column-order {
+	flex: 1;
 }
 .admin_page_pmpro-userfields li.pmpro_userfield-group-column-label {
+	flex: 4;
+}
+.admin_page_pmpro-userfields li.pmpro_userfield-group-column-name {
+	flex: 2;
+}
+.admin_page_pmpro-userfields li.pmpro_userfield-group-column-type {
+	flex: 2;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-tbody li.pmpro_userfield-group-column-label .pmpro_userfield-label {
+	display: block;
 	font-weight: bold;
 }
-.admin_page_pmpro-userfields li.pmpro_userfield-group-column-options a {
-	font-size: 90%;
-	display: inline-block;
-	margin-right: 5px;
+.admin_page_pmpro-userfields .pmpro_userfield-group-field-collapse li.pmpro_userfield-group-column-label .pmpro_userfield-label {
+	margin-bottom: .2em;
 }
-.admin_page_pmpro-userfields .pmpro_userfield-group-field-expand li.pmpro_userfield-group-column-options a {
+
+.admin_page_pmpro-userfields .pmpro_userfield-group-field .pmpro_userfield-group-options {
+	color: #DDD;
+	font-size: 13px;
+	left: -9999em;
+	position: relative;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-field .pmpro_userfield-group-options a {
+	text-decoration: none;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-field .pmpro_userfield-group-options a:hover {
+	text-decoration: underline;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-field-collapse:hover .pmpro_userfield-group-options {
+	left: 0;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-field-expand .pmpro_userfield-group-options {
 	display: none;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-field-expand .pmpro_userfield-group-options a {
+	color: #FFF;
 }
 .admin_page_pmpro-userfields .pmpro_userfield-group-field {
 	border-bottom: 1px solid #ccd0d4;
 }
-
 .admin_page_pmpro-userfields .pmpro_userfield-group-header {
 	align-items: center;
 	background: #f5f5f5;
@@ -242,24 +274,36 @@
 	align-items: center;
 	display: flex;
 	flex-grow: 1;
-	margin: 0;
+	margin: 0 0 0 12px;
 }
 .admin_page_pmpro-userfields .pmpro_userfield-group-header h3 label {
 	display: inline-block;
 	margin-right: 5px;
 }
-
 .admin_page_pmpro-userfields .pmpro_userfield-field-settings {
 	padding: 0 12px;
 }
 .admin_page_pmpro-userfields .pmpro_userfield-field-settings .pmpro_userfield-field-setting {
 	margin: 12px 0;
 }
+.admin_page_pmpro-userfields .pmpro_userfield-field-settings .pmpro_userfield-field-setting-dual {
+	display: flex;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-field-settings .pmpro_userfield-field-setting-dual .pmpro_userfield-field-setting {
+    margin: 0;
+}
 .admin_page_pmpro-userfields .pmpro_userfield-field-settings .pmpro_userfield-field-setting-radio span {
 	display: inline-block;
 	margin-right: 12px;	
 }
-
+.admin_page_pmpro-userfields .pmpro_userfield-field-actions {
+	padding: 8px 12px;
+}
+.admin_page_pmpro-userfields .pmpro_userfield-group-actions {
+	background: #f5f5f5;
+	padding: 8px 12px;
+	text-align: center;
+}
 /*
 .admin_page_pmpro-userfields .pmpro_userfield-group-field-header {
 	align-items: center;


### PR DESCRIPTION
[x] “Restrict Group for Membership Levels” should be a checkbox list
[x] “name” (meta key) should not allow dashes; make sure name is smart and detects whether it uses an invalid key.
[x] yes/no as dropdown vs. radio for required and readonly. default to no, have no / yes order in dropdown.
[x] remove conditional right now.
[x] hint should be a textarea vs. input text.
[x] move edit | duplicate | delete as hover on row.
[x] left align close field and maybe darker background on + add field.
[x] up / down arrows in order column; maybe have to keep the numbers reordered.