### PR TITLE
Granular expirations

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -519,8 +519,7 @@ if ( function_exists( 'pmpro_displayAds' ) && pmpro_displayAds() ) {
 				}
 				pmpro_updateRecaptchaTRs();
 			</script>
-		</div> <!-- end pmpro_admin_section-other-settings -->
-
+		</div> <!-- end pmpro_admin_section-other-settings -->		
 		<p class="submit">
 			<input name="savesettings" type="submit" class="button button-primary" value="<?php _e('Save Settings', 'paid-memberships-pro' );?>" />
 		</p>

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -692,8 +692,10 @@
 									<input id="expiration_number" name="expiration_number[]" type="text" size="10" value="<?php echo str_replace("\"", "&quot;", stripslashes($level->expiration_number))?>" />
 									<select id="expiration_period" name="expiration_period[]">
 									  <?php
-										$cycles = array( __('Day(s)', 'paid-memberships-pro' ) => 'Day', __('Week(s)', 'paid-memberships-pro' ) => 'Week', __('Month(s)', 'paid-memberships-pro' ) => 'Month', __('Year(s)', 'paid-memberships-pro' ) => 'Year' );
+
+										$cycles = array( __('Hour(s)', 'paid-memberships-pro' ) => 'Hour', __('Day(s)', 'paid-memberships-pro' ) => 'Day', __('Week(s)', 'paid-memberships-pro' ) => 'Week', __('Month(s)', 'paid-memberships-pro' ) => 'Month', __('Year(s)', 'paid-memberships-pro' ) => 'Year' );
 										foreach ( $cycles as $name => $value ) {
+
 										  echo "<option value='$value'";
 										  if ( $level->expiration_period == $value ) echo " selected='selected'";
 										  echo ">$name</option>";

--- a/adminpages/functions.php
+++ b/adminpages/functions.php
@@ -432,4 +432,3 @@ function pmpro_add_email_order_modal() {
 	</div>
 	<?php
 }
-

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -281,7 +281,6 @@
 				),
 					OBJECT
 				);
-				var_dump($level);
 				$temp_id = $level->id;
 			} elseif(!empty($copy) && $copy > 0) {
 				$level = $wpdb->get_row( $wpdb->prepare( "
@@ -562,7 +561,6 @@
 				<tr class="expiration_info" <?php if(!pmpro_isLevelExpiring($level)) {?>style="display: none;"<?php } ?>>					
 					<th scope="row" valign="top"><label for="billing_amount"><?php _e('Expires In', 'paid-memberships-pro' );?>:</label></th>
 					<td>
-						<?php var_dump($level->expiration_period);?>
 						<input id="expiration_number" name="expiration_number" type="text" value="<?php echo esc_attr($level->expiration_number);?>" class="small-text" />
 						<select id="expiration_period" name="expiration_period">
 						  <?php

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -281,6 +281,7 @@
 				),
 					OBJECT
 				);
+				var_dump($level);
 				$temp_id = $level->id;
 			} elseif(!empty($copy) && $copy > 0) {
 				$level = $wpdb->get_row( $wpdb->prepare( "
@@ -561,14 +562,13 @@
 				<tr class="expiration_info" <?php if(!pmpro_isLevelExpiring($level)) {?>style="display: none;"<?php } ?>>					
 					<th scope="row" valign="top"><label for="billing_amount"><?php _e('Expires In', 'paid-memberships-pro' );?>:</label></th>
 					<td>
+						<?php var_dump($level->expiration_period);?>
 						<input id="expiration_number" name="expiration_number" type="text" value="<?php echo esc_attr($level->expiration_number);?>" class="small-text" />
 						<select id="expiration_period" name="expiration_period">
 						  <?php
-							$cycles = array( __('Day(s)', 'paid-memberships-pro' ) => 'Day', __('Week(s)', 'paid-memberships-pro' ) => 'Week', __('Month(s)', 'paid-memberships-pro' ) => 'Month', __('Year(s)', 'paid-memberships-pro' ) => 'Year' );
+							$cycles = array( __('Hour(s)', 'paid-memberships-pro' ) => 'Hour', __('Day(s)', 'paid-memberships-pro' ) => 'Day', __('Week(s)', 'paid-memberships-pro' ) => 'Week', __('Month(s)', 'paid-memberships-pro' ) => 'Month', __('Year(s)', 'paid-memberships-pro' ) => 'Year' );													
 							foreach ( $cycles as $name => $value ) {
-							  echo "<option value='$value'";
-							  if ( $level->expiration_period == $value ) echo " selected='selected'";
-							  echo ">$name</option>";
+							  echo "<option value='$value' ".selected( $level->expiration_period, $value, true ).">$name</option>";
 							}
 						  ?>
 						</select>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1549,6 +1549,8 @@ function pmpro_calculateRecurringRevenue( $s, $l ) {
 			UNION
 		SELECT SUM((365/cycle_number)*billing_amount) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND cycle_period = 'Day' AND cycle_number <> 365 $user_ids_query
 			UNION
+		SELECT SUM((24/cycle_number)*billing_amount) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND cycle_period = 'Hour' AND cycle_number <> 24 $user_ids_query
+			UNION
 		SELECT SUM((52/cycle_number)*billing_amount) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND cycle_period = 'Week' AND cycle_number <> 52 $user_ids_query
 			UNION
 		SELECT SUM(billing_amount) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND cycle_period = 'Year' $user_ids_query
@@ -3472,13 +3474,3 @@ function pmpro_adjusted_expiration_schedule( $schedules ) {
 
 }
 add_filter( 'cron_schedules', 'pmpro_adjusted_expiration_schedule', 10, 1 );
-
-function pmpro_reschedule_expiration_cron(){
-
-	$timestamp = wp_next_scheduled( 'pmpro_cron_expire_memberships' );
-
-	wp_unschedule_event( $timestamp, 'pmpro_cron_expire_memberships' );
-
-	wp_schedule_event( current_time( 'timestamp' ), 'pmpro_expiration_schedule', 'pmpro_cron_expire_memberships' );
-
-}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3458,15 +3458,3 @@ function pmpro_doing_webhook( $gateway = null ){
 	}
 	
 }
-
-function pmpro_adjusted_expiration_schedule( $schedules ) { 
-
-    $schedules['pmpro_expiration_schedule'] = array(
-        'interval' => 3600,
-        'display'  => esc_html__( 'PMPro Custom Expiration Cron' )
-    );
-
-    return $schedules;
-
-}
-add_filter( 'cron_schedules', 'pmpro_adjusted_expiration_schedule', 10, 1 );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3431,11 +3431,7 @@ function pmpro_insert_or_replace( $table, $data, $format, $primary_key = 'id' ) 
 		return $wpdb->insert( $table, $data, $format );
 	} else {		
 		// Replace.
-		var_dump($table);
-		var_dump($data);
-		var_dump($format);
 		$replaced = $wpdb->replace( $table, $data, $format );
-		var_dump($replaced);
 	}
 }
 

--- a/includes/localization.php
+++ b/includes/localization.php
@@ -25,11 +25,14 @@ function pmpro_load_textdomain()
 add_action("init", "pmpro_load_textdomain", 1);
 
 function pmpro_translate_billing_period($period, $number = 1)
-{
+{	
 	//note as of v1.8, we stopped using _n and split things up to aid in localization
 	if($number == 1)
 	{
-		if($period == "Day")
+
+		if( $period == "Hour" ){
+			return __("Hour", "paid-memberships-pro" );
+		} else if($period == "Day")
 			return __("Day", 'paid-memberships-pro' );
 		elseif($period == "Week")
 			return __("Week", 'paid-memberships-pro' );
@@ -39,8 +42,10 @@ function pmpro_translate_billing_period($period, $number = 1)
 			return __("Year", 'paid-memberships-pro' );
 	}
 	else
-	{
-		if($period == "Day")
+	{	
+		if( $period == "Hour" ){
+			return __("Hours", "paid-memberships-pro" );
+		} else if($period == "Day")
 			return __("Days", 'paid-memberships-pro' );
 		elseif($period == "Week")
 			return __("Weeks", 'paid-memberships-pro' );

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -81,6 +81,9 @@ function pmpro_membership_level_profile_fields($user)
 			$selected_expires_day =  date( 'j', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
 			$selected_expires_month =  date( 'm', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
 			$selected_expires_year =  date( 'Y', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
+			$selected_expires_hour = date( 'H', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
+
+			$selected_expires_minute = date( 'i', $end_date ? $user->membership_level->enddate : current_time('timestamp') );
 		?>
 		<tr>
 			<th><label for="expiration"><?php _e("Expires", 'paid-memberships-pro' ); ?></label></th>
@@ -103,6 +106,21 @@ function pmpro_membership_level_profile_fields($user)
 					</select>
 					<input name="expires_day" type="text" size="2" value="<?php echo $selected_expires_day?>" />
 					<input name="expires_year" type="text" size="4" value="<?php echo $selected_expires_year?>" />
+					<?php _e('at', 'paid-memberships-pro'); ?>
+					<select name='expires_hour'>
+						<?php
+						for( $i = 0; $i <= 24; $i++ ){
+							echo "<option value='".$i."' ".selected( $selected_expires_hour, sprintf("%02d", $i ), true ).">".sprintf("%02d", $i )."</option>";
+						}
+						?>
+					</select>
+					<select name='expires_minute'>
+						<?php
+						for( $i = 0; $i <= 59; $i++ ){
+							echo "<option value='".$i."' ".selected( $selected_expires_minute, sprintf("%02d", $i ), true ).">".sprintf("%02d", $i )."</option>";
+						}
+						?>
+					</select>
 				</span>
 				<script>
 					jQuery('#expires').change(function() {
@@ -313,6 +331,14 @@ function pmpro_membership_level_profile_fields_update()
 	{
 		//update the expiration date
 		$expiration_date = intval($_REQUEST['expires_year']) . "-" . str_pad(intval($_REQUEST['expires_month']), 2, "0", STR_PAD_LEFT) . "-" . str_pad(intval($_REQUEST['expires_day']), 2, "0", STR_PAD_LEFT);
+		if( !empty( $_REQUEST['expires_hour'] ) ){
+			if( !empty( $_REQUEST['expires_minute'] ) ){
+				$expiration_date = $expiration_date ." ".$_REQUEST['expires_hour'].":".$_REQUEST['expires_minute'].":00";
+			} else{
+				$expiration_date = $expiration_date ." ".$_REQUEST['expires_hour'].":00:00";
+			}
+		}
+		
 		$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users SET enddate = '" . $expiration_date . "' WHERE status = 'active' AND membership_id = '" . intval($_REQUEST['membership_level']) . "' AND user_id = '" . $user_ID . "' LIMIT 1";
 		if($wpdb->query($sqlQuery))
 			$expiration_changed = true;

--- a/includes/setup.sql
+++ b/includes/setup.sql
@@ -45,7 +45,7 @@ CREATE TABLE `wp_pmpro_discount_codes_levels` (
   `trial_amount` decimal(18,8) NOT NULL DEFAULT '0.00',
   `trial_limit` int(11) NOT NULL DEFAULT '0',
   `expiration_number` int(10) unsigned NOT NULL,
-  `expiration_period` enum('Day','Week','Month','Year') NOT NULL,
+  `expiration_period` enum('Hour','Day','Week','Month','Year') NOT NULL,
   PRIMARY KEY (`code_id`,`level_id`),
   KEY `initial_payment` (`initial_payment`)
 );
@@ -87,7 +87,7 @@ CREATE TABLE `wp_pmpro_membership_levels` (
   `trial_limit` int(11) NOT NULL DEFAULT '0',
   `allow_signups` tinyint(4) NOT NULL DEFAULT '1',
   `expiration_number` int(10) unsigned NOT NULL,
-  `expiration_period` enum('Day','Week','Month','Year') NOT NULL,
+  `expiration_period` enum('Hour','Day','Week','Month','Year') NOT NULL,
   PRIMARY KEY (`id`),
   KEY `allow_signups` (`allow_signups`),
   KEY `initial_payment` (`initial_payment`),

--- a/includes/updates/upgrade_2_6.php
+++ b/includes/updates/upgrade_2_6.php
@@ -1,0 +1,92 @@
+<?php
+
+function pmpro_upgrade_2_6(){
+
+	global $wpdb;
+	$wpdb->hide_errors();
+
+	$wpdb->pmpro_membership_levels = $wpdb->prefix . 'pmpro_membership_levels';
+	$wpdb->pmpro_discount_codes_levels = $wpdb->prefix . 'pmpro_discount_codes_levels';
+
+	$sqlQuery = "
+		ALTER TABLE  `" . $wpdb->pmpro_membership_levels . "` CHANGE `expiration_period` `expiration_period` enum('Hour', Day','Week','Month','Year') NOT NULL
+	";
+	$wpdb->query($sqlQuery);
+
+	$sqlQuery = "
+		ALTER TABLE  `" . $wpdb->pmpro_discount_codes_levels . "` CHANGE `expiration_period` `expiration_period` enum('Hour', Day','Week','Month','Year') NOT NULL
+	";
+	$wpdb->query($sqlQuery);
+
+	/**
+	 * Update all existing orders 
+	 */
+	
+	$sqlQuery = "SELECT * 
+                 FROM $wpdb->pmpro_membership_orders
+                    AND status = 'success'
+				ORDER BY id";
+	$orders = $wpdb->get_results( $sqlQuery );
+	
+	if(!empty($orders)) {
+		if(count($orders) > 10) {
+			//if more than 10 orders, we'll need to do this via AJAX
+			pmpro_addUpdate( 'pmpro_upgrade_2_6_ajax' );
+		} else {
+			//less than 10, let's just do them now
+			$stripe = new PMProGateway_stripe();
+			require_once( ABSPATH . "/wp-includes/pluggable.php" );
+            foreach($orders as $order) {                
+                $subscription = $stripe->getSubscription( $order );
+                
+                if ( ! empty( $subscription ) ) {
+                    $sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET subscription_transaction_id = '" . esc_sql( $subscription->id ) . "' WHERE id = '" . esc_sql( $order->id ) . "' LIMIT 1";
+                    $wpdb->query( $sqlQuery );
+                }
+			}
+			update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
+		}
+	}
+
+}
+
+function pmpro_upgrade_2_6_ajax(){
+
+	//keeping track of which order we're working on
+	$last_order_id = get_option( 'pmpro_upgrade_2_6_last_order_id', 0 );
+
+	//get orders
+	$sqlQuery = "SELECT * 
+                 FROM $wpdb->pmpro_membership_orders
+                 WHERE id > '" . esc_sql( $last_order_id ) . "'
+				 	AND gateway = 'stripe'
+                    AND total = 0
+                    AND payment_transaction_id = ''
+                    AND subscription_transaction_id = ''
+                    AND status = 'success'
+				ORDER BY id";
+	$orders = $wpdb->get_results( $sqlQuery );
+
+	if(empty($orders)) {
+		//done with this update
+		pmpro_removeUpdate('pmpro_upgrade_2_4_ajax');
+		delete_option( 'pmpro_upgrade_2_6_last_order_id' );
+	} else {
+		//less than 10, let's just do them now
+		$stripe = new PMProGateway_stripe();
+		require_once( ABSPATH . "/wp-includes/pluggable.php" );
+		foreach($orders as $order) {                
+			$subscription = $stripe->getSubscription( $order );
+			
+			if ( ! empty( $subscription ) ) {
+				$sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET subscription_transaction_id = '" . esc_sql( $subscription->id ) . "' WHERE id = '" . esc_sql( $order->id ) . "' LIMIT 1";
+				$wpdb->query( $sqlQuery );
+			}
+			
+			$last_order_id = $order->id;
+		}
+
+		update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
+	}
+	
+}

--- a/includes/updates/upgrade_2_6.php
+++ b/includes/updates/upgrade_2_6.php
@@ -3,7 +3,8 @@
 function pmpro_upgrade_2_6(){
 
 	global $wpdb;
-	$wpdb->show_errors();
+
+	$wpdb->hide_errors();
 
 	$wpdb->pmpro_membership_levels = $wpdb->prefix . 'pmpro_membership_levels';
 	$wpdb->pmpro_discount_codes_levels = $wpdb->prefix . 'pmpro_discount_codes_levels';
@@ -25,74 +26,7 @@ function pmpro_upgrade_2_6(){
 
 	wp_unschedule_event( $timestamp, 'pmpro_cron_expire_memberships' );
 
-	wp_schedule_event( current_time( 'timestamp' ), 'pmpro_expiration_schedule', 'pmpro_cron_expire_memberships' );
-
-	/**
-	 * Update all existing orders - Do we still need to do this? 
-	 */
-	
-	// $sqlQuery = "SELECT * 
- //                 FROM $wpdb->pmpro_membership_orders
- //                    AND status = 'success'
-	// 			ORDER BY id";
-	// $orders = $wpdb->get_results( $sqlQuery );
-	
-	// if(!empty($orders)) {
-	// 	if(count($orders) > 10) {
-	// 		//if more than 10 orders, we'll need to do this via AJAX
-	// 		pmpro_addUpdate( 'pmpro_upgrade_2_6_ajax' );
-	// 	} else {
-	// 		//less than 10, let's just do them now
-	// 		$stripe = new PMProGateway_stripe();
-	// 		require_once( ABSPATH . "/wp-includes/pluggable.php" );
- //            foreach($orders as $order) {                
- //                $subscription = $stripe->getSubscription( $order );
-                
- //                if ( ! empty( $subscription ) ) {
- //                    $sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET subscription_transaction_id = '" . esc_sql( $subscription->id ) . "' WHERE id = '" . esc_sql( $order->id ) . "' LIMIT 1";
- //                    $wpdb->query( $sqlQuery );
- //                }
-	// 		}
-	// 		update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
-	// 	}
-	// }
-
+	wp_schedule_event( current_time( 'timestamp' ), 'hourly', 'pmpro_cron_expire_memberships' );
 
 }
 
-function pmpro_upgrade_2_6_ajax(){
-
-	//keeping track of which order we're working on
-	$last_order_id = get_option( 'pmpro_upgrade_2_6_last_order_id', 0 );
-
-	//get orders
-	$sqlQuery = "SELECT * 
-                 FROM $wpdb->pmpro_membership_orders
-                 WHERE id > '" . esc_sql( $last_order_id ) . "'
-                    AND status = 'success' AND enddate IS NOT NULL AND enddate <> '0000-00-00 00:00:00'
-				ORDER BY id";
-	$orders = $wpdb->get_results( $sqlQuery );
-
-	if(empty($orders)) {
-		//done with this update
-		pmpro_removeUpdate('pmpro_upgrade_2_4_ajax');
-		delete_option( 'pmpro_upgrade_2_6_last_order_id' );
-	} else {
-		//less than 10, let's just do them now
-		$stripe = new PMProGateway_stripe();
-		require_once( ABSPATH . "/wp-includes/pluggable.php" );
-		foreach($orders as $order) {                
-			$subscription = $stripe->getSubscription( $order );
-			
-			if ( ! empty( $subscription ) ) {
-				$sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET subscription_transaction_id = '" . esc_sql( $subscription->id ) . "' WHERE id = '" . esc_sql( $order->id ) . "' LIMIT 1";
-				$wpdb->query( $sqlQuery );
-			}
-			
-			$last_order_id = $order->id;
-		}
-
-		update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
-	}
-
-}

--- a/includes/updates/upgrade_2_6.php
+++ b/includes/updates/upgrade_2_6.php
@@ -3,50 +3,60 @@
 function pmpro_upgrade_2_6(){
 
 	global $wpdb;
-	$wpdb->hide_errors();
+	$wpdb->show_errors();
 
 	$wpdb->pmpro_membership_levels = $wpdb->prefix . 'pmpro_membership_levels';
 	$wpdb->pmpro_discount_codes_levels = $wpdb->prefix . 'pmpro_discount_codes_levels';
 
 	$sqlQuery = "
-		ALTER TABLE  `" . $wpdb->pmpro_membership_levels . "` CHANGE `expiration_period` `expiration_period` enum('Hour', Day','Week','Month','Year') NOT NULL
+		ALTER TABLE  `" . $wpdb->pmpro_membership_levels . "` MODIFY `expiration_period` enum('Hour', 'Day','Week','Month','Year') NOT NULL
 	";
 	$wpdb->query($sqlQuery);
 
 	$sqlQuery = "
-		ALTER TABLE  `" . $wpdb->pmpro_discount_codes_levels . "` CHANGE `expiration_period` `expiration_period` enum('Hour', Day','Week','Month','Year') NOT NULL
+		ALTER TABLE  `" . $wpdb->pmpro_discount_codes_levels . "` MODIFY `expiration_period` enum('Hour', 'Day','Week','Month','Year') NOT NULL
 	";
 	$wpdb->query($sqlQuery);
 
 	/**
-	 * Update all existing orders 
+	 * Reschedule Cron Job for Hourly Checks
+	 */
+	$timestamp = wp_next_scheduled( 'pmpro_cron_expire_memberships' );
+
+	wp_unschedule_event( $timestamp, 'pmpro_cron_expire_memberships' );
+
+	wp_schedule_event( current_time( 'timestamp' ), 'pmpro_expiration_schedule', 'pmpro_cron_expire_memberships' );
+
+	/**
+	 * Update all existing orders - Do we still need to do this? 
 	 */
 	
-	$sqlQuery = "SELECT * 
-                 FROM $wpdb->pmpro_membership_orders
-                    AND status = 'success'
-				ORDER BY id";
-	$orders = $wpdb->get_results( $sqlQuery );
+	// $sqlQuery = "SELECT * 
+ //                 FROM $wpdb->pmpro_membership_orders
+ //                    AND status = 'success'
+	// 			ORDER BY id";
+	// $orders = $wpdb->get_results( $sqlQuery );
 	
-	if(!empty($orders)) {
-		if(count($orders) > 10) {
-			//if more than 10 orders, we'll need to do this via AJAX
-			pmpro_addUpdate( 'pmpro_upgrade_2_6_ajax' );
-		} else {
-			//less than 10, let's just do them now
-			$stripe = new PMProGateway_stripe();
-			require_once( ABSPATH . "/wp-includes/pluggable.php" );
-            foreach($orders as $order) {                
-                $subscription = $stripe->getSubscription( $order );
+	// if(!empty($orders)) {
+	// 	if(count($orders) > 10) {
+	// 		//if more than 10 orders, we'll need to do this via AJAX
+	// 		pmpro_addUpdate( 'pmpro_upgrade_2_6_ajax' );
+	// 	} else {
+	// 		//less than 10, let's just do them now
+	// 		$stripe = new PMProGateway_stripe();
+	// 		require_once( ABSPATH . "/wp-includes/pluggable.php" );
+ //            foreach($orders as $order) {                
+ //                $subscription = $stripe->getSubscription( $order );
                 
-                if ( ! empty( $subscription ) ) {
-                    $sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET subscription_transaction_id = '" . esc_sql( $subscription->id ) . "' WHERE id = '" . esc_sql( $order->id ) . "' LIMIT 1";
-                    $wpdb->query( $sqlQuery );
-                }
-			}
-			update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
-		}
-	}
+ //                if ( ! empty( $subscription ) ) {
+ //                    $sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET subscription_transaction_id = '" . esc_sql( $subscription->id ) . "' WHERE id = '" . esc_sql( $order->id ) . "' LIMIT 1";
+ //                    $wpdb->query( $sqlQuery );
+ //                }
+	// 		}
+	// 		update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
+	// 	}
+	// }
+
 
 }
 
@@ -59,11 +69,7 @@ function pmpro_upgrade_2_6_ajax(){
 	$sqlQuery = "SELECT * 
                  FROM $wpdb->pmpro_membership_orders
                  WHERE id > '" . esc_sql( $last_order_id ) . "'
-				 	AND gateway = 'stripe'
-                    AND total = 0
-                    AND payment_transaction_id = ''
-                    AND subscription_transaction_id = ''
-                    AND status = 'success'
+                    AND status = 'success' AND enddate IS NOT NULL AND enddate <> '0000-00-00 00:00:00'
 				ORDER BY id";
 	$orders = $wpdb->get_results( $sqlQuery );
 
@@ -88,5 +94,5 @@ function pmpro_upgrade_2_6_ajax(){
 
 		update_option( 'pmpro_upgrade_2_6_last_order_id', $last_order_id );
 	}
-	
+
 }

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -257,6 +257,16 @@ function pmpro_checkForUpgrades()
 		$pmpro_db_version = 2.5;
 		pmpro_setOption( 'db_version', '2.5' );
 	}
+
+	/**
+	 * Version 2.4
+	 * Fixing subscription_transaction_id
+	 * for orders created through a Stripe Update.
+	 */
+	require_once( PMPRO_DIR . "/includes/updates/upgrade_2_6.php" );	
+ 	if($pmpro_db_version < 2.6) {
+ 		$pmpro_db_version = pmpro_upgrade_2_6();
+ 	}
 }
 
 function pmpro_db_delta()

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -125,6 +125,10 @@
 	<ul>
 		<li><strong><?php _e('Account', 'paid-memberships-pro' );?>:</strong> <?php echo esc_html( $current_user->display_name );?> (<?php echo esc_html( $current_user->user_email );?>)</li>
 		<li><strong><?php _e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php if(!empty($current_user->membership_level)) echo esc_html( $current_user->membership_level->name ); else _e("Pending", 'paid-memberships-pro' );?></li>
+		<?php if( !empty( $current_user->membership_level->expiration_period ) && $current_user->membership_level->expiration_period == 'Hour' && apply_filters( 'pmpro_confirmation_display_hour_expiration', true, $current_user ) ){ ?>
+		<li><strong><?php _e('Expires In', 'paid-memberships-pro' );?>:</strong> <?php echo $current_user->membership_level->expiration_number .' '.pmpro_translate_billing_period( $current_user->membership_level->expiration_period, $current_user->membership_level->expiration_number ); ?></li>
+		<?php }
+		?>
 	</ul>
 <?php
 	}

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -199,8 +199,8 @@ add_filter( 'cron_schedules', 'pmpro_cron_schedules_monthly' );
 // activation
 function pmpro_activation() {
 	// schedule crons
-	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'pmpro_expiration_schedule', 'pmpro_cron_expire_memberships' );
-	pmpro_maybe_schedule_event( current_time( 'timestamp' ) + 1, 'daily', 'pmpro_cron_expiration_warnings' );
+	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'hourly', 'pmpro_cron_expire_memberships' );
+	pmpro_maybe_schedule_event( current_time( 'timestamp' ) + 1, 'hourly', 'pmpro_cron_expiration_warnings' );
 	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'monthly', 'pmpro_cron_credit_card_expiring_warnings' );
 	pmpro_maybe_schedule_event( strtotime( '10:30:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ), 'daily', 'pmpro_cron_admin_activity_email' );
 

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -199,7 +199,7 @@ add_filter( 'cron_schedules', 'pmpro_cron_schedules_monthly' );
 // activation
 function pmpro_activation() {
 	// schedule crons
-	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'daily', 'pmpro_cron_expire_memberships' );
+	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'pmpro_expiration_schedule', 'pmpro_cron_expire_memberships' );
 	pmpro_maybe_schedule_event( current_time( 'timestamp' ) + 1, 'daily', 'pmpro_cron_expiration_warnings' );
 	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'monthly', 'pmpro_cron_credit_card_expiring_warnings' );
 	pmpro_maybe_schedule_event( strtotime( '10:30:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ), 'daily', 'pmpro_cron_admin_activity_email' );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -586,7 +586,11 @@ if ( ! empty( $pmpro_confirmed ) ) {
 
 		//calculate the end date
 		if ( ! empty( $pmpro_level->expiration_number ) ) {
-			$enddate =  date( "Y-m-d H:i:s", strtotime( "+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, current_time( "timestamp" ) ) );
+			if( $pmpro_level->cycle_period == 'Hour' ){
+				$enddate =  date( "Y-m-d H:i:s", strtotime( "+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, current_time( "timestamp" ) ) );
+			} else {
+				$enddate =  date( "Y-m-d 23:59:59", strtotime( "+ " . $pmpro_level->expiration_number . " " . $pmpro_level->expiration_period, current_time( "timestamp" ) ) );
+			}
 		} else {
 			$enddate = "NULL";
 		}
@@ -731,6 +735,10 @@ if ( ! empty( $pmpro_confirmed ) ) {
 				if ( empty( $old_lastname ) ) {
 					update_user_meta( $user_id, "last_name", $blastname );
 				}
+			}
+
+			if( $pmpro_level->expiration_period == 'Hour' ){
+				update_user_meta( $user_id, 'pmpro_disable_notifications', true );
 			}
 
 			//show the confirmation

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -21,14 +21,19 @@ function pmpro_cron_expire_memberships()
 
 	foreach($expired as $e)
 	{
-		do_action("pmpro_membership_pre_membership_expiry", $e->user_id, $e->membership_id );
+		do_action("pmpro_membership_pre_membership_expiry", $e->user_id, $e->membership_id );		
 
 		//remove their membership
 		pmpro_changeMembershipLevel(false, $e->user_id, 'expired', $e->membership_id);
 
 		do_action("pmpro_membership_post_membership_expiry", $e->user_id, $e->membership_id );
 
+		if( get_user_meta( $e->user_id, 'pmpro_disable_notifications', true ) ){
+			$send_email = false;
+		}
+		
 		$send_email = apply_filters("pmpro_send_expiration_email", true, $e->user_id);
+
 		if($send_email)
 		{
 			//send an email

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -13,11 +13,10 @@ function pmpro_cron_expire_memberships()
 	$today = date("Y-m-d H:i:00", current_time("timestamp"));
 
 	//look for memberships that expired before today
-	$sqlQuery = "SELECT mu.user_id, mu.membership_id, mu.startdate, mu.enddate FROM $wpdb->pmpro_memberships_users mu WHERE mu.status = 'active' AND mu.enddate IS NOT NULL AND mu.enddate <> '0000-00-00 00:00:00' AND DATE(mu.enddate) <= '" . esc_sql( $today ) . "' ORDER BY mu.enddate";
+	$sqlQuery = "SELECT mu.user_id, mu.membership_id, mu.startdate, mu.enddate FROM $wpdb->pmpro_memberships_users mu WHERE mu.status = 'active' AND mu.enddate IS NOT NULL AND mu.enddate <> '0000-00-00 00:00:00' AND mu.enddate <= '" . esc_sql( $today ) . "' ORDER BY mu.enddate";
 
 	if(defined('PMPRO_CRON_LIMIT'))
 		$sqlQuery .= " LIMIT " . PMPRO_CRON_LIMIT;
-
 	$expired = $wpdb->get_results($sqlQuery);
 
 	foreach($expired as $e)

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -1,7 +1,7 @@
 <?php
 /*
 	Expiring Memberships
-*/
+*/	
 add_action("pmpro_cron_expire_memberships", "pmpro_cron_expire_memberships");
 function pmpro_cron_expire_memberships()
 {
@@ -10,7 +10,7 @@ function pmpro_cron_expire_memberships()
 	//clean up errors in the memberships_users table that could cause problems
 	pmpro_cleanup_memberships_users_table();
 
-	$today = date("Y-m-d", current_time("timestamp"));
+	$today = date("Y-m-d H:i:00", current_time("timestamp"));
 
 	//look for memberships that expired before today
 	$sqlQuery = "SELECT mu.user_id, mu.membership_id, mu.startdate, mu.enddate FROM $wpdb->pmpro_memberships_users mu WHERE mu.status = 'active' AND mu.enddate IS NOT NULL AND mu.enddate <> '0000-00-00 00:00:00' AND DATE(mu.enddate) <= '" . esc_sql( $today ) . "' ORDER BY mu.enddate";
@@ -59,13 +59,13 @@ function pmpro_cron_expiration_warnings()
 	//clean up errors in the memberships_users table that could cause problems
 	pmpro_cleanup_memberships_users_table();
 
-	$today = date("Y-m-d 00:00:00", current_time("timestamp"));
+	$today = date("Y-m-d H:i:s", current_time("timestamp"));
 
 	$pmpro_email_days_before_expiration = apply_filters("pmpro_email_days_before_expiration", 7);
 
 	// Configure the interval to select records from
 	$interval_start = $today;
-	$interval_end = date( 'Y-m-d 00:00:00', strtotime( "{$today} +{$pmpro_email_days_before_expiration} days", current_time( 'timestamp' ) ) );
+	$interval_end = date( 'Y-m-d H:i:s', strtotime( "{$today} +{$pmpro_email_days_before_expiration} days", current_time( 'timestamp' ) ) );
 
 	//look for memberships that are going to expire within one week (but we haven't emailed them within a week)
 	$sqlQuery = $wpdb->prepare(

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -127,12 +127,16 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 								</td>
 								<td class="<?php echo pmpro_get_element_class( 'pmpro_account-membership-expiration' ); ?>">
 								<?php
-									if($level->enddate)
+									if($level->enddate){
 										$expiration_text = date_i18n( get_option( 'date_format' ), $level->enddate );
-									else
+										if( apply_filters( 'pmpro_show_time_on_expiration_date', true ) ){
+											$expiration_text = date_i18n( get_option( 'date_format' ).' - H:i', $level->enddate );
+										}
+									} else {
 										$expiration_text = "---";
-
-								    	echo apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level );
+								    	
+								    }
+								    echo apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level );
 								?>
 								</td>
 							</tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces granular expiration dates to levels. You can now set an expiration period to hours. Expirations are also set on a date and time basis where memberships can expire within an hour instead of a day.

### How to test the changes in this Pull Request:

1. Create a level and set the expiration date to x hours
2. The same option is available in a discount code
3. Sign up for the level you created
4. Cancel your level
5. An expiration date will be set for x amount of hours from your current time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Granular Expiration Dates Introduced, allowing you to expire memberships down to the hour/minute.
