### PR TITLE
Bump license year 2021 (🎉 10 years!)

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 Paid Memberships Pro 
 
-Copyright (C) 2011-2020 Stranger Studios, LLC and other contributors
+Copyright (C) 2011-2021 Stranger Studios, LLC and other contributors
 
 Paid Memberships Pro uses the same software license as the current version of WordPress: GPLv2. You can get the text of that license in the license.txt file of your root WordPress directory or online at https://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
 


### PR DESCRIPTION
🎉