### PR TITLE
WP-CLI make-pot

### DIFF
--- a/languages/paid-memberships-pro.pot
+++ b/languages/paid-memberships-pro.pot
@@ -1,766 +1,1014 @@
-#
-# Hi there! Details on how to help out translating Paid Memberships Pro can be found at:
-# https://www.paidmembershipspro.com/documentation/languages/
-#
+# Copyright (C) 2021 Stranger Studios
+# This file is distributed under the same license as the Paid Memberships Pro plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: paid-memberships-pro\n"
+"Project-Id-Version: Paid Memberships Pro 2.5.4\n"
 "Report-Msgid-Bugs-To: info@paidmembershipspro.com\n"
-"POT-Creation-Date: 2021-01-29 09:55+1100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: \n"
-"Language-Team: Stranger Studios <info@paidmembershipspro.com>\n"
+"Last-Translator: Paid Memberships Pro <info@paidmembershipspro.com>\n"
+"Language-Team: Paid Memberships Pro <info@paidmembershipspro.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2021-02-09T08:11:51+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.3.0\n"
 
-#: adminpages/addons.php:5 adminpages/advancedsettings.php:5
-#: adminpages/discountcodes.php:5 adminpages/emailsettings.php:5
-#: adminpages/license.php:4 adminpages/membershiplevels.php:5
-#: adminpages/memberslist-csv.php:5 adminpages/orders-csv.php:4
-#: adminpages/orders-print.php:12 adminpages/orders.php:4
-#: adminpages/pagesettings.php:4 adminpages/paymentsettings.php:5
-#: adminpages/updates.php:5 includes/services.php:91 includes/services.php:104
-#: adminpages/addons.php:5 adminpages/addons.php:21
-#: adminpages/advancedsettings.php:5 adminpages/discountcodes.php:5
-#: adminpages/emailsettings.php:5 adminpages/license.php:4
-#: adminpages/membershiplevels.php:5 adminpages/memberslist-csv.php:5
-#: adminpages/memberslist.php:5 adminpages/orders-csv.php:4
-#: adminpages/orders-csv.php:5 adminpages/orders-print.php:12
-#: adminpages/orders.php:4 adminpages/orders.php:5
-#: adminpages/pagesettings.php:4 adminpages/pagesettings.php:5
-#: adminpages/paymentsettings.php:5 adminpages/updates.php:5
+#: adminpages/addons.php:5
+#: adminpages/advancedsettings.php:5
+#: adminpages/discountcodes.php:5
+#: adminpages/emailsettings.php:5
+#: adminpages/license.php:4
+#: adminpages/membershiplevels.php:5
+#: adminpages/memberslist-csv.php:5
+#: adminpages/orders-csv.php:4
+#: adminpages/orders-print.php:12
+#: adminpages/orders.php:4
+#: adminpages/pagesettings.php:4
+#: adminpages/paymentsettings.php:5
+#: adminpages/updates.php:5
+#: includes/services.php:91
+#: includes/services.php:104
+#: adminpages/addons.php:21
+#: adminpages/memberslist.php:5
+#: adminpages/orders-csv.php:5
+#: adminpages/orders.php:5
+#: adminpages/pagesettings.php:5
 #: includes/license.php:36
 msgid "You do not have permissions to perform this action."
 msgstr ""
 
-#: adminpages/addons.php:81 adminpages/admin_header.php:241
-#: includes/adminpages.php:55 includes/adminpages.php:203
-#: adminpages/addons.php:64 adminpages/addons.php:67 adminpages/addons.php:80
-#: adminpages/addons.php:81 adminpages/admin_header.php:133
-#: adminpages/admin_header.php:154 adminpages/admin_header.php:170
-#: adminpages/admin_header.php:179 adminpages/admin_header.php:191
-#: adminpages/admin_header.php:204 adminpages/admin_header.php:208
-#: adminpages/admin_header.php:209 adminpages/admin_header.php:216
-#: adminpages/admin_header.php:224 adminpages/admin_header.php:241
-#: includes/adminpages.php:14 includes/adminpages.php:52
-#: includes/adminpages.php:53 includes/adminpages.php:55
-#: includes/adminpages.php:69 includes/adminpages.php:135
-#: includes/adminpages.php:142 includes/adminpages.php:146
-#: includes/adminpages.php:151 includes/adminpages.php:192
-#: includes/adminpages.php:193 includes/adminpages.php:201
+#: adminpages/addons.php:81
+#: adminpages/admin_header.php:241
+#: includes/adminpages.php:55
 #: includes/adminpages.php:203
+#: adminpages/addons.php:64
+#: adminpages/addons.php:67
+#: adminpages/addons.php:80
+#: adminpages/admin_header.php:133
+#: adminpages/admin_header.php:154
+#: adminpages/admin_header.php:170
+#: adminpages/admin_header.php:179
+#: adminpages/admin_header.php:191
+#: adminpages/admin_header.php:204
+#: adminpages/admin_header.php:208
+#: adminpages/admin_header.php:209
+#: adminpages/admin_header.php:216
+#: adminpages/admin_header.php:224
+#: includes/adminpages.php:14
+#: includes/adminpages.php:52
+#: includes/adminpages.php:53
+#: includes/adminpages.php:69
+#: includes/adminpages.php:135
+#: includes/adminpages.php:142
+#: includes/adminpages.php:146
+#: includes/adminpages.php:151
+#: includes/adminpages.php:192
+#: includes/adminpages.php:193
+#: includes/adminpages.php:201
 msgid "Add Ons"
 msgstr ""
 
-#: adminpages/addons.php:89 adminpages/addons.php:71 adminpages/addons.php:74
-#: adminpages/addons.php:87 adminpages/addons.php:88 adminpages/addons.php:89
+#: adminpages/addons.php:89
+#: adminpages/addons.php:71
+#: adminpages/addons.php:74
+#: adminpages/addons.php:87
+#: adminpages/addons.php:88
 #, php-format
 msgid "Last checked on %s at %s."
 msgstr ""
 
-#: adminpages/addons.php:90 adminpages/addons.php:72 adminpages/addons.php:75
-#: adminpages/addons.php:88 adminpages/addons.php:89 adminpages/addons.php:90
+#: adminpages/addons.php:90
+#: adminpages/addons.php:72
+#: adminpages/addons.php:75
+#: adminpages/addons.php:88
+#: adminpages/addons.php:89
 msgid "Check Again"
 msgstr ""
 
-#: adminpages/addons.php:94 adminpages/orders.php:1004 adminpages/addons.php:76
-#: adminpages/addons.php:79 adminpages/addons.php:92 adminpages/addons.php:93
-#: adminpages/addons.php:94 adminpages/orders.php:605 adminpages/orders.php:712
-#: adminpages/orders.php:741 adminpages/orders.php:850
-#: adminpages/orders.php:881 adminpages/orders.php:892
-#: adminpages/orders.php:983 adminpages/orders.php:984
-#: adminpages/orders.php:989 adminpages/orders.php:994
+#: adminpages/addons.php:94
+#: adminpages/orders.php:1004
+#: adminpages/addons.php:76
+#: adminpages/addons.php:79
+#: adminpages/addons.php:92
+#: adminpages/addons.php:93
+#: adminpages/orders.php:605
+#: adminpages/orders.php:712
+#: adminpages/orders.php:741
+#: adminpages/orders.php:850
+#: adminpages/orders.php:881
+#: adminpages/orders.php:892
+#: adminpages/orders.php:983
+#: adminpages/orders.php:984
+#: adminpages/orders.php:989
+#: adminpages/orders.php:994
 #: adminpages/orders.php:1039
 msgid "All"
 msgstr ""
 
-#: adminpages/addons.php:95 adminpages/addons.php:77 adminpages/addons.php:80
-#: adminpages/addons.php:93 adminpages/addons.php:94 adminpages/addons.php:95
+#: adminpages/addons.php:95
+#: adminpages/addons.php:77
+#: adminpages/addons.php:80
+#: adminpages/addons.php:93
+#: adminpages/addons.php:94
 msgid "Active"
 msgstr ""
 
-#: adminpages/addons.php:96 adminpages/addons.php:78 adminpages/addons.php:81
-#: adminpages/addons.php:94 adminpages/addons.php:95 adminpages/addons.php:96
+#: adminpages/addons.php:96
+#: adminpages/addons.php:78
+#: adminpages/addons.php:81
+#: adminpages/addons.php:94
+#: adminpages/addons.php:95
 msgid "Inactive"
 msgstr ""
 
-#: adminpages/addons.php:97 adminpages/addons.php:79 adminpages/addons.php:82
-#: adminpages/addons.php:95 adminpages/addons.php:96 adminpages/addons.php:97
+#: adminpages/addons.php:97
+#: adminpages/addons.php:79
+#: adminpages/addons.php:82
+#: adminpages/addons.php:95
+#: adminpages/addons.php:96
 msgid "Update Available"
 msgstr ""
 
-#: adminpages/addons.php:98 adminpages/addons.php:80 adminpages/addons.php:83
-#: adminpages/addons.php:96 adminpages/addons.php:97 adminpages/addons.php:98
+#: adminpages/addons.php:98
+#: adminpages/addons.php:80
+#: adminpages/addons.php:83
+#: adminpages/addons.php:96
+#: adminpages/addons.php:97
 msgid "Not Installed"
 msgstr ""
 
-#: adminpages/addons.php:109 adminpages/addons.php:93 adminpages/addons.php:96
-#: adminpages/addons.php:109 adminpages/addons.php:110
+#: adminpages/addons.php:109
+#: adminpages/addons.php:93
+#: adminpages/addons.php:96
+#: adminpages/addons.php:110
 msgid "Add On Name"
 msgstr ""
 
-#: adminpages/addons.php:110 adminpages/addons.php:94 adminpages/addons.php:97
-#: adminpages/addons.php:110 adminpages/addons.php:111
+#: adminpages/addons.php:110
+#: adminpages/addons.php:94
+#: adminpages/addons.php:97
+#: adminpages/addons.php:111
 msgid "Type"
 msgstr ""
 
-#: adminpages/addons.php:111 adminpages/membershiplevels.php:359
-#: adminpages/addons.php:95 adminpages/addons.php:98 adminpages/addons.php:111
-#: adminpages/addons.php:112 adminpages/membershiplevels.php:296
-#: adminpages/membershiplevels.php:298 adminpages/membershiplevels.php:300
-#: adminpages/membershiplevels.php:324 adminpages/membershiplevels.php:334
-#: adminpages/membershiplevels.php:356 adminpages/membershiplevels.php:358
+#: adminpages/addons.php:111
 #: adminpages/membershiplevels.php:359
+#: adminpages/addons.php:95
+#: adminpages/addons.php:98
+#: adminpages/addons.php:112
+#: adminpages/membershiplevels.php:296
+#: adminpages/membershiplevels.php:298
+#: adminpages/membershiplevels.php:300
+#: adminpages/membershiplevels.php:324
+#: adminpages/membershiplevels.php:334
+#: adminpages/membershiplevels.php:356
+#: adminpages/membershiplevels.php:358
 msgid "Description"
 msgstr ""
 
-#: adminpages/addons.php:135 adminpages/addons.php:118
-#: adminpages/addons.php:121 adminpages/addons.php:134
-#: adminpages/addons.php:135 adminpages/addons.php:136
+#: adminpages/addons.php:135
+#: adminpages/addons.php:118
+#: adminpages/addons.php:121
+#: adminpages/addons.php:134
+#: adminpages/addons.php:136
 msgid "No Add Ons found."
 msgstr ""
 
-#: adminpages/addons.php:196 adminpages/addons.php:201
-#: adminpages/addons.php:213 adminpages/addons.php:179
-#: adminpages/addons.php:182 adminpages/addons.php:184
-#: adminpages/addons.php:187 adminpages/addons.php:195
-#: adminpages/addons.php:196 adminpages/addons.php:197
-#: adminpages/addons.php:199 adminpages/addons.php:200
-#: adminpages/addons.php:201 adminpages/addons.php:202
-#: adminpages/addons.php:212 adminpages/addons.php:213
+#: adminpages/addons.php:196
+#: adminpages/addons.php:201
+#: adminpages/addons.php:213
+#: adminpages/addons.php:179
+#: adminpages/addons.php:182
+#: adminpages/addons.php:184
+#: adminpages/addons.php:187
+#: adminpages/addons.php:195
+#: adminpages/addons.php:197
+#: adminpages/addons.php:199
+#: adminpages/addons.php:200
+#: adminpages/addons.php:202
+#: adminpages/addons.php:212
 #: adminpages/addons.php:214
 msgid "Install Now"
 msgstr ""
 
-#: adminpages/addons.php:202 adminpages/addons.php:208
-#: adminpages/addons.php:214 adminpages/addons.php:220
-#: adminpages/addons.php:185 adminpages/addons.php:188
-#: adminpages/addons.php:191 adminpages/addons.php:194
-#: adminpages/addons.php:197 adminpages/addons.php:200
-#: adminpages/addons.php:201 adminpages/addons.php:202
-#: adminpages/addons.php:203 adminpages/addons.php:206
-#: adminpages/addons.php:207 adminpages/addons.php:208
-#: adminpages/addons.php:209 adminpages/addons.php:213
-#: adminpages/addons.php:214 adminpages/addons.php:215
-#: adminpages/addons.php:219 adminpages/addons.php:220
+#: adminpages/addons.php:202
+#: adminpages/addons.php:208
+#: adminpages/addons.php:214
+#: adminpages/addons.php:220
+#: adminpages/addons.php:185
+#: adminpages/addons.php:188
+#: adminpages/addons.php:191
+#: adminpages/addons.php:194
+#: adminpages/addons.php:197
+#: adminpages/addons.php:200
+#: adminpages/addons.php:201
+#: adminpages/addons.php:203
+#: adminpages/addons.php:206
+#: adminpages/addons.php:207
+#: adminpages/addons.php:209
+#: adminpages/addons.php:213
+#: adminpages/addons.php:215
+#: adminpages/addons.php:219
 #: adminpages/addons.php:221
 msgid "Download"
 msgstr ""
 
-#: adminpages/addons.php:207 adminpages/addons.php:219
-#: adminpages/addons.php:190 adminpages/addons.php:193
-#: adminpages/addons.php:202 adminpages/addons.php:205
-#: adminpages/addons.php:206 adminpages/addons.php:207
-#: adminpages/addons.php:208 adminpages/addons.php:218
-#: adminpages/addons.php:219 adminpages/addons.php:220
+#: adminpages/addons.php:207
+#: adminpages/addons.php:219
+#: adminpages/addons.php:190
+#: adminpages/addons.php:193
+#: adminpages/addons.php:202
+#: adminpages/addons.php:205
+#: adminpages/addons.php:206
+#: adminpages/addons.php:208
+#: adminpages/addons.php:218
+#: adminpages/addons.php:220
 msgid "Update License"
 msgstr ""
 
-#: adminpages/addons.php:225 adminpages/addons.php:208
-#: adminpages/addons.php:211 adminpages/addons.php:224
-#: adminpages/addons.php:225 adminpages/addons.php:226
+#: adminpages/addons.php:225
+#: adminpages/addons.php:208
+#: adminpages/addons.php:211
+#: adminpages/addons.php:224
+#: adminpages/addons.php:226
 msgid "Deactivate"
 msgstr ""
 
-#: adminpages/addons.php:225 adminpages/addons.php:208
-#: adminpages/addons.php:211 adminpages/addons.php:224
-#: adminpages/addons.php:225 adminpages/addons.php:226
+#: adminpages/addons.php:225
+#: adminpages/addons.php:208
+#: adminpages/addons.php:211
+#: adminpages/addons.php:224
+#: adminpages/addons.php:226
 #, php-format
 msgid "Deactivate %s"
 msgstr ""
 
-#: adminpages/addons.php:229 adminpages/addons.php:212
-#: adminpages/addons.php:215 adminpages/addons.php:228
-#: adminpages/addons.php:229 adminpages/addons.php:230
+#: adminpages/addons.php:229
+#: adminpages/addons.php:212
+#: adminpages/addons.php:215
+#: adminpages/addons.php:228
+#: adminpages/addons.php:230
 msgid "Activate"
 msgstr ""
 
-#: adminpages/addons.php:229 adminpages/addons.php:212
-#: adminpages/addons.php:215 adminpages/addons.php:228
-#: adminpages/addons.php:229 adminpages/addons.php:230
+#: adminpages/addons.php:229
+#: adminpages/addons.php:212
+#: adminpages/addons.php:215
+#: adminpages/addons.php:228
+#: adminpages/addons.php:230
 #, php-format
 msgid "Activate %s"
 msgstr ""
 
-#: adminpages/addons.php:230 adminpages/discountcodes.php:813
-#: adminpages/membershiplevels.php:803 adminpages/orders.php:1362
-#: adminpages/addons.php:213 adminpages/addons.php:216
-#: adminpages/addons.php:229 adminpages/addons.php:230
-#: adminpages/addons.php:231 adminpages/discountcodes.php:771
-#: adminpages/discountcodes.php:772 adminpages/discountcodes.php:773
-#: adminpages/discountcodes.php:779 adminpages/discountcodes.php:781
-#: adminpages/discountcodes.php:813 adminpages/membershiplevels.php:762
-#: adminpages/membershiplevels.php:779 adminpages/membershiplevels.php:784
-#: adminpages/membershiplevels.php:789 adminpages/membershiplevels.php:794
-#: adminpages/membershiplevels.php:801 adminpages/membershiplevels.php:803
-#: adminpages/orders.php:1338 adminpages/orders.php:1343
-#: adminpages/orders.php:1344 adminpages/orders.php:1353
+#: adminpages/addons.php:230
+#: adminpages/discountcodes.php:813
+#: adminpages/membershiplevels.php:803
+#: adminpages/orders.php:1362
+#: adminpages/addons.php:213
+#: adminpages/addons.php:216
+#: adminpages/addons.php:229
+#: adminpages/addons.php:231
+#: adminpages/discountcodes.php:771
+#: adminpages/discountcodes.php:772
+#: adminpages/discountcodes.php:773
+#: adminpages/discountcodes.php:779
+#: adminpages/discountcodes.php:781
+#: adminpages/membershiplevels.php:762
+#: adminpages/membershiplevels.php:779
+#: adminpages/membershiplevels.php:784
+#: adminpages/membershiplevels.php:789
+#: adminpages/membershiplevels.php:794
+#: adminpages/membershiplevels.php:801
+#: adminpages/orders.php:1338
+#: adminpages/orders.php:1343
+#: adminpages/orders.php:1344
+#: adminpages/orders.php:1353
 #: adminpages/orders.php:1358
 msgid "Delete"
 msgstr ""
 
-#: adminpages/addons.php:230 adminpages/addons.php:213
-#: adminpages/addons.php:216 adminpages/addons.php:229
-#: adminpages/addons.php:230 adminpages/addons.php:231
+#: adminpages/addons.php:230
+#: adminpages/addons.php:213
+#: adminpages/addons.php:216
+#: adminpages/addons.php:229
+#: adminpages/addons.php:231
 #, php-format
 msgid "Delete %s"
 msgstr ""
 
-#: adminpages/addons.php:240 adminpages/addons.php:223
-#: adminpages/addons.php:226 adminpages/addons.php:239
-#: adminpages/addons.php:240 adminpages/addons.php:241
+#: adminpages/addons.php:240
+#: adminpages/addons.php:223
+#: adminpages/addons.php:226
+#: adminpages/addons.php:239
+#: adminpages/addons.php:241
 msgid "PMPro Free"
 msgstr ""
 
-#: adminpages/addons.php:242 adminpages/addons.php:225
-#: adminpages/addons.php:228 adminpages/addons.php:241
-#: adminpages/addons.php:242 adminpages/addons.php:243
+#: adminpages/addons.php:242
+#: adminpages/addons.php:225
+#: adminpages/addons.php:228
+#: adminpages/addons.php:241
+#: adminpages/addons.php:243
 msgid "PMPro Core"
 msgstr ""
 
-#: adminpages/addons.php:244 adminpages/addons.php:227
-#: adminpages/addons.php:230 adminpages/addons.php:243
-#: adminpages/addons.php:244 adminpages/addons.php:245
+#: adminpages/addons.php:244
+#: adminpages/addons.php:227
+#: adminpages/addons.php:230
+#: adminpages/addons.php:243
+#: adminpages/addons.php:245
 msgid "PMPro Plus"
 msgstr ""
 
-#: adminpages/addons.php:246 adminpages/addons.php:229
-#: adminpages/addons.php:232 adminpages/addons.php:245
-#: adminpages/addons.php:246 adminpages/addons.php:247
+#: adminpages/addons.php:246
+#: adminpages/addons.php:229
+#: adminpages/addons.php:232
+#: adminpages/addons.php:245
+#: adminpages/addons.php:247
 msgid "WordPress.org"
 msgstr ""
 
-#: adminpages/addons.php:248 adminpages/orders.php:580
-#: adminpages/orders.php:913 adminpages/orders.php:1454
-#: adminpages/orders.php:1464 includes/profile.php:155
-#: shortcodes/pmpro_account.php:241 adminpages/addons.php:231
-#: adminpages/addons.php:234 adminpages/addons.php:247
-#: adminpages/addons.php:248 adminpages/addons.php:249
-#: adminpages/orders.php:855 adminpages/orders.php:891
-#: adminpages/orders.php:895 adminpages/orders.php:900
-#: adminpages/orders.php:901 adminpages/orders.php:910
-#: adminpages/orders.php:1340 adminpages/orders.php:1350
-#: adminpages/orders.php:1424 adminpages/orders.php:1429
-#: adminpages/orders.php:1430 adminpages/orders.php:1434
-#: adminpages/orders.php:1439 adminpages/orders.php:1440
-#: adminpages/orders.php:1445 adminpages/orders.php:1455
-#: adminpages/orders.php:1462 adminpages/orders.php:1472
-#: includes/profile.php:155 includes/profile.php:186 includes/profile.php:191
-#: shortcodes/pmpro_account.php:145 shortcodes/pmpro_account.php:146
-#: shortcodes/pmpro_account.php:148 shortcodes/pmpro_account.php:158
-#: shortcodes/pmpro_account.php:234 shortcodes/pmpro_account.php:241
+#: adminpages/addons.php:248
+#: adminpages/orders.php:580
+#: adminpages/orders.php:913
+#: adminpages/orders.php:1454
+#: adminpages/orders.php:1464
+#: includes/profile.php:155
+#: shortcodes/pmpro_account.php:241
+#: adminpages/addons.php:231
+#: adminpages/addons.php:234
+#: adminpages/addons.php:247
+#: adminpages/addons.php:249
+#: adminpages/orders.php:855
+#: adminpages/orders.php:891
+#: adminpages/orders.php:895
+#: adminpages/orders.php:900
+#: adminpages/orders.php:901
+#: adminpages/orders.php:910
+#: adminpages/orders.php:1340
+#: adminpages/orders.php:1350
+#: adminpages/orders.php:1424
+#: adminpages/orders.php:1429
+#: adminpages/orders.php:1430
+#: adminpages/orders.php:1434
+#: adminpages/orders.php:1439
+#: adminpages/orders.php:1440
+#: adminpages/orders.php:1445
+#: adminpages/orders.php:1455
+#: adminpages/orders.php:1462
+#: adminpages/orders.php:1472
+#: includes/profile.php:186
+#: includes/profile.php:191
+#: shortcodes/pmpro_account.php:145
+#: shortcodes/pmpro_account.php:146
+#: shortcodes/pmpro_account.php:148
+#: shortcodes/pmpro_account.php:158
+#: shortcodes/pmpro_account.php:234
 msgid "N/A"
 msgstr ""
 
-#: adminpages/addons.php:257 adminpages/addons.php:240
-#: adminpages/addons.php:243 adminpages/addons.php:256
-#: adminpages/addons.php:257 adminpages/addons.php:258
+#: adminpages/addons.php:257
+#: adminpages/addons.php:240
+#: adminpages/addons.php:243
+#: adminpages/addons.php:256
+#: adminpages/addons.php:258
 #, php-format
 msgid "Version %s"
 msgstr ""
 
-#: adminpages/addons.php:262 adminpages/addons.php:245
-#: adminpages/addons.php:248 adminpages/addons.php:261
-#: adminpages/addons.php:262 adminpages/addons.php:263
+#: adminpages/addons.php:262
+#: adminpages/addons.php:245
+#: adminpages/addons.php:248
+#: adminpages/addons.php:261
+#: adminpages/addons.php:263
 #, php-format
 msgid "By %s"
 msgstr ""
 
-#: adminpages/addons.php:269 adminpages/addons.php:252
-#: adminpages/addons.php:255 adminpages/addons.php:268
-#: adminpages/addons.php:269 adminpages/addons.php:270
+#: adminpages/addons.php:269
+#: adminpages/addons.php:252
+#: adminpages/addons.php:255
+#: adminpages/addons.php:268
+#: adminpages/addons.php:270
 #, php-format
 msgid "More information about %s"
 msgstr ""
 
-#: adminpages/addons.php:271 adminpages/addons.php:254
-#: adminpages/addons.php:257 adminpages/addons.php:270
-#: adminpages/addons.php:271 adminpages/addons.php:272
+#: adminpages/addons.php:271
+#: adminpages/addons.php:254
+#: adminpages/addons.php:257
+#: adminpages/addons.php:270
+#: adminpages/addons.php:272
 msgid "View details"
 msgstr ""
 
-#: adminpages/addons.php:276 adminpages/addons.php:259
-#: adminpages/addons.php:262 adminpages/addons.php:275
-#: adminpages/addons.php:276 adminpages/addons.php:277
+#: adminpages/addons.php:276
+#: adminpages/addons.php:259
+#: adminpages/addons.php:262
+#: adminpages/addons.php:275
+#: adminpages/addons.php:277
 msgid "Visit plugin site"
 msgstr ""
 
-#: adminpages/admin_header.php:25 adminpages/admin_header.php:25
+#: adminpages/admin_header.php:25
 msgid "Add a membership level to get started."
 msgstr ""
 
-#: adminpages/admin_header.php:27 adminpages/admin_header.php:29
-#: adminpages/admin_header.php:27 adminpages/admin_header.php:29
+#: adminpages/admin_header.php:27
+#: adminpages/admin_header.php:29
 msgid "Next step:"
 msgstr ""
 
-#: adminpages/admin_header.php:27 adminpages/admin_header.php:27
+#: adminpages/admin_header.php:27
 msgid "Set up the membership pages"
 msgstr ""
 
-#: adminpages/admin_header.php:29 adminpages/admin_header.php:29
+#: adminpages/admin_header.php:29
 msgid "Set up your SSL certificate and payment gateway"
 msgstr ""
 
-#: adminpages/admin_header.php:39 adminpages/admin_header.php:38
 #: adminpages/admin_header.php:39
-msgid ""
-"The billing details for some of your membership levels is not supported by "
-"Stripe."
+#: adminpages/admin_header.php:38
+msgid "The billing details for some of your membership levels is not supported by Stripe."
 msgstr ""
 
-#: adminpages/admin_header.php:47 adminpages/admin_header.php:46
 #: adminpages/admin_header.php:47
-msgid ""
-"The billing details for this level are not supported by Stripe. Please "
-"review the notes in the Billing Details section below."
+#: adminpages/admin_header.php:46
+msgid "The billing details for this level are not supported by Stripe. Please review the notes in the Billing Details section below."
 msgstr ""
 
-#: adminpages/admin_header.php:51 adminpages/admin_header.php:71
-#: adminpages/admin_header.php:98 adminpages/admin_header.php:122
-#: adminpages/admin_header.php:50 adminpages/admin_header.php:51
-#: adminpages/admin_header.php:70 adminpages/admin_header.php:71
-#: adminpages/admin_header.php:90 adminpages/admin_header.php:91
-#: adminpages/admin_header.php:98 adminpages/admin_header.php:111
-#: adminpages/admin_header.php:112 adminpages/admin_header.php:122
+#: adminpages/admin_header.php:51
+#: adminpages/admin_header.php:71
+#: adminpages/admin_header.php:98
+#: adminpages/admin_header.php:122
+#: adminpages/admin_header.php:50
+#: adminpages/admin_header.php:70
+#: adminpages/admin_header.php:90
+#: adminpages/admin_header.php:91
+#: adminpages/admin_header.php:111
+#: adminpages/admin_header.php:112
 msgid "The levels with issues are highlighted below."
 msgstr ""
 
-#: adminpages/admin_header.php:53 adminpages/admin_header.php:73
-#: adminpages/admin_header.php:101 adminpages/admin_header.php:124
-#: adminpages/admin_header.php:52 adminpages/admin_header.php:53
-#: adminpages/admin_header.php:72 adminpages/admin_header.php:73
-#: adminpages/admin_header.php:92 adminpages/admin_header.php:93
-#: adminpages/admin_header.php:101 adminpages/admin_header.php:113
-#: adminpages/admin_header.php:114 adminpages/admin_header.php:124
+#: adminpages/admin_header.php:53
+#: adminpages/admin_header.php:73
+#: adminpages/admin_header.php:101
+#: adminpages/admin_header.php:124
+#: adminpages/admin_header.php:52
+#: adminpages/admin_header.php:72
+#: adminpages/admin_header.php:92
+#: adminpages/admin_header.php:93
+#: adminpages/admin_header.php:113
+#: adminpages/admin_header.php:114
 msgid "Please edit your levels"
 msgstr ""
 
-#: adminpages/admin_header.php:59 adminpages/admin_header.php:58
 #: adminpages/admin_header.php:59
-msgid ""
-"The billing details for some of your membership levels is not supported by "
-"Payflow."
+#: adminpages/admin_header.php:58
+msgid "The billing details for some of your membership levels is not supported by Payflow."
 msgstr ""
 
-#: adminpages/admin_header.php:67 adminpages/admin_header.php:66
 #: adminpages/admin_header.php:67
-msgid ""
-"The billing details for this level are not supported by Payflow. Please "
-"review the notes in the Billing Details section below."
+#: adminpages/admin_header.php:66
+msgid "The billing details for this level are not supported by Payflow. Please review the notes in the Billing Details section below."
 msgstr ""
 
-#: adminpages/admin_header.php:82 adminpages/admin_header.php:78
-#: adminpages/admin_header.php:79 adminpages/admin_header.php:82
-msgid ""
-"The billing details for some of your membership levels is not supported by "
-"Braintree."
+#: adminpages/admin_header.php:82
+#: adminpages/admin_header.php:78
+#: adminpages/admin_header.php:79
+msgid "The billing details for some of your membership levels is not supported by Braintree."
 msgstr ""
 
-#: adminpages/admin_header.php:93 adminpages/admin_header.php:86
-#: adminpages/admin_header.php:87 adminpages/admin_header.php:93
-msgid ""
-"The billing details for this level are not supported by Braintree. Please "
-"review the notes in the Billing Details section below."
+#: adminpages/admin_header.php:93
+#: adminpages/admin_header.php:86
+#: adminpages/admin_header.php:87
+msgid "The billing details for this level are not supported by Braintree. Please review the notes in the Billing Details section below."
 msgstr ""
 
-#: adminpages/admin_header.php:109 adminpages/admin_header.php:98
-#: adminpages/admin_header.php:99 adminpages/admin_header.php:109
-msgid ""
-"The billing details for some of your membership levels is not supported by "
-"TwoCheckout."
+#: adminpages/admin_header.php:109
+#: adminpages/admin_header.php:98
+#: adminpages/admin_header.php:99
+msgid "The billing details for some of your membership levels is not supported by TwoCheckout."
 msgstr ""
 
-#: adminpages/admin_header.php:118 adminpages/admin_header.php:107
-#: adminpages/admin_header.php:108 adminpages/admin_header.php:118
-msgid ""
-"The billing details for this level are not supported by 2Checkout. Please "
-"review the notes in the Billing Details section below."
+#: adminpages/admin_header.php:118
+#: adminpages/admin_header.php:107
+#: adminpages/admin_header.php:108
+msgid "The billing details for this level are not supported by 2Checkout. Please review the notes in the Billing Details section below."
 msgstr ""
 
-#: adminpages/admin_header.php:129 adminpages/admin_header.php:129
-msgid ""
-"The billing details for some of your discount codes are not supported by "
-"your gateway."
+#: adminpages/admin_header.php:129
+msgid "The billing details for some of your discount codes are not supported by your gateway."
 msgstr ""
 
-#: adminpages/admin_header.php:133 adminpages/admin_header.php:133
-msgid ""
-"The billing details for this discount code are not supported by your gateway."
+#: adminpages/admin_header.php:133
+msgid "The billing details for this discount code are not supported by your gateway."
 msgstr ""
 
-#: adminpages/admin_header.php:137 adminpages/admin_header.php:137
+#: adminpages/admin_header.php:137
 msgid "The discount codes with issues are highlighted below."
 msgstr ""
 
-#: adminpages/admin_header.php:139 adminpages/admin_header.php:139
+#: adminpages/admin_header.php:139
 msgid "Please edit your discount codes"
 msgstr ""
 
 #: adminpages/admin_header.php:152
 #: classes/gateways/class.pmprogateway_stripe.php:75
-#: adminpages/admin_header.php:125 adminpages/admin_header.php:135
-#: adminpages/admin_header.php:152
+#: adminpages/admin_header.php:125
+#: adminpages/admin_header.php:135
 #: classes/gateways/class.pmprogateway_stripe.php:66
 #: classes/gateways/class.pmprogateway_stripe.php:68
 #: classes/gateways/class.pmprogateway_stripe.php:71
 #: classes/gateways/class.pmprogateway_stripe.php:73
 #: classes/gateways/class.pmprogateway_stripe.php:74
 #, php-format
-msgid ""
-"The Stripe Gateway requires PHP 5.3.29 or greater. We recommend upgrading to "
-"PHP %s or greater. Ask your host to upgrade."
+msgid "The Stripe Gateway requires PHP 5.3.29 or greater. We recommend upgrading to PHP %s or greater. Ask your host to upgrade."
 msgstr ""
 
 #: adminpages/admin_header.php:155
 #: classes/gateways/class.pmprogateway_braintree.php:73
-#: adminpages/admin_header.php:128 adminpages/admin_header.php:138
-#: adminpages/admin_header.php:155
+#: adminpages/admin_header.php:128
+#: adminpages/admin_header.php:138
 #: classes/gateways/class.pmprogateway_braintree.php:50
 #: classes/gateways/class.pmprogateway_braintree.php:70
-#: classes/gateways/class.pmprogateway_braintree.php:73
 #, php-format
-msgid ""
-"The Braintree Gateway requires PHP 5.4.45 or greater. We recommend upgrading "
-"to PHP %s or greater. Ask your host to upgrade."
+msgid "The Braintree Gateway requires PHP 5.4.45 or greater. We recommend upgrading to PHP %s or greater. Ask your host to upgrade."
 msgstr ""
 
-#: adminpages/admin_header.php:161 adminpages/admin_header.php:134
-#: adminpages/admin_header.php:144 adminpages/admin_header.php:161
+#: adminpages/admin_header.php:161
+#: adminpages/admin_header.php:134
+#: adminpages/admin_header.php:144
 #, php-format
 msgid "We recommend upgrading to PHP %s or greater. Ask your host to upgrade."
 msgstr ""
 
-#: adminpages/admin_header.php:173 adminpages/admin_header.php:156
-#: adminpages/admin_header.php:160 adminpages/admin_header.php:173
+#: adminpages/admin_header.php:173
+#: adminpages/admin_header.php:156
+#: adminpages/admin_header.php:160
 msgid "Documentation"
 msgstr ""
 
 #: adminpages/admin_header.php:174
 #: classes/class-pmpro-admin-activity-email.php:356
-#: adminpages/admin_header.php:157 adminpages/admin_header.php:161
-#: adminpages/admin_header.php:174
+#: adminpages/admin_header.php:157
+#: adminpages/admin_header.php:161
 msgid "Get Support"
 msgstr ""
 
-#: adminpages/admin_header.php:177 adminpages/admin_header.php:160
 #: adminpages/admin_header.php:177
+#: adminpages/admin_header.php:160
 #, php-format
-msgid ""
-"<a class=\"pmpro_license_tag pmpro_license_tag-valid\" href=\"%s\">Valid "
-"License</a>"
+msgid "<a class=\"pmpro_license_tag pmpro_license_tag-valid\" href=\"%s\">Valid License</a>"
 msgstr ""
 
-#: adminpages/admin_header.php:179 adminpages/admin_header.php:162
 #: adminpages/admin_header.php:179
+#: adminpages/admin_header.php:162
 #, php-format
-msgid ""
-"<a class=\"pmpro_license_tag pmpro_license_tag-invalid\" href=\"%s\">No "
-"License</a>"
+msgid "<a class=\"pmpro_license_tag pmpro_license_tag-invalid\" href=\"%s\">No License</a>"
 msgstr ""
 
-#: adminpages/admin_header.php:221 includes/adminpages.php:50
-#: includes/adminpages.php:143 adminpages/admin_header.php:188
-#: adminpages/admin_header.php:189 adminpages/admin_header.php:196
-#: adminpages/admin_header.php:204 adminpages/admin_header.php:221
-#: includes/adminpages.php:50 includes/adminpages.php:132
-#: includes/adminpages.php:133 includes/adminpages.php:141
+#: adminpages/admin_header.php:221
+#: includes/adminpages.php:50
 #: includes/adminpages.php:143
+#: adminpages/admin_header.php:188
+#: adminpages/admin_header.php:189
+#: adminpages/admin_header.php:196
+#: adminpages/admin_header.php:204
+#: includes/adminpages.php:132
+#: includes/adminpages.php:133
+#: includes/adminpages.php:141
 msgid "Dashboard"
 msgstr ""
 
-#: adminpages/admin_header.php:225 includes/adminpages.php:51
-#: includes/adminpages.php:155 adminpages/admin_header.php:192
-#: adminpages/admin_header.php:193 adminpages/admin_header.php:200
-#: adminpages/admin_header.php:208 adminpages/admin_header.php:225
-#: includes/adminpages.php:51 includes/adminpages.php:144
-#: includes/adminpages.php:145 includes/adminpages.php:153
+#: adminpages/admin_header.php:225
+#: includes/adminpages.php:51
 #: includes/adminpages.php:155
+#: adminpages/admin_header.php:192
+#: adminpages/admin_header.php:193
+#: adminpages/admin_header.php:200
+#: adminpages/admin_header.php:208
+#: includes/adminpages.php:144
+#: includes/adminpages.php:145
+#: includes/adminpages.php:153
 msgid "Members"
 msgstr ""
 
-#: adminpages/admin_header.php:229 adminpages/discountcodes.php:817
-#: adminpages/orders.php:960 classes/class-pmpro-admin-activity-email.php:221
-#: includes/adminpages.php:52 includes/adminpages.php:167
-#: adminpages/admin_header.php:196 adminpages/admin_header.php:197
-#: adminpages/admin_header.php:204 adminpages/admin_header.php:212
-#: adminpages/admin_header.php:229 adminpages/discountcodes.php:775
-#: adminpages/discountcodes.php:776 adminpages/discountcodes.php:777
-#: adminpages/discountcodes.php:783 adminpages/discountcodes.php:785
-#: adminpages/discountcodes.php:817 adminpages/orders.php:520
-#: adminpages/orders.php:570 adminpages/orders.php:677
-#: adminpages/orders.php:706 adminpages/orders.php:810
-#: adminpages/orders.php:841 adminpages/orders.php:852
-#: adminpages/orders.php:939 adminpages/orders.php:944
-#: adminpages/orders.php:949 adminpages/orders.php:994
-#: classes/class-pmpro-admin-activity-email.php:219 includes/adminpages.php:17
-#: includes/adminpages.php:52 includes/adminpages.php:55
-#: includes/adminpages.php:56 includes/adminpages.php:84
-#: includes/adminpages.php:156 includes/adminpages.php:157
-#: includes/adminpages.php:163 includes/adminpages.php:165
-#: includes/adminpages.php:167 includes/adminpages.php:172
+#: adminpages/admin_header.php:229
+#: adminpages/discountcodes.php:817
+#: adminpages/orders.php:960
+#: classes/class-pmpro-admin-activity-email.php:221
+#: includes/adminpages.php:52
+#: includes/adminpages.php:167
+#: adminpages/admin_header.php:196
+#: adminpages/admin_header.php:197
+#: adminpages/admin_header.php:204
+#: adminpages/admin_header.php:212
+#: adminpages/discountcodes.php:775
+#: adminpages/discountcodes.php:776
+#: adminpages/discountcodes.php:777
+#: adminpages/discountcodes.php:783
+#: adminpages/discountcodes.php:785
+#: adminpages/orders.php:520
+#: adminpages/orders.php:570
+#: adminpages/orders.php:677
+#: adminpages/orders.php:706
+#: adminpages/orders.php:810
+#: adminpages/orders.php:841
+#: adminpages/orders.php:852
+#: adminpages/orders.php:939
+#: adminpages/orders.php:944
+#: adminpages/orders.php:949
+#: adminpages/orders.php:994
+#: classes/class-pmpro-admin-activity-email.php:219
+#: includes/adminpages.php:17
+#: includes/adminpages.php:55
+#: includes/adminpages.php:56
+#: includes/adminpages.php:84
+#: includes/adminpages.php:156
+#: includes/adminpages.php:157
+#: includes/adminpages.php:163
+#: includes/adminpages.php:165
+#: includes/adminpages.php:172
 msgid "Orders"
 msgstr ""
 
-#: adminpages/admin_header.php:233 includes/adminpages.php:53
-#: includes/adminpages.php:179 adminpages/admin_header.php:200
-#: adminpages/admin_header.php:201 adminpages/admin_header.php:208
-#: adminpages/admin_header.php:216 adminpages/admin_header.php:233
-#: includes/adminpages.php:16 includes/adminpages.php:53
-#: includes/adminpages.php:54 includes/adminpages.php:55
-#: includes/adminpages.php:79 includes/adminpages.php:149
-#: includes/adminpages.php:156 includes/adminpages.php:160
-#: includes/adminpages.php:165 includes/adminpages.php:168
-#: includes/adminpages.php:169 includes/adminpages.php:177
+#: adminpages/admin_header.php:233
+#: includes/adminpages.php:53
 #: includes/adminpages.php:179
+#: adminpages/admin_header.php:200
+#: adminpages/admin_header.php:201
+#: adminpages/admin_header.php:208
+#: adminpages/admin_header.php:216
+#: includes/adminpages.php:16
+#: includes/adminpages.php:54
+#: includes/adminpages.php:55
+#: includes/adminpages.php:79
+#: includes/adminpages.php:149
+#: includes/adminpages.php:156
+#: includes/adminpages.php:160
+#: includes/adminpages.php:165
+#: includes/adminpages.php:168
+#: includes/adminpages.php:169
+#: includes/adminpages.php:177
 msgid "Reports"
 msgstr ""
 
-#: adminpages/admin_header.php:237 includes/adminpages.php:54
-#: includes/adminpages.php:191 adminpages/admin_header.php:204
-#: adminpages/admin_header.php:205 adminpages/admin_header.php:212
-#: adminpages/admin_header.php:220 adminpages/admin_header.php:237
-#: includes/adminpages.php:54 includes/adminpages.php:180
-#: includes/adminpages.php:181 includes/adminpages.php:189
+#: adminpages/admin_header.php:237
+#: includes/adminpages.php:54
 #: includes/adminpages.php:191
+#: adminpages/admin_header.php:204
+#: adminpages/admin_header.php:205
+#: adminpages/admin_header.php:212
+#: adminpages/admin_header.php:220
+#: includes/adminpages.php:180
+#: includes/adminpages.php:181
+#: includes/adminpages.php:189
 msgid "Settings"
 msgstr ""
 
-#: adminpages/admin_header.php:245 includes/adminpages.php:64
-#: adminpages/admin_header.php:213 adminpages/admin_header.php:220
-#: adminpages/admin_header.php:228 adminpages/admin_header.php:245
-#: includes/adminpages.php:56 includes/adminpages.php:64
+#: adminpages/admin_header.php:245
+#: includes/adminpages.php:64
+#: adminpages/admin_header.php:213
+#: adminpages/admin_header.php:220
+#: adminpages/admin_header.php:228
+#: includes/adminpages.php:56
 #: includes/adminpages.php:205
 msgid "License"
 msgstr ""
 
-#: adminpages/admin_header.php:252 adminpages/discountcodes.php:785
-#: adminpages/admin_header.php:215 adminpages/admin_header.php:220
-#: adminpages/admin_header.php:227 adminpages/admin_header.php:235
-#: adminpages/admin_header.php:252 adminpages/discountcodes.php:552
-#: adminpages/discountcodes.php:562 adminpages/discountcodes.php:590
-#: adminpages/discountcodes.php:591 adminpages/discountcodes.php:592
-#: adminpages/discountcodes.php:597 adminpages/discountcodes.php:670
-#: adminpages/discountcodes.php:724 adminpages/discountcodes.php:750
-#: adminpages/discountcodes.php:751 adminpages/discountcodes.php:752
+#: adminpages/admin_header.php:252
 #: adminpages/discountcodes.php:785
+#: adminpages/admin_header.php:215
+#: adminpages/admin_header.php:220
+#: adminpages/admin_header.php:227
+#: adminpages/admin_header.php:235
+#: adminpages/discountcodes.php:552
+#: adminpages/discountcodes.php:562
+#: adminpages/discountcodes.php:590
+#: adminpages/discountcodes.php:591
+#: adminpages/discountcodes.php:592
+#: adminpages/discountcodes.php:597
+#: adminpages/discountcodes.php:670
+#: adminpages/discountcodes.php:724
+#: adminpages/discountcodes.php:750
+#: adminpages/discountcodes.php:751
+#: adminpages/discountcodes.php:752
 msgid "Levels"
 msgstr ""
 
-#: adminpages/admin_header.php:252 adminpages/membershiplevels.php:760
-#: adminpages/pagesettings.php:98 includes/compatibility/beaver-builder.php:134
-#: includes/metaboxes.php:131 adminpages/admin_header.php:128
-#: adminpages/admin_header.php:149 adminpages/admin_header.php:150
-#: adminpages/admin_header.php:159 adminpages/admin_header.php:171
-#: adminpages/admin_header.php:184 adminpages/admin_header.php:215
-#: adminpages/admin_header.php:220 adminpages/admin_header.php:227
-#: adminpages/admin_header.php:235 adminpages/admin_header.php:252
-#: adminpages/membershiplevels.php:490 adminpages/membershiplevels.php:496
-#: adminpages/membershiplevels.php:498 adminpages/membershiplevels.php:525
-#: adminpages/membershiplevels.php:526 adminpages/membershiplevels.php:569
-#: adminpages/membershiplevels.php:607 adminpages/membershiplevels.php:609
-#: adminpages/membershiplevels.php:618 adminpages/membershiplevels.php:619
-#: adminpages/membershiplevels.php:631 adminpages/membershiplevels.php:641
-#: adminpages/membershiplevels.php:700 adminpages/membershiplevels.php:702
-#: adminpages/membershiplevels.php:728 adminpages/membershiplevels.php:745
-#: adminpages/membershiplevels.php:750 adminpages/membershiplevels.php:755
-#: adminpages/pagesettings.php:69 adminpages/pagesettings.php:70
-#: adminpages/pagesettings.php:71 adminpages/pagesettings.php:85
-#: adminpages/pagesettings.php:98 includes/adminpages.php:44
-#: includes/adminpages.php:64 includes/adminpages.php:65
-#: includes/adminpages.php:69 includes/adminpages.php:70
-#: includes/adminpages.php:100 includes/adminpages.php:107
-#: includes/adminpages.php:111 includes/adminpages.php:116
-#: includes/compatibility/beaver-builder.php:130 includes/metaboxes.php:126
-#: includes/metaboxes.php:130 includes/metaboxes.php:131
+#: adminpages/admin_header.php:252
+#: adminpages/membershiplevels.php:760
+#: adminpages/pagesettings.php:98
+#: includes/compatibility/beaver-builder.php:134
+#: includes/metaboxes.php:131
+#: adminpages/admin_header.php:128
+#: adminpages/admin_header.php:149
+#: adminpages/admin_header.php:150
+#: adminpages/admin_header.php:159
+#: adminpages/admin_header.php:171
+#: adminpages/admin_header.php:184
+#: adminpages/admin_header.php:215
+#: adminpages/admin_header.php:220
+#: adminpages/admin_header.php:227
+#: adminpages/admin_header.php:235
+#: adminpages/membershiplevels.php:490
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:498
+#: adminpages/membershiplevels.php:525
+#: adminpages/membershiplevels.php:526
+#: adminpages/membershiplevels.php:569
+#: adminpages/membershiplevels.php:607
+#: adminpages/membershiplevels.php:609
+#: adminpages/membershiplevels.php:618
+#: adminpages/membershiplevels.php:619
+#: adminpages/membershiplevels.php:631
+#: adminpages/membershiplevels.php:641
+#: adminpages/membershiplevels.php:700
+#: adminpages/membershiplevels.php:702
+#: adminpages/membershiplevels.php:728
+#: adminpages/membershiplevels.php:745
+#: adminpages/membershiplevels.php:750
+#: adminpages/membershiplevels.php:755
+#: adminpages/pagesettings.php:69
+#: adminpages/pagesettings.php:70
+#: adminpages/pagesettings.php:71
+#: adminpages/pagesettings.php:85
+#: includes/adminpages.php:44
+#: includes/adminpages.php:64
+#: includes/adminpages.php:65
+#: includes/adminpages.php:69
+#: includes/adminpages.php:70
+#: includes/adminpages.php:100
+#: includes/adminpages.php:107
+#: includes/adminpages.php:111
+#: includes/adminpages.php:116
+#: includes/compatibility/beaver-builder.php:130
+#: includes/metaboxes.php:126
+#: includes/metaboxes.php:130
 #: includes/metaboxes.php:132
 msgid "Membership Levels"
 msgstr ""
 
-#: adminpages/admin_header.php:256 includes/adminpages.php:67
-#: adminpages/admin_header.php:219 adminpages/admin_header.php:224
-#: adminpages/admin_header.php:231 adminpages/admin_header.php:239
-#: adminpages/admin_header.php:256 includes/adminpages.php:18
-#: includes/adminpages.php:56 includes/adminpages.php:57
-#: includes/adminpages.php:58 includes/adminpages.php:59
-#: includes/adminpages.php:67 includes/adminpages.php:89
-#: includes/adminpages.php:163 includes/adminpages.php:170
-#: includes/adminpages.php:174 includes/adminpages.php:179
+#: adminpages/admin_header.php:256
+#: includes/adminpages.php:67
+#: adminpages/admin_header.php:219
+#: adminpages/admin_header.php:224
+#: adminpages/admin_header.php:231
+#: adminpages/admin_header.php:239
+#: includes/adminpages.php:18
+#: includes/adminpages.php:56
+#: includes/adminpages.php:57
+#: includes/adminpages.php:58
+#: includes/adminpages.php:59
+#: includes/adminpages.php:89
+#: includes/adminpages.php:163
+#: includes/adminpages.php:170
+#: includes/adminpages.php:174
+#: includes/adminpages.php:179
 msgid "Discount Codes"
 msgstr ""
 
-#: adminpages/admin_header.php:260 adminpages/pagesettings.php:149
-#: includes/adminpages.php:68 adminpages/admin_header.php:223
-#: adminpages/admin_header.php:228 adminpages/admin_header.php:235
-#: adminpages/admin_header.php:243 adminpages/admin_header.php:260
-#: adminpages/pagesettings.php:108 includes/adminpages.php:10
-#: includes/adminpages.php:48 includes/adminpages.php:49
-#: includes/adminpages.php:59 includes/adminpages.php:60
-#: includes/adminpages.php:68 includes/adminpages.php:107
-#: includes/adminpages.php:114 includes/adminpages.php:118
+#: adminpages/admin_header.php:260
+#: adminpages/pagesettings.php:149
+#: includes/adminpages.php:68
+#: adminpages/admin_header.php:223
+#: adminpages/admin_header.php:228
+#: adminpages/admin_header.php:235
+#: adminpages/admin_header.php:243
+#: adminpages/pagesettings.php:108
+#: includes/adminpages.php:10
+#: includes/adminpages.php:48
+#: includes/adminpages.php:49
+#: includes/adminpages.php:59
+#: includes/adminpages.php:60
+#: includes/adminpages.php:107
+#: includes/adminpages.php:114
+#: includes/adminpages.php:118
 #: includes/adminpages.php:123
 msgid "Page Settings"
 msgstr ""
 
-#: adminpages/admin_header.php:260 adminpages/admin_header.php:129
-#: adminpages/admin_header.php:150 adminpages/admin_header.php:154
-#: adminpages/admin_header.php:163 adminpages/admin_header.php:175
-#: adminpages/admin_header.php:188 adminpages/admin_header.php:223
-#: adminpages/admin_header.php:228 adminpages/admin_header.php:235
-#: adminpages/admin_header.php:243 adminpages/admin_header.php:260
-#: adminpages/pagesettings.php:92 adminpages/pagesettings.php:93
-#: adminpages/pagesettings.php:108 adminpages/pagesettings.php:120
+#: adminpages/admin_header.php:260
+#: adminpages/admin_header.php:129
+#: adminpages/admin_header.php:150
+#: adminpages/admin_header.php:154
+#: adminpages/admin_header.php:163
+#: adminpages/admin_header.php:175
+#: adminpages/admin_header.php:188
+#: adminpages/admin_header.php:223
+#: adminpages/admin_header.php:228
+#: adminpages/admin_header.php:235
+#: adminpages/admin_header.php:243
+#: adminpages/pagesettings.php:92
+#: adminpages/pagesettings.php:93
+#: adminpages/pagesettings.php:108
+#: adminpages/pagesettings.php:120
 msgid "Pages"
 msgstr ""
 
-#: adminpages/admin_header.php:264 adminpages/admin_header.php:130
-#: adminpages/admin_header.php:151 adminpages/admin_header.php:158
-#: adminpages/admin_header.php:167 adminpages/admin_header.php:179
-#: adminpages/admin_header.php:192 adminpages/admin_header.php:227
-#: adminpages/admin_header.php:232 adminpages/admin_header.php:239
-#: adminpages/admin_header.php:247 adminpages/admin_header.php:264
+#: adminpages/admin_header.php:264
+#: adminpages/admin_header.php:130
+#: adminpages/admin_header.php:151
+#: adminpages/admin_header.php:158
+#: adminpages/admin_header.php:167
+#: adminpages/admin_header.php:179
+#: adminpages/admin_header.php:192
+#: adminpages/admin_header.php:227
+#: adminpages/admin_header.php:232
+#: adminpages/admin_header.php:239
+#: adminpages/admin_header.php:247
 msgid "Payment Gateway &amp; SSL"
 msgstr ""
 
-#: adminpages/admin_header.php:264 adminpages/admin_header.php:227
-#: adminpages/admin_header.php:232 adminpages/admin_header.php:239
-#: adminpages/admin_header.php:247 adminpages/admin_header.php:264
+#: adminpages/admin_header.php:264
+#: adminpages/admin_header.php:227
+#: adminpages/admin_header.php:232
+#: adminpages/admin_header.php:239
+#: adminpages/admin_header.php:247
 msgid "Payment Gateway &amp; SSL Settings"
 msgstr ""
 
-#: adminpages/admin_header.php:268 adminpages/orders.php:384
-#: adminpages/orders.php:1369 includes/profile.php:510
-#: shortcodes/pmpro_account.php:161 adminpages/admin_header.php:131
-#: adminpages/admin_header.php:152 adminpages/admin_header.php:162
-#: adminpages/admin_header.php:171 adminpages/admin_header.php:183
-#: adminpages/admin_header.php:196 adminpages/admin_header.php:231
-#: adminpages/admin_header.php:236 adminpages/admin_header.php:243
-#: adminpages/admin_header.php:251 adminpages/admin_header.php:268
-#: adminpages/memberslist.php:115 adminpages/memberslist.php:148
-#: adminpages/memberslist.php:158 adminpages/memberslist.php:168
-#: adminpages/memberslist.php:172 adminpages/orders.php:371
-#: adminpages/orders.php:372 adminpages/orders.php:376
-#: adminpages/orders.php:1345 adminpages/orders.php:1350
-#: adminpages/orders.php:1351 adminpages/orders.php:1360
-#: adminpages/orders.php:1365 includes/profile.php:493 includes/profile.php:502
-#: includes/profile.php:511 includes/profile.php:539 pages/account.php:52
-#: pages/account.php:56 pages/account.php:77 shortcodes/pmpro_account.php:106
-#: shortcodes/pmpro_account.php:108 shortcodes/pmpro_account.php:109
-#: shortcodes/pmpro_account.php:111 shortcodes/pmpro_account.php:160
+#: adminpages/admin_header.php:268
+#: adminpages/orders.php:384
+#: adminpages/orders.php:1369
+#: includes/profile.php:510
 #: shortcodes/pmpro_account.php:161
+#: adminpages/admin_header.php:131
+#: adminpages/admin_header.php:152
+#: adminpages/admin_header.php:162
+#: adminpages/admin_header.php:171
+#: adminpages/admin_header.php:183
+#: adminpages/admin_header.php:196
+#: adminpages/admin_header.php:231
+#: adminpages/admin_header.php:236
+#: adminpages/admin_header.php:243
+#: adminpages/admin_header.php:251
+#: adminpages/memberslist.php:115
+#: adminpages/memberslist.php:148
+#: adminpages/memberslist.php:158
+#: adminpages/memberslist.php:168
+#: adminpages/memberslist.php:172
+#: adminpages/orders.php:371
+#: adminpages/orders.php:372
+#: adminpages/orders.php:376
+#: adminpages/orders.php:1345
+#: adminpages/orders.php:1350
+#: adminpages/orders.php:1351
+#: adminpages/orders.php:1360
+#: adminpages/orders.php:1365
+#: includes/profile.php:493
+#: includes/profile.php:502
+#: includes/profile.php:511
+#: includes/profile.php:539
+#: pages/account.php:52
+#: pages/account.php:56
+#: pages/account.php:77
+#: shortcodes/pmpro_account.php:106
+#: shortcodes/pmpro_account.php:108
+#: shortcodes/pmpro_account.php:109
+#: shortcodes/pmpro_account.php:111
+#: shortcodes/pmpro_account.php:160
 msgid "Email"
 msgstr ""
 
-#: adminpages/admin_header.php:268 adminpages/emailsettings.php:83
-#: includes/adminpages.php:70 adminpages/admin_header.php:231
-#: adminpages/admin_header.php:236 adminpages/admin_header.php:243
-#: adminpages/admin_header.php:251 adminpages/admin_header.php:268
-#: adminpages/emailsettings.php:60 adminpages/emailsettings.php:69
-#: adminpages/emailsettings.php:79 adminpages/emailsettings.php:83
-#: includes/adminpages.php:12 includes/adminpages.php:50
-#: includes/adminpages.php:51 includes/adminpages.php:59
-#: includes/adminpages.php:61 includes/adminpages.php:62
-#: includes/adminpages.php:70 includes/adminpages.php:121
-#: includes/adminpages.php:128 includes/adminpages.php:132
+#: adminpages/admin_header.php:268
+#: adminpages/emailsettings.php:83
+#: includes/adminpages.php:70
+#: adminpages/admin_header.php:231
+#: adminpages/admin_header.php:236
+#: adminpages/admin_header.php:243
+#: adminpages/admin_header.php:251
+#: adminpages/emailsettings.php:60
+#: adminpages/emailsettings.php:69
+#: adminpages/emailsettings.php:79
+#: includes/adminpages.php:12
+#: includes/adminpages.php:50
+#: includes/adminpages.php:51
+#: includes/adminpages.php:59
+#: includes/adminpages.php:61
+#: includes/adminpages.php:62
+#: includes/adminpages.php:121
+#: includes/adminpages.php:128
+#: includes/adminpages.php:132
 #: includes/adminpages.php:137
 msgid "Email Settings"
 msgstr ""
 
-#: adminpages/admin_header.php:272 adminpages/admin_header.php:132
-#: adminpages/admin_header.php:153 adminpages/admin_header.php:166
-#: adminpages/admin_header.php:175 adminpages/admin_header.php:187
-#: adminpages/admin_header.php:200 adminpages/admin_header.php:235
-#: adminpages/admin_header.php:240 adminpages/admin_header.php:247
-#: adminpages/admin_header.php:255 adminpages/admin_header.php:272
+#: adminpages/admin_header.php:272
+#: adminpages/admin_header.php:132
+#: adminpages/admin_header.php:153
+#: adminpages/admin_header.php:166
+#: adminpages/admin_header.php:175
+#: adminpages/admin_header.php:187
+#: adminpages/admin_header.php:200
+#: adminpages/admin_header.php:235
+#: adminpages/admin_header.php:240
+#: adminpages/admin_header.php:247
+#: adminpages/admin_header.php:255
 msgid "Advanced"
 msgstr ""
 
-#: adminpages/admin_header.php:272 adminpages/advancedsettings.php:132
-#: includes/adminpages.php:71 adminpages/admin_header.php:235
-#: adminpages/admin_header.php:240 adminpages/admin_header.php:247
-#: adminpages/admin_header.php:255 adminpages/admin_header.php:272
-#: adminpages/advancedsettings.php:79 adminpages/advancedsettings.php:86
-#: adminpages/advancedsettings.php:88 adminpages/advancedsettings.php:91
-#: adminpages/advancedsettings.php:107 adminpages/advancedsettings.php:109
-#: includes/adminpages.php:13 includes/adminpages.php:51
-#: includes/adminpages.php:52 includes/adminpages.php:62
-#: includes/adminpages.php:63 includes/adminpages.php:64
-#: includes/adminpages.php:71 includes/adminpages.php:128
-#: includes/adminpages.php:135 includes/adminpages.php:139
+#: adminpages/admin_header.php:272
+#: adminpages/advancedsettings.php:132
+#: includes/adminpages.php:71
+#: adminpages/admin_header.php:235
+#: adminpages/admin_header.php:240
+#: adminpages/admin_header.php:247
+#: adminpages/admin_header.php:255
+#: adminpages/advancedsettings.php:79
+#: adminpages/advancedsettings.php:86
+#: adminpages/advancedsettings.php:88
+#: adminpages/advancedsettings.php:91
+#: adminpages/advancedsettings.php:107
+#: adminpages/advancedsettings.php:109
+#: includes/adminpages.php:13
+#: includes/adminpages.php:51
+#: includes/adminpages.php:52
+#: includes/adminpages.php:62
+#: includes/adminpages.php:63
+#: includes/adminpages.php:64
+#: includes/adminpages.php:128
+#: includes/adminpages.php:135
+#: includes/adminpages.php:139
 #: includes/adminpages.php:144
 msgid "Advanced Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:13 adminpages/discountcodes.php:63
-#: adminpages/discountcodes.php:311 adminpages/emailsettings.php:16
-#: adminpages/membershiplevels.php:43 adminpages/pagesettings.php:29
-#: adminpages/pagesettings.php:72 adminpages/paymentsettings.php:19
-#: adminpages/advancedsettings.php:13 adminpages/discountcodes.php:58
-#: adminpages/discountcodes.php:61 adminpages/discountcodes.php:63
-#: adminpages/discountcodes.php:304 adminpages/discountcodes.php:309
-#: adminpages/discountcodes.php:311 adminpages/emailsettings.php:16
-#: adminpages/membershiplevels.php:43 adminpages/pagesettings.php:29
-#: adminpages/pagesettings.php:68 adminpages/pagesettings.php:72
+#: adminpages/advancedsettings.php:13
+#: adminpages/discountcodes.php:63
+#: adminpages/discountcodes.php:311
+#: adminpages/emailsettings.php:16
+#: adminpages/membershiplevels.php:43
+#: adminpages/pagesettings.php:29
+#: adminpages/pagesettings.php:72
 #: adminpages/paymentsettings.php:19
+#: adminpages/discountcodes.php:58
+#: adminpages/discountcodes.php:61
+#: adminpages/discountcodes.php:304
+#: adminpages/discountcodes.php:309
+#: adminpages/pagesettings.php:68
 msgid "Are you sure you want to do that? Try again."
 msgstr ""
 
-#: adminpages/advancedsettings.php:68 adminpages/advancedsettings.php:35
-#: adminpages/advancedsettings.php:42 adminpages/advancedsettings.php:43
-#: adminpages/advancedsettings.php:46 adminpages/advancedsettings.php:60
-#: adminpages/advancedsettings.php:61 adminpages/advancedsettings.php:62
-#: adminpages/advancedsettings.php:67 adminpages/advancedsettings.php:68
+#: adminpages/advancedsettings.php:68
+#: adminpages/advancedsettings.php:35
+#: adminpages/advancedsettings.php:42
+#: adminpages/advancedsettings.php:43
+#: adminpages/advancedsettings.php:46
+#: adminpages/advancedsettings.php:60
+#: adminpages/advancedsettings.php:61
+#: adminpages/advancedsettings.php:62
+#: adminpages/advancedsettings.php:67
 msgid "Your advanced settings have been updated."
 msgstr ""
 
-#: adminpages/advancedsettings.php:106 includes/updates/upgrade_1.php:7
-#: adminpages/advancedsettings.php:104 adminpages/advancedsettings.php:106
+#: adminpages/advancedsettings.php:106
 #: includes/updates/upgrade_1.php:7
+#: adminpages/advancedsettings.php:104
 #, php-format
-msgid ""
-"This content is for !!levels!! members only.<br /><a href=\"%s\">Join Now</a>"
+msgid "This content is for !!levels!! members only.<br /><a href=\"%s\">Join Now</a>"
 msgstr ""
 
-#: adminpages/advancedsettings.php:111 adminpages/advancedsettings.php:109
 #: adminpages/advancedsettings.php:111
+#: adminpages/advancedsettings.php:109
 #, php-format
-msgid ""
-"This content is for !!levels!! members only.<br /><a href=\"%s\">Log In</a> "
-"<a href=\"%s\">Join Now</a>"
+msgid "This content is for !!levels!! members only.<br /><a href=\"%s\">Log In</a> <a href=\"%s\">Join Now</a>"
 msgstr ""
 
-#: adminpages/advancedsettings.php:116 includes/updates/upgrade_1.php:13
-#: adminpages/advancedsettings.php:76 adminpages/advancedsettings.php:78
-#: adminpages/advancedsettings.php:81 adminpages/advancedsettings.php:95
-#: adminpages/advancedsettings.php:97 adminpages/advancedsettings.php:99
-#: adminpages/advancedsettings.php:114 adminpages/advancedsettings.php:116
+#: adminpages/advancedsettings.php:116
 #: includes/updates/upgrade_1.php:13
-msgid ""
-"This content is for members only. Visit the site and log in/register to read."
+#: adminpages/advancedsettings.php:76
+#: adminpages/advancedsettings.php:78
+#: adminpages/advancedsettings.php:81
+#: adminpages/advancedsettings.php:95
+#: adminpages/advancedsettings.php:97
+#: adminpages/advancedsettings.php:99
+#: adminpages/advancedsettings.php:114
+msgid "This content is for members only. Visit the site and log in/register to read."
 msgstr ""
 
 #: adminpages/advancedsettings.php:135
 msgid "Restrict Dashboard Access"
 msgstr ""
 
-#: adminpages/advancedsettings.php:140 adminpages/advancedsettings.php:138
 #: adminpages/advancedsettings.php:140
+#: adminpages/advancedsettings.php:138
 msgid "WordPress Dashboard"
 msgstr ""
 
-#: adminpages/advancedsettings.php:143 adminpages/advancedsettings.php:141
 #: adminpages/advancedsettings.php:143
+#: adminpages/advancedsettings.php:141
 msgid "Block all users with the Subscriber role from accessing the Dashboard."
 msgstr ""
 
-#: adminpages/advancedsettings.php:148 adminpages/advancedsettings.php:146
 #: adminpages/advancedsettings.php:148
+#: adminpages/advancedsettings.php:146
 msgid "WordPress Toolbar"
 msgstr ""
 
-#: adminpages/advancedsettings.php:151 adminpages/advancedsettings.php:149
 #: adminpages/advancedsettings.php:151
+#: adminpages/advancedsettings.php:149
 msgid "Hide the Toolbar from all users with the Subscriber role."
 msgstr ""
 
@@ -768,123 +1016,174 @@ msgstr ""
 msgid "Message Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:164 adminpages/advancedsettings.php:85
-#: adminpages/advancedsettings.php:92 adminpages/advancedsettings.php:94
-#: adminpages/advancedsettings.php:97 adminpages/advancedsettings.php:113
-#: adminpages/advancedsettings.php:115 adminpages/advancedsettings.php:118
-#: adminpages/advancedsettings.php:162 adminpages/advancedsettings.php:164
+#: adminpages/advancedsettings.php:164
+#: adminpages/advancedsettings.php:85
+#: adminpages/advancedsettings.php:92
+#: adminpages/advancedsettings.php:94
+#: adminpages/advancedsettings.php:97
+#: adminpages/advancedsettings.php:113
+#: adminpages/advancedsettings.php:115
+#: adminpages/advancedsettings.php:118
+#: adminpages/advancedsettings.php:162
 msgid "Message for Logged-in Non-members"
 msgstr ""
 
-#: adminpages/advancedsettings.php:168 adminpages/advancedsettings.php:89
-#: adminpages/advancedsettings.php:96 adminpages/advancedsettings.php:98
-#: adminpages/advancedsettings.php:101 adminpages/advancedsettings.php:117
-#: adminpages/advancedsettings.php:119 adminpages/advancedsettings.php:122
-#: adminpages/advancedsettings.php:166 adminpages/advancedsettings.php:168
-msgid ""
-"This message replaces the post content for non-members. Available variables"
+#: adminpages/advancedsettings.php:168
+#: adminpages/advancedsettings.php:89
+#: adminpages/advancedsettings.php:96
+#: adminpages/advancedsettings.php:98
+#: adminpages/advancedsettings.php:101
+#: adminpages/advancedsettings.php:117
+#: adminpages/advancedsettings.php:119
+#: adminpages/advancedsettings.php:122
+#: adminpages/advancedsettings.php:166
+msgid "This message replaces the post content for non-members. Available variables"
 msgstr ""
 
-#: adminpages/advancedsettings.php:173 adminpages/advancedsettings.php:94
-#: adminpages/advancedsettings.php:101 adminpages/advancedsettings.php:103
-#: adminpages/advancedsettings.php:106 adminpages/advancedsettings.php:122
-#: adminpages/advancedsettings.php:124 adminpages/advancedsettings.php:127
-#: adminpages/advancedsettings.php:171 adminpages/advancedsettings.php:173
+#: adminpages/advancedsettings.php:173
+#: adminpages/advancedsettings.php:94
+#: adminpages/advancedsettings.php:101
+#: adminpages/advancedsettings.php:103
+#: adminpages/advancedsettings.php:106
+#: adminpages/advancedsettings.php:122
+#: adminpages/advancedsettings.php:124
+#: adminpages/advancedsettings.php:127
+#: adminpages/advancedsettings.php:171
 msgid "Message for Logged-out Users"
 msgstr ""
 
-#: adminpages/advancedsettings.php:177 adminpages/advancedsettings.php:186
-#: adminpages/advancedsettings.php:175 adminpages/advancedsettings.php:177
-#: adminpages/advancedsettings.php:184 adminpages/advancedsettings.php:186
+#: adminpages/advancedsettings.php:177
+#: adminpages/advancedsettings.php:186
+#: adminpages/advancedsettings.php:175
+#: adminpages/advancedsettings.php:184
 msgid "Available variables"
 msgstr ""
 
-#: adminpages/advancedsettings.php:177 adminpages/advancedsettings.php:98
-#: adminpages/advancedsettings.php:105 adminpages/advancedsettings.php:107
-#: adminpages/advancedsettings.php:110 adminpages/advancedsettings.php:126
-#: adminpages/advancedsettings.php:128 adminpages/advancedsettings.php:131
-#: adminpages/advancedsettings.php:175 adminpages/advancedsettings.php:177
+#: adminpages/advancedsettings.php:177
+#: adminpages/advancedsettings.php:98
+#: adminpages/advancedsettings.php:105
+#: adminpages/advancedsettings.php:107
+#: adminpages/advancedsettings.php:110
+#: adminpages/advancedsettings.php:126
+#: adminpages/advancedsettings.php:128
+#: adminpages/advancedsettings.php:131
+#: adminpages/advancedsettings.php:175
 msgid "This message replaces the post content for logged-out visitors."
 msgstr ""
 
-#: adminpages/advancedsettings.php:182 adminpages/advancedsettings.php:103
-#: adminpages/advancedsettings.php:110 adminpages/advancedsettings.php:112
-#: adminpages/advancedsettings.php:115 adminpages/advancedsettings.php:131
-#: adminpages/advancedsettings.php:133 adminpages/advancedsettings.php:136
-#: adminpages/advancedsettings.php:180 adminpages/advancedsettings.php:182
+#: adminpages/advancedsettings.php:182
+#: adminpages/advancedsettings.php:103
+#: adminpages/advancedsettings.php:110
+#: adminpages/advancedsettings.php:112
+#: adminpages/advancedsettings.php:115
+#: adminpages/advancedsettings.php:131
+#: adminpages/advancedsettings.php:133
+#: adminpages/advancedsettings.php:136
+#: adminpages/advancedsettings.php:180
 msgid "Message for RSS Feed"
 msgstr ""
 
-#: adminpages/advancedsettings.php:186 adminpages/advancedsettings.php:107
-#: adminpages/advancedsettings.php:114 adminpages/advancedsettings.php:116
-#: adminpages/advancedsettings.php:119 adminpages/advancedsettings.php:135
-#: adminpages/advancedsettings.php:137 adminpages/advancedsettings.php:140
-#: adminpages/advancedsettings.php:184 adminpages/advancedsettings.php:186
+#: adminpages/advancedsettings.php:186
+#: adminpages/advancedsettings.php:107
+#: adminpages/advancedsettings.php:114
+#: adminpages/advancedsettings.php:116
+#: adminpages/advancedsettings.php:119
+#: adminpages/advancedsettings.php:135
+#: adminpages/advancedsettings.php:137
+#: adminpages/advancedsettings.php:140
+#: adminpages/advancedsettings.php:184
 msgid "This message replaces the post content in RSS feeds."
 msgstr ""
 
-#: adminpages/advancedsettings.php:194 adminpages/membershiplevels.php:604
-#: adminpages/advancedsettings.php:143 adminpages/membershiplevels.php:457
-#: adminpages/membershiplevels.php:463 adminpages/membershiplevels.php:465
-#: adminpages/membershiplevels.php:492 adminpages/membershiplevels.php:493
-#: adminpages/membershiplevels.php:495 adminpages/membershiplevels.php:496
-#: adminpages/membershiplevels.php:517 adminpages/membershiplevels.php:527
-#: adminpages/membershiplevels.php:570 adminpages/membershiplevels.php:572
-#: adminpages/membershiplevels.php:589 adminpages/membershiplevels.php:594
+#: adminpages/advancedsettings.php:194
+#: adminpages/membershiplevels.php:604
+#: adminpages/advancedsettings.php:143
+#: adminpages/membershiplevels.php:457
+#: adminpages/membershiplevels.php:463
+#: adminpages/membershiplevels.php:465
+#: adminpages/membershiplevels.php:492
+#: adminpages/membershiplevels.php:493
+#: adminpages/membershiplevels.php:495
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:517
+#: adminpages/membershiplevels.php:527
+#: adminpages/membershiplevels.php:570
+#: adminpages/membershiplevels.php:572
+#: adminpages/membershiplevels.php:589
+#: adminpages/membershiplevels.php:594
 #: adminpages/membershiplevels.php:599
 msgid "Content Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:199 adminpages/advancedsettings.php:122
-#: adminpages/advancedsettings.php:125 adminpages/advancedsettings.php:141
-#: adminpages/advancedsettings.php:143 adminpages/advancedsettings.php:148
-#: adminpages/advancedsettings.php:151 adminpages/advancedsettings.php:197
 #: adminpages/advancedsettings.php:199
+#: adminpages/advancedsettings.php:122
+#: adminpages/advancedsettings.php:125
+#: adminpages/advancedsettings.php:141
+#: adminpages/advancedsettings.php:143
+#: adminpages/advancedsettings.php:148
+#: adminpages/advancedsettings.php:151
+#: adminpages/advancedsettings.php:197
 msgid "Filter searches and archives?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:203 adminpages/advancedsettings.php:126
-#: adminpages/advancedsettings.php:129 adminpages/advancedsettings.php:145
-#: adminpages/advancedsettings.php:147 adminpages/advancedsettings.php:152
-#: adminpages/advancedsettings.php:155 adminpages/advancedsettings.php:201
 #: adminpages/advancedsettings.php:203
-msgid ""
-"No - Non-members will see restricted posts/pages in searches and archives."
+#: adminpages/advancedsettings.php:126
+#: adminpages/advancedsettings.php:129
+#: adminpages/advancedsettings.php:145
+#: adminpages/advancedsettings.php:147
+#: adminpages/advancedsettings.php:152
+#: adminpages/advancedsettings.php:155
+#: adminpages/advancedsettings.php:201
+msgid "No - Non-members will see restricted posts/pages in searches and archives."
 msgstr ""
 
-#: adminpages/advancedsettings.php:204 adminpages/advancedsettings.php:127
-#: adminpages/advancedsettings.php:130 adminpages/advancedsettings.php:146
-#: adminpages/advancedsettings.php:148 adminpages/advancedsettings.php:153
-#: adminpages/advancedsettings.php:156 adminpages/advancedsettings.php:202
 #: adminpages/advancedsettings.php:204
-msgid ""
-"Yes - Only members will see restricted posts/pages in searches and archives."
+#: adminpages/advancedsettings.php:127
+#: adminpages/advancedsettings.php:130
+#: adminpages/advancedsettings.php:146
+#: adminpages/advancedsettings.php:148
+#: adminpages/advancedsettings.php:153
+#: adminpages/advancedsettings.php:156
+#: adminpages/advancedsettings.php:202
+msgid "Yes - Only members will see restricted posts/pages in searches and archives."
 msgstr ""
 
-#: adminpages/advancedsettings.php:210 adminpages/advancedsettings.php:113
-#: adminpages/advancedsettings.php:120 adminpages/advancedsettings.php:133
-#: adminpages/advancedsettings.php:136 adminpages/advancedsettings.php:152
-#: adminpages/advancedsettings.php:154 adminpages/advancedsettings.php:159
-#: adminpages/advancedsettings.php:162 adminpages/advancedsettings.php:208
 #: adminpages/advancedsettings.php:210
+#: adminpages/advancedsettings.php:113
+#: adminpages/advancedsettings.php:120
+#: adminpages/advancedsettings.php:133
+#: adminpages/advancedsettings.php:136
+#: adminpages/advancedsettings.php:152
+#: adminpages/advancedsettings.php:154
+#: adminpages/advancedsettings.php:159
+#: adminpages/advancedsettings.php:162
+#: adminpages/advancedsettings.php:208
 msgid "Show Excerpts to Non-Members?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:214 adminpages/advancedsettings.php:117
-#: adminpages/advancedsettings.php:124 adminpages/advancedsettings.php:137
-#: adminpages/advancedsettings.php:140 adminpages/advancedsettings.php:156
-#: adminpages/advancedsettings.php:158 adminpages/advancedsettings.php:163
-#: adminpages/advancedsettings.php:166 adminpages/advancedsettings.php:212
 #: adminpages/advancedsettings.php:214
+#: adminpages/advancedsettings.php:117
+#: adminpages/advancedsettings.php:124
+#: adminpages/advancedsettings.php:137
+#: adminpages/advancedsettings.php:140
+#: adminpages/advancedsettings.php:156
+#: adminpages/advancedsettings.php:158
+#: adminpages/advancedsettings.php:163
+#: adminpages/advancedsettings.php:166
+#: adminpages/advancedsettings.php:212
 msgid "No - Hide excerpts."
 msgstr ""
 
-#: adminpages/advancedsettings.php:215 adminpages/advancedsettings.php:118
-#: adminpages/advancedsettings.php:125 adminpages/advancedsettings.php:138
-#: adminpages/advancedsettings.php:141 adminpages/advancedsettings.php:157
-#: adminpages/advancedsettings.php:159 adminpages/advancedsettings.php:164
-#: adminpages/advancedsettings.php:167 adminpages/advancedsettings.php:213
 #: adminpages/advancedsettings.php:215
+#: adminpages/advancedsettings.php:118
+#: adminpages/advancedsettings.php:125
+#: adminpages/advancedsettings.php:138
+#: adminpages/advancedsettings.php:141
+#: adminpages/advancedsettings.php:157
+#: adminpages/advancedsettings.php:159
+#: adminpages/advancedsettings.php:164
+#: adminpages/advancedsettings.php:167
+#: adminpages/advancedsettings.php:213
 msgid "Yes - Show excerpts."
 msgstr ""
 
@@ -892,75 +1191,116 @@ msgstr ""
 msgid "Checkout Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:229 adminpages/advancedsettings.php:218
-#: adminpages/advancedsettings.php:225 adminpages/advancedsettings.php:227
-#: adminpages/advancedsettings.php:229 adminpages/advancedsettings.php:238
-#: adminpages/advancedsettings.php:241 adminpages/advancedsettings.php:257
-#: adminpages/advancedsettings.php:266 adminpages/advancedsettings.php:290
+#: adminpages/advancedsettings.php:229
+#: adminpages/advancedsettings.php:218
+#: adminpages/advancedsettings.php:225
+#: adminpages/advancedsettings.php:227
+#: adminpages/advancedsettings.php:238
+#: adminpages/advancedsettings.php:241
+#: adminpages/advancedsettings.php:257
+#: adminpages/advancedsettings.php:266
+#: adminpages/advancedsettings.php:290
 #: adminpages/advancedsettings.php:308
 msgid "Require Terms of Service on signups?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:236 adminpages/advancedsettings.php:225
-#: adminpages/advancedsettings.php:232 adminpages/advancedsettings.php:234
-#: adminpages/advancedsettings.php:236 adminpages/advancedsettings.php:245
-#: adminpages/advancedsettings.php:248 adminpages/advancedsettings.php:264
-#: adminpages/advancedsettings.php:273 adminpages/advancedsettings.php:297
+#: adminpages/advancedsettings.php:236
+#: adminpages/advancedsettings.php:225
+#: adminpages/advancedsettings.php:232
+#: adminpages/advancedsettings.php:234
+#: adminpages/advancedsettings.php:245
+#: adminpages/advancedsettings.php:248
+#: adminpages/advancedsettings.php:264
+#: adminpages/advancedsettings.php:273
+#: adminpages/advancedsettings.php:297
 #: adminpages/advancedsettings.php:315
-msgid ""
-"If yes, create a WordPress page containing your TOS agreement and assign it "
-"using the dropdown above."
+msgid "If yes, create a WordPress page containing your TOS agreement and assign it using the dropdown above."
 msgstr ""
 
-#: adminpages/advancedsettings.php:241 adminpages/advancedsettings.php:176
-#: adminpages/advancedsettings.php:179 adminpages/advancedsettings.php:195
-#: adminpages/advancedsettings.php:202 adminpages/advancedsettings.php:215
-#: adminpages/advancedsettings.php:218 adminpages/advancedsettings.php:234
-#: adminpages/advancedsettings.php:236 adminpages/advancedsettings.php:239
 #: adminpages/advancedsettings.php:241
+#: adminpages/advancedsettings.php:176
+#: adminpages/advancedsettings.php:179
+#: adminpages/advancedsettings.php:195
+#: adminpages/advancedsettings.php:202
+#: adminpages/advancedsettings.php:215
+#: adminpages/advancedsettings.php:218
+#: adminpages/advancedsettings.php:234
+#: adminpages/advancedsettings.php:236
+#: adminpages/advancedsettings.php:239
 msgid "Use reCAPTCHA?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:245 adminpages/advancedsettings.php:337
-#: adminpages/advancedsettings.php:393 adminpages/advancedsettings.php:476
-#: adminpages/membershiplevels.php:820 adminpages/paymentsettings.php:259
+#: adminpages/advancedsettings.php:245
+#: adminpages/advancedsettings.php:337
+#: adminpages/advancedsettings.php:393
+#: adminpages/advancedsettings.php:476
+#: adminpages/membershiplevels.php:820
+#: adminpages/paymentsettings.php:259
 #: classes/gateways/class.pmprogateway_stripe.php:401
 #: classes/gateways/class.pmprogateway_stripe.php:415
 #: includes/compatibility/beaver-builder.php:45
-#: includes/compatibility/beaver-builder.php:141 includes/profile.php:89
-#: adminpages/advancedsettings.php:128 adminpages/advancedsettings.php:135
-#: adminpages/advancedsettings.php:148 adminpages/advancedsettings.php:151
-#: adminpages/advancedsettings.php:167 adminpages/advancedsettings.php:169
-#: adminpages/advancedsettings.php:180 adminpages/advancedsettings.php:183
-#: adminpages/advancedsettings.php:187 adminpages/advancedsettings.php:194
-#: adminpages/advancedsettings.php:199 adminpages/advancedsettings.php:206
-#: adminpages/advancedsettings.php:207 adminpages/advancedsettings.php:210
-#: adminpages/advancedsettings.php:219 adminpages/advancedsettings.php:222
-#: adminpages/advancedsettings.php:225 adminpages/advancedsettings.php:226
-#: adminpages/advancedsettings.php:228 adminpages/advancedsettings.php:238
-#: adminpages/advancedsettings.php:240 adminpages/advancedsettings.php:243
-#: adminpages/advancedsettings.php:245 adminpages/advancedsettings.php:282
-#: adminpages/advancedsettings.php:300 adminpages/advancedsettings.php:335
-#: adminpages/advancedsettings.php:337 adminpages/advancedsettings.php:392
-#: adminpages/advancedsettings.php:393 adminpages/advancedsettings.php:471
-#: adminpages/advancedsettings.php:476 adminpages/membershiplevels.php:563
-#: adminpages/membershiplevels.php:569 adminpages/membershiplevels.php:571
-#: adminpages/membershiplevels.php:578 adminpages/membershiplevels.php:598
-#: adminpages/membershiplevels.php:658 adminpages/membershiplevels.php:660
-#: adminpages/membershiplevels.php:662 adminpages/membershiplevels.php:667
-#: adminpages/membershiplevels.php:668 adminpages/membershiplevels.php:672
-#: adminpages/membershiplevels.php:684 adminpages/membershiplevels.php:694
-#: adminpages/membershiplevels.php:744 adminpages/membershiplevels.php:746
-#: adminpages/membershiplevels.php:779 adminpages/membershiplevels.php:796
-#: adminpages/membershiplevels.php:801 adminpages/membershiplevels.php:806
-#: adminpages/membershiplevels.php:811 adminpages/membershiplevels.php:818
-#: adminpages/membershiplevels.php:820 adminpages/paymentsettings.php:210
-#: adminpages/paymentsettings.php:219 adminpages/paymentsettings.php:236
-#: adminpages/paymentsettings.php:253 adminpages/paymentsettings.php:256
-#: adminpages/paymentsettings.php:257 adminpages/paymentsettings.php:259
-#: adminpages/paymentsettings.php:414 adminpages/paymentsettings.php:429
-#: adminpages/paymentsettings.php:434 adminpages/paymentsettings.php:436
-#: adminpages/paymentsettings.php:454 adminpages/paymentsettings.php:459
+#: includes/compatibility/beaver-builder.php:141
+#: includes/profile.php:89
+#: adminpages/advancedsettings.php:128
+#: adminpages/advancedsettings.php:135
+#: adminpages/advancedsettings.php:148
+#: adminpages/advancedsettings.php:151
+#: adminpages/advancedsettings.php:167
+#: adminpages/advancedsettings.php:169
+#: adminpages/advancedsettings.php:180
+#: adminpages/advancedsettings.php:183
+#: adminpages/advancedsettings.php:187
+#: adminpages/advancedsettings.php:194
+#: adminpages/advancedsettings.php:199
+#: adminpages/advancedsettings.php:206
+#: adminpages/advancedsettings.php:207
+#: adminpages/advancedsettings.php:210
+#: adminpages/advancedsettings.php:219
+#: adminpages/advancedsettings.php:222
+#: adminpages/advancedsettings.php:225
+#: adminpages/advancedsettings.php:226
+#: adminpages/advancedsettings.php:228
+#: adminpages/advancedsettings.php:238
+#: adminpages/advancedsettings.php:240
+#: adminpages/advancedsettings.php:243
+#: adminpages/advancedsettings.php:282
+#: adminpages/advancedsettings.php:300
+#: adminpages/advancedsettings.php:335
+#: adminpages/advancedsettings.php:392
+#: adminpages/advancedsettings.php:471
+#: adminpages/membershiplevels.php:563
+#: adminpages/membershiplevels.php:569
+#: adminpages/membershiplevels.php:571
+#: adminpages/membershiplevels.php:578
+#: adminpages/membershiplevels.php:598
+#: adminpages/membershiplevels.php:658
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:662
+#: adminpages/membershiplevels.php:667
+#: adminpages/membershiplevels.php:668
+#: adminpages/membershiplevels.php:672
+#: adminpages/membershiplevels.php:684
+#: adminpages/membershiplevels.php:694
+#: adminpages/membershiplevels.php:744
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:779
+#: adminpages/membershiplevels.php:796
+#: adminpages/membershiplevels.php:801
+#: adminpages/membershiplevels.php:806
+#: adminpages/membershiplevels.php:811
+#: adminpages/membershiplevels.php:818
+#: adminpages/paymentsettings.php:210
+#: adminpages/paymentsettings.php:219
+#: adminpages/paymentsettings.php:236
+#: adminpages/paymentsettings.php:253
+#: adminpages/paymentsettings.php:256
+#: adminpages/paymentsettings.php:257
+#: adminpages/paymentsettings.php:414
+#: adminpages/paymentsettings.php:429
+#: adminpages/paymentsettings.php:434
+#: adminpages/paymentsettings.php:436
+#: adminpages/paymentsettings.php:454
+#: adminpages/paymentsettings.php:459
 #: adminpages/paymentsettings.php:461
 #: classes/gateways/class.pmprogateway_stripe.php:173
 #: classes/gateways/class.pmprogateway_stripe.php:174
@@ -984,84 +1324,117 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:393
 #: classes/gateways/class.pmprogateway_stripe.php:406
 #: includes/compatibility/beaver-builder.php:43
-#: includes/compatibility/beaver-builder.php:137 includes/profile.php:89
-#: includes/profile.php:101 includes/profile.php:105 includes/profile.php:110
-#: includes/profile.php:117 includes/profile.php:120 includes/profile.php:121
-#: includes/profile.php:123 includes/profile.php:125
+#: includes/compatibility/beaver-builder.php:137
+#: includes/profile.php:101
+#: includes/profile.php:105
+#: includes/profile.php:110
+#: includes/profile.php:117
+#: includes/profile.php:120
+#: includes/profile.php:121
+#: includes/profile.php:123
+#: includes/profile.php:125
 msgid "No"
 msgstr ""
 
-#: adminpages/advancedsettings.php:246 adminpages/advancedsettings.php:181
-#: adminpages/advancedsettings.php:184 adminpages/advancedsettings.php:200
-#: adminpages/advancedsettings.php:207 adminpages/advancedsettings.php:220
-#: adminpages/advancedsettings.php:223 adminpages/advancedsettings.php:239
-#: adminpages/advancedsettings.php:241 adminpages/advancedsettings.php:244
 #: adminpages/advancedsettings.php:246
+#: adminpages/advancedsettings.php:181
+#: adminpages/advancedsettings.php:184
+#: adminpages/advancedsettings.php:200
+#: adminpages/advancedsettings.php:207
+#: adminpages/advancedsettings.php:220
+#: adminpages/advancedsettings.php:223
+#: adminpages/advancedsettings.php:239
+#: adminpages/advancedsettings.php:241
+#: adminpages/advancedsettings.php:244
 msgid "Yes - Free memberships only."
 msgstr ""
 
-#: adminpages/advancedsettings.php:247 adminpages/advancedsettings.php:182
-#: adminpages/advancedsettings.php:185 adminpages/advancedsettings.php:201
-#: adminpages/advancedsettings.php:208 adminpages/advancedsettings.php:221
-#: adminpages/advancedsettings.php:224 adminpages/advancedsettings.php:240
-#: adminpages/advancedsettings.php:242 adminpages/advancedsettings.php:245
 #: adminpages/advancedsettings.php:247
+#: adminpages/advancedsettings.php:182
+#: adminpages/advancedsettings.php:185
+#: adminpages/advancedsettings.php:201
+#: adminpages/advancedsettings.php:208
+#: adminpages/advancedsettings.php:221
+#: adminpages/advancedsettings.php:224
+#: adminpages/advancedsettings.php:240
+#: adminpages/advancedsettings.php:242
+#: adminpages/advancedsettings.php:245
 msgid "Yes - All memberships."
 msgstr ""
 
-#: adminpages/advancedsettings.php:249 adminpages/advancedsettings.php:184
-#: adminpages/advancedsettings.php:187 adminpages/advancedsettings.php:203
-#: adminpages/advancedsettings.php:210 adminpages/advancedsettings.php:223
-#: adminpages/advancedsettings.php:226 adminpages/advancedsettings.php:242
-#: adminpages/advancedsettings.php:244 adminpages/advancedsettings.php:247
 #: adminpages/advancedsettings.php:249
+#: adminpages/advancedsettings.php:184
+#: adminpages/advancedsettings.php:187
+#: adminpages/advancedsettings.php:203
+#: adminpages/advancedsettings.php:210
+#: adminpages/advancedsettings.php:223
+#: adminpages/advancedsettings.php:226
+#: adminpages/advancedsettings.php:242
+#: adminpages/advancedsettings.php:244
+#: adminpages/advancedsettings.php:247
 msgid "A free reCAPTCHA key is required."
 msgstr ""
 
-#: adminpages/advancedsettings.php:249 adminpages/advancedsettings.php:184
-#: adminpages/advancedsettings.php:187 adminpages/advancedsettings.php:203
-#: adminpages/advancedsettings.php:210 adminpages/advancedsettings.php:223
-#: adminpages/advancedsettings.php:226 adminpages/advancedsettings.php:242
-#: adminpages/advancedsettings.php:244 adminpages/advancedsettings.php:247
 #: adminpages/advancedsettings.php:249
+#: adminpages/advancedsettings.php:184
+#: adminpages/advancedsettings.php:187
+#: adminpages/advancedsettings.php:203
+#: adminpages/advancedsettings.php:210
+#: adminpages/advancedsettings.php:223
+#: adminpages/advancedsettings.php:226
+#: adminpages/advancedsettings.php:242
+#: adminpages/advancedsettings.php:244
+#: adminpages/advancedsettings.php:247
 msgid "Click here to signup for reCAPTCHA"
 msgstr ""
 
-#: adminpages/advancedsettings.php:257 adminpages/advancedsettings.php:192
-#: adminpages/advancedsettings.php:195 adminpages/advancedsettings.php:250
-#: adminpages/advancedsettings.php:255 adminpages/advancedsettings.php:257
+#: adminpages/advancedsettings.php:257
+#: adminpages/advancedsettings.php:192
+#: adminpages/advancedsettings.php:195
+#: adminpages/advancedsettings.php:250
+#: adminpages/advancedsettings.php:255
 msgid "reCAPTCHA Version"
 msgstr ""
 
-#: adminpages/advancedsettings.php:260 adminpages/advancedsettings.php:195
-#: adminpages/advancedsettings.php:198 adminpages/advancedsettings.php:252
-#: adminpages/advancedsettings.php:258 adminpages/advancedsettings.php:260
+#: adminpages/advancedsettings.php:260
+#: adminpages/advancedsettings.php:195
+#: adminpages/advancedsettings.php:198
+#: adminpages/advancedsettings.php:252
+#: adminpages/advancedsettings.php:258
 msgid " v2 - Checkbox"
 msgstr ""
 
-#: adminpages/advancedsettings.php:261 adminpages/advancedsettings.php:196
-#: adminpages/advancedsettings.php:199 adminpages/advancedsettings.php:253
-#: adminpages/advancedsettings.php:259 adminpages/advancedsettings.php:261
+#: adminpages/advancedsettings.php:261
+#: adminpages/advancedsettings.php:196
+#: adminpages/advancedsettings.php:199
+#: adminpages/advancedsettings.php:253
+#: adminpages/advancedsettings.php:259
 msgid "v3 - Invisible"
 msgstr ""
 
-#: adminpages/advancedsettings.php:263 adminpages/advancedsettings.php:198
-#: adminpages/advancedsettings.php:201 adminpages/advancedsettings.php:255
-#: adminpages/advancedsettings.php:261 adminpages/advancedsettings.php:263
+#: adminpages/advancedsettings.php:263
+#: adminpages/advancedsettings.php:198
+#: adminpages/advancedsettings.php:201
+#: adminpages/advancedsettings.php:255
+#: adminpages/advancedsettings.php:261
 msgid "Changing your version will require new API keys."
 msgstr ""
 
-#: adminpages/advancedsettings.php:267 adminpages/advancedsettings.php:202
-#: adminpages/advancedsettings.php:205 adminpages/advancedsettings.php:248
-#: adminpages/advancedsettings.php:257 adminpages/advancedsettings.php:265
 #: adminpages/advancedsettings.php:267
+#: adminpages/advancedsettings.php:202
+#: adminpages/advancedsettings.php:205
+#: adminpages/advancedsettings.php:248
+#: adminpages/advancedsettings.php:257
+#: adminpages/advancedsettings.php:265
 msgid "reCAPTCHA Site Key"
 msgstr ""
 
-#: adminpages/advancedsettings.php:273 adminpages/advancedsettings.php:208
-#: adminpages/advancedsettings.php:211 adminpages/advancedsettings.php:251
-#: adminpages/advancedsettings.php:260 adminpages/advancedsettings.php:271
 #: adminpages/advancedsettings.php:273
+#: adminpages/advancedsettings.php:208
+#: adminpages/advancedsettings.php:211
+#: adminpages/advancedsettings.php:251
+#: adminpages/advancedsettings.php:260
+#: adminpages/advancedsettings.php:271
 msgid "reCAPTCHA Secret Key"
 msgstr ""
 
@@ -1069,185 +1442,252 @@ msgstr ""
 msgid "Communication Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:286 adminpages/advancedsettings.php:246
-#: adminpages/advancedsettings.php:284 adminpages/advancedsettings.php:286
+#: adminpages/advancedsettings.php:286
+#: adminpages/advancedsettings.php:246
+#: adminpages/advancedsettings.php:284
 msgid "Notifications"
 msgstr ""
 
-#: adminpages/advancedsettings.php:290 adminpages/advancedsettings.php:250
-#: adminpages/advancedsettings.php:288 adminpages/advancedsettings.php:290
+#: adminpages/advancedsettings.php:290
+#: adminpages/advancedsettings.php:250
+#: adminpages/advancedsettings.php:288
 msgid "Show all notifications."
 msgstr ""
 
-#: adminpages/advancedsettings.php:293 adminpages/advancedsettings.php:253
-#: adminpages/advancedsettings.php:291 adminpages/advancedsettings.php:293
+#: adminpages/advancedsettings.php:293
+#: adminpages/advancedsettings.php:253
+#: adminpages/advancedsettings.php:291
 msgid "Show only security notifications."
 msgstr ""
 
-#: adminpages/advancedsettings.php:297 adminpages/advancedsettings.php:257
-#: adminpages/advancedsettings.php:295 adminpages/advancedsettings.php:297
-msgid ""
-"Notifications are occasionally shown on the Paid Memberships Pro settings "
-"pages."
+#: adminpages/advancedsettings.php:297
+#: adminpages/advancedsettings.php:257
+#: adminpages/advancedsettings.php:295
+msgid "Notifications are occasionally shown on the Paid Memberships Pro settings pages."
 msgstr ""
 
-#: adminpages/advancedsettings.php:302 adminpages/advancedsettings.php:300
 #: adminpages/advancedsettings.php:302
+#: adminpages/advancedsettings.php:300
 msgid "Activity Email Frequency"
 msgstr ""
 
-#: adminpages/advancedsettings.php:307 adminpages/reports/memberships.php:351
-#: adminpages/reports/sales.php:290 adminpages/advancedsettings.php:305
-#: adminpages/advancedsettings.php:307 adminpages/reports/memberships.php:258
+#: adminpages/advancedsettings.php:307
+#: adminpages/reports/memberships.php:351
+#: adminpages/reports/sales.php:290
+#: adminpages/advancedsettings.php:305
+#: adminpages/reports/memberships.php:258
 #: adminpages/reports/memberships.php:265
 #: adminpages/reports/memberships.php:278
 #: adminpages/reports/memberships.php:294
 #: adminpages/reports/memberships.php:306
 #: adminpages/reports/memberships.php:330
-#: adminpages/reports/memberships.php:351 adminpages/reports/sales.php:187
-#: adminpages/reports/sales.php:195 adminpages/reports/sales.php:196
-#: adminpages/reports/sales.php:204 adminpages/reports/sales.php:205
-#: adminpages/reports/sales.php:221 adminpages/reports/sales.php:290
+#: adminpages/reports/sales.php:187
+#: adminpages/reports/sales.php:195
+#: adminpages/reports/sales.php:196
+#: adminpages/reports/sales.php:204
+#: adminpages/reports/sales.php:205
+#: adminpages/reports/sales.php:221
 msgid "Daily"
 msgstr ""
 
-#: adminpages/advancedsettings.php:310 adminpages/advancedsettings.php:308
 #: adminpages/advancedsettings.php:310
+#: adminpages/advancedsettings.php:308
 msgid "Weekly"
 msgstr ""
 
-#: adminpages/advancedsettings.php:313 adminpages/reports/memberships.php:352
-#: adminpages/reports/sales.php:291 adminpages/advancedsettings.php:311
-#: adminpages/advancedsettings.php:313 adminpages/reports/memberships.php:259
+#: adminpages/advancedsettings.php:313
+#: adminpages/reports/memberships.php:352
+#: adminpages/reports/sales.php:291
+#: adminpages/advancedsettings.php:311
+#: adminpages/reports/memberships.php:259
 #: adminpages/reports/memberships.php:266
 #: adminpages/reports/memberships.php:279
 #: adminpages/reports/memberships.php:295
 #: adminpages/reports/memberships.php:307
 #: adminpages/reports/memberships.php:331
-#: adminpages/reports/memberships.php:352 adminpages/reports/sales.php:188
-#: adminpages/reports/sales.php:196 adminpages/reports/sales.php:197
-#: adminpages/reports/sales.php:205 adminpages/reports/sales.php:206
-#: adminpages/reports/sales.php:222 adminpages/reports/sales.php:291
+#: adminpages/reports/sales.php:188
+#: adminpages/reports/sales.php:196
+#: adminpages/reports/sales.php:197
+#: adminpages/reports/sales.php:205
+#: adminpages/reports/sales.php:206
+#: adminpages/reports/sales.php:222
 msgid "Monthly"
 msgstr ""
 
-#: adminpages/advancedsettings.php:316 includes/privacy.php:175
-#: adminpages/advancedsettings.php:314 adminpages/advancedsettings.php:316
-#: adminpages/memberslist.php:184 adminpages/memberslist.php:212
+#: adminpages/advancedsettings.php:316
 #: includes/privacy.php:175
+#: adminpages/advancedsettings.php:314
+#: adminpages/memberslist.php:184
+#: adminpages/memberslist.php:212
 msgid "Never"
 msgstr ""
 
-#: adminpages/advancedsettings.php:320 adminpages/advancedsettings.php:318
 #: adminpages/advancedsettings.php:320
-msgid ""
-"Send periodic sales and revenue updates from this site to the administration "
-"email address."
+#: adminpages/advancedsettings.php:318
+msgid "Send periodic sales and revenue updates from this site to the administration email address."
 msgstr ""
 
-#: adminpages/advancedsettings.php:328 adminpages/dashboard.php:140
-#: adminpages/membershiplevels.php:537 adminpages/advancedsettings.php:216
-#: adminpages/membershiplevels.php:422 adminpages/membershiplevels.php:428
-#: adminpages/membershiplevels.php:430 adminpages/membershiplevels.php:457
-#: adminpages/membershiplevels.php:458 adminpages/membershiplevels.php:460
-#: adminpages/membershiplevels.php:461 adminpages/membershiplevels.php:482
-#: adminpages/membershiplevels.php:492 adminpages/membershiplevels.php:516
-#: adminpages/membershiplevels.php:518 adminpages/membershiplevels.php:524
-#: adminpages/membershiplevels.php:529 adminpages/membershiplevels.php:534
+#: adminpages/advancedsettings.php:328
+#: adminpages/dashboard.php:140
+#: adminpages/membershiplevels.php:537
+#: adminpages/advancedsettings.php:216
+#: adminpages/membershiplevels.php:422
+#: adminpages/membershiplevels.php:428
+#: adminpages/membershiplevels.php:430
+#: adminpages/membershiplevels.php:457
+#: adminpages/membershiplevels.php:458
+#: adminpages/membershiplevels.php:460
+#: adminpages/membershiplevels.php:461
+#: adminpages/membershiplevels.php:482
+#: adminpages/membershiplevels.php:492
+#: adminpages/membershiplevels.php:516
+#: adminpages/membershiplevels.php:518
+#: adminpages/membershiplevels.php:524
+#: adminpages/membershiplevels.php:529
+#: adminpages/membershiplevels.php:534
 msgid "Other Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:333 adminpages/advancedsettings.php:144
-#: adminpages/advancedsettings.php:147 adminpages/advancedsettings.php:163
-#: adminpages/advancedsettings.php:165 adminpages/advancedsettings.php:221
-#: adminpages/advancedsettings.php:224 adminpages/advancedsettings.php:331
 #: adminpages/advancedsettings.php:333
+#: adminpages/advancedsettings.php:144
+#: adminpages/advancedsettings.php:147
+#: adminpages/advancedsettings.php:163
+#: adminpages/advancedsettings.php:165
+#: adminpages/advancedsettings.php:221
+#: adminpages/advancedsettings.php:224
+#: adminpages/advancedsettings.php:331
 msgid "Hide Ads From Members?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:338 adminpages/advancedsettings.php:129
-#: adminpages/advancedsettings.php:136 adminpages/advancedsettings.php:149
-#: adminpages/advancedsettings.php:152 adminpages/advancedsettings.php:168
-#: adminpages/advancedsettings.php:170 adminpages/advancedsettings.php:226
-#: adminpages/advancedsettings.php:229 adminpages/advancedsettings.php:336
 #: adminpages/advancedsettings.php:338
+#: adminpages/advancedsettings.php:129
+#: adminpages/advancedsettings.php:136
+#: adminpages/advancedsettings.php:149
+#: adminpages/advancedsettings.php:152
+#: adminpages/advancedsettings.php:168
+#: adminpages/advancedsettings.php:170
+#: adminpages/advancedsettings.php:226
+#: adminpages/advancedsettings.php:229
+#: adminpages/advancedsettings.php:336
 msgid "Hide Ads From All Members"
 msgstr ""
 
-#: adminpages/advancedsettings.php:339 adminpages/advancedsettings.php:130
-#: adminpages/advancedsettings.php:137 adminpages/advancedsettings.php:150
-#: adminpages/advancedsettings.php:153 adminpages/advancedsettings.php:169
-#: adminpages/advancedsettings.php:171 adminpages/advancedsettings.php:227
-#: adminpages/advancedsettings.php:230 adminpages/advancedsettings.php:337
 #: adminpages/advancedsettings.php:339
+#: adminpages/advancedsettings.php:130
+#: adminpages/advancedsettings.php:137
+#: adminpages/advancedsettings.php:150
+#: adminpages/advancedsettings.php:153
+#: adminpages/advancedsettings.php:169
+#: adminpages/advancedsettings.php:171
+#: adminpages/advancedsettings.php:227
+#: adminpages/advancedsettings.php:230
+#: adminpages/advancedsettings.php:337
 msgid "Hide Ads From Certain Members"
 msgstr ""
 
-#: adminpages/advancedsettings.php:346 adminpages/advancedsettings.php:138
-#: adminpages/advancedsettings.php:145 adminpages/advancedsettings.php:158
-#: adminpages/advancedsettings.php:161 adminpages/advancedsettings.php:177
-#: adminpages/advancedsettings.php:179 adminpages/advancedsettings.php:235
-#: adminpages/advancedsettings.php:238 adminpages/advancedsettings.php:345
 #: adminpages/advancedsettings.php:346
+#: adminpages/advancedsettings.php:138
+#: adminpages/advancedsettings.php:145
+#: adminpages/advancedsettings.php:158
+#: adminpages/advancedsettings.php:161
+#: adminpages/advancedsettings.php:177
+#: adminpages/advancedsettings.php:179
+#: adminpages/advancedsettings.php:235
+#: adminpages/advancedsettings.php:238
+#: adminpages/advancedsettings.php:345
 msgid "To hide ads in your template code, use code like the following"
 msgstr ""
 
-#: adminpages/advancedsettings.php:355 adminpages/advancedsettings.php:149
-#: adminpages/advancedsettings.php:156 adminpages/advancedsettings.php:169
-#: adminpages/advancedsettings.php:172 adminpages/advancedsettings.php:188
-#: adminpages/advancedsettings.php:190 adminpages/advancedsettings.php:244
-#: adminpages/advancedsettings.php:262 adminpages/advancedsettings.php:354
 #: adminpages/advancedsettings.php:355
+#: adminpages/advancedsettings.php:149
+#: adminpages/advancedsettings.php:156
+#: adminpages/advancedsettings.php:169
+#: adminpages/advancedsettings.php:172
+#: adminpages/advancedsettings.php:188
+#: adminpages/advancedsettings.php:190
+#: adminpages/advancedsettings.php:244
+#: adminpages/advancedsettings.php:262
+#: adminpages/advancedsettings.php:354
 msgid "Choose Levels to Hide Ads From"
 msgstr ""
 
-#: adminpages/advancedsettings.php:389 adminpages/advancedsettings.php:183
-#: adminpages/advancedsettings.php:190 adminpages/advancedsettings.php:203
-#: adminpages/advancedsettings.php:206 adminpages/advancedsettings.php:222
-#: adminpages/advancedsettings.php:224 adminpages/advancedsettings.php:278
-#: adminpages/advancedsettings.php:296 adminpages/advancedsettings.php:388
 #: adminpages/advancedsettings.php:389
+#: adminpages/advancedsettings.php:183
+#: adminpages/advancedsettings.php:190
+#: adminpages/advancedsettings.php:203
+#: adminpages/advancedsettings.php:206
+#: adminpages/advancedsettings.php:222
+#: adminpages/advancedsettings.php:224
+#: adminpages/advancedsettings.php:278
+#: adminpages/advancedsettings.php:296
+#: adminpages/advancedsettings.php:388
 msgid "Redirect all traffic from registration page to /susbcription/?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:389 adminpages/advancedsettings.php:183
-#: adminpages/advancedsettings.php:190 adminpages/advancedsettings.php:203
-#: adminpages/advancedsettings.php:206 adminpages/advancedsettings.php:222
-#: adminpages/advancedsettings.php:224 adminpages/advancedsettings.php:278
-#: adminpages/advancedsettings.php:296 adminpages/advancedsettings.php:388
 #: adminpages/advancedsettings.php:389
+#: adminpages/advancedsettings.php:183
+#: adminpages/advancedsettings.php:190
+#: adminpages/advancedsettings.php:203
+#: adminpages/advancedsettings.php:206
+#: adminpages/advancedsettings.php:222
+#: adminpages/advancedsettings.php:224
+#: adminpages/advancedsettings.php:278
+#: adminpages/advancedsettings.php:296
+#: adminpages/advancedsettings.php:388
 msgid "multisite only"
 msgstr ""
 
-#: adminpages/advancedsettings.php:394 adminpages/membershiplevels.php:820
+#: adminpages/advancedsettings.php:394
+#: adminpages/membershiplevels.php:820
 #: adminpages/paymentsettings.php:260
 #: classes/gateways/class.pmprogateway_stripe.php:403
 #: classes/gateways/class.pmprogateway_stripe.php:417
 #: includes/compatibility/beaver-builder.php:44
-#: includes/compatibility/beaver-builder.php:140 includes/profile.php:90
-#: adminpages/advancedsettings.php:188 adminpages/advancedsettings.php:195
-#: adminpages/advancedsettings.php:208 adminpages/advancedsettings.php:211
-#: adminpages/advancedsettings.php:227 adminpages/advancedsettings.php:229
-#: adminpages/advancedsettings.php:283 adminpages/advancedsettings.php:301
-#: adminpages/advancedsettings.php:393 adminpages/advancedsettings.php:394
-#: adminpages/membershiplevels.php:563 adminpages/membershiplevels.php:569
-#: adminpages/membershiplevels.php:571 adminpages/membershiplevels.php:578
-#: adminpages/membershiplevels.php:598 adminpages/membershiplevels.php:658
-#: adminpages/membershiplevels.php:660 adminpages/membershiplevels.php:662
-#: adminpages/membershiplevels.php:667 adminpages/membershiplevels.php:668
-#: adminpages/membershiplevels.php:672 adminpages/membershiplevels.php:684
-#: adminpages/membershiplevels.php:694 adminpages/membershiplevels.php:744
-#: adminpages/membershiplevels.php:746 adminpages/membershiplevels.php:779
-#: adminpages/membershiplevels.php:796 adminpages/membershiplevels.php:801
-#: adminpages/membershiplevels.php:806 adminpages/membershiplevels.php:811
-#: adminpages/membershiplevels.php:818 adminpages/membershiplevels.php:820
-#: adminpages/paymentsettings.php:211 adminpages/paymentsettings.php:220
-#: adminpages/paymentsettings.php:237 adminpages/paymentsettings.php:254
-#: adminpages/paymentsettings.php:257 adminpages/paymentsettings.php:258
-#: adminpages/paymentsettings.php:260 adminpages/paymentsettings.php:415
-#: adminpages/paymentsettings.php:424 adminpages/paymentsettings.php:430
-#: adminpages/paymentsettings.php:435 adminpages/paymentsettings.php:437
-#: adminpages/paymentsettings.php:455 adminpages/paymentsettings.php:460
+#: includes/compatibility/beaver-builder.php:140
+#: includes/profile.php:90
+#: adminpages/advancedsettings.php:188
+#: adminpages/advancedsettings.php:195
+#: adminpages/advancedsettings.php:208
+#: adminpages/advancedsettings.php:211
+#: adminpages/advancedsettings.php:227
+#: adminpages/advancedsettings.php:229
+#: adminpages/advancedsettings.php:283
+#: adminpages/advancedsettings.php:301
+#: adminpages/advancedsettings.php:393
+#: adminpages/membershiplevels.php:563
+#: adminpages/membershiplevels.php:569
+#: adminpages/membershiplevels.php:571
+#: adminpages/membershiplevels.php:578
+#: adminpages/membershiplevels.php:598
+#: adminpages/membershiplevels.php:658
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:662
+#: adminpages/membershiplevels.php:667
+#: adminpages/membershiplevels.php:668
+#: adminpages/membershiplevels.php:672
+#: adminpages/membershiplevels.php:684
+#: adminpages/membershiplevels.php:694
+#: adminpages/membershiplevels.php:744
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:779
+#: adminpages/membershiplevels.php:796
+#: adminpages/membershiplevels.php:801
+#: adminpages/membershiplevels.php:806
+#: adminpages/membershiplevels.php:811
+#: adminpages/membershiplevels.php:818
+#: adminpages/paymentsettings.php:211
+#: adminpages/paymentsettings.php:220
+#: adminpages/paymentsettings.php:237
+#: adminpages/paymentsettings.php:254
+#: adminpages/paymentsettings.php:257
+#: adminpages/paymentsettings.php:258
+#: adminpages/paymentsettings.php:415
+#: adminpages/paymentsettings.php:424
+#: adminpages/paymentsettings.php:430
+#: adminpages/paymentsettings.php:435
+#: adminpages/paymentsettings.php:437
+#: adminpages/paymentsettings.php:455
+#: adminpages/paymentsettings.php:460
 #: adminpages/paymentsettings.php:462
 #: classes/gateways/class.pmprogateway_stripe.php:174
 #: classes/gateways/class.pmprogateway_stripe.php:175
@@ -1271,96 +1711,117 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:395
 #: classes/gateways/class.pmprogateway_stripe.php:408
 #: includes/compatibility/beaver-builder.php:42
-#: includes/compatibility/beaver-builder.php:136 includes/profile.php:90
-#: includes/profile.php:102 includes/profile.php:106 includes/profile.php:111
-#: includes/profile.php:118 includes/profile.php:121 includes/profile.php:122
-#: includes/profile.php:124 includes/profile.php:126
+#: includes/compatibility/beaver-builder.php:136
+#: includes/profile.php:102
+#: includes/profile.php:106
+#: includes/profile.php:111
+#: includes/profile.php:118
+#: includes/profile.php:121
+#: includes/profile.php:122
+#: includes/profile.php:124
+#: includes/profile.php:126
 msgid "Yes"
 msgstr ""
 
-#: adminpages/advancedsettings.php:472 adminpages/advancedsettings.php:467
 #: adminpages/advancedsettings.php:472
+#: adminpages/advancedsettings.php:467
 msgid "Uninstall PMPro on deletion?"
 msgstr ""
 
-#: adminpages/advancedsettings.php:477 adminpages/advancedsettings.php:472
 #: adminpages/advancedsettings.php:477
+#: adminpages/advancedsettings.php:472
 msgid "Yes - Delete all PMPro Data."
 msgstr ""
 
 #: adminpages/advancedsettings.php:479
-msgid ""
-"To delete all PMPro data from the database, set to Yes, deactivate PMPro, "
-"and then click to delete PMPro from the plugins page."
+msgid "To delete all PMPro data from the database, set to Yes, deactivate PMPro, and then click to delete PMPro from the plugins page."
 msgstr ""
 
-#: adminpages/advancedsettings.php:525 adminpages/pagesettings.php:439
-#: adminpages/paymentsettings.php:290 adminpages/advancedsettings.php:284
-#: adminpages/advancedsettings.php:355 adminpages/advancedsettings.php:359
-#: adminpages/advancedsettings.php:368 adminpages/advancedsettings.php:375
-#: adminpages/advancedsettings.php:384 adminpages/advancedsettings.php:407
-#: adminpages/advancedsettings.php:427 adminpages/advancedsettings.php:507
-#: adminpages/advancedsettings.php:520 adminpages/advancedsettings.php:525
-#: adminpages/pagesettings.php:209 adminpages/pagesettings.php:223
-#: adminpages/pagesettings.php:251 adminpages/pagesettings.php:254
-#: adminpages/pagesettings.php:294 adminpages/pagesettings.php:295
-#: adminpages/pagesettings.php:310 adminpages/pagesettings.php:315
-#: adminpages/pagesettings.php:329 adminpages/pagesettings.php:331
-#: adminpages/pagesettings.php:338 adminpages/pagesettings.php:439
-#: adminpages/paymentsettings.php:238 adminpages/paymentsettings.php:250
-#: adminpages/paymentsettings.php:267 adminpages/paymentsettings.php:284
-#: adminpages/paymentsettings.php:287 adminpages/paymentsettings.php:288
-#: adminpages/paymentsettings.php:290 adminpages/paymentsettings.php:485
-#: adminpages/paymentsettings.php:526 adminpages/paymentsettings.php:532
+#: adminpages/advancedsettings.php:525
+#: adminpages/pagesettings.php:439
+#: adminpages/paymentsettings.php:290
+#: adminpages/advancedsettings.php:284
+#: adminpages/advancedsettings.php:355
+#: adminpages/advancedsettings.php:359
+#: adminpages/advancedsettings.php:368
+#: adminpages/advancedsettings.php:375
+#: adminpages/advancedsettings.php:384
+#: adminpages/advancedsettings.php:407
+#: adminpages/advancedsettings.php:427
+#: adminpages/advancedsettings.php:507
+#: adminpages/advancedsettings.php:520
+#: adminpages/pagesettings.php:209
+#: adminpages/pagesettings.php:223
+#: adminpages/pagesettings.php:251
+#: adminpages/pagesettings.php:254
+#: adminpages/pagesettings.php:294
+#: adminpages/pagesettings.php:295
+#: adminpages/pagesettings.php:310
+#: adminpages/pagesettings.php:315
+#: adminpages/pagesettings.php:329
+#: adminpages/pagesettings.php:331
+#: adminpages/pagesettings.php:338
+#: adminpages/paymentsettings.php:238
+#: adminpages/paymentsettings.php:250
+#: adminpages/paymentsettings.php:267
+#: adminpages/paymentsettings.php:284
+#: adminpages/paymentsettings.php:287
+#: adminpages/paymentsettings.php:288
+#: adminpages/paymentsettings.php:485
+#: adminpages/paymentsettings.php:526
+#: adminpages/paymentsettings.php:532
 #: adminpages/paymentsettings.php:534
 msgid "Save Settings"
 msgstr ""
 
-#: adminpages/dashboard.php:12 adminpages/dashboard.php:12
+#: adminpages/dashboard.php:12
 #: adminpages/dashboard.php:13
 msgid "Welcome to Paid Memberships Pro"
 msgstr ""
 
-#: adminpages/dashboard.php:19 adminpages/reports/sales.php:20
+#: adminpages/dashboard.php:19
+#: adminpages/reports/sales.php:20
 #: adminpages/reports/sales.php:284
-#: classes/class-pmpro-admin-activity-email.php:103 adminpages/dashboard.php:19
-#: adminpages/dashboard.php:20 adminpages/reports/sales.php:20
-#: adminpages/reports/sales.php:180 adminpages/reports/sales.php:189
-#: adminpages/reports/sales.php:198 adminpages/reports/sales.php:199
-#: adminpages/reports/sales.php:215 adminpages/reports/sales.php:284
+#: classes/class-pmpro-admin-activity-email.php:103
+#: adminpages/dashboard.php:20
+#: adminpages/reports/sales.php:180
+#: adminpages/reports/sales.php:189
+#: adminpages/reports/sales.php:198
+#: adminpages/reports/sales.php:199
+#: adminpages/reports/sales.php:215
 msgid "Sales and Revenue"
 msgstr ""
 
-#: adminpages/dashboard.php:26 adminpages/reports/memberships.php:18
-#: adminpages/reports/memberships.php:345 adminpages/dashboard.php:26
-#: adminpages/dashboard.php:27 adminpages/reports/memberships.php:18
+#: adminpages/dashboard.php:26
+#: adminpages/reports/memberships.php:18
+#: adminpages/reports/memberships.php:345
+#: adminpages/dashboard.php:27
 #: adminpages/reports/memberships.php:252
 #: adminpages/reports/memberships.php:259
 #: adminpages/reports/memberships.php:272
 #: adminpages/reports/memberships.php:288
 #: adminpages/reports/memberships.php:300
 #: adminpages/reports/memberships.php:324
-#: adminpages/reports/memberships.php:345
 msgid "Membership Stats"
 msgstr ""
 
-#: adminpages/dashboard.php:33 adminpages/reports/login.php:16
-#: adminpages/dashboard.php:33 adminpages/dashboard.php:34
+#: adminpages/dashboard.php:33
 #: adminpages/reports/login.php:16
+#: adminpages/dashboard.php:34
 msgid "Visits, Views, and Logins"
 msgstr ""
 
-#: adminpages/dashboard.php:40 adminpages/dashboard.php:40
+#: adminpages/dashboard.php:40
 #: adminpages/dashboard.php:41
 msgid "Recent Members"
 msgstr ""
 
-#: adminpages/dashboard.php:47 adminpages/dashboard.php:47
+#: adminpages/dashboard.php:47
 #: adminpages/dashboard.php:48
 msgid "Recent Orders"
 msgstr ""
 
-#: adminpages/dashboard.php:54 adminpages/dashboard.php:54
+#: adminpages/dashboard.php:54
 #: adminpages/dashboard.php:55
 msgid "Paid Memberships Pro News and Updates"
 msgstr ""
@@ -1369,7 +1830,8 @@ msgstr ""
 msgid "Initial Setup"
 msgstr ""
 
-#: adminpages/dashboard.php:113 adminpages/membershiplevels.php:747
+#: adminpages/dashboard.php:113
+#: adminpages/membershiplevels.php:747
 msgid "Create a Membership Level"
 msgstr ""
 
@@ -1385,7 +1847,8 @@ msgstr ""
 msgid "Manage Membership Pages"
 msgstr ""
 
-#: adminpages/dashboard.php:133 adminpages/dashboard.php:135
+#: adminpages/dashboard.php:133
+#: adminpages/dashboard.php:135
 msgid "Configure Payment Settings"
 msgstr ""
 
@@ -1401,7 +1864,7 @@ msgstr ""
 msgid "Explore Add Ons for Additional Features"
 msgstr ""
 
-#: adminpages/dashboard.php:156 adminpages/dashboard.php:156
+#: adminpages/dashboard.php:156
 #: adminpages/dashboard.php:164
 msgid "For guidance as your begin these steps,"
 msgstr ""
@@ -1418,38 +1881,35 @@ msgstr ""
 msgid "No support license key found."
 msgstr ""
 
-#: adminpages/dashboard.php:170 adminpages/dashboard.php:170
+#: adminpages/dashboard.php:170
 #: adminpages/dashboard.php:178
 #, php-format
 msgid "<a href=\"%s\">Enter your key here &raquo;</a>"
 msgstr ""
 
-#: adminpages/dashboard.php:174 adminpages/license.php:49
-#: adminpages/license.php:49 includes/license.php:91 includes/license.php:93
+#: adminpages/dashboard.php:174
+#: adminpages/license.php:49
+#: includes/license.php:91
+#: includes/license.php:93
 #: includes/license.php:94
 msgid "Your license is invalid or expired."
 msgstr ""
 
-#: adminpages/dashboard.php:175 adminpages/dashboard.php:175
+#: adminpages/dashboard.php:175
 #: adminpages/dashboard.php:183
 #, php-format
-msgid ""
-"<a href=\"%s\">View your membership account</a> to verify your license key."
+msgid "<a href=\"%s\">View your membership account</a> to verify your license key."
 msgstr ""
 
-#: adminpages/dashboard.php:177 adminpages/license.php:51
-#: adminpages/dashboard.php:177 adminpages/dashboard.php:185
+#: adminpages/dashboard.php:177
 #: adminpages/license.php:51
+#: adminpages/dashboard.php:185
 #, php-format
-msgid ""
-"<strong>Thank you!</strong> A valid <strong>%s</strong> license key has been "
-"used to activate your support license on this site."
+msgid "<strong>Thank you!</strong> A valid <strong>%s</strong> license key has been used to activate your support license on this site."
 msgstr ""
 
 #: adminpages/dashboard.php:181
-msgid ""
-"An annual support license is recommended for websites running Paid "
-"Memberships Pro."
+msgid "An annual support license is recommended for websites running Paid Memberships Pro."
 msgstr ""
 
 #: adminpages/dashboard.php:181
@@ -1460,13 +1920,10 @@ msgstr ""
 msgid "Upgrade"
 msgstr ""
 
-#: adminpages/dashboard.php:185 adminpages/dashboard.php:185
+#: adminpages/dashboard.php:185
 #: adminpages/dashboard.php:193
 #, php-format
-msgid ""
-"Paid Memberships Pro and our add ons are distributed under the <a target="
-"\"_blank\" href=\"%s\">GPLv2 license</a>. This means, among other things, "
-"that you may use the software on this site or any other site free of charge."
+msgid "Paid Memberships Pro and our add ons are distributed under the <a target=\"_blank\" href=\"%s\">GPLv2 license</a>. This means, among other things, that you may use the software on this site or any other site free of charge."
 msgstr ""
 
 #: adminpages/dashboard.php:188
@@ -1509,97 +1966,171 @@ msgstr ""
 msgid "Translation Dashboard"
 msgstr ""
 
-#: adminpages/dashboard.php:219 adminpages/orders.php:1323
-#: adminpages/reports/login.php:179 classes/class.memberorder.php:945
-#: pages/checkout.php:121 shortcodes/pmpro_account.php:160
-#: adminpages/dashboard.php:215 adminpages/dashboard.php:219
-#: adminpages/dashboard.php:223 adminpages/memberslist.php:112
-#: adminpages/memberslist.php:145 adminpages/memberslist.php:155
-#: adminpages/memberslist.php:165 adminpages/memberslist.php:169
-#: adminpages/orders.php:1298 adminpages/orders.php:1304
-#: adminpages/orders.php:1313 adminpages/reports/login.php:179
-#: classes/class.memberorder.php:858 classes/class.memberorder.php:870
-#: classes/class.memberorder.php:943 pages/account.php:51 pages/account.php:55
-#: pages/account.php:76 pages/checkout.php:118 pages/checkout.php:167
-#: pages/checkout.php:168 pages/checkout.php:171 pages/checkout.php:173
-#: pages/checkout.php:175 pages/checkout.php:180 pages/checkout.php:182
-#: pages/checkout.php:184 pages/checkout.php:191 pages/checkout.php:194
-#: shortcodes/pmpro_account.php:105 shortcodes/pmpro_account.php:107
-#: shortcodes/pmpro_account.php:108 shortcodes/pmpro_account.php:110
-#: shortcodes/pmpro_account.php:159 shortcodes/pmpro_account.php:160
+#: adminpages/dashboard.php:219
+#: adminpages/orders.php:1323
+#: adminpages/reports/login.php:179
+#: classes/class.memberorder.php:945
+#: pages/checkout.php:121
+#: shortcodes/pmpro_account.php:160
+#: adminpages/dashboard.php:215
+#: adminpages/dashboard.php:223
+#: adminpages/memberslist.php:112
+#: adminpages/memberslist.php:145
+#: adminpages/memberslist.php:155
+#: adminpages/memberslist.php:165
+#: adminpages/memberslist.php:169
+#: adminpages/orders.php:1298
+#: adminpages/orders.php:1304
+#: adminpages/orders.php:1313
+#: classes/class.memberorder.php:858
+#: classes/class.memberorder.php:870
+#: classes/class.memberorder.php:943
+#: pages/account.php:51
+#: pages/account.php:55
+#: pages/account.php:76
+#: pages/checkout.php:118
+#: pages/checkout.php:167
+#: pages/checkout.php:168
+#: pages/checkout.php:171
+#: pages/checkout.php:173
+#: pages/checkout.php:175
+#: pages/checkout.php:180
+#: pages/checkout.php:182
+#: pages/checkout.php:184
+#: pages/checkout.php:191
+#: pages/checkout.php:194
+#: shortcodes/pmpro_account.php:105
+#: shortcodes/pmpro_account.php:107
+#: shortcodes/pmpro_account.php:108
+#: shortcodes/pmpro_account.php:110
+#: shortcodes/pmpro_account.php:159
 msgid "Username"
 msgstr ""
 
-#: adminpages/dashboard.php:220 adminpages/dashboard.php:288
-#: adminpages/orders.php:1325 adminpages/reports/login.php:181
-#: includes/privacy.php:241 pages/billing.php:58 pages/cancel.php:60
-#: pages/invoice.php:113 pages/levels.php:35 shortcodes/pmpro_account.php:42
-#: shortcodes/pmpro_account.php:211 adminpages/dashboard.php:216
-#: adminpages/dashboard.php:220 adminpages/dashboard.php:284
-#: adminpages/dashboard.php:288 adminpages/dashboard.php:292
-#: adminpages/memberslist.php:175 adminpages/orders.php:1300
-#: adminpages/orders.php:1306 adminpages/orders.php:1315
-#: adminpages/reports/login.php:181 includes/privacy.php:241
-#: pages/account.php:12 pages/account.php:18 pages/account.php:92
-#: pages/billing.php:16 pages/billing.php:25 pages/billing.php:27
-#: pages/billing.php:28 pages/billing.php:30 pages/billing.php:41
-#: pages/billing.php:44 pages/billing.php:45 pages/billing.php:49
-#: pages/billing.php:50 pages/billing.php:57 pages/billing.php:58
-#: pages/cancel.php:52 pages/cancel.php:60 pages/cancel.php:61
-#: pages/invoice.php:89 pages/invoice.php:101 pages/invoice.php:102
-#: pages/invoice.php:103 pages/invoice.php:104 pages/invoice.php:109
-#: pages/invoice.php:112 pages/invoice.php:113 pages/levels.php:13
-#: pages/levels.php:35 shortcodes/pmpro_account.php:42
-#: shortcodes/pmpro_account.php:43 shortcodes/pmpro_account.php:44
-#: shortcodes/pmpro_account.php:123 shortcodes/pmpro_account.php:125
-#: shortcodes/pmpro_account.php:126 shortcodes/pmpro_account.php:128
-#: shortcodes/pmpro_account.php:204 shortcodes/pmpro_account.php:211
+#: adminpages/dashboard.php:220
+#: adminpages/dashboard.php:288
+#: adminpages/orders.php:1325
+#: adminpages/reports/login.php:181
+#: includes/privacy.php:241
+#: pages/billing.php:58
+#: pages/cancel.php:60
+#: pages/invoice.php:113
+#: pages/levels.php:35
+#: shortcodes/pmpro_account.php:42
+#: shortcodes/pmpro_account.php:211
+#: adminpages/dashboard.php:216
+#: adminpages/dashboard.php:284
+#: adminpages/dashboard.php:292
+#: adminpages/memberslist.php:175
+#: adminpages/orders.php:1300
+#: adminpages/orders.php:1306
+#: adminpages/orders.php:1315
+#: pages/account.php:12
+#: pages/account.php:18
+#: pages/account.php:92
+#: pages/billing.php:16
+#: pages/billing.php:25
+#: pages/billing.php:27
+#: pages/billing.php:28
+#: pages/billing.php:30
+#: pages/billing.php:41
+#: pages/billing.php:44
+#: pages/billing.php:45
+#: pages/billing.php:49
+#: pages/billing.php:50
+#: pages/billing.php:57
+#: pages/cancel.php:52
+#: pages/cancel.php:61
+#: pages/invoice.php:89
+#: pages/invoice.php:101
+#: pages/invoice.php:102
+#: pages/invoice.php:103
+#: pages/invoice.php:104
+#: pages/invoice.php:109
+#: pages/invoice.php:112
+#: pages/levels.php:13
+#: shortcodes/pmpro_account.php:43
+#: shortcodes/pmpro_account.php:44
+#: shortcodes/pmpro_account.php:123
+#: shortcodes/pmpro_account.php:125
+#: shortcodes/pmpro_account.php:126
+#: shortcodes/pmpro_account.php:128
+#: shortcodes/pmpro_account.php:204
+#: blocks/checkout-button/inspector.js:39
 msgid "Level"
 msgstr ""
 
-#: adminpages/dashboard.php:221 adminpages/reports/login.php:182
-#: adminpages/dashboard.php:217 adminpages/dashboard.php:221
-#: adminpages/dashboard.php:225 adminpages/memberslist.php:120
-#: adminpages/memberslist.php:153 adminpages/memberslist.php:163
-#: adminpages/memberslist.php:173 adminpages/memberslist.php:177
-#: adminpages/reports/login.php:144 adminpages/reports/login.php:146
-#: adminpages/reports/login.php:162 adminpages/reports/login.php:166
+#: adminpages/dashboard.php:221
 #: adminpages/reports/login.php:182
+#: adminpages/dashboard.php:217
+#: adminpages/dashboard.php:225
+#: adminpages/memberslist.php:120
+#: adminpages/memberslist.php:153
+#: adminpages/memberslist.php:163
+#: adminpages/memberslist.php:173
+#: adminpages/memberslist.php:177
+#: adminpages/reports/login.php:144
+#: adminpages/reports/login.php:146
+#: adminpages/reports/login.php:162
+#: adminpages/reports/login.php:166
 msgid "Joined"
 msgstr ""
 
-#: adminpages/dashboard.php:222 adminpages/discountcodes.php:783
-#: adminpages/reports/login.php:183 includes/profile.php:86
-#: adminpages/dashboard.php:218 adminpages/dashboard.php:222
-#: adminpages/dashboard.php:226 adminpages/discountcodes.php:550
-#: adminpages/discountcodes.php:560 adminpages/discountcodes.php:588
-#: adminpages/discountcodes.php:589 adminpages/discountcodes.php:590
-#: adminpages/discountcodes.php:595 adminpages/discountcodes.php:668
-#: adminpages/discountcodes.php:722 adminpages/discountcodes.php:748
-#: adminpages/discountcodes.php:749 adminpages/discountcodes.php:750
-#: adminpages/discountcodes.php:783 adminpages/memberslist.php:121
-#: adminpages/memberslist.php:159 adminpages/memberslist.php:169
-#: adminpages/memberslist.php:179 adminpages/memberslist.php:183
-#: adminpages/memberslist.php:187 adminpages/reports/login.php:145
-#: adminpages/reports/login.php:147 adminpages/reports/login.php:163
-#: adminpages/reports/login.php:167 adminpages/reports/login.php:183
-#: includes/profile.php:86 includes/profile.php:98 includes/profile.php:102
-#: includes/profile.php:107 includes/profile.php:114 includes/profile.php:117
-#: includes/profile.php:118 includes/profile.php:120 includes/profile.php:122
+#: adminpages/dashboard.php:222
+#: adminpages/discountcodes.php:783
+#: adminpages/reports/login.php:183
+#: includes/profile.php:86
+#: adminpages/dashboard.php:218
+#: adminpages/dashboard.php:226
+#: adminpages/discountcodes.php:550
+#: adminpages/discountcodes.php:560
+#: adminpages/discountcodes.php:588
+#: adminpages/discountcodes.php:589
+#: adminpages/discountcodes.php:590
+#: adminpages/discountcodes.php:595
+#: adminpages/discountcodes.php:668
+#: adminpages/discountcodes.php:722
+#: adminpages/discountcodes.php:748
+#: adminpages/discountcodes.php:749
+#: adminpages/discountcodes.php:750
+#: adminpages/memberslist.php:121
+#: adminpages/memberslist.php:159
+#: adminpages/memberslist.php:169
+#: adminpages/memberslist.php:179
+#: adminpages/memberslist.php:183
+#: adminpages/memberslist.php:187
+#: adminpages/reports/login.php:145
+#: adminpages/reports/login.php:147
+#: adminpages/reports/login.php:163
+#: adminpages/reports/login.php:167
+#: includes/profile.php:98
+#: includes/profile.php:102
+#: includes/profile.php:107
+#: includes/profile.php:114
+#: includes/profile.php:117
+#: includes/profile.php:118
+#: includes/profile.php:120
+#: includes/profile.php:122
 msgid "Expires"
 msgstr ""
 
-#: adminpages/dashboard.php:228 adminpages/reports/login.php:261
-#: classes/class-pmpro-members-list-table.php:226 adminpages/dashboard.php:224
-#: adminpages/dashboard.php:228 adminpages/dashboard.php:232
-#: adminpages/memberslist.php:195 adminpages/memberslist.php:223
-#: adminpages/memberslist.php:251 adminpages/memberslist.php:261
-#: adminpages/memberslist.php:262 adminpages/memberslist.php:266
-#: adminpages/memberslist.php:268 adminpages/memberslist.php:272
-#: adminpages/reports/login.php:210 adminpages/reports/login.php:212
-#: adminpages/reports/login.php:228 adminpages/reports/login.php:232
+#: adminpages/dashboard.php:228
 #: adminpages/reports/login.php:261
 #: classes/class-pmpro-members-list-table.php:226
+#: adminpages/dashboard.php:224
+#: adminpages/dashboard.php:232
+#: adminpages/memberslist.php:195
+#: adminpages/memberslist.php:223
+#: adminpages/memberslist.php:251
+#: adminpages/memberslist.php:261
+#: adminpages/memberslist.php:262
+#: adminpages/memberslist.php:266
+#: adminpages/memberslist.php:268
+#: adminpages/memberslist.php:272
+#: adminpages/reports/login.php:210
+#: adminpages/reports/login.php:212
+#: adminpages/reports/login.php:228
+#: adminpages/reports/login.php:232
 #: classes/class-pmpro-members-list-table.php:252
 #: classes/class-pmpro-members-list-table.php:257
 msgid "No members found."
@@ -1609,172 +2140,296 @@ msgstr ""
 msgid "View All Members "
 msgstr ""
 
-#: adminpages/dashboard.php:286 adminpages/discountcodes.php:449
-#: adminpages/discountcodes.php:781 adminpages/orders.php:421
-#: adminpages/orders.php:1322 adminpages/dashboard.php:282
-#: adminpages/dashboard.php:286 adminpages/dashboard.php:290
-#: adminpages/discountcodes.php:311 adminpages/discountcodes.php:314
-#: adminpages/discountcodes.php:315 adminpages/discountcodes.php:316
-#: adminpages/discountcodes.php:321 adminpages/discountcodes.php:386
-#: adminpages/discountcodes.php:427 adminpages/discountcodes.php:447
-#: adminpages/discountcodes.php:449 adminpages/discountcodes.php:548
-#: adminpages/discountcodes.php:558 adminpages/discountcodes.php:586
-#: adminpages/discountcodes.php:587 adminpages/discountcodes.php:588
-#: adminpages/discountcodes.php:593 adminpages/discountcodes.php:666
-#: adminpages/discountcodes.php:720 adminpages/discountcodes.php:746
-#: adminpages/discountcodes.php:747 adminpages/discountcodes.php:748
-#: adminpages/discountcodes.php:781 adminpages/orders.php:215
-#: adminpages/orders.php:265 adminpages/orders.php:337
-#: adminpages/orders.php:349 adminpages/orders.php:366
-#: adminpages/orders.php:380 adminpages/orders.php:391
-#: adminpages/orders.php:401 adminpages/orders.php:408
-#: adminpages/orders.php:409 adminpages/orders.php:413
-#: adminpages/orders.php:415 adminpages/orders.php:419
-#: adminpages/orders.php:598 adminpages/orders.php:901
-#: adminpages/orders.php:911 adminpages/orders.php:938
-#: adminpages/orders.php:967 adminpages/orders.php:1104
-#: adminpages/orders.php:1135 adminpages/orders.php:1141
-#: adminpages/orders.php:1232 adminpages/orders.php:1297
-#: adminpages/orders.php:1303 adminpages/orders.php:1308
-#: adminpages/orders.php:1312 adminpages/orders.php:1353
+#: adminpages/dashboard.php:286
+#: adminpages/discountcodes.php:449
+#: adminpages/discountcodes.php:781
+#: adminpages/orders.php:421
+#: adminpages/orders.php:1322
+#: adminpages/dashboard.php:282
+#: adminpages/dashboard.php:290
+#: adminpages/discountcodes.php:311
+#: adminpages/discountcodes.php:314
+#: adminpages/discountcodes.php:315
+#: adminpages/discountcodes.php:316
+#: adminpages/discountcodes.php:321
+#: adminpages/discountcodes.php:386
+#: adminpages/discountcodes.php:427
+#: adminpages/discountcodes.php:447
+#: adminpages/discountcodes.php:548
+#: adminpages/discountcodes.php:558
+#: adminpages/discountcodes.php:586
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:588
+#: adminpages/discountcodes.php:593
+#: adminpages/discountcodes.php:666
+#: adminpages/discountcodes.php:720
+#: adminpages/discountcodes.php:746
+#: adminpages/discountcodes.php:747
+#: adminpages/discountcodes.php:748
+#: adminpages/orders.php:215
+#: adminpages/orders.php:265
+#: adminpages/orders.php:337
+#: adminpages/orders.php:349
+#: adminpages/orders.php:366
+#: adminpages/orders.php:380
+#: adminpages/orders.php:391
+#: adminpages/orders.php:401
+#: adminpages/orders.php:408
+#: adminpages/orders.php:409
+#: adminpages/orders.php:413
+#: adminpages/orders.php:415
+#: adminpages/orders.php:419
+#: adminpages/orders.php:598
+#: adminpages/orders.php:901
+#: adminpages/orders.php:911
+#: adminpages/orders.php:938
+#: adminpages/orders.php:967
+#: adminpages/orders.php:1104
+#: adminpages/orders.php:1135
+#: adminpages/orders.php:1141
+#: adminpages/orders.php:1232
+#: adminpages/orders.php:1297
+#: adminpages/orders.php:1303
+#: adminpages/orders.php:1308
+#: adminpages/orders.php:1312
+#: adminpages/orders.php:1353
 msgid "Code"
 msgstr ""
 
 #: adminpages/dashboard.php:287
 #: classes/gateways/class.pmprogateway_payflowpro.php:117
-#: adminpages/dashboard.php:283 adminpages/dashboard.php:287
-#: adminpages/dashboard.php:291 adminpages/orders.php:599
-#: adminpages/orders.php:902 adminpages/orders.php:912
-#: adminpages/orders.php:939 adminpages/orders.php:968
-#: adminpages/orders.php:1105 adminpages/orders.php:1136
-#: adminpages/orders.php:1142 adminpages/orders.php:1233
-#: adminpages/orders.php:1309 adminpages/orders.php:1354
-#: adminpages/paymentsettings.php:211 adminpages/paymentsettings.php:215
-#: adminpages/paymentsettings.php:220 adminpages/reports/login.php:141
-#: adminpages/reports/login.php:143 adminpages/reports/login.php:159
-#: adminpages/reports/login.php:163 adminpages/reports/login.php:179
+#: adminpages/dashboard.php:283
+#: adminpages/dashboard.php:291
+#: adminpages/orders.php:599
+#: adminpages/orders.php:902
+#: adminpages/orders.php:912
+#: adminpages/orders.php:939
+#: adminpages/orders.php:968
+#: adminpages/orders.php:1105
+#: adminpages/orders.php:1136
+#: adminpages/orders.php:1142
+#: adminpages/orders.php:1233
+#: adminpages/orders.php:1309
+#: adminpages/orders.php:1354
+#: adminpages/paymentsettings.php:211
+#: adminpages/paymentsettings.php:215
+#: adminpages/paymentsettings.php:220
+#: adminpages/reports/login.php:141
+#: adminpages/reports/login.php:143
+#: adminpages/reports/login.php:159
+#: adminpages/reports/login.php:163
+#: adminpages/reports/login.php:179
 #: classes/gateways/class.pmprogateway_payflowpro.php:116
-#: classes/gateways/class.pmprogateway_payflowpro.php:117
 msgid "User"
 msgstr ""
 
-#: adminpages/dashboard.php:289 adminpages/orders.php:643
-#: adminpages/orders.php:1326 adminpages/templates/orders-email.php:64
-#: adminpages/templates/orders-print.php:93 includes/privacy.php:285
-#: pages/confirmation.php:99 pages/invoice.php:89 adminpages/dashboard.php:285
-#: adminpages/dashboard.php:289 adminpages/dashboard.php:293
-#: adminpages/orders.php:320 adminpages/orders.php:370
-#: adminpages/orders.php:442 adminpages/orders.php:471
-#: adminpages/orders.php:504 adminpages/orders.php:535
-#: adminpages/orders.php:546 adminpages/orders.php:582
-#: adminpages/orders.php:602 adminpages/orders.php:622
-#: adminpages/orders.php:626 adminpages/orders.php:627
-#: adminpages/orders.php:637 adminpages/orders.php:905
-#: adminpages/orders.php:915 adminpages/orders.php:942
-#: adminpages/orders.php:971 adminpages/orders.php:1108
-#: adminpages/orders.php:1139 adminpages/orders.php:1145
-#: adminpages/orders.php:1236 adminpages/orders.php:1301
-#: adminpages/orders.php:1307 adminpages/orders.php:1312
-#: adminpages/orders.php:1316 adminpages/orders.php:1357
+#: adminpages/dashboard.php:289
+#: adminpages/orders.php:643
+#: adminpages/orders.php:1326
 #: adminpages/templates/orders-email.php:64
-#: adminpages/templates/orders-print.php:93 includes/privacy.php:285
-#: pages/confirmation.php:95 pages/confirmation.php:96
-#: pages/confirmation.php:98 pages/confirmation.php:99 pages/invoice.php:77
-#: pages/invoice.php:78 pages/invoice.php:79 pages/invoice.php:80
-#: pages/invoice.php:82 pages/invoice.php:84 pages/invoice.php:88
+#: adminpages/templates/orders-print.php:93
+#: includes/privacy.php:285
+#: pages/confirmation.php:99
 #: pages/invoice.php:89
+#: adminpages/dashboard.php:285
+#: adminpages/dashboard.php:293
+#: adminpages/orders.php:320
+#: adminpages/orders.php:370
+#: adminpages/orders.php:442
+#: adminpages/orders.php:471
+#: adminpages/orders.php:504
+#: adminpages/orders.php:535
+#: adminpages/orders.php:546
+#: adminpages/orders.php:582
+#: adminpages/orders.php:602
+#: adminpages/orders.php:622
+#: adminpages/orders.php:626
+#: adminpages/orders.php:627
+#: adminpages/orders.php:637
+#: adminpages/orders.php:905
+#: adminpages/orders.php:915
+#: adminpages/orders.php:942
+#: adminpages/orders.php:971
+#: adminpages/orders.php:1108
+#: adminpages/orders.php:1139
+#: adminpages/orders.php:1145
+#: adminpages/orders.php:1236
+#: adminpages/orders.php:1301
+#: adminpages/orders.php:1307
+#: adminpages/orders.php:1312
+#: adminpages/orders.php:1316
+#: adminpages/orders.php:1357
+#: pages/confirmation.php:95
+#: pages/confirmation.php:96
+#: pages/confirmation.php:98
+#: pages/invoice.php:77
+#: pages/invoice.php:78
+#: pages/invoice.php:79
+#: pages/invoice.php:80
+#: pages/invoice.php:82
+#: pages/invoice.php:84
+#: pages/invoice.php:88
 msgid "Total"
 msgstr ""
 
-#: adminpages/dashboard.php:290 adminpages/orders.php:735
-#: adminpages/orders.php:1330 includes/privacy.php:202 includes/privacy.php:309
-#: pages/invoice.php:28 shortcodes/pmpro_account.php:213
-#: adminpages/dashboard.php:286 adminpages/dashboard.php:290
-#: adminpages/dashboard.php:294 adminpages/orders.php:373
-#: adminpages/orders.php:423 adminpages/orders.php:495
-#: adminpages/orders.php:524 adminpages/orders.php:579
-#: adminpages/orders.php:606 adminpages/orders.php:610
-#: adminpages/orders.php:621 adminpages/orders.php:667
-#: adminpages/orders.php:705 adminpages/orders.php:709
-#: adminpages/orders.php:710 adminpages/orders.php:712
-#: adminpages/orders.php:722 adminpages/orders.php:909
-#: adminpages/orders.php:919 adminpages/orders.php:946
-#: adminpages/orders.php:975 adminpages/orders.php:1112
-#: adminpages/orders.php:1143 adminpages/orders.php:1149
-#: adminpages/orders.php:1240 adminpages/orders.php:1305
-#: adminpages/orders.php:1311 adminpages/orders.php:1316
-#: adminpages/orders.php:1320 adminpages/orders.php:1361
-#: includes/privacy.php:202 includes/privacy.php:309 pages/invoice.php:27
-#: pages/invoice.php:28 pages/invoice.php:29 shortcodes/pmpro_account.php:130
-#: shortcodes/pmpro_account.php:206 shortcodes/pmpro_account.php:213
+#: adminpages/dashboard.php:290
+#: adminpages/orders.php:735
+#: adminpages/orders.php:1330
+#: includes/privacy.php:202
+#: includes/privacy.php:309
+#: pages/invoice.php:28
+#: shortcodes/pmpro_account.php:213
+#: adminpages/dashboard.php:286
+#: adminpages/dashboard.php:294
+#: adminpages/orders.php:373
+#: adminpages/orders.php:423
+#: adminpages/orders.php:495
+#: adminpages/orders.php:524
+#: adminpages/orders.php:579
+#: adminpages/orders.php:606
+#: adminpages/orders.php:610
+#: adminpages/orders.php:621
+#: adminpages/orders.php:667
+#: adminpages/orders.php:705
+#: adminpages/orders.php:709
+#: adminpages/orders.php:710
+#: adminpages/orders.php:712
+#: adminpages/orders.php:722
+#: adminpages/orders.php:909
+#: adminpages/orders.php:919
+#: adminpages/orders.php:946
+#: adminpages/orders.php:975
+#: adminpages/orders.php:1112
+#: adminpages/orders.php:1143
+#: adminpages/orders.php:1149
+#: adminpages/orders.php:1240
+#: adminpages/orders.php:1305
+#: adminpages/orders.php:1311
+#: adminpages/orders.php:1316
+#: adminpages/orders.php:1320
+#: adminpages/orders.php:1361
+#: pages/invoice.php:27
+#: pages/invoice.php:29
+#: shortcodes/pmpro_account.php:130
+#: shortcodes/pmpro_account.php:206
 msgid "Status"
 msgstr ""
 
-#: adminpages/dashboard.php:291 adminpages/orders.php:828
-#: adminpages/orders.php:1331 pages/invoice.php:111
-#: shortcodes/pmpro_account.php:210 adminpages/dashboard.php:287
-#: adminpages/dashboard.php:291 adminpages/dashboard.php:295
-#: adminpages/orders.php:442 adminpages/orders.php:492
-#: adminpages/orders.php:493 adminpages/orders.php:565
-#: adminpages/orders.php:594 adminpages/orders.php:607
-#: adminpages/orders.php:679 adminpages/orders.php:710
-#: adminpages/orders.php:721 adminpages/orders.php:770
-#: adminpages/orders.php:806 adminpages/orders.php:810
-#: adminpages/orders.php:811 adminpages/orders.php:815
-#: adminpages/orders.php:825 adminpages/orders.php:910
-#: adminpages/orders.php:920 adminpages/orders.php:947
-#: adminpages/orders.php:976 adminpages/orders.php:1113
-#: adminpages/orders.php:1144 adminpages/orders.php:1150
-#: adminpages/orders.php:1241 adminpages/orders.php:1306
-#: adminpages/orders.php:1312 adminpages/orders.php:1317
-#: adminpages/orders.php:1321 adminpages/orders.php:1362 pages/account.php:91
-#: pages/invoice.php:87 pages/invoice.php:99 pages/invoice.php:100
-#: pages/invoice.php:101 pages/invoice.php:102 pages/invoice.php:105
-#: pages/invoice.php:107 pages/invoice.php:110 pages/invoice.php:111
-#: shortcodes/pmpro_account.php:122 shortcodes/pmpro_account.php:124
-#: shortcodes/pmpro_account.php:125 shortcodes/pmpro_account.php:127
-#: shortcodes/pmpro_account.php:203 shortcodes/pmpro_account.php:210
+#: adminpages/dashboard.php:291
+#: adminpages/orders.php:828
+#: adminpages/orders.php:1331
+#: pages/invoice.php:111
+#: shortcodes/pmpro_account.php:210
+#: adminpages/dashboard.php:287
+#: adminpages/dashboard.php:295
+#: adminpages/orders.php:442
+#: adminpages/orders.php:492
+#: adminpages/orders.php:493
+#: adminpages/orders.php:565
+#: adminpages/orders.php:594
+#: adminpages/orders.php:607
+#: adminpages/orders.php:679
+#: adminpages/orders.php:710
+#: adminpages/orders.php:721
+#: adminpages/orders.php:770
+#: adminpages/orders.php:806
+#: adminpages/orders.php:810
+#: adminpages/orders.php:811
+#: adminpages/orders.php:815
+#: adminpages/orders.php:825
+#: adminpages/orders.php:910
+#: adminpages/orders.php:920
+#: adminpages/orders.php:947
+#: adminpages/orders.php:976
+#: adminpages/orders.php:1113
+#: adminpages/orders.php:1144
+#: adminpages/orders.php:1150
+#: adminpages/orders.php:1241
+#: adminpages/orders.php:1306
+#: adminpages/orders.php:1312
+#: adminpages/orders.php:1317
+#: adminpages/orders.php:1321
+#: adminpages/orders.php:1362
+#: pages/account.php:91
+#: pages/invoice.php:87
+#: pages/invoice.php:99
+#: pages/invoice.php:100
+#: pages/invoice.php:101
+#: pages/invoice.php:102
+#: pages/invoice.php:105
+#: pages/invoice.php:107
+#: pages/invoice.php:110
+#: shortcodes/pmpro_account.php:122
+#: shortcodes/pmpro_account.php:124
+#: shortcodes/pmpro_account.php:125
+#: shortcodes/pmpro_account.php:127
+#: shortcodes/pmpro_account.php:203
 msgid "Date"
 msgstr ""
 
-#: adminpages/dashboard.php:298 adminpages/orders.php:1487
-#: adminpages/dashboard.php:294 adminpages/dashboard.php:298
-#: adminpages/dashboard.php:302 adminpages/orders.php:674
-#: adminpages/orders.php:977 adminpages/orders.php:995
-#: adminpages/orders.php:1005 adminpages/orders.php:1008
-#: adminpages/orders.php:1043 adminpages/orders.php:1072
-#: adminpages/orders.php:1228 adminpages/orders.php:1262
-#: adminpages/orders.php:1268 adminpages/orders.php:1383
-#: adminpages/orders.php:1457 adminpages/orders.php:1462
-#: adminpages/orders.php:1463 adminpages/orders.php:1478
+#: adminpages/dashboard.php:298
+#: adminpages/orders.php:1487
+#: adminpages/dashboard.php:294
+#: adminpages/dashboard.php:302
+#: adminpages/orders.php:674
+#: adminpages/orders.php:977
+#: adminpages/orders.php:995
+#: adminpages/orders.php:1005
+#: adminpages/orders.php:1008
+#: adminpages/orders.php:1043
+#: adminpages/orders.php:1072
+#: adminpages/orders.php:1228
+#: adminpages/orders.php:1262
+#: adminpages/orders.php:1268
+#: adminpages/orders.php:1383
+#: adminpages/orders.php:1457
+#: adminpages/orders.php:1462
+#: adminpages/orders.php:1463
+#: adminpages/orders.php:1478
 #: adminpages/orders.php:1512
 msgid "No orders found."
 msgstr ""
 
-#: adminpages/dashboard.php:315 adminpages/dashboard.php:330
-#: adminpages/orders.php:1393 adminpages/orders.php:1405
-#: adminpages/dashboard.php:311 adminpages/dashboard.php:315
-#: adminpages/dashboard.php:319 adminpages/dashboard.php:326
-#: adminpages/dashboard.php:330 adminpages/orders.php:630
-#: adminpages/orders.php:933 adminpages/orders.php:943
-#: adminpages/orders.php:972 adminpages/orders.php:1001
-#: adminpages/orders.php:1141 adminpages/orders.php:1172
-#: adminpages/orders.php:1178 adminpages/orders.php:1273
-#: adminpages/orders.php:1345 adminpages/orders.php:1369
-#: adminpages/orders.php:1374 adminpages/orders.php:1375
-#: adminpages/orders.php:1384 adminpages/orders.php:1395
+#: adminpages/dashboard.php:315
+#: adminpages/dashboard.php:330
+#: adminpages/orders.php:1393
+#: adminpages/orders.php:1405
+#: adminpages/dashboard.php:311
+#: adminpages/dashboard.php:319
+#: adminpages/dashboard.php:326
+#: adminpages/orders.php:630
+#: adminpages/orders.php:933
+#: adminpages/orders.php:943
+#: adminpages/orders.php:972
+#: adminpages/orders.php:1001
+#: adminpages/orders.php:1141
+#: adminpages/orders.php:1172
+#: adminpages/orders.php:1178
+#: adminpages/orders.php:1273
+#: adminpages/orders.php:1345
+#: adminpages/orders.php:1369
+#: adminpages/orders.php:1374
+#: adminpages/orders.php:1375
+#: adminpages/orders.php:1384
+#: adminpages/orders.php:1395
 #: adminpages/orders.php:1396
 msgid "deleted"
 msgstr ""
 
-#: adminpages/dashboard.php:317 adminpages/dashboard.php:332
-#: adminpages/orders.php:1395 adminpages/orders.php:1407
-#: adminpages/dashboard.php:313 adminpages/dashboard.php:317
-#: adminpages/dashboard.php:321 adminpages/dashboard.php:328
-#: adminpages/dashboard.php:332 adminpages/orders.php:1275
-#: adminpages/orders.php:1347 adminpages/orders.php:1371
-#: adminpages/orders.php:1376 adminpages/orders.php:1377
-#: adminpages/orders.php:1386 adminpages/orders.php:1397
+#: adminpages/dashboard.php:317
+#: adminpages/dashboard.php:332
+#: adminpages/orders.php:1395
+#: adminpages/orders.php:1407
+#: adminpages/dashboard.php:313
+#: adminpages/dashboard.php:321
+#: adminpages/dashboard.php:328
+#: adminpages/orders.php:1275
+#: adminpages/orders.php:1347
+#: adminpages/orders.php:1371
+#: adminpages/orders.php:1376
+#: adminpages/orders.php:1377
+#: adminpages/orders.php:1386
+#: adminpages/orders.php:1397
 #: adminpages/orders.php:1398
 msgid "none"
 msgstr ""
@@ -1785,16 +2440,19 @@ msgstr ""
 
 #: adminpages/dashboard.php:387
 #: classes/class-pmpro-admin-activity-email.php:346
-#: adminpages/dashboard.php:372 adminpages/dashboard.php:377
-#: adminpages/dashboard.php:380 adminpages/dashboard.php:383
-#: adminpages/dashboard.php:387
+#: adminpages/dashboard.php:372
+#: adminpages/dashboard.php:377
+#: adminpages/dashboard.php:380
+#: adminpages/dashboard.php:383
 #: classes/class-pmpro-admin-activity-email.php:344
 msgid "No news found."
 msgstr ""
 
-#: adminpages/dashboard.php:393 adminpages/dashboard.php:378
-#: adminpages/dashboard.php:383 adminpages/dashboard.php:386
-#: adminpages/dashboard.php:389 adminpages/dashboard.php:393
+#: adminpages/dashboard.php:393
+#: adminpages/dashboard.php:378
+#: adminpages/dashboard.php:383
+#: adminpages/dashboard.php:386
+#: adminpages/dashboard.php:389
 #, php-format
 msgid "Posted %s"
 msgstr ""
@@ -1803,198 +2461,293 @@ msgstr ""
 msgid "View More"
 msgstr ""
 
-#: adminpages/discountcodes.php:107 adminpages/discountcodes.php:64
-#: adminpages/discountcodes.php:65 adminpages/discountcodes.php:70
-#: adminpages/discountcodes.php:71 adminpages/discountcodes.php:102
-#: adminpages/discountcodes.php:105 adminpages/discountcodes.php:107
+#: adminpages/discountcodes.php:107
+#: adminpages/discountcodes.php:64
+#: adminpages/discountcodes.php:65
+#: adminpages/discountcodes.php:70
+#: adminpages/discountcodes.php:71
+#: adminpages/discountcodes.php:102
+#: adminpages/discountcodes.php:105
 msgid "Discount code added successfully."
 msgstr ""
 
-#: adminpages/discountcodes.php:113 adminpages/discountcodes.php:48
-#: adminpages/discountcodes.php:49 adminpages/discountcodes.php:54
-#: adminpages/discountcodes.php:77 adminpages/discountcodes.php:108
-#: adminpages/discountcodes.php:111 adminpages/discountcodes.php:113
+#: adminpages/discountcodes.php:113
+#: adminpages/discountcodes.php:48
+#: adminpages/discountcodes.php:49
+#: adminpages/discountcodes.php:54
+#: adminpages/discountcodes.php:77
+#: adminpages/discountcodes.php:108
+#: adminpages/discountcodes.php:111
 msgid "Discount code updated successfully."
 msgstr ""
 
-#: adminpages/discountcodes.php:121 adminpages/discountcodes.php:71
-#: adminpages/discountcodes.php:72 adminpages/discountcodes.php:73
-#: adminpages/discountcodes.php:78 adminpages/discountcodes.php:85
-#: adminpages/discountcodes.php:116 adminpages/discountcodes.php:119
 #: adminpages/discountcodes.php:121
+#: adminpages/discountcodes.php:71
+#: adminpages/discountcodes.php:72
+#: adminpages/discountcodes.php:73
+#: adminpages/discountcodes.php:78
+#: adminpages/discountcodes.php:85
+#: adminpages/discountcodes.php:116
+#: adminpages/discountcodes.php:119
 msgid "Error adding discount code. That code may already be in use."
 msgstr ""
 
-#: adminpages/discountcodes.php:125 adminpages/discountcodes.php:55
-#: adminpages/discountcodes.php:56 adminpages/discountcodes.php:61
-#: adminpages/discountcodes.php:89 adminpages/discountcodes.php:120
-#: adminpages/discountcodes.php:123 adminpages/discountcodes.php:125
+#: adminpages/discountcodes.php:125
+#: adminpages/discountcodes.php:55
+#: adminpages/discountcodes.php:56
+#: adminpages/discountcodes.php:61
+#: adminpages/discountcodes.php:89
+#: adminpages/discountcodes.php:120
+#: adminpages/discountcodes.php:123
 msgid "Error updating discount code. That code may already be in use."
 msgstr ""
 
-#: adminpages/discountcodes.php:287 adminpages/discountcodes.php:196
-#: adminpages/discountcodes.php:197 adminpages/discountcodes.php:198
-#: adminpages/discountcodes.php:203 adminpages/discountcodes.php:247
-#: adminpages/discountcodes.php:280 adminpages/discountcodes.php:285
 #: adminpages/discountcodes.php:287
+#: adminpages/discountcodes.php:196
+#: adminpages/discountcodes.php:197
+#: adminpages/discountcodes.php:198
+#: adminpages/discountcodes.php:203
+#: adminpages/discountcodes.php:247
+#: adminpages/discountcodes.php:280
+#: adminpages/discountcodes.php:285
 #, php-format
 msgid "Error saving values for the %s level."
 msgstr ""
 
-#: adminpages/discountcodes.php:295 adminpages/discountcodes.php:204
-#: adminpages/discountcodes.php:205 adminpages/discountcodes.php:206
-#: adminpages/discountcodes.php:211 adminpages/discountcodes.php:255
-#: adminpages/discountcodes.php:288 adminpages/discountcodes.php:293
 #: adminpages/discountcodes.php:295
+#: adminpages/discountcodes.php:204
+#: adminpages/discountcodes.php:205
+#: adminpages/discountcodes.php:206
+#: adminpages/discountcodes.php:211
+#: adminpages/discountcodes.php:255
+#: adminpages/discountcodes.php:288
+#: adminpages/discountcodes.php:293
 msgid "There were errors updating the level values: "
 msgstr ""
 
-#: adminpages/discountcodes.php:335 adminpages/discountcodes.php:234
-#: adminpages/discountcodes.php:237 adminpages/discountcodes.php:238
-#: adminpages/discountcodes.php:239 adminpages/discountcodes.php:244
-#: adminpages/discountcodes.php:288 adminpages/discountcodes.php:328
-#: adminpages/discountcodes.php:333 adminpages/discountcodes.php:335
+#: adminpages/discountcodes.php:335
+#: adminpages/discountcodes.php:234
+#: adminpages/discountcodes.php:237
+#: adminpages/discountcodes.php:238
+#: adminpages/discountcodes.php:239
+#: adminpages/discountcodes.php:244
+#: adminpages/discountcodes.php:288
+#: adminpages/discountcodes.php:328
+#: adminpages/discountcodes.php:333
 #, php-format
 msgid "Code %s deleted successfully."
 msgstr ""
 
-#: adminpages/discountcodes.php:340 adminpages/discountcodes.php:239
-#: adminpages/discountcodes.php:242 adminpages/discountcodes.php:243
-#: adminpages/discountcodes.php:244 adminpages/discountcodes.php:249
-#: adminpages/discountcodes.php:293 adminpages/discountcodes.php:333
-#: adminpages/discountcodes.php:338 adminpages/discountcodes.php:340
-msgid ""
-"Error deleting discount code. The code was only partially deleted. Please "
-"try again."
+#: adminpages/discountcodes.php:340
+#: adminpages/discountcodes.php:239
+#: adminpages/discountcodes.php:242
+#: adminpages/discountcodes.php:243
+#: adminpages/discountcodes.php:244
+#: adminpages/discountcodes.php:249
+#: adminpages/discountcodes.php:293
+#: adminpages/discountcodes.php:333
+#: adminpages/discountcodes.php:338
+msgid "Error deleting discount code. The code was only partially deleted. Please try again."
 msgstr ""
 
-#: adminpages/discountcodes.php:346 adminpages/discountcodes.php:245
-#: adminpages/discountcodes.php:248 adminpages/discountcodes.php:249
-#: adminpages/discountcodes.php:250 adminpages/discountcodes.php:255
-#: adminpages/discountcodes.php:299 adminpages/discountcodes.php:339
-#: adminpages/discountcodes.php:344 adminpages/discountcodes.php:346
+#: adminpages/discountcodes.php:346
+#: adminpages/discountcodes.php:245
+#: adminpages/discountcodes.php:248
+#: adminpages/discountcodes.php:249
+#: adminpages/discountcodes.php:250
+#: adminpages/discountcodes.php:255
+#: adminpages/discountcodes.php:299
+#: adminpages/discountcodes.php:339
+#: adminpages/discountcodes.php:344
 msgid "Error deleting code. Please try again."
 msgstr ""
 
-#: adminpages/discountcodes.php:352 adminpages/discountcodes.php:793
-#: adminpages/discountcodes.php:251 adminpages/discountcodes.php:254
-#: adminpages/discountcodes.php:255 adminpages/discountcodes.php:256
-#: adminpages/discountcodes.php:261 adminpages/discountcodes.php:305
-#: adminpages/discountcodes.php:345 adminpages/discountcodes.php:350
 #: adminpages/discountcodes.php:352
+#: adminpages/discountcodes.php:793
+#: adminpages/discountcodes.php:251
+#: adminpages/discountcodes.php:254
+#: adminpages/discountcodes.php:255
+#: adminpages/discountcodes.php:256
+#: adminpages/discountcodes.php:261
+#: adminpages/discountcodes.php:305
+#: adminpages/discountcodes.php:345
+#: adminpages/discountcodes.php:350
 msgid "Code not found."
 msgstr ""
 
-#: adminpages/discountcodes.php:358 adminpages/membershiplevels.php:169
-#: adminpages/discountcodes.php:356 adminpages/discountcodes.php:358
+#: adminpages/discountcodes.php:358
 #: adminpages/membershiplevels.php:169
+#: adminpages/discountcodes.php:356
 #, php-format
-msgid ""
-"WARNING: A level was set with both a recurring billing amount and an "
-"expiration date. You only need to set one of these unless you really want "
-"this membership to expire after a specific time period. For more "
-"information, <a target=\"_blank\" href=\"%s\">see our post here</a>."
+msgid "WARNING: A level was set with both a recurring billing amount and an expiration date. You only need to set one of these unless you really want this membership to expire after a specific time period. For more information, <a target=\"_blank\" href=\"%s\">see our post here</a>."
 msgstr ""
 
-#: adminpages/discountcodes.php:373 adminpages/discountcodes.php:264
-#: adminpages/discountcodes.php:267 adminpages/discountcodes.php:268
-#: adminpages/discountcodes.php:269 adminpages/discountcodes.php:274
-#: adminpages/discountcodes.php:318 adminpages/discountcodes.php:358
-#: adminpages/discountcodes.php:371 adminpages/discountcodes.php:373
+#: adminpages/discountcodes.php:373
+#: adminpages/discountcodes.php:264
+#: adminpages/discountcodes.php:267
+#: adminpages/discountcodes.php:268
+#: adminpages/discountcodes.php:269
+#: adminpages/discountcodes.php:274
+#: adminpages/discountcodes.php:318
+#: adminpages/discountcodes.php:358
+#: adminpages/discountcodes.php:371
 msgid "Edit Discount Code"
 msgstr ""
 
-#: adminpages/discountcodes.php:375 adminpages/discountcodes.php:732
-#: adminpages/discountcodes.php:266 adminpages/discountcodes.php:269
-#: adminpages/discountcodes.php:270 adminpages/discountcodes.php:271
-#: adminpages/discountcodes.php:276 adminpages/discountcodes.php:320
-#: adminpages/discountcodes.php:360 adminpages/discountcodes.php:373
-#: adminpages/discountcodes.php:375 adminpages/discountcodes.php:526
-#: adminpages/discountcodes.php:529 adminpages/discountcodes.php:557
-#: adminpages/discountcodes.php:558 adminpages/discountcodes.php:559
-#: adminpages/discountcodes.php:564 adminpages/discountcodes.php:637
-#: adminpages/discountcodes.php:678 adminpages/discountcodes.php:698
+#: adminpages/discountcodes.php:375
+#: adminpages/discountcodes.php:732
+#: adminpages/discountcodes.php:266
+#: adminpages/discountcodes.php:269
+#: adminpages/discountcodes.php:270
+#: adminpages/discountcodes.php:271
+#: adminpages/discountcodes.php:276
+#: adminpages/discountcodes.php:320
+#: adminpages/discountcodes.php:360
+#: adminpages/discountcodes.php:373
+#: adminpages/discountcodes.php:526
+#: adminpages/discountcodes.php:529
+#: adminpages/discountcodes.php:557
+#: adminpages/discountcodes.php:558
+#: adminpages/discountcodes.php:559
+#: adminpages/discountcodes.php:564
+#: adminpages/discountcodes.php:637
+#: adminpages/discountcodes.php:678
+#: adminpages/discountcodes.php:698
 msgid "Add New Discount Code"
 msgstr ""
 
-#: adminpages/discountcodes.php:444 adminpages/discountcodes.php:780
-#: adminpages/membershiplevels.php:347 adminpages/membershiplevels.php:775
-#: adminpages/orders.php:1321 adminpages/reports/login.php:178
+#: adminpages/discountcodes.php:444
+#: adminpages/discountcodes.php:780
+#: adminpages/membershiplevels.php:347
+#: adminpages/membershiplevels.php:775
+#: adminpages/orders.php:1321
+#: adminpages/reports/login.php:178
 #: adminpages/templates/orders-email.php:46
-#: adminpages/templates/orders-print.php:75 adminpages/discountcodes.php:306
-#: adminpages/discountcodes.php:309 adminpages/discountcodes.php:310
-#: adminpages/discountcodes.php:311 adminpages/discountcodes.php:316
-#: adminpages/discountcodes.php:381 adminpages/discountcodes.php:422
-#: adminpages/discountcodes.php:442 adminpages/discountcodes.php:444
-#: adminpages/discountcodes.php:547 adminpages/discountcodes.php:557
-#: adminpages/discountcodes.php:585 adminpages/discountcodes.php:586
-#: adminpages/discountcodes.php:587 adminpages/discountcodes.php:592
-#: adminpages/discountcodes.php:665 adminpages/discountcodes.php:719
-#: adminpages/discountcodes.php:745 adminpages/discountcodes.php:746
-#: adminpages/discountcodes.php:747 adminpages/discountcodes.php:780
-#: adminpages/membershiplevels.php:284 adminpages/membershiplevels.php:286
-#: adminpages/membershiplevels.php:288 adminpages/membershiplevels.php:312
-#: adminpages/membershiplevels.php:322 adminpages/membershiplevels.php:344
-#: adminpages/membershiplevels.php:346 adminpages/membershiplevels.php:347
-#: adminpages/membershiplevels.php:505 adminpages/membershiplevels.php:511
-#: adminpages/membershiplevels.php:513 adminpages/membershiplevels.php:540
-#: adminpages/membershiplevels.php:541 adminpages/membershiplevels.php:583
-#: adminpages/membershiplevels.php:629 adminpages/membershiplevels.php:631
-#: adminpages/membershiplevels.php:636 adminpages/membershiplevels.php:637
-#: adminpages/membershiplevels.php:641 adminpages/membershiplevels.php:653
-#: adminpages/membershiplevels.php:663 adminpages/membershiplevels.php:713
-#: adminpages/membershiplevels.php:715 adminpages/membershiplevels.php:741
-#: adminpages/membershiplevels.php:758 adminpages/membershiplevels.php:763
-#: adminpages/membershiplevels.php:768 adminpages/membershiplevels.php:773
-#: adminpages/membershiplevels.php:775 adminpages/memberslist.php:111
-#: adminpages/memberslist.php:144 adminpages/memberslist.php:154
-#: adminpages/memberslist.php:164 adminpages/memberslist.php:168
-#: adminpages/orders.php:597 adminpages/orders.php:900
-#: adminpages/orders.php:910 adminpages/orders.php:937
-#: adminpages/orders.php:966 adminpages/orders.php:1103
-#: adminpages/orders.php:1134 adminpages/orders.php:1140
-#: adminpages/orders.php:1231 adminpages/orders.php:1296
-#: adminpages/orders.php:1302 adminpages/orders.php:1307
-#: adminpages/orders.php:1311 adminpages/orders.php:1352
-#: adminpages/reports/login.php:140 adminpages/reports/login.php:142
-#: adminpages/reports/login.php:158 adminpages/reports/login.php:162
-#: adminpages/reports/login.php:178 adminpages/templates/orders-email.php:46
 #: adminpages/templates/orders-print.php:75
+#: adminpages/discountcodes.php:306
+#: adminpages/discountcodes.php:309
+#: adminpages/discountcodes.php:310
+#: adminpages/discountcodes.php:311
+#: adminpages/discountcodes.php:316
+#: adminpages/discountcodes.php:381
+#: adminpages/discountcodes.php:422
+#: adminpages/discountcodes.php:442
+#: adminpages/discountcodes.php:547
+#: adminpages/discountcodes.php:557
+#: adminpages/discountcodes.php:585
+#: adminpages/discountcodes.php:586
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:592
+#: adminpages/discountcodes.php:665
+#: adminpages/discountcodes.php:719
+#: adminpages/discountcodes.php:745
+#: adminpages/discountcodes.php:746
+#: adminpages/discountcodes.php:747
+#: adminpages/membershiplevels.php:284
+#: adminpages/membershiplevels.php:286
+#: adminpages/membershiplevels.php:288
+#: adminpages/membershiplevels.php:312
+#: adminpages/membershiplevels.php:322
+#: adminpages/membershiplevels.php:344
+#: adminpages/membershiplevels.php:346
+#: adminpages/membershiplevels.php:505
+#: adminpages/membershiplevels.php:511
+#: adminpages/membershiplevels.php:513
+#: adminpages/membershiplevels.php:540
+#: adminpages/membershiplevels.php:541
+#: adminpages/membershiplevels.php:583
+#: adminpages/membershiplevels.php:629
+#: adminpages/membershiplevels.php:631
+#: adminpages/membershiplevels.php:636
+#: adminpages/membershiplevels.php:637
+#: adminpages/membershiplevels.php:641
+#: adminpages/membershiplevels.php:653
+#: adminpages/membershiplevels.php:663
+#: adminpages/membershiplevels.php:713
+#: adminpages/membershiplevels.php:715
+#: adminpages/membershiplevels.php:741
+#: adminpages/membershiplevels.php:758
+#: adminpages/membershiplevels.php:763
+#: adminpages/membershiplevels.php:768
+#: adminpages/membershiplevels.php:773
+#: adminpages/memberslist.php:111
+#: adminpages/memberslist.php:144
+#: adminpages/memberslist.php:154
+#: adminpages/memberslist.php:164
+#: adminpages/memberslist.php:168
+#: adminpages/orders.php:597
+#: adminpages/orders.php:900
+#: adminpages/orders.php:910
+#: adminpages/orders.php:937
+#: adminpages/orders.php:966
+#: adminpages/orders.php:1103
+#: adminpages/orders.php:1134
+#: adminpages/orders.php:1140
+#: adminpages/orders.php:1231
+#: adminpages/orders.php:1296
+#: adminpages/orders.php:1302
+#: adminpages/orders.php:1307
+#: adminpages/orders.php:1311
+#: adminpages/orders.php:1352
+#: adminpages/reports/login.php:140
+#: adminpages/reports/login.php:142
+#: adminpages/reports/login.php:158
+#: adminpages/reports/login.php:162
 msgid "ID"
 msgstr ""
 
-#: adminpages/discountcodes.php:445 adminpages/orders.php:414
-#: adminpages/discountcodes.php:307 adminpages/discountcodes.php:310
-#: adminpages/discountcodes.php:311 adminpages/discountcodes.php:312
-#: adminpages/discountcodes.php:317 adminpages/discountcodes.php:382
-#: adminpages/discountcodes.php:423 adminpages/discountcodes.php:443
-#: adminpages/discountcodes.php:445 adminpages/orders.php:211
-#: adminpages/orders.php:261 adminpages/orders.php:333
-#: adminpages/orders.php:344 adminpages/orders.php:362
-#: adminpages/orders.php:375 adminpages/orders.php:386
-#: adminpages/orders.php:394 adminpages/orders.php:401
-#: adminpages/orders.php:402 adminpages/orders.php:406
-#: adminpages/orders.php:408 adminpages/orders.php:412
+#: adminpages/discountcodes.php:445
+#: adminpages/orders.php:414
+#: adminpages/discountcodes.php:307
+#: adminpages/discountcodes.php:310
+#: adminpages/discountcodes.php:311
+#: adminpages/discountcodes.php:312
+#: adminpages/discountcodes.php:317
+#: adminpages/discountcodes.php:382
+#: adminpages/discountcodes.php:423
+#: adminpages/discountcodes.php:443
+#: adminpages/orders.php:211
+#: adminpages/orders.php:261
+#: adminpages/orders.php:333
+#: adminpages/orders.php:344
+#: adminpages/orders.php:362
+#: adminpages/orders.php:375
+#: adminpages/orders.php:386
+#: adminpages/orders.php:394
+#: adminpages/orders.php:401
+#: adminpages/orders.php:402
+#: adminpages/orders.php:406
+#: adminpages/orders.php:408
+#: adminpages/orders.php:412
 msgid "This will be generated when you save."
 msgstr ""
 
-#: adminpages/discountcodes.php:487 includes/privacy.php:186
-#: adminpages/discountcodes.php:349 adminpages/discountcodes.php:352
-#: adminpages/discountcodes.php:353 adminpages/discountcodes.php:354
-#: adminpages/discountcodes.php:359 adminpages/discountcodes.php:424
-#: adminpages/discountcodes.php:465 adminpages/discountcodes.php:485
-#: adminpages/discountcodes.php:487 includes/privacy.php:186
+#: adminpages/discountcodes.php:487
+#: includes/privacy.php:186
+#: adminpages/discountcodes.php:349
+#: adminpages/discountcodes.php:352
+#: adminpages/discountcodes.php:353
+#: adminpages/discountcodes.php:354
+#: adminpages/discountcodes.php:359
+#: adminpages/discountcodes.php:424
+#: adminpages/discountcodes.php:465
+#: adminpages/discountcodes.php:485
 msgid "Start Date"
 msgstr ""
 
 #: adminpages/discountcodes.php:505
 #: classes/gateways/class.pmprogateway_braintree.php:479
-#: classes/gateways/class.pmprogateway_stripe.php:1086 pages/billing.php:363
-#: pages/checkout.php:392 adminpages/discountcodes.php:367
-#: adminpages/discountcodes.php:370 adminpages/discountcodes.php:371
-#: adminpages/discountcodes.php:372 adminpages/discountcodes.php:377
-#: adminpages/discountcodes.php:442 adminpages/discountcodes.php:483
-#: adminpages/discountcodes.php:503 adminpages/discountcodes.php:505
+#: classes/gateways/class.pmprogateway_stripe.php:1086
+#: pages/billing.php:363
+#: pages/checkout.php:392
+#: adminpages/discountcodes.php:367
+#: adminpages/discountcodes.php:370
+#: adminpages/discountcodes.php:371
+#: adminpages/discountcodes.php:372
+#: adminpages/discountcodes.php:377
+#: adminpages/discountcodes.php:442
+#: adminpages/discountcodes.php:483
+#: adminpages/discountcodes.php:503
 #: classes/gateways/class.pmprogateway_braintree.php:308
 #: classes/gateways/class.pmprogateway_braintree.php:321
 #: classes/gateways/class.pmprogateway_braintree.php:323
@@ -2005,7 +2758,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:423
 #: classes/gateways/class.pmprogateway_braintree.php:459
 #: classes/gateways/class.pmprogateway_braintree.php:478
-#: classes/gateways/class.pmprogateway_braintree.php:479
 #: classes/gateways/class.pmprogateway_braintree.php:480
 #: classes/gateways/class.pmprogateway_braintree.php:485
 #: classes/gateways/class.pmprogateway_braintree.php:486
@@ -2032,134 +2784,219 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:630
 #: classes/gateways/class.pmprogateway_stripe.php:931
 #: classes/gateways/class.pmprogateway_stripe.php:1001
-#: classes/gateways/class.pmprogateway_stripe.php:1075 pages/billing.php:249
-#: pages/billing.php:253 pages/billing.php:262 pages/billing.php:265
-#: pages/billing.php:268 pages/billing.php:310 pages/billing.php:313
-#: pages/billing.php:316 pages/billing.php:317 pages/billing.php:319
-#: pages/billing.php:321 pages/billing.php:322 pages/billing.php:330
-#: pages/billing.php:339 pages/billing.php:342 pages/billing.php:363
-#: pages/checkout.php:389 pages/checkout.php:463 pages/checkout.php:471
-#: pages/checkout.php:508 pages/checkout.php:524 pages/checkout.php:525
-#: pages/checkout.php:532 pages/checkout.php:553 pages/checkout.php:562
-#: pages/checkout.php:571 pages/checkout.php:575 pages/checkout.php:582
+#: classes/gateways/class.pmprogateway_stripe.php:1075
+#: pages/billing.php:249
+#: pages/billing.php:253
+#: pages/billing.php:262
+#: pages/billing.php:265
+#: pages/billing.php:268
+#: pages/billing.php:310
+#: pages/billing.php:313
+#: pages/billing.php:316
+#: pages/billing.php:317
+#: pages/billing.php:319
+#: pages/billing.php:321
+#: pages/billing.php:322
+#: pages/billing.php:330
+#: pages/billing.php:339
+#: pages/billing.php:342
+#: pages/checkout.php:389
+#: pages/checkout.php:463
+#: pages/checkout.php:471
+#: pages/checkout.php:508
+#: pages/checkout.php:524
+#: pages/checkout.php:525
+#: pages/checkout.php:532
+#: pages/checkout.php:553
+#: pages/checkout.php:562
+#: pages/checkout.php:571
+#: pages/checkout.php:575
+#: pages/checkout.php:582
 #: pages/checkout.php:585
 msgid "Expiration Date"
 msgstr ""
 
-#: adminpages/discountcodes.php:523 adminpages/discountcodes.php:784
-#: adminpages/discountcodes.php:385 adminpages/discountcodes.php:388
-#: adminpages/discountcodes.php:389 adminpages/discountcodes.php:390
-#: adminpages/discountcodes.php:395 adminpages/discountcodes.php:460
-#: adminpages/discountcodes.php:501 adminpages/discountcodes.php:521
-#: adminpages/discountcodes.php:523 adminpages/discountcodes.php:551
-#: adminpages/discountcodes.php:561 adminpages/discountcodes.php:589
-#: adminpages/discountcodes.php:590 adminpages/discountcodes.php:591
-#: adminpages/discountcodes.php:596 adminpages/discountcodes.php:669
-#: adminpages/discountcodes.php:723 adminpages/discountcodes.php:749
-#: adminpages/discountcodes.php:750 adminpages/discountcodes.php:751
+#: adminpages/discountcodes.php:523
 #: adminpages/discountcodes.php:784
+#: adminpages/discountcodes.php:385
+#: adminpages/discountcodes.php:388
+#: adminpages/discountcodes.php:389
+#: adminpages/discountcodes.php:390
+#: adminpages/discountcodes.php:395
+#: adminpages/discountcodes.php:460
+#: adminpages/discountcodes.php:501
+#: adminpages/discountcodes.php:521
+#: adminpages/discountcodes.php:551
+#: adminpages/discountcodes.php:561
+#: adminpages/discountcodes.php:589
+#: adminpages/discountcodes.php:590
+#: adminpages/discountcodes.php:591
+#: adminpages/discountcodes.php:596
+#: adminpages/discountcodes.php:669
+#: adminpages/discountcodes.php:723
+#: adminpages/discountcodes.php:749
+#: adminpages/discountcodes.php:750
+#: adminpages/discountcodes.php:751
 msgid "Uses"
 msgstr ""
 
-#: adminpages/discountcodes.php:526 adminpages/discountcodes.php:388
-#: adminpages/discountcodes.php:391 adminpages/discountcodes.php:392
-#: adminpages/discountcodes.php:393 adminpages/discountcodes.php:398
-#: adminpages/discountcodes.php:463 adminpages/discountcodes.php:504
-#: adminpages/discountcodes.php:524 adminpages/discountcodes.php:526
+#: adminpages/discountcodes.php:526
+#: adminpages/discountcodes.php:388
+#: adminpages/discountcodes.php:391
+#: adminpages/discountcodes.php:392
+#: adminpages/discountcodes.php:393
+#: adminpages/discountcodes.php:398
+#: adminpages/discountcodes.php:463
+#: adminpages/discountcodes.php:504
+#: adminpages/discountcodes.php:524
 msgid "Leave blank for unlimited uses."
 msgstr ""
 
-#: adminpages/discountcodes.php:535 adminpages/discountcodes.php:400
-#: adminpages/discountcodes.php:401 adminpages/discountcodes.php:402
-#: adminpages/discountcodes.php:407 adminpages/discountcodes.php:472
-#: adminpages/discountcodes.php:513 adminpages/discountcodes.php:533
 #: adminpages/discountcodes.php:535
+#: adminpages/discountcodes.php:400
+#: adminpages/discountcodes.php:401
+#: adminpages/discountcodes.php:402
+#: adminpages/discountcodes.php:407
+#: adminpages/discountcodes.php:472
+#: adminpages/discountcodes.php:513
+#: adminpages/discountcodes.php:533
 msgid "Which Levels Will This Code Apply To?"
 msgstr ""
 
-#: adminpages/discountcodes.php:573 adminpages/membershiplevels.php:401
-#: adminpages/discountcodes.php:427 adminpages/discountcodes.php:430
-#: adminpages/discountcodes.php:431 adminpages/discountcodes.php:432
-#: adminpages/discountcodes.php:437 adminpages/discountcodes.php:510
-#: adminpages/discountcodes.php:551 adminpages/discountcodes.php:571
-#: adminpages/discountcodes.php:573 adminpages/membershiplevels.php:337
-#: adminpages/membershiplevels.php:339 adminpages/membershiplevels.php:341
-#: adminpages/membershiplevels.php:342 adminpages/membershiplevels.php:365
-#: adminpages/membershiplevels.php:375 adminpages/membershiplevels.php:398
-#: adminpages/membershiplevels.php:400 adminpages/membershiplevels.php:401
-#: adminpages/membershiplevels.php:507 adminpages/membershiplevels.php:513
-#: adminpages/membershiplevels.php:515 adminpages/membershiplevels.php:542
+#: adminpages/discountcodes.php:573
+#: adminpages/membershiplevels.php:401
+#: adminpages/discountcodes.php:427
+#: adminpages/discountcodes.php:430
+#: adminpages/discountcodes.php:431
+#: adminpages/discountcodes.php:432
+#: adminpages/discountcodes.php:437
+#: adminpages/discountcodes.php:510
+#: adminpages/discountcodes.php:551
+#: adminpages/discountcodes.php:571
+#: adminpages/membershiplevels.php:337
+#: adminpages/membershiplevels.php:339
+#: adminpages/membershiplevels.php:341
+#: adminpages/membershiplevels.php:342
+#: adminpages/membershiplevels.php:365
+#: adminpages/membershiplevels.php:375
+#: adminpages/membershiplevels.php:398
+#: adminpages/membershiplevels.php:400
+#: adminpages/membershiplevels.php:507
+#: adminpages/membershiplevels.php:513
+#: adminpages/membershiplevels.php:515
+#: adminpages/membershiplevels.php:542
 #: pages/levels.php:14
 msgid "Initial Payment"
 msgstr ""
 
-#: adminpages/discountcodes.php:584 adminpages/membershiplevels.php:412
-#: adminpages/discountcodes.php:428 adminpages/discountcodes.php:431
-#: adminpages/discountcodes.php:441 adminpages/discountcodes.php:442
-#: adminpages/discountcodes.php:443 adminpages/discountcodes.php:448
-#: adminpages/discountcodes.php:521 adminpages/discountcodes.php:562
-#: adminpages/discountcodes.php:582 adminpages/discountcodes.php:584
-#: adminpages/membershiplevels.php:338 adminpages/membershiplevels.php:340
-#: adminpages/membershiplevels.php:350 adminpages/membershiplevels.php:352
-#: adminpages/membershiplevels.php:353 adminpages/membershiplevels.php:376
-#: adminpages/membershiplevels.php:386 adminpages/membershiplevels.php:409
-#: adminpages/membershiplevels.php:411 adminpages/membershiplevels.php:412
+#: adminpages/discountcodes.php:584
+#: adminpages/membershiplevels.php:412
+#: adminpages/discountcodes.php:428
+#: adminpages/discountcodes.php:431
+#: adminpages/discountcodes.php:441
+#: adminpages/discountcodes.php:442
+#: adminpages/discountcodes.php:443
+#: adminpages/discountcodes.php:448
+#: adminpages/discountcodes.php:521
+#: adminpages/discountcodes.php:562
+#: adminpages/discountcodes.php:582
+#: adminpages/membershiplevels.php:338
+#: adminpages/membershiplevels.php:340
+#: adminpages/membershiplevels.php:350
+#: adminpages/membershiplevels.php:352
+#: adminpages/membershiplevels.php:353
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:386
+#: adminpages/membershiplevels.php:409
+#: adminpages/membershiplevels.php:411
 msgid "The initial amount collected at registration."
 msgstr ""
 
-#: adminpages/discountcodes.php:589 adminpages/membershiplevels.php:417
-#: adminpages/discountcodes.php:432 adminpages/discountcodes.php:435
-#: adminpages/discountcodes.php:446 adminpages/discountcodes.php:447
-#: adminpages/discountcodes.php:448 adminpages/discountcodes.php:453
-#: adminpages/discountcodes.php:526 adminpages/discountcodes.php:567
-#: adminpages/discountcodes.php:587 adminpages/discountcodes.php:589
-#: adminpages/membershiplevels.php:342 adminpages/membershiplevels.php:344
-#: adminpages/membershiplevels.php:354 adminpages/membershiplevels.php:356
-#: adminpages/membershiplevels.php:357 adminpages/membershiplevels.php:380
-#: adminpages/membershiplevels.php:390 adminpages/membershiplevels.php:413
-#: adminpages/membershiplevels.php:415 adminpages/membershiplevels.php:416
+#: adminpages/discountcodes.php:589
 #: adminpages/membershiplevels.php:417
+#: adminpages/discountcodes.php:432
+#: adminpages/discountcodes.php:435
+#: adminpages/discountcodes.php:446
+#: adminpages/discountcodes.php:447
+#: adminpages/discountcodes.php:448
+#: adminpages/discountcodes.php:453
+#: adminpages/discountcodes.php:526
+#: adminpages/discountcodes.php:567
+#: adminpages/discountcodes.php:587
+#: adminpages/membershiplevels.php:342
+#: adminpages/membershiplevels.php:344
+#: adminpages/membershiplevels.php:354
+#: adminpages/membershiplevels.php:356
+#: adminpages/membershiplevels.php:357
+#: adminpages/membershiplevels.php:380
+#: adminpages/membershiplevels.php:390
+#: adminpages/membershiplevels.php:413
+#: adminpages/membershiplevels.php:415
+#: adminpages/membershiplevels.php:416
 msgid "Recurring Subscription"
 msgstr ""
 
-#: adminpages/discountcodes.php:590 adminpages/membershiplevels.php:418
-#: adminpages/discountcodes.php:433 adminpages/discountcodes.php:436
-#: adminpages/discountcodes.php:447 adminpages/discountcodes.php:448
-#: adminpages/discountcodes.php:449 adminpages/discountcodes.php:454
-#: adminpages/discountcodes.php:527 adminpages/discountcodes.php:568
-#: adminpages/discountcodes.php:588 adminpages/discountcodes.php:590
-#: adminpages/membershiplevels.php:343 adminpages/membershiplevels.php:345
-#: adminpages/membershiplevels.php:355 adminpages/membershiplevels.php:357
-#: adminpages/membershiplevels.php:358 adminpages/membershiplevels.php:381
-#: adminpages/membershiplevels.php:391 adminpages/membershiplevels.php:414
-#: adminpages/membershiplevels.php:416 adminpages/membershiplevels.php:417
+#: adminpages/discountcodes.php:590
 #: adminpages/membershiplevels.php:418
+#: adminpages/discountcodes.php:433
+#: adminpages/discountcodes.php:436
+#: adminpages/discountcodes.php:447
+#: adminpages/discountcodes.php:448
+#: adminpages/discountcodes.php:449
+#: adminpages/discountcodes.php:454
+#: adminpages/discountcodes.php:527
+#: adminpages/discountcodes.php:568
+#: adminpages/discountcodes.php:588
+#: adminpages/membershiplevels.php:343
+#: adminpages/membershiplevels.php:345
+#: adminpages/membershiplevels.php:355
+#: adminpages/membershiplevels.php:357
+#: adminpages/membershiplevels.php:358
+#: adminpages/membershiplevels.php:381
+#: adminpages/membershiplevels.php:391
+#: adminpages/membershiplevels.php:414
+#: adminpages/membershiplevels.php:416
+#: adminpages/membershiplevels.php:417
 msgid "Check if this level has a recurring subscription payment."
 msgstr ""
 
-#: adminpages/discountcodes.php:594 adminpages/membershiplevels.php:422
-#: adminpages/discountcodes.php:440 adminpages/discountcodes.php:451
-#: adminpages/discountcodes.php:452 adminpages/discountcodes.php:453
-#: adminpages/discountcodes.php:458 adminpages/discountcodes.php:531
-#: adminpages/discountcodes.php:572 adminpages/discountcodes.php:592
-#: adminpages/discountcodes.php:594 adminpages/membershiplevels.php:347
-#: adminpages/membershiplevels.php:349 adminpages/membershiplevels.php:359
-#: adminpages/membershiplevels.php:361 adminpages/membershiplevels.php:362
-#: adminpages/membershiplevels.php:385 adminpages/membershiplevels.php:395
-#: adminpages/membershiplevels.php:418 adminpages/membershiplevels.php:420
-#: adminpages/membershiplevels.php:421 adminpages/membershiplevels.php:422
+#: adminpages/discountcodes.php:594
+#: adminpages/membershiplevels.php:422
+#: adminpages/discountcodes.php:440
+#: adminpages/discountcodes.php:451
+#: adminpages/discountcodes.php:452
+#: adminpages/discountcodes.php:453
+#: adminpages/discountcodes.php:458
+#: adminpages/discountcodes.php:531
+#: adminpages/discountcodes.php:572
+#: adminpages/discountcodes.php:592
+#: adminpages/membershiplevels.php:347
+#: adminpages/membershiplevels.php:349
+#: adminpages/membershiplevels.php:359
+#: adminpages/membershiplevels.php:361
+#: adminpages/membershiplevels.php:362
+#: adminpages/membershiplevels.php:385
+#: adminpages/membershiplevels.php:395
+#: adminpages/membershiplevels.php:418
+#: adminpages/membershiplevels.php:420
+#: adminpages/membershiplevels.php:421
 msgid "Billing Amount"
 msgstr ""
 
-#: adminpages/discountcodes.php:605 adminpages/membershiplevels.php:433
-#: classes/gateways/class.pmprogateway_stripe.php:1263
-#: adminpages/discountcodes.php:603 adminpages/discountcodes.php:605
-#: adminpages/membershiplevels.php:349 adminpages/membershiplevels.php:351
-#: adminpages/membershiplevels.php:370 adminpages/membershiplevels.php:372
-#: adminpages/membershiplevels.php:373 adminpages/membershiplevels.php:396
-#: adminpages/membershiplevels.php:406 adminpages/membershiplevels.php:429
-#: adminpages/membershiplevels.php:431 adminpages/membershiplevels.php:432
+#: adminpages/discountcodes.php:605
 #: adminpages/membershiplevels.php:433
+#: classes/gateways/class.pmprogateway_stripe.php:1263
+#: adminpages/discountcodes.php:603
+#: adminpages/membershiplevels.php:349
+#: adminpages/membershiplevels.php:351
+#: adminpages/membershiplevels.php:370
+#: adminpages/membershiplevels.php:372
+#: adminpages/membershiplevels.php:373
+#: adminpages/membershiplevels.php:396
+#: adminpages/membershiplevels.php:406
+#: adminpages/membershiplevels.php:429
+#: adminpages/membershiplevels.php:431
+#: adminpages/membershiplevels.php:432
 #: classes/gateways/class.pmprogateway_stripe.php:619
 #: classes/gateways/class.pmprogateway_stripe.php:620
 #: classes/gateways/class.pmprogateway_stripe.php:630
@@ -2187,31 +3024,51 @@ msgstr ""
 msgid "per"
 msgstr ""
 
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:695
-#: adminpages/membershiplevels.php:437 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:695
+#: adminpages/membershiplevels.php:437
+#: adminpages/membershiplevels.php:567
 #: classes/gateways/class.pmprogateway_stripe.php:1129
-#: adminpages/discountcodes.php:446 adminpages/discountcodes.php:466
-#: adminpages/discountcodes.php:467 adminpages/discountcodes.php:468
-#: adminpages/discountcodes.php:473 adminpages/discountcodes.php:492
-#: adminpages/discountcodes.php:520 adminpages/discountcodes.php:521
-#: adminpages/discountcodes.php:522 adminpages/discountcodes.php:527
-#: adminpages/discountcodes.php:546 adminpages/discountcodes.php:587
-#: adminpages/discountcodes.php:600 adminpages/discountcodes.php:607
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:641
-#: adminpages/discountcodes.php:661 adminpages/discountcodes.php:663
-#: adminpages/discountcodes.php:695 adminpages/membershiplevels.php:353
-#: adminpages/membershiplevels.php:355 adminpages/membershiplevels.php:374
-#: adminpages/membershiplevels.php:376 adminpages/membershiplevels.php:377
-#: adminpages/membershiplevels.php:400 adminpages/membershiplevels.php:410
-#: adminpages/membershiplevels.php:433 adminpages/membershiplevels.php:435
-#: adminpages/membershiplevels.php:436 adminpages/membershiplevels.php:437
-#: adminpages/membershiplevels.php:449 adminpages/membershiplevels.php:476
-#: adminpages/membershiplevels.php:477 adminpages/membershiplevels.php:479
-#: adminpages/membershiplevels.php:480 adminpages/membershiplevels.php:501
-#: adminpages/membershiplevels.php:511 adminpages/membershiplevels.php:535
-#: adminpages/membershiplevels.php:537 adminpages/membershiplevels.php:554
-#: adminpages/membershiplevels.php:559 adminpages/membershiplevels.php:564
-#: adminpages/membershiplevels.php:565 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:446
+#: adminpages/discountcodes.php:466
+#: adminpages/discountcodes.php:467
+#: adminpages/discountcodes.php:468
+#: adminpages/discountcodes.php:473
+#: adminpages/discountcodes.php:492
+#: adminpages/discountcodes.php:520
+#: adminpages/discountcodes.php:521
+#: adminpages/discountcodes.php:522
+#: adminpages/discountcodes.php:527
+#: adminpages/discountcodes.php:546
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:600
+#: adminpages/discountcodes.php:607
+#: adminpages/discountcodes.php:641
+#: adminpages/discountcodes.php:661
+#: adminpages/discountcodes.php:663
+#: adminpages/membershiplevels.php:353
+#: adminpages/membershiplevels.php:355
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:377
+#: adminpages/membershiplevels.php:400
+#: adminpages/membershiplevels.php:410
+#: adminpages/membershiplevels.php:433
+#: adminpages/membershiplevels.php:435
+#: adminpages/membershiplevels.php:436
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:476
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:479
+#: adminpages/membershiplevels.php:480
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:511
+#: adminpages/membershiplevels.php:535
+#: adminpages/membershiplevels.php:537
+#: adminpages/membershiplevels.php:554
+#: adminpages/membershiplevels.php:559
+#: adminpages/membershiplevels.php:564
+#: adminpages/membershiplevels.php:565
 #: classes/gateways/class.pmprogateway_stripe.php:521
 #: classes/gateways/class.pmprogateway_stripe.php:522
 #: classes/gateways/class.pmprogateway_stripe.php:532
@@ -2240,31 +3097,51 @@ msgstr ""
 msgid "Day(s)"
 msgstr ""
 
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:695
-#: adminpages/membershiplevels.php:437 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:695
+#: adminpages/membershiplevels.php:437
+#: adminpages/membershiplevels.php:567
 #: classes/gateways/class.pmprogateway_stripe.php:1131
-#: adminpages/discountcodes.php:446 adminpages/discountcodes.php:466
-#: adminpages/discountcodes.php:467 adminpages/discountcodes.php:468
-#: adminpages/discountcodes.php:473 adminpages/discountcodes.php:492
-#: adminpages/discountcodes.php:520 adminpages/discountcodes.php:521
-#: adminpages/discountcodes.php:522 adminpages/discountcodes.php:527
-#: adminpages/discountcodes.php:546 adminpages/discountcodes.php:587
-#: adminpages/discountcodes.php:600 adminpages/discountcodes.php:607
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:641
-#: adminpages/discountcodes.php:661 adminpages/discountcodes.php:663
-#: adminpages/discountcodes.php:695 adminpages/membershiplevels.php:353
-#: adminpages/membershiplevels.php:355 adminpages/membershiplevels.php:374
-#: adminpages/membershiplevels.php:376 adminpages/membershiplevels.php:377
-#: adminpages/membershiplevels.php:400 adminpages/membershiplevels.php:410
-#: adminpages/membershiplevels.php:433 adminpages/membershiplevels.php:435
-#: adminpages/membershiplevels.php:436 adminpages/membershiplevels.php:437
-#: adminpages/membershiplevels.php:449 adminpages/membershiplevels.php:476
-#: adminpages/membershiplevels.php:477 adminpages/membershiplevels.php:479
-#: adminpages/membershiplevels.php:480 adminpages/membershiplevels.php:501
-#: adminpages/membershiplevels.php:511 adminpages/membershiplevels.php:535
-#: adminpages/membershiplevels.php:537 adminpages/membershiplevels.php:554
-#: adminpages/membershiplevels.php:559 adminpages/membershiplevels.php:564
-#: adminpages/membershiplevels.php:565 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:446
+#: adminpages/discountcodes.php:466
+#: adminpages/discountcodes.php:467
+#: adminpages/discountcodes.php:468
+#: adminpages/discountcodes.php:473
+#: adminpages/discountcodes.php:492
+#: adminpages/discountcodes.php:520
+#: adminpages/discountcodes.php:521
+#: adminpages/discountcodes.php:522
+#: adminpages/discountcodes.php:527
+#: adminpages/discountcodes.php:546
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:600
+#: adminpages/discountcodes.php:607
+#: adminpages/discountcodes.php:641
+#: adminpages/discountcodes.php:661
+#: adminpages/discountcodes.php:663
+#: adminpages/membershiplevels.php:353
+#: adminpages/membershiplevels.php:355
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:377
+#: adminpages/membershiplevels.php:400
+#: adminpages/membershiplevels.php:410
+#: adminpages/membershiplevels.php:433
+#: adminpages/membershiplevels.php:435
+#: adminpages/membershiplevels.php:436
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:476
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:479
+#: adminpages/membershiplevels.php:480
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:511
+#: adminpages/membershiplevels.php:535
+#: adminpages/membershiplevels.php:537
+#: adminpages/membershiplevels.php:554
+#: adminpages/membershiplevels.php:559
+#: adminpages/membershiplevels.php:564
+#: adminpages/membershiplevels.php:565
 #: classes/gateways/class.pmprogateway_stripe.php:521
 #: classes/gateways/class.pmprogateway_stripe.php:522
 #: classes/gateways/class.pmprogateway_stripe.php:532
@@ -2293,31 +3170,51 @@ msgstr ""
 msgid "Month(s)"
 msgstr ""
 
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:695
-#: adminpages/membershiplevels.php:437 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:695
+#: adminpages/membershiplevels.php:437
+#: adminpages/membershiplevels.php:567
 #: classes/gateways/class.pmprogateway_stripe.php:1130
-#: adminpages/discountcodes.php:446 adminpages/discountcodes.php:466
-#: adminpages/discountcodes.php:467 adminpages/discountcodes.php:468
-#: adminpages/discountcodes.php:473 adminpages/discountcodes.php:492
-#: adminpages/discountcodes.php:520 adminpages/discountcodes.php:521
-#: adminpages/discountcodes.php:522 adminpages/discountcodes.php:527
-#: adminpages/discountcodes.php:546 adminpages/discountcodes.php:587
-#: adminpages/discountcodes.php:600 adminpages/discountcodes.php:607
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:641
-#: adminpages/discountcodes.php:661 adminpages/discountcodes.php:663
-#: adminpages/discountcodes.php:695 adminpages/membershiplevels.php:353
-#: adminpages/membershiplevels.php:355 adminpages/membershiplevels.php:374
-#: adminpages/membershiplevels.php:376 adminpages/membershiplevels.php:377
-#: adminpages/membershiplevels.php:400 adminpages/membershiplevels.php:410
-#: adminpages/membershiplevels.php:433 adminpages/membershiplevels.php:435
-#: adminpages/membershiplevels.php:436 adminpages/membershiplevels.php:437
-#: adminpages/membershiplevels.php:449 adminpages/membershiplevels.php:476
-#: adminpages/membershiplevels.php:477 adminpages/membershiplevels.php:479
-#: adminpages/membershiplevels.php:480 adminpages/membershiplevels.php:501
-#: adminpages/membershiplevels.php:511 adminpages/membershiplevels.php:535
-#: adminpages/membershiplevels.php:537 adminpages/membershiplevels.php:554
-#: adminpages/membershiplevels.php:559 adminpages/membershiplevels.php:564
-#: adminpages/membershiplevels.php:565 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:446
+#: adminpages/discountcodes.php:466
+#: adminpages/discountcodes.php:467
+#: adminpages/discountcodes.php:468
+#: adminpages/discountcodes.php:473
+#: adminpages/discountcodes.php:492
+#: adminpages/discountcodes.php:520
+#: adminpages/discountcodes.php:521
+#: adminpages/discountcodes.php:522
+#: adminpages/discountcodes.php:527
+#: adminpages/discountcodes.php:546
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:600
+#: adminpages/discountcodes.php:607
+#: adminpages/discountcodes.php:641
+#: adminpages/discountcodes.php:661
+#: adminpages/discountcodes.php:663
+#: adminpages/membershiplevels.php:353
+#: adminpages/membershiplevels.php:355
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:377
+#: adminpages/membershiplevels.php:400
+#: adminpages/membershiplevels.php:410
+#: adminpages/membershiplevels.php:433
+#: adminpages/membershiplevels.php:435
+#: adminpages/membershiplevels.php:436
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:476
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:479
+#: adminpages/membershiplevels.php:480
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:511
+#: adminpages/membershiplevels.php:535
+#: adminpages/membershiplevels.php:537
+#: adminpages/membershiplevels.php:554
+#: adminpages/membershiplevels.php:559
+#: adminpages/membershiplevels.php:564
+#: adminpages/membershiplevels.php:565
 #: classes/gateways/class.pmprogateway_stripe.php:521
 #: classes/gateways/class.pmprogateway_stripe.php:522
 #: classes/gateways/class.pmprogateway_stripe.php:532
@@ -2346,31 +3243,51 @@ msgstr ""
 msgid "Week(s)"
 msgstr ""
 
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:695
-#: adminpages/membershiplevels.php:437 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:695
+#: adminpages/membershiplevels.php:437
+#: adminpages/membershiplevels.php:567
 #: classes/gateways/class.pmprogateway_stripe.php:1132
-#: adminpages/discountcodes.php:446 adminpages/discountcodes.php:466
-#: adminpages/discountcodes.php:467 adminpages/discountcodes.php:468
-#: adminpages/discountcodes.php:473 adminpages/discountcodes.php:492
-#: adminpages/discountcodes.php:520 adminpages/discountcodes.php:521
-#: adminpages/discountcodes.php:522 adminpages/discountcodes.php:527
-#: adminpages/discountcodes.php:546 adminpages/discountcodes.php:587
-#: adminpages/discountcodes.php:600 adminpages/discountcodes.php:607
-#: adminpages/discountcodes.php:609 adminpages/discountcodes.php:641
-#: adminpages/discountcodes.php:661 adminpages/discountcodes.php:663
-#: adminpages/discountcodes.php:695 adminpages/membershiplevels.php:353
-#: adminpages/membershiplevels.php:355 adminpages/membershiplevels.php:374
-#: adminpages/membershiplevels.php:376 adminpages/membershiplevels.php:377
-#: adminpages/membershiplevels.php:400 adminpages/membershiplevels.php:410
-#: adminpages/membershiplevels.php:433 adminpages/membershiplevels.php:435
-#: adminpages/membershiplevels.php:436 adminpages/membershiplevels.php:437
-#: adminpages/membershiplevels.php:449 adminpages/membershiplevels.php:476
-#: adminpages/membershiplevels.php:477 adminpages/membershiplevels.php:479
-#: adminpages/membershiplevels.php:480 adminpages/membershiplevels.php:501
-#: adminpages/membershiplevels.php:511 adminpages/membershiplevels.php:535
-#: adminpages/membershiplevels.php:537 adminpages/membershiplevels.php:554
-#: adminpages/membershiplevels.php:559 adminpages/membershiplevels.php:564
-#: adminpages/membershiplevels.php:565 adminpages/membershiplevels.php:567
+#: adminpages/discountcodes.php:446
+#: adminpages/discountcodes.php:466
+#: adminpages/discountcodes.php:467
+#: adminpages/discountcodes.php:468
+#: adminpages/discountcodes.php:473
+#: adminpages/discountcodes.php:492
+#: adminpages/discountcodes.php:520
+#: adminpages/discountcodes.php:521
+#: adminpages/discountcodes.php:522
+#: adminpages/discountcodes.php:527
+#: adminpages/discountcodes.php:546
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:600
+#: adminpages/discountcodes.php:607
+#: adminpages/discountcodes.php:641
+#: adminpages/discountcodes.php:661
+#: adminpages/discountcodes.php:663
+#: adminpages/membershiplevels.php:353
+#: adminpages/membershiplevels.php:355
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:377
+#: adminpages/membershiplevels.php:400
+#: adminpages/membershiplevels.php:410
+#: adminpages/membershiplevels.php:433
+#: adminpages/membershiplevels.php:435
+#: adminpages/membershiplevels.php:436
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:476
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:479
+#: adminpages/membershiplevels.php:480
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:511
+#: adminpages/membershiplevels.php:535
+#: adminpages/membershiplevels.php:537
+#: adminpages/membershiplevels.php:554
+#: adminpages/membershiplevels.php:559
+#: adminpages/membershiplevels.php:564
+#: adminpages/membershiplevels.php:565
 #: classes/gateways/class.pmprogateway_stripe.php:521
 #: classes/gateways/class.pmprogateway_stripe.php:522
 #: classes/gateways/class.pmprogateway_stripe.php:532
@@ -2399,311 +3316,471 @@ msgstr ""
 msgid "Year(s)"
 msgstr ""
 
-#: adminpages/discountcodes.php:617 adminpages/membershiplevels.php:446
-#: adminpages/discountcodes.php:451 adminpages/discountcodes.php:454
-#: adminpages/discountcodes.php:474 adminpages/discountcodes.php:475
-#: adminpages/discountcodes.php:476 adminpages/discountcodes.php:481
-#: adminpages/discountcodes.php:554 adminpages/discountcodes.php:595
-#: adminpages/discountcodes.php:615 adminpages/discountcodes.php:617
-#: adminpages/membershiplevels.php:362 adminpages/membershiplevels.php:364
-#: adminpages/membershiplevels.php:383 adminpages/membershiplevels.php:385
-#: adminpages/membershiplevels.php:386 adminpages/membershiplevels.php:409
-#: adminpages/membershiplevels.php:419 adminpages/membershiplevels.php:442
-#: adminpages/membershiplevels.php:444 adminpages/membershiplevels.php:445
+#: adminpages/discountcodes.php:617
 #: adminpages/membershiplevels.php:446
+#: adminpages/discountcodes.php:451
+#: adminpages/discountcodes.php:454
+#: adminpages/discountcodes.php:474
+#: adminpages/discountcodes.php:475
+#: adminpages/discountcodes.php:476
+#: adminpages/discountcodes.php:481
+#: adminpages/discountcodes.php:554
+#: adminpages/discountcodes.php:595
+#: adminpages/discountcodes.php:615
+#: adminpages/membershiplevels.php:362
+#: adminpages/membershiplevels.php:364
+#: adminpages/membershiplevels.php:383
+#: adminpages/membershiplevels.php:385
+#: adminpages/membershiplevels.php:386
+#: adminpages/membershiplevels.php:409
+#: adminpages/membershiplevels.php:419
+#: adminpages/membershiplevels.php:442
+#: adminpages/membershiplevels.php:444
+#: adminpages/membershiplevels.php:445
 msgid "The amount to be billed one cycle after the initial payment."
 msgstr ""
 
-#: adminpages/discountcodes.php:619 adminpages/membershiplevels.php:448
-#: adminpages/discountcodes.php:619 adminpages/membershiplevels.php:366
-#: adminpages/membershiplevels.php:368 adminpages/membershiplevels.php:387
-#: adminpages/membershiplevels.php:389 adminpages/membershiplevels.php:390
-#: adminpages/membershiplevels.php:413 adminpages/membershiplevels.php:423
-#: adminpages/membershiplevels.php:444 adminpages/membershiplevels.php:446
-#: adminpages/membershiplevels.php:447 adminpages/membershiplevels.php:448
-msgid ""
-"Braintree integration currently only supports billing periods of \"Month\" "
-"or \"Year\"."
+#: adminpages/discountcodes.php:619
+#: adminpages/membershiplevels.php:448
+#: adminpages/membershiplevels.php:366
+#: adminpages/membershiplevels.php:368
+#: adminpages/membershiplevels.php:387
+#: adminpages/membershiplevels.php:389
+#: adminpages/membershiplevels.php:390
+#: adminpages/membershiplevels.php:413
+#: adminpages/membershiplevels.php:423
+#: adminpages/membershiplevels.php:444
+#: adminpages/membershiplevels.php:446
+#: adminpages/membershiplevels.php:447
+msgid "Braintree integration currently only supports billing periods of \"Month\" or \"Year\"."
 msgstr ""
 
-#: adminpages/discountcodes.php:621 adminpages/membershiplevels.php:450
-#: adminpages/discountcodes.php:621 adminpages/membershiplevels.php:450
+#: adminpages/discountcodes.php:621
+#: adminpages/membershiplevels.php:450
 msgid "Stripe integration does not allow billing periods longer than 1 year."
 msgstr ""
 
-#: adminpages/discountcodes.php:627 adminpages/membershiplevels.php:465
-#: adminpages/discountcodes.php:456 adminpages/discountcodes.php:459
-#: adminpages/discountcodes.php:479 adminpages/discountcodes.php:480
-#: adminpages/discountcodes.php:481 adminpages/discountcodes.php:486
-#: adminpages/discountcodes.php:559 adminpages/discountcodes.php:600
-#: adminpages/discountcodes.php:620 adminpages/discountcodes.php:622
-#: adminpages/discountcodes.php:627 adminpages/membershiplevels.php:380
-#: adminpages/membershiplevels.php:382 adminpages/membershiplevels.php:401
-#: adminpages/membershiplevels.php:403 adminpages/membershiplevels.php:404
-#: adminpages/membershiplevels.php:425 adminpages/membershiplevels.php:435
-#: adminpages/membershiplevels.php:438 adminpages/membershiplevels.php:459
-#: adminpages/membershiplevels.php:461 adminpages/membershiplevels.php:462
-#: adminpages/membershiplevels.php:463 adminpages/membershiplevels.php:465
+#: adminpages/discountcodes.php:627
+#: adminpages/membershiplevels.php:465
+#: adminpages/discountcodes.php:456
+#: adminpages/discountcodes.php:459
+#: adminpages/discountcodes.php:479
+#: adminpages/discountcodes.php:480
+#: adminpages/discountcodes.php:481
+#: adminpages/discountcodes.php:486
+#: adminpages/discountcodes.php:559
+#: adminpages/discountcodes.php:600
+#: adminpages/discountcodes.php:620
+#: adminpages/discountcodes.php:622
+#: adminpages/membershiplevels.php:380
+#: adminpages/membershiplevels.php:382
+#: adminpages/membershiplevels.php:401
+#: adminpages/membershiplevels.php:403
+#: adminpages/membershiplevels.php:404
+#: adminpages/membershiplevels.php:425
+#: adminpages/membershiplevels.php:435
+#: adminpages/membershiplevels.php:438
+#: adminpages/membershiplevels.php:459
+#: adminpages/membershiplevels.php:461
+#: adminpages/membershiplevels.php:462
+#: adminpages/membershiplevels.php:463
 msgid "Billing Cycle Limit"
 msgstr ""
 
-#: adminpages/discountcodes.php:631 adminpages/membershiplevels.php:469
-#: adminpages/discountcodes.php:459 adminpages/discountcodes.php:462
-#: adminpages/discountcodes.php:482 adminpages/discountcodes.php:483
-#: adminpages/discountcodes.php:484 adminpages/discountcodes.php:489
-#: adminpages/discountcodes.php:562 adminpages/discountcodes.php:603
-#: adminpages/discountcodes.php:623 adminpages/discountcodes.php:625
-#: adminpages/discountcodes.php:631 adminpages/membershiplevels.php:384
-#: adminpages/membershiplevels.php:386 adminpages/membershiplevels.php:405
-#: adminpages/membershiplevels.php:407 adminpages/membershiplevels.php:408
-#: adminpages/membershiplevels.php:429 adminpages/membershiplevels.php:439
-#: adminpages/membershiplevels.php:442 adminpages/membershiplevels.php:463
-#: adminpages/membershiplevels.php:465 adminpages/membershiplevels.php:466
-#: adminpages/membershiplevels.php:467 adminpages/membershiplevels.php:469
-msgid ""
-"The <strong>total</strong> number of recurring billing cycles for this "
-"level, including the trial period (if applicable) but not including the "
-"initial payment. Set to zero if membership is indefinite."
+#: adminpages/discountcodes.php:631
+#: adminpages/membershiplevels.php:469
+#: adminpages/discountcodes.php:459
+#: adminpages/discountcodes.php:462
+#: adminpages/discountcodes.php:482
+#: adminpages/discountcodes.php:483
+#: adminpages/discountcodes.php:484
+#: adminpages/discountcodes.php:489
+#: adminpages/discountcodes.php:562
+#: adminpages/discountcodes.php:603
+#: adminpages/discountcodes.php:623
+#: adminpages/discountcodes.php:625
+#: adminpages/membershiplevels.php:384
+#: adminpages/membershiplevels.php:386
+#: adminpages/membershiplevels.php:405
+#: adminpages/membershiplevels.php:407
+#: adminpages/membershiplevels.php:408
+#: adminpages/membershiplevels.php:429
+#: adminpages/membershiplevels.php:439
+#: adminpages/membershiplevels.php:442
+#: adminpages/membershiplevels.php:463
+#: adminpages/membershiplevels.php:465
+#: adminpages/membershiplevels.php:466
+#: adminpages/membershiplevels.php:467
+msgid "The <strong>total</strong> number of recurring billing cycles for this level, including the trial period (if applicable) but not including the initial payment. Set to zero if membership is indefinite."
 msgstr ""
 
-#: adminpages/discountcodes.php:633 adminpages/membershiplevels.php:471
-#: adminpages/discountcodes.php:633 adminpages/membershiplevels.php:386
-#: adminpages/membershiplevels.php:388 adminpages/membershiplevels.php:407
-#: adminpages/membershiplevels.php:409 adminpages/membershiplevels.php:410
-#: adminpages/membershiplevels.php:431 adminpages/membershiplevels.php:441
-#: adminpages/membershiplevels.php:465 adminpages/membershiplevels.php:467
-#: adminpages/membershiplevels.php:468 adminpages/membershiplevels.php:469
+#: adminpages/discountcodes.php:633
 #: adminpages/membershiplevels.php:471
-msgid ""
-"Stripe integration currently does not support billing limits. You can still "
-"set an expiration date below."
+#: adminpages/membershiplevels.php:386
+#: adminpages/membershiplevels.php:388
+#: adminpages/membershiplevels.php:407
+#: adminpages/membershiplevels.php:409
+#: adminpages/membershiplevels.php:410
+#: adminpages/membershiplevels.php:431
+#: adminpages/membershiplevels.php:441
+#: adminpages/membershiplevels.php:465
+#: adminpages/membershiplevels.php:467
+#: adminpages/membershiplevels.php:468
+#: adminpages/membershiplevels.php:469
+msgid "Stripe integration currently does not support billing limits. You can still set an expiration date below."
 msgstr ""
 
-#: adminpages/discountcodes.php:642 adminpages/membershiplevels.php:480
-#: adminpages/discountcodes.php:642 adminpages/membershiplevels.php:477
-#: adminpages/membershiplevels.php:478 adminpages/membershiplevels.php:480
+#: adminpages/discountcodes.php:642
+#: adminpages/membershiplevels.php:480
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:478
 #, php-format
-msgid ""
-"Optional: Allow billing limits with Stripe using the <a href=\"%s\" title="
-"\"Paid Memberships Pro - Stripe Billing Limits Add On\" target=\"_blank"
-"\">Stripe Billing Limits Add On</a>."
+msgid "Optional: Allow billing limits with Stripe using the <a href=\"%s\" title=\"Paid Memberships Pro - Stripe Billing Limits Add On\" target=\"_blank\">Stripe Billing Limits Add On</a>."
 msgstr ""
 
-#: adminpages/discountcodes.php:650 adminpages/membershiplevels.php:488
-#: adminpages/discountcodes.php:464 adminpages/discountcodes.php:467
-#: adminpages/discountcodes.php:487 adminpages/discountcodes.php:488
-#: adminpages/discountcodes.php:489 adminpages/discountcodes.php:494
-#: adminpages/discountcodes.php:567 adminpages/discountcodes.php:608
-#: adminpages/discountcodes.php:628 adminpages/discountcodes.php:630
-#: adminpages/discountcodes.php:650 adminpages/membershiplevels.php:393
-#: adminpages/membershiplevels.php:395 adminpages/membershiplevels.php:414
-#: adminpages/membershiplevels.php:416 adminpages/membershiplevels.php:417
-#: adminpages/membershiplevels.php:438 adminpages/membershiplevels.php:448
-#: adminpages/membershiplevels.php:472 adminpages/membershiplevels.php:474
-#: adminpages/membershiplevels.php:475 adminpages/membershiplevels.php:485
-#: adminpages/membershiplevels.php:486 adminpages/membershiplevels.php:488
+#: adminpages/discountcodes.php:650
+#: adminpages/membershiplevels.php:488
+#: adminpages/discountcodes.php:464
+#: adminpages/discountcodes.php:467
+#: adminpages/discountcodes.php:487
+#: adminpages/discountcodes.php:488
+#: adminpages/discountcodes.php:489
+#: adminpages/discountcodes.php:494
+#: adminpages/discountcodes.php:567
+#: adminpages/discountcodes.php:608
+#: adminpages/discountcodes.php:628
+#: adminpages/discountcodes.php:630
+#: adminpages/membershiplevels.php:393
+#: adminpages/membershiplevels.php:395
+#: adminpages/membershiplevels.php:414
+#: adminpages/membershiplevels.php:416
+#: adminpages/membershiplevels.php:417
+#: adminpages/membershiplevels.php:438
+#: adminpages/membershiplevels.php:448
+#: adminpages/membershiplevels.php:472
+#: adminpages/membershiplevels.php:474
+#: adminpages/membershiplevels.php:475
+#: adminpages/membershiplevels.php:485
+#: adminpages/membershiplevels.php:486
 msgid "Custom Trial"
 msgstr ""
 
-#: adminpages/discountcodes.php:652 adminpages/membershiplevels.php:490
-#: adminpages/discountcodes.php:465 adminpages/discountcodes.php:468
-#: adminpages/discountcodes.php:488 adminpages/discountcodes.php:489
-#: adminpages/discountcodes.php:490 adminpages/discountcodes.php:495
-#: adminpages/discountcodes.php:568 adminpages/discountcodes.php:609
-#: adminpages/discountcodes.php:629 adminpages/discountcodes.php:631
-#: adminpages/discountcodes.php:652 adminpages/membershiplevels.php:394
-#: adminpages/membershiplevels.php:395 adminpages/membershiplevels.php:397
-#: adminpages/membershiplevels.php:416 adminpages/membershiplevels.php:418
-#: adminpages/membershiplevels.php:419 adminpages/membershiplevels.php:440
-#: adminpages/membershiplevels.php:450 adminpages/membershiplevels.php:474
-#: adminpages/membershiplevels.php:476 adminpages/membershiplevels.php:477
-#: adminpages/membershiplevels.php:487 adminpages/membershiplevels.php:488
+#: adminpages/discountcodes.php:652
 #: adminpages/membershiplevels.php:490
+#: adminpages/discountcodes.php:465
+#: adminpages/discountcodes.php:468
+#: adminpages/discountcodes.php:488
+#: adminpages/discountcodes.php:489
+#: adminpages/discountcodes.php:490
+#: adminpages/discountcodes.php:495
+#: adminpages/discountcodes.php:568
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:629
+#: adminpages/discountcodes.php:631
+#: adminpages/membershiplevels.php:394
+#: adminpages/membershiplevels.php:395
+#: adminpages/membershiplevels.php:397
+#: adminpages/membershiplevels.php:416
+#: adminpages/membershiplevels.php:418
+#: adminpages/membershiplevels.php:419
+#: adminpages/membershiplevels.php:440
+#: adminpages/membershiplevels.php:450
+#: adminpages/membershiplevels.php:474
+#: adminpages/membershiplevels.php:476
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:487
+#: adminpages/membershiplevels.php:488
 msgid "Check to add a custom trial period."
 msgstr ""
 
-#: adminpages/discountcodes.php:654 adminpages/membershiplevels.php:493
-#: adminpages/discountcodes.php:654 adminpages/membershiplevels.php:398
-#: adminpages/membershiplevels.php:400 adminpages/membershiplevels.php:419
-#: adminpages/membershiplevels.php:421 adminpages/membershiplevels.php:422
-#: adminpages/membershiplevels.php:443 adminpages/membershiplevels.php:453
-#: adminpages/membershiplevels.php:477 adminpages/membershiplevels.php:479
-#: adminpages/membershiplevels.php:480 adminpages/membershiplevels.php:490
-#: adminpages/membershiplevels.php:491 adminpages/membershiplevels.php:493
-msgid ""
-"2Checkout integration does not support custom trials. You can do one period "
-"trials by setting an initial payment different from the billing amount."
+#: adminpages/discountcodes.php:654
+#: adminpages/membershiplevels.php:493
+#: adminpages/membershiplevels.php:398
+#: adminpages/membershiplevels.php:400
+#: adminpages/membershiplevels.php:419
+#: adminpages/membershiplevels.php:421
+#: adminpages/membershiplevels.php:422
+#: adminpages/membershiplevels.php:443
+#: adminpages/membershiplevels.php:453
+#: adminpages/membershiplevels.php:477
+#: adminpages/membershiplevels.php:479
+#: adminpages/membershiplevels.php:480
+#: adminpages/membershiplevels.php:490
+#: adminpages/membershiplevels.php:491
+msgid "2Checkout integration does not support custom trials. You can do one period trials by setting an initial payment different from the billing amount."
 msgstr ""
 
-#: adminpages/discountcodes.php:660 adminpages/membershiplevels.php:510
-#: adminpages/discountcodes.php:469 adminpages/discountcodes.php:472
-#: adminpages/discountcodes.php:492 adminpages/discountcodes.php:493
-#: adminpages/discountcodes.php:494 adminpages/discountcodes.php:499
-#: adminpages/discountcodes.php:572 adminpages/discountcodes.php:613
-#: adminpages/discountcodes.php:633 adminpages/discountcodes.php:635
-#: adminpages/discountcodes.php:660 adminpages/membershiplevels.php:398
-#: adminpages/membershiplevels.php:404 adminpages/membershiplevels.php:406
-#: adminpages/membershiplevels.php:425 adminpages/membershiplevels.php:427
-#: adminpages/membershiplevels.php:428 adminpages/membershiplevels.php:449
-#: adminpages/membershiplevels.php:459 adminpages/membershiplevels.php:483
-#: adminpages/membershiplevels.php:485 adminpages/membershiplevels.php:496
-#: adminpages/membershiplevels.php:497 adminpages/membershiplevels.php:507
-#: adminpages/membershiplevels.php:508 adminpages/membershiplevels.php:510
+#: adminpages/discountcodes.php:660
+#: adminpages/membershiplevels.php:510
+#: adminpages/discountcodes.php:469
+#: adminpages/discountcodes.php:472
+#: adminpages/discountcodes.php:492
+#: adminpages/discountcodes.php:493
+#: adminpages/discountcodes.php:494
+#: adminpages/discountcodes.php:499
+#: adminpages/discountcodes.php:572
+#: adminpages/discountcodes.php:613
+#: adminpages/discountcodes.php:633
+#: adminpages/discountcodes.php:635
+#: adminpages/membershiplevels.php:398
+#: adminpages/membershiplevels.php:404
+#: adminpages/membershiplevels.php:406
+#: adminpages/membershiplevels.php:425
+#: adminpages/membershiplevels.php:427
+#: adminpages/membershiplevels.php:428
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:459
+#: adminpages/membershiplevels.php:483
+#: adminpages/membershiplevels.php:485
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:497
+#: adminpages/membershiplevels.php:507
+#: adminpages/membershiplevels.php:508
 msgid "Trial Billing Amount"
 msgstr ""
 
-#: adminpages/discountcodes.php:671 adminpages/membershiplevels.php:521
-#: adminpages/discountcodes.php:472 adminpages/discountcodes.php:475
-#: adminpages/discountcodes.php:503 adminpages/discountcodes.php:504
-#: adminpages/discountcodes.php:505 adminpages/discountcodes.php:510
-#: adminpages/discountcodes.php:583 adminpages/discountcodes.php:624
-#: adminpages/discountcodes.php:644 adminpages/discountcodes.php:646
-#: adminpages/discountcodes.php:671 adminpages/membershiplevels.php:401
-#: adminpages/membershiplevels.php:407 adminpages/membershiplevels.php:409
-#: adminpages/membershiplevels.php:436 adminpages/membershiplevels.php:438
-#: adminpages/membershiplevels.php:439 adminpages/membershiplevels.php:460
-#: adminpages/membershiplevels.php:470 adminpages/membershiplevels.php:494
-#: adminpages/membershiplevels.php:496 adminpages/membershiplevels.php:507
-#: adminpages/membershiplevels.php:508 adminpages/membershiplevels.php:518
-#: adminpages/membershiplevels.php:519 adminpages/membershiplevels.php:521
+#: adminpages/discountcodes.php:671
+#: adminpages/membershiplevels.php:521
+#: adminpages/discountcodes.php:472
+#: adminpages/discountcodes.php:475
+#: adminpages/discountcodes.php:503
+#: adminpages/discountcodes.php:504
+#: adminpages/discountcodes.php:505
+#: adminpages/discountcodes.php:510
+#: adminpages/discountcodes.php:583
+#: adminpages/discountcodes.php:624
+#: adminpages/discountcodes.php:644
+#: adminpages/discountcodes.php:646
+#: adminpages/membershiplevels.php:401
+#: adminpages/membershiplevels.php:407
+#: adminpages/membershiplevels.php:409
+#: adminpages/membershiplevels.php:436
+#: adminpages/membershiplevels.php:438
+#: adminpages/membershiplevels.php:439
+#: adminpages/membershiplevels.php:460
+#: adminpages/membershiplevels.php:470
+#: adminpages/membershiplevels.php:494
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:507
+#: adminpages/membershiplevels.php:508
+#: adminpages/membershiplevels.php:518
+#: adminpages/membershiplevels.php:519
 msgid "for the first"
 msgstr ""
 
-#: adminpages/discountcodes.php:673 adminpages/membershiplevels.php:523
-#: adminpages/discountcodes.php:474 adminpages/discountcodes.php:477
-#: adminpages/discountcodes.php:505 adminpages/discountcodes.php:506
-#: adminpages/discountcodes.php:507 adminpages/discountcodes.php:512
-#: adminpages/discountcodes.php:585 adminpages/discountcodes.php:626
-#: adminpages/discountcodes.php:646 adminpages/discountcodes.php:648
-#: adminpages/discountcodes.php:673 adminpages/membershiplevels.php:403
-#: adminpages/membershiplevels.php:409 adminpages/membershiplevels.php:411
-#: adminpages/membershiplevels.php:438 adminpages/membershiplevels.php:440
-#: adminpages/membershiplevels.php:441 adminpages/membershiplevels.php:462
-#: adminpages/membershiplevels.php:472 adminpages/membershiplevels.php:496
-#: adminpages/membershiplevels.php:498 adminpages/membershiplevels.php:509
-#: adminpages/membershiplevels.php:510 adminpages/membershiplevels.php:520
-#: adminpages/membershiplevels.php:521 adminpages/membershiplevels.php:523
+#: adminpages/discountcodes.php:673
+#: adminpages/membershiplevels.php:523
+#: adminpages/discountcodes.php:474
+#: adminpages/discountcodes.php:477
+#: adminpages/discountcodes.php:505
+#: adminpages/discountcodes.php:506
+#: adminpages/discountcodes.php:507
+#: adminpages/discountcodes.php:512
+#: adminpages/discountcodes.php:585
+#: adminpages/discountcodes.php:626
+#: adminpages/discountcodes.php:646
+#: adminpages/discountcodes.php:648
+#: adminpages/membershiplevels.php:403
+#: adminpages/membershiplevels.php:409
+#: adminpages/membershiplevels.php:411
+#: adminpages/membershiplevels.php:438
+#: adminpages/membershiplevels.php:440
+#: adminpages/membershiplevels.php:441
+#: adminpages/membershiplevels.php:462
+#: adminpages/membershiplevels.php:472
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:498
+#: adminpages/membershiplevels.php:509
+#: adminpages/membershiplevels.php:510
+#: adminpages/membershiplevels.php:520
+#: adminpages/membershiplevels.php:521
 msgid "subscription payments"
 msgstr ""
 
-#: adminpages/discountcodes.php:675 adminpages/membershiplevels.php:525
-#: adminpages/discountcodes.php:675 adminpages/membershiplevels.php:406
-#: adminpages/membershiplevels.php:412 adminpages/membershiplevels.php:414
-#: adminpages/membershiplevels.php:441 adminpages/membershiplevels.php:443
-#: adminpages/membershiplevels.php:444 adminpages/membershiplevels.php:465
-#: adminpages/membershiplevels.php:475 adminpages/membershiplevels.php:499
-#: adminpages/membershiplevels.php:501 adminpages/membershiplevels.php:512
-#: adminpages/membershiplevels.php:522 adminpages/membershiplevels.php:523
+#: adminpages/discountcodes.php:675
 #: adminpages/membershiplevels.php:525
-msgid ""
-"Stripe integration currently does not support trial amounts greater than $0."
+#: adminpages/membershiplevels.php:406
+#: adminpages/membershiplevels.php:412
+#: adminpages/membershiplevels.php:414
+#: adminpages/membershiplevels.php:441
+#: adminpages/membershiplevels.php:443
+#: adminpages/membershiplevels.php:444
+#: adminpages/membershiplevels.php:465
+#: adminpages/membershiplevels.php:475
+#: adminpages/membershiplevels.php:499
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:512
+#: adminpages/membershiplevels.php:522
+#: adminpages/membershiplevels.php:523
+msgid "Stripe integration currently does not support trial amounts greater than $0."
 msgstr ""
 
-#: adminpages/discountcodes.php:677 adminpages/membershiplevels.php:527
-#: adminpages/discountcodes.php:677 adminpages/membershiplevels.php:410
-#: adminpages/membershiplevels.php:416 adminpages/membershiplevels.php:418
-#: adminpages/membershiplevels.php:445 adminpages/membershiplevels.php:447
-#: adminpages/membershiplevels.php:448 adminpages/membershiplevels.php:469
-#: adminpages/membershiplevels.php:479 adminpages/membershiplevels.php:503
-#: adminpages/membershiplevels.php:505 adminpages/membershiplevels.php:514
-#: adminpages/membershiplevels.php:516 adminpages/membershiplevels.php:524
-#: adminpages/membershiplevels.php:525 adminpages/membershiplevels.php:527
-msgid ""
-"Braintree integration currently does not support trial amounts greater than "
-"$0."
+#: adminpages/discountcodes.php:677
+#: adminpages/membershiplevels.php:527
+#: adminpages/membershiplevels.php:410
+#: adminpages/membershiplevels.php:416
+#: adminpages/membershiplevels.php:418
+#: adminpages/membershiplevels.php:445
+#: adminpages/membershiplevels.php:447
+#: adminpages/membershiplevels.php:448
+#: adminpages/membershiplevels.php:469
+#: adminpages/membershiplevels.php:479
+#: adminpages/membershiplevels.php:503
+#: adminpages/membershiplevels.php:505
+#: adminpages/membershiplevels.php:514
+#: adminpages/membershiplevels.php:516
+#: adminpages/membershiplevels.php:524
+#: adminpages/membershiplevels.php:525
+msgid "Braintree integration currently does not support trial amounts greater than $0."
 msgstr ""
 
-#: adminpages/discountcodes.php:679 adminpages/membershiplevels.php:529
-#: adminpages/discountcodes.php:679 adminpages/membershiplevels.php:414
-#: adminpages/membershiplevels.php:420 adminpages/membershiplevels.php:422
-#: adminpages/membershiplevels.php:449 adminpages/membershiplevels.php:451
-#: adminpages/membershiplevels.php:452 adminpages/membershiplevels.php:473
-#: adminpages/membershiplevels.php:483 adminpages/membershiplevels.php:507
-#: adminpages/membershiplevels.php:509 adminpages/membershiplevels.php:516
-#: adminpages/membershiplevels.php:520 adminpages/membershiplevels.php:526
-#: adminpages/membershiplevels.php:527 adminpages/membershiplevels.php:529
-msgid ""
-"Payflow integration currently does not support trial amounts greater than $0."
+#: adminpages/discountcodes.php:679
+#: adminpages/membershiplevels.php:529
+#: adminpages/membershiplevels.php:414
+#: adminpages/membershiplevels.php:420
+#: adminpages/membershiplevels.php:422
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:451
+#: adminpages/membershiplevels.php:452
+#: adminpages/membershiplevels.php:473
+#: adminpages/membershiplevels.php:483
+#: adminpages/membershiplevels.php:507
+#: adminpages/membershiplevels.php:509
+#: adminpages/membershiplevels.php:516
+#: adminpages/membershiplevels.php:520
+#: adminpages/membershiplevels.php:526
+#: adminpages/membershiplevels.php:527
+msgid "Payflow integration currently does not support trial amounts greater than $0."
 msgstr ""
 
-#: adminpages/discountcodes.php:685 adminpages/membershiplevels.php:546
-#: adminpages/discountcodes.php:479 adminpages/discountcodes.php:482
-#: adminpages/discountcodes.php:510 adminpages/discountcodes.php:511
-#: adminpages/discountcodes.php:512 adminpages/discountcodes.php:517
-#: adminpages/discountcodes.php:590 adminpages/discountcodes.php:631
-#: adminpages/discountcodes.php:651 adminpages/discountcodes.php:653
-#: adminpages/discountcodes.php:685 adminpages/membershiplevels.php:431
-#: adminpages/membershiplevels.php:437 adminpages/membershiplevels.php:439
-#: adminpages/membershiplevels.php:466 adminpages/membershiplevels.php:467
-#: adminpages/membershiplevels.php:469 adminpages/membershiplevels.php:470
-#: adminpages/membershiplevels.php:491 adminpages/membershiplevels.php:501
-#: adminpages/membershiplevels.php:525 adminpages/membershiplevels.php:527
-#: adminpages/membershiplevels.php:533 adminpages/membershiplevels.php:538
-#: adminpages/membershiplevels.php:543 adminpages/membershiplevels.php:544
+#: adminpages/discountcodes.php:685
 #: adminpages/membershiplevels.php:546
+#: adminpages/discountcodes.php:479
+#: adminpages/discountcodes.php:482
+#: adminpages/discountcodes.php:510
+#: adminpages/discountcodes.php:511
+#: adminpages/discountcodes.php:512
+#: adminpages/discountcodes.php:517
+#: adminpages/discountcodes.php:590
+#: adminpages/discountcodes.php:631
+#: adminpages/discountcodes.php:651
+#: adminpages/discountcodes.php:653
+#: adminpages/membershiplevels.php:431
+#: adminpages/membershiplevels.php:437
+#: adminpages/membershiplevels.php:439
+#: adminpages/membershiplevels.php:466
+#: adminpages/membershiplevels.php:467
+#: adminpages/membershiplevels.php:469
+#: adminpages/membershiplevels.php:470
+#: adminpages/membershiplevels.php:491
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:525
+#: adminpages/membershiplevels.php:527
+#: adminpages/membershiplevels.php:533
+#: adminpages/membershiplevels.php:538
+#: adminpages/membershiplevels.php:543
+#: adminpages/membershiplevels.php:544
 msgid "Membership Expiration"
 msgstr ""
 
-#: adminpages/discountcodes.php:686 adminpages/membershiplevels.php:547
-#: adminpages/discountcodes.php:483 adminpages/discountcodes.php:511
-#: adminpages/discountcodes.php:512 adminpages/discountcodes.php:513
-#: adminpages/discountcodes.php:518 adminpages/discountcodes.php:591
-#: adminpages/discountcodes.php:632 adminpages/discountcodes.php:652
-#: adminpages/discountcodes.php:654 adminpages/discountcodes.php:686
-#: adminpages/membershiplevels.php:432 adminpages/membershiplevels.php:438
-#: adminpages/membershiplevels.php:440 adminpages/membershiplevels.php:467
-#: adminpages/membershiplevels.php:468 adminpages/membershiplevels.php:470
-#: adminpages/membershiplevels.php:471 adminpages/membershiplevels.php:492
-#: adminpages/membershiplevels.php:502 adminpages/membershiplevels.php:526
-#: adminpages/membershiplevels.php:528 adminpages/membershiplevels.php:534
-#: adminpages/membershiplevels.php:539 adminpages/membershiplevels.php:544
-#: adminpages/membershiplevels.php:545 adminpages/membershiplevels.php:547
+#: adminpages/discountcodes.php:686
+#: adminpages/membershiplevels.php:547
+#: adminpages/discountcodes.php:483
+#: adminpages/discountcodes.php:511
+#: adminpages/discountcodes.php:512
+#: adminpages/discountcodes.php:513
+#: adminpages/discountcodes.php:518
+#: adminpages/discountcodes.php:591
+#: adminpages/discountcodes.php:632
+#: adminpages/discountcodes.php:652
+#: adminpages/discountcodes.php:654
+#: adminpages/membershiplevels.php:432
+#: adminpages/membershiplevels.php:438
+#: adminpages/membershiplevels.php:440
+#: adminpages/membershiplevels.php:467
+#: adminpages/membershiplevels.php:468
+#: adminpages/membershiplevels.php:470
+#: adminpages/membershiplevels.php:471
+#: adminpages/membershiplevels.php:492
+#: adminpages/membershiplevels.php:502
+#: adminpages/membershiplevels.php:526
+#: adminpages/membershiplevels.php:528
+#: adminpages/membershiplevels.php:534
+#: adminpages/membershiplevels.php:539
+#: adminpages/membershiplevels.php:544
+#: adminpages/membershiplevels.php:545
 msgid "Check this to set when membership access expires."
 msgstr ""
 
-#: adminpages/discountcodes.php:690 adminpages/membershiplevels.php:562
-#: adminpages/discountcodes.php:484 adminpages/discountcodes.php:487
-#: adminpages/discountcodes.php:515 adminpages/discountcodes.php:516
-#: adminpages/discountcodes.php:517 adminpages/discountcodes.php:522
-#: adminpages/discountcodes.php:595 adminpages/discountcodes.php:636
-#: adminpages/discountcodes.php:656 adminpages/discountcodes.php:658
-#: adminpages/discountcodes.php:690 adminpages/membershiplevels.php:436
-#: adminpages/membershiplevels.php:442 adminpages/membershiplevels.php:444
-#: adminpages/membershiplevels.php:471 adminpages/membershiplevels.php:472
-#: adminpages/membershiplevels.php:474 adminpages/membershiplevels.php:475
-#: adminpages/membershiplevels.php:496 adminpages/membershiplevels.php:506
-#: adminpages/membershiplevels.php:530 adminpages/membershiplevels.php:532
-#: adminpages/membershiplevels.php:549 adminpages/membershiplevels.php:554
-#: adminpages/membershiplevels.php:559 adminpages/membershiplevels.php:560
+#: adminpages/discountcodes.php:690
 #: adminpages/membershiplevels.php:562
+#: adminpages/discountcodes.php:484
+#: adminpages/discountcodes.php:487
+#: adminpages/discountcodes.php:515
+#: adminpages/discountcodes.php:516
+#: adminpages/discountcodes.php:517
+#: adminpages/discountcodes.php:522
+#: adminpages/discountcodes.php:595
+#: adminpages/discountcodes.php:636
+#: adminpages/discountcodes.php:656
+#: adminpages/discountcodes.php:658
+#: adminpages/membershiplevels.php:436
+#: adminpages/membershiplevels.php:442
+#: adminpages/membershiplevels.php:444
+#: adminpages/membershiplevels.php:471
+#: adminpages/membershiplevels.php:472
+#: adminpages/membershiplevels.php:474
+#: adminpages/membershiplevels.php:475
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:506
+#: adminpages/membershiplevels.php:530
+#: adminpages/membershiplevels.php:532
+#: adminpages/membershiplevels.php:549
+#: adminpages/membershiplevels.php:554
+#: adminpages/membershiplevels.php:559
+#: adminpages/membershiplevels.php:560
 msgid "Expires In"
 msgstr ""
 
-#: adminpages/discountcodes.php:704 adminpages/membershiplevels.php:575
-#: adminpages/discountcodes.php:500 adminpages/discountcodes.php:528
-#: adminpages/discountcodes.php:529 adminpages/discountcodes.php:530
-#: adminpages/discountcodes.php:535 adminpages/discountcodes.php:608
-#: adminpages/discountcodes.php:649 adminpages/discountcodes.php:669
-#: adminpages/discountcodes.php:671 adminpages/discountcodes.php:704
-#: adminpages/membershiplevels.php:449 adminpages/membershiplevels.php:455
-#: adminpages/membershiplevels.php:457 adminpages/membershiplevels.php:484
-#: adminpages/membershiplevels.php:485 adminpages/membershiplevels.php:487
-#: adminpages/membershiplevels.php:488 adminpages/membershiplevels.php:509
-#: adminpages/membershiplevels.php:519 adminpages/membershiplevels.php:543
-#: adminpages/membershiplevels.php:545 adminpages/membershiplevels.php:562
-#: adminpages/membershiplevels.php:567 adminpages/membershiplevels.php:572
-#: adminpages/membershiplevels.php:573 adminpages/membershiplevels.php:575
-msgid ""
-"Set the duration of membership access. Note that the any future payments "
-"(recurring subscription, if any) will be cancelled when the membership "
-"expires."
+#: adminpages/discountcodes.php:704
+#: adminpages/membershiplevels.php:575
+#: adminpages/discountcodes.php:500
+#: adminpages/discountcodes.php:528
+#: adminpages/discountcodes.php:529
+#: adminpages/discountcodes.php:530
+#: adminpages/discountcodes.php:535
+#: adminpages/discountcodes.php:608
+#: adminpages/discountcodes.php:649
+#: adminpages/discountcodes.php:669
+#: adminpages/discountcodes.php:671
+#: adminpages/membershiplevels.php:449
+#: adminpages/membershiplevels.php:455
+#: adminpages/membershiplevels.php:457
+#: adminpages/membershiplevels.php:484
+#: adminpages/membershiplevels.php:485
+#: adminpages/membershiplevels.php:487
+#: adminpages/membershiplevels.php:488
+#: adminpages/membershiplevels.php:509
+#: adminpages/membershiplevels.php:519
+#: adminpages/membershiplevels.php:543
+#: adminpages/membershiplevels.php:545
+#: adminpages/membershiplevels.php:562
+#: adminpages/membershiplevels.php:567
+#: adminpages/membershiplevels.php:572
+#: adminpages/membershiplevels.php:573
+msgid "Set the duration of membership access. Note that the any future payments (recurring subscription, if any) will be cancelled when the membership expires."
 msgstr ""
 
-#: adminpages/discountcodes.php:731 adminpages/discountcodes.php:525
-#: adminpages/discountcodes.php:528 adminpages/discountcodes.php:556
-#: adminpages/discountcodes.php:557 adminpages/discountcodes.php:558
-#: adminpages/discountcodes.php:563 adminpages/discountcodes.php:636
-#: adminpages/discountcodes.php:677 adminpages/discountcodes.php:697
+#: adminpages/discountcodes.php:731
+#: adminpages/discountcodes.php:525
+#: adminpages/discountcodes.php:528
+#: adminpages/discountcodes.php:556
+#: adminpages/discountcodes.php:557
+#: adminpages/discountcodes.php:558
+#: adminpages/discountcodes.php:563
+#: adminpages/discountcodes.php:636
+#: adminpages/discountcodes.php:677
+#: adminpages/discountcodes.php:697
 msgid "Memberships Discount Codes"
 msgstr ""
 
@@ -2711,11 +3788,11 @@ msgstr ""
 msgid "No Discount Codes Found"
 msgstr ""
 
-#: adminpages/discountcodes.php:752 adminpages/discountcodes.php:717
-#: adminpages/discountcodes.php:718 adminpages/discountcodes.php:719
 #: adminpages/discountcodes.php:752
-msgid ""
-"Discount codes allow you to override your membership level's default pricing."
+#: adminpages/discountcodes.php:717
+#: adminpages/discountcodes.php:718
+#: adminpages/discountcodes.php:719
+msgid "Discount codes allow you to override your membership level's default pricing."
 msgstr ""
 
 #: adminpages/discountcodes.php:753
@@ -2726,173 +3803,202 @@ msgstr ""
 msgid "Documentation: Discount Codes"
 msgstr ""
 
-#: adminpages/discountcodes.php:763 adminpages/discountcodes.php:700
-#: adminpages/discountcodes.php:728 adminpages/discountcodes.php:729
-#: adminpages/discountcodes.php:730 adminpages/discountcodes.php:763
+#: adminpages/discountcodes.php:763
+#: adminpages/discountcodes.php:700
+#: adminpages/discountcodes.php:728
+#: adminpages/discountcodes.php:729
+#: adminpages/discountcodes.php:730
 #, php-format
 msgid "%d discount codes found."
 msgstr ""
 
-#: adminpages/discountcodes.php:768 adminpages/discountcodes.php:535
-#: adminpages/discountcodes.php:538 adminpages/discountcodes.php:566
-#: adminpages/discountcodes.php:567 adminpages/discountcodes.php:568
-#: adminpages/discountcodes.php:573 adminpages/discountcodes.php:646
-#: adminpages/discountcodes.php:707 adminpages/discountcodes.php:733
-#: adminpages/discountcodes.php:734 adminpages/discountcodes.php:735
 #: adminpages/discountcodes.php:768
+#: adminpages/discountcodes.php:535
+#: adminpages/discountcodes.php:538
+#: adminpages/discountcodes.php:566
+#: adminpages/discountcodes.php:567
+#: adminpages/discountcodes.php:568
+#: adminpages/discountcodes.php:573
+#: adminpages/discountcodes.php:646
+#: adminpages/discountcodes.php:707
+#: adminpages/discountcodes.php:733
+#: adminpages/discountcodes.php:734
+#: adminpages/discountcodes.php:735
 msgid "Search Discount Codes"
 msgstr ""
 
-#: adminpages/discountcodes.php:771 adminpages/reports/login.php:119
-#: adminpages/discountcodes.php:538 adminpages/discountcodes.php:541
-#: adminpages/discountcodes.php:569 adminpages/discountcodes.php:570
-#: adminpages/discountcodes.php:571 adminpages/discountcodes.php:576
-#: adminpages/discountcodes.php:649 adminpages/discountcodes.php:710
-#: adminpages/discountcodes.php:736 adminpages/discountcodes.php:737
-#: adminpages/discountcodes.php:738 adminpages/discountcodes.php:771
-#: adminpages/reports/login.php:81 adminpages/reports/login.php:83
-#: adminpages/reports/login.php:99 adminpages/reports/login.php:103
+#: adminpages/discountcodes.php:771
 #: adminpages/reports/login.php:119
+#: adminpages/discountcodes.php:538
+#: adminpages/discountcodes.php:541
+#: adminpages/discountcodes.php:569
+#: adminpages/discountcodes.php:570
+#: adminpages/discountcodes.php:571
+#: adminpages/discountcodes.php:576
+#: adminpages/discountcodes.php:649
+#: adminpages/discountcodes.php:710
+#: adminpages/discountcodes.php:736
+#: adminpages/discountcodes.php:737
+#: adminpages/discountcodes.php:738
+#: adminpages/reports/login.php:81
+#: adminpages/reports/login.php:83
+#: adminpages/reports/login.php:99
+#: adminpages/reports/login.php:103
 msgid "Search"
 msgstr ""
 
-#: adminpages/discountcodes.php:782 adminpages/discountcodes.php:549
-#: adminpages/discountcodes.php:559 adminpages/discountcodes.php:587
-#: adminpages/discountcodes.php:588 adminpages/discountcodes.php:589
-#: adminpages/discountcodes.php:594 adminpages/discountcodes.php:667
-#: adminpages/discountcodes.php:721 adminpages/discountcodes.php:747
-#: adminpages/discountcodes.php:748 adminpages/discountcodes.php:749
 #: adminpages/discountcodes.php:782
+#: adminpages/discountcodes.php:549
+#: adminpages/discountcodes.php:559
+#: adminpages/discountcodes.php:587
+#: adminpages/discountcodes.php:588
+#: adminpages/discountcodes.php:589
+#: adminpages/discountcodes.php:594
+#: adminpages/discountcodes.php:667
+#: adminpages/discountcodes.php:721
+#: adminpages/discountcodes.php:747
+#: adminpages/discountcodes.php:748
+#: adminpages/discountcodes.php:749
 msgid "Starts"
 msgstr ""
 
-#: adminpages/discountcodes.php:807 adminpages/membershiplevels.php:801
-#: adminpages/orders.php:1354 adminpages/discountcodes.php:765
-#: adminpages/discountcodes.php:766 adminpages/discountcodes.php:767
-#: adminpages/discountcodes.php:773 adminpages/discountcodes.php:775
-#: adminpages/discountcodes.php:807 adminpages/membershiplevels.php:760
-#: adminpages/membershiplevels.php:777 adminpages/membershiplevels.php:782
-#: adminpages/membershiplevels.php:787 adminpages/membershiplevels.php:792
-#: adminpages/membershiplevels.php:799 adminpages/membershiplevels.php:801
-#: adminpages/orders.php:1332 adminpages/orders.php:1337
-#: adminpages/orders.php:1338 adminpages/orders.php:1347
+#: adminpages/discountcodes.php:807
+#: adminpages/membershiplevels.php:801
+#: adminpages/orders.php:1354
+#: adminpages/discountcodes.php:765
+#: adminpages/discountcodes.php:766
+#: adminpages/discountcodes.php:767
+#: adminpages/discountcodes.php:773
+#: adminpages/discountcodes.php:775
+#: adminpages/membershiplevels.php:760
+#: adminpages/membershiplevels.php:777
+#: adminpages/membershiplevels.php:782
+#: adminpages/membershiplevels.php:787
+#: adminpages/membershiplevels.php:792
+#: adminpages/membershiplevels.php:799
+#: adminpages/orders.php:1332
+#: adminpages/orders.php:1337
+#: adminpages/orders.php:1338
+#: adminpages/orders.php:1347
 #: adminpages/orders.php:1352
 msgid "Edit"
 msgstr ""
 
-#: adminpages/discountcodes.php:810 adminpages/membershiplevels.php:802
-#: adminpages/orders.php:1357 adminpages/discountcodes.php:768
-#: adminpages/discountcodes.php:769 adminpages/discountcodes.php:770
-#: adminpages/discountcodes.php:776 adminpages/discountcodes.php:778
-#: adminpages/discountcodes.php:810 adminpages/membershiplevels.php:761
-#: adminpages/membershiplevels.php:778 adminpages/membershiplevels.php:783
-#: adminpages/membershiplevels.php:788 adminpages/membershiplevels.php:793
-#: adminpages/membershiplevels.php:800 adminpages/membershiplevels.php:802
-#: adminpages/orders.php:1335 adminpages/orders.php:1340
-#: adminpages/orders.php:1341 adminpages/orders.php:1350
+#: adminpages/discountcodes.php:810
+#: adminpages/membershiplevels.php:802
+#: adminpages/orders.php:1357
+#: adminpages/discountcodes.php:768
+#: adminpages/discountcodes.php:769
+#: adminpages/discountcodes.php:770
+#: adminpages/discountcodes.php:776
+#: adminpages/discountcodes.php:778
+#: adminpages/membershiplevels.php:761
+#: adminpages/membershiplevels.php:778
+#: adminpages/membershiplevels.php:783
+#: adminpages/membershiplevels.php:788
+#: adminpages/membershiplevels.php:793
+#: adminpages/membershiplevels.php:800
+#: adminpages/orders.php:1335
+#: adminpages/orders.php:1340
+#: adminpages/orders.php:1341
+#: adminpages/orders.php:1350
 #: adminpages/orders.php:1355
 msgid "Copy"
 msgstr ""
 
-#: adminpages/discountcodes.php:813 adminpages/discountcodes.php:617
-#: adminpages/discountcodes.php:622 adminpages/discountcodes.php:650
-#: adminpages/discountcodes.php:651 adminpages/discountcodes.php:652
-#: adminpages/discountcodes.php:653 adminpages/discountcodes.php:658
-#: adminpages/discountcodes.php:738 adminpages/discountcodes.php:771
-#: adminpages/discountcodes.php:772 adminpages/discountcodes.php:773
-#: adminpages/discountcodes.php:779 adminpages/discountcodes.php:781
-#: adminpages/discountcodes.php:792 adminpages/discountcodes.php:805
 #: adminpages/discountcodes.php:813
+#: adminpages/discountcodes.php:617
+#: adminpages/discountcodes.php:622
+#: adminpages/discountcodes.php:650
+#: adminpages/discountcodes.php:651
+#: adminpages/discountcodes.php:652
+#: adminpages/discountcodes.php:653
+#: adminpages/discountcodes.php:658
+#: adminpages/discountcodes.php:738
+#: adminpages/discountcodes.php:771
+#: adminpages/discountcodes.php:772
+#: adminpages/discountcodes.php:773
+#: adminpages/discountcodes.php:779
+#: adminpages/discountcodes.php:781
+#: adminpages/discountcodes.php:792
+#: adminpages/discountcodes.php:805
 #, php-format
-msgid ""
-"Are you sure you want to delete the %s discount code? The subscriptions for "
-"existing users will not change, but new users will not be able to use this "
-"code anymore."
+msgid "Are you sure you want to delete the %s discount code? The subscriptions for existing users will not change, but new users will not be able to use this code anymore."
 msgstr ""
 
-#: adminpages/discountcodes.php:817 adminpages/discountcodes.php:775
-#: adminpages/discountcodes.php:776 adminpages/discountcodes.php:777
-#: adminpages/discountcodes.php:783 adminpages/discountcodes.php:785
 #: adminpages/discountcodes.php:817
+#: adminpages/discountcodes.php:775
+#: adminpages/discountcodes.php:776
+#: adminpages/discountcodes.php:777
+#: adminpages/discountcodes.php:783
+#: adminpages/discountcodes.php:785
 msgid " View Orders"
 msgstr ""
 
-#: adminpages/emailsettings.php:85 adminpages/emailsettings.php:85
+#: adminpages/emailsettings.php:85
 msgid "Send Emails From"
 msgstr ""
 
-#: adminpages/emailsettings.php:86 adminpages/emailsettings.php:61
-#: adminpages/emailsettings.php:70 adminpages/emailsettings.php:80
-#: adminpages/emailsettings.php:84 adminpages/emailsettings.php:86
-msgid ""
-"By default, system generated emails are sent from "
-"<em><strong>wordpress@yourdomain.com</strong></em>. You can update this from "
-"address using the fields below."
+#: adminpages/emailsettings.php:86
+#: adminpages/emailsettings.php:61
+#: adminpages/emailsettings.php:70
+#: adminpages/emailsettings.php:80
+#: adminpages/emailsettings.php:84
+msgid "By default, system generated emails are sent from <em><strong>wordpress@yourdomain.com</strong></em>. You can update this from address using the fields below."
 msgstr ""
 
-#: adminpages/emailsettings.php:92 adminpages/emailsettings.php:69
-#: adminpages/emailsettings.php:78 adminpages/emailsettings.php:88
-#: adminpages/emailsettings.php:92 adminpages/emailsettings.php:94
+#: adminpages/emailsettings.php:92
+#: adminpages/emailsettings.php:69
+#: adminpages/emailsettings.php:78
+#: adminpages/emailsettings.php:88
+#: adminpages/emailsettings.php:94
 msgid "From Email"
 msgstr ""
 
-#: adminpages/emailsettings.php:100 adminpages/emailsettings.php:77
-#: adminpages/emailsettings.php:86 adminpages/emailsettings.php:96
-#: adminpages/emailsettings.php:100 adminpages/emailsettings.php:102
+#: adminpages/emailsettings.php:100
+#: adminpages/emailsettings.php:77
+#: adminpages/emailsettings.php:86
+#: adminpages/emailsettings.php:96
+#: adminpages/emailsettings.php:102
 msgid "From Name"
 msgstr ""
 
-#: adminpages/emailsettings.php:108 adminpages/emailsettings.php:94
-#: adminpages/emailsettings.php:104 adminpages/emailsettings.php:108
+#: adminpages/emailsettings.php:108
+#: adminpages/emailsettings.php:94
+#: adminpages/emailsettings.php:104
 #: adminpages/emailsettings.php:110
 msgid "Only Filter PMPro Emails?"
 msgstr ""
 
-#: adminpages/emailsettings.php:112 adminpages/emailsettings.php:98
-#: adminpages/emailsettings.php:108 adminpages/emailsettings.php:112
+#: adminpages/emailsettings.php:112
+#: adminpages/emailsettings.php:98
+#: adminpages/emailsettings.php:108
 #: adminpages/emailsettings.php:114
 #, php-format
-msgid ""
-"If unchecked, all emails from \"WordPress &lt;%s&gt;\" will be filtered to "
-"use the above settings."
+msgid "If unchecked, all emails from \"WordPress &lt;%s&gt;\" will be filtered to use the above settings."
 msgstr ""
 
-#: adminpages/emailsettings.php:117 adminpages/emailsettings.php:204
+#: adminpages/emailsettings.php:117
+#: adminpages/emailsettings.php:204
 msgid "Save All Settings"
 msgstr ""
 
-#: adminpages/emailsettings.php:120 adminpages/emailsettings.php:120
+#: adminpages/emailsettings.php:120
 msgid "Customizing Email Content"
 msgstr ""
 
-#: adminpages/emailsettings.php:129 adminpages/emailsettings.php:129
+#: adminpages/emailsettings.php:129
 #, php-format
-msgid ""
-"There are several ways to modify the appearance of your Paid Memberships Pro "
-"emails. We recommend using the free <a href=\"%s\" title=\"Paid Memberships "
-"Pro - Email Templates Admin Editor Add On\" target=\"_blank\">Email "
-"Templates Admin Editor Add On</a>, which allows you to modify the email "
-"header, footer, subject, and body content for all member and admin "
-"communications. <a title=\"Paid Memberships Pro - Member Communications\" "
-"target=\"_blank\" href=\"%s\">Click here to learn more about Paid "
-"Memberships Pro emails</a>."
+msgid "There are several ways to modify the appearance of your Paid Memberships Pro emails. We recommend using the free <a href=\"%s\" title=\"Paid Memberships Pro - Email Templates Admin Editor Add On\" target=\"_blank\">Email Templates Admin Editor Add On</a>, which allows you to modify the email header, footer, subject, and body content for all member and admin communications. <a title=\"Paid Memberships Pro - Member Communications\" target=\"_blank\" href=\"%s\">Click here to learn more about Paid Memberships Pro emails</a>."
 msgstr ""
 
-#: adminpages/emailsettings.php:134 adminpages/emailsettings.php:134
+#: adminpages/emailsettings.php:134
 msgid "Email Deliverability"
 msgstr ""
 
-#: adminpages/emailsettings.php:145 adminpages/emailsettings.php:145
+#: adminpages/emailsettings.php:145
 #, php-format
-msgid ""
-"If you are having issues with email delivery from your server, <a href=\"%s"
-"\" title=\"Paid Memberships Pro - Subscription Delays Add On\" target="
-"\"_blank\">please read our email troubleshooting guide</a>. As an "
-"alternative, Paid Memberships Pro offers built-in integration for SendWP. "
-"<em>Optional: SendWP is a third-party service for transactional email in "
-"WordPress. <a href=\"%s\" title=\"Documentation on SendWP and Paid "
-"Memberships Pro\" target=\"_blank\">Click here to learn more about SendWP "
-"and Paid Memberships Pro</a></em>."
+msgid "If you are having issues with email delivery from your server, <a href=\"%s\" title=\"Paid Memberships Pro - Subscription Delays Add On\" target=\"_blank\">please read our email troubleshooting guide</a>. As an alternative, Paid Memberships Pro offers built-in integration for SendWP. <em>Optional: SendWP is a third-party service for transactional email in WordPress. <a href=\"%s\" title=\"Documentation on SendWP and Paid Memberships Pro\" target=\"_blank\">Click here to learn more about SendWP and Paid Memberships Pro</a></em>."
 msgstr ""
 
 #: adminpages/emailsettings.php:153
@@ -2903,15 +4009,15 @@ msgstr ""
 msgid "Disconnect from SendWP"
 msgstr ""
 
-#: adminpages/emailsettings.php:161 adminpages/emailsettings.php:161
+#: adminpages/emailsettings.php:161
 msgid "View Your SendWP Account"
 msgstr ""
 
-#: adminpages/emailsettings.php:161 adminpages/emailsettings.php:161
+#: adminpages/emailsettings.php:161
 msgid "Your site is connected to SendWP."
 msgstr ""
 
-#: adminpages/emailsettings.php:162 adminpages/emailsettings.php:162
+#: adminpages/emailsettings.php:162
 #, php-format
 msgid "Please enable email sending inside %s."
 msgstr ""
@@ -2920,326 +4026,405 @@ msgstr ""
 msgid "Other Email Settings"
 msgstr ""
 
-#: adminpages/emailsettings.php:174 adminpages/emailsettings.php:86
-#: adminpages/emailsettings.php:104 adminpages/emailsettings.php:115
-#: adminpages/emailsettings.php:125 adminpages/emailsettings.php:129
-#: adminpages/emailsettings.php:130 adminpages/emailsettings.php:174
+#: adminpages/emailsettings.php:174
+#: adminpages/emailsettings.php:86
+#: adminpages/emailsettings.php:104
+#: adminpages/emailsettings.php:115
+#: adminpages/emailsettings.php:125
+#: adminpages/emailsettings.php:129
+#: adminpages/emailsettings.php:130
 msgid "Send the site admin emails"
 msgstr ""
 
-#: adminpages/emailsettings.php:178 adminpages/emailsettings.php:96
-#: adminpages/emailsettings.php:114 adminpages/emailsettings.php:125
-#: adminpages/emailsettings.php:135 adminpages/emailsettings.php:139
-#: adminpages/emailsettings.php:140 adminpages/emailsettings.php:141
 #: adminpages/emailsettings.php:178
+#: adminpages/emailsettings.php:96
+#: adminpages/emailsettings.php:114
+#: adminpages/emailsettings.php:125
+#: adminpages/emailsettings.php:135
+#: adminpages/emailsettings.php:139
+#: adminpages/emailsettings.php:140
+#: adminpages/emailsettings.php:141
 msgid "when a member checks out."
 msgstr ""
 
-#: adminpages/emailsettings.php:181 adminpages/emailsettings.php:105
-#: adminpages/emailsettings.php:123 adminpages/emailsettings.php:134
-#: adminpages/emailsettings.php:144 adminpages/emailsettings.php:148
-#: adminpages/emailsettings.php:149 adminpages/emailsettings.php:150
 #: adminpages/emailsettings.php:181
+#: adminpages/emailsettings.php:105
+#: adminpages/emailsettings.php:123
+#: adminpages/emailsettings.php:134
+#: adminpages/emailsettings.php:144
+#: adminpages/emailsettings.php:148
+#: adminpages/emailsettings.php:149
+#: adminpages/emailsettings.php:150
 msgid "when an admin changes a user's membership level through the dashboard."
 msgstr ""
 
-#: adminpages/emailsettings.php:184 adminpages/emailsettings.php:114
-#: adminpages/emailsettings.php:132 adminpages/emailsettings.php:143
-#: adminpages/emailsettings.php:153 adminpages/emailsettings.php:157
-#: adminpages/emailsettings.php:158 adminpages/emailsettings.php:159
 #: adminpages/emailsettings.php:184
+#: adminpages/emailsettings.php:114
+#: adminpages/emailsettings.php:132
+#: adminpages/emailsettings.php:143
+#: adminpages/emailsettings.php:153
+#: adminpages/emailsettings.php:157
+#: adminpages/emailsettings.php:158
+#: adminpages/emailsettings.php:159
 msgid "when a user cancels his or her account."
 msgstr ""
 
-#: adminpages/emailsettings.php:187 adminpages/emailsettings.php:123
-#: adminpages/emailsettings.php:141 adminpages/emailsettings.php:152
-#: adminpages/emailsettings.php:162 adminpages/emailsettings.php:166
-#: adminpages/emailsettings.php:167 adminpages/emailsettings.php:168
 #: adminpages/emailsettings.php:187
+#: adminpages/emailsettings.php:123
+#: adminpages/emailsettings.php:141
+#: adminpages/emailsettings.php:152
+#: adminpages/emailsettings.php:162
+#: adminpages/emailsettings.php:166
+#: adminpages/emailsettings.php:167
+#: adminpages/emailsettings.php:168
 msgid "when a user updates his or her billing information."
 msgstr ""
 
-#: adminpages/emailsettings.php:192 adminpages/emailsettings.php:129
-#: adminpages/emailsettings.php:147 adminpages/emailsettings.php:158
-#: adminpages/emailsettings.php:168 adminpages/emailsettings.php:172
-#: adminpages/emailsettings.php:174 adminpages/emailsettings.php:192
+#: adminpages/emailsettings.php:192
+#: adminpages/emailsettings.php:129
+#: adminpages/emailsettings.php:147
+#: adminpages/emailsettings.php:158
+#: adminpages/emailsettings.php:168
+#: adminpages/emailsettings.php:172
+#: adminpages/emailsettings.php:174
 msgid "Send members emails"
 msgstr ""
 
-#: adminpages/emailsettings.php:196 adminpages/emailsettings.php:184
 #: adminpages/emailsettings.php:196
+#: adminpages/emailsettings.php:184
 msgid "Default WP notification email."
 msgstr ""
 
-#: adminpages/emailsettings.php:197 adminpages/emailsettings.php:185
 #: adminpages/emailsettings.php:197
-msgid ""
-"Recommended: Leave unchecked. Members will still get an email confirmation "
-"from PMPro after checkout."
+#: adminpages/emailsettings.php:185
+msgid "Recommended: Leave unchecked. Members will still get an email confirmation from PMPro after checkout."
 msgstr ""
 
-#: adminpages/functions.php:394 adminpages/functions.php:269
-#: adminpages/functions.php:270 adminpages/functions.php:394
-#: adminpages/orders.php:146 adminpages/orders.php:155
+#: adminpages/functions.php:394
+#: adminpages/functions.php:269
+#: adminpages/functions.php:270
+#: adminpages/orders.php:146
+#: adminpages/orders.php:155
 #: adminpages/orders.php:158
 msgid "Invoice emailed successfully."
 msgstr ""
 
-#: adminpages/functions.php:398 adminpages/functions.php:273
-#: adminpages/functions.php:274 adminpages/functions.php:398
-#: adminpages/orders.php:149 adminpages/orders.php:160
+#: adminpages/functions.php:398
+#: adminpages/functions.php:273
+#: adminpages/functions.php:274
+#: adminpages/orders.php:149
+#: adminpages/orders.php:160
 #: adminpages/orders.php:161
 msgid "Error emailing invoice."
 msgstr ""
 
-#: adminpages/functions.php:425 adminpages/functions.php:300
-#: adminpages/functions.php:301 adminpages/functions.php:425
-#: adminpages/orders.php:667 adminpages/orders.php:696
-#: adminpages/orders.php:800 adminpages/orders.php:831
-#: adminpages/orders.php:842 adminpages/orders.php:929
+#: adminpages/functions.php:425
+#: adminpages/functions.php:300
+#: adminpages/functions.php:301
+#: adminpages/orders.php:667
+#: adminpages/orders.php:696
+#: adminpages/orders.php:800
+#: adminpages/orders.php:831
+#: adminpages/orders.php:842
+#: adminpages/orders.php:929
 #: adminpages/orders.php:984
 msgid "Email Invoice"
 msgstr ""
 
-#: adminpages/functions.php:428 adminpages/functions.php:303
-#: adminpages/functions.php:304 adminpages/functions.php:428
-#: adminpages/orders.php:670 adminpages/orders.php:699
-#: adminpages/orders.php:803 adminpages/orders.php:834
-#: adminpages/orders.php:845 adminpages/orders.php:932
+#: adminpages/functions.php:428
+#: adminpages/functions.php:303
+#: adminpages/functions.php:304
+#: adminpages/orders.php:670
+#: adminpages/orders.php:699
+#: adminpages/orders.php:803
+#: adminpages/orders.php:834
+#: adminpages/orders.php:845
+#: adminpages/orders.php:932
 #: adminpages/orders.php:987
 msgid "Send an invoice for this order to: "
 msgstr ""
 
-#: adminpages/functions.php:430 adminpages/functions.php:305
-#: adminpages/functions.php:306 adminpages/functions.php:430
-#: adminpages/orders.php:672 adminpages/orders.php:701
-#: adminpages/orders.php:805 adminpages/orders.php:836
-#: adminpages/orders.php:847 adminpages/orders.php:934
+#: adminpages/functions.php:430
+#: adminpages/functions.php:305
+#: adminpages/functions.php:306
+#: adminpages/orders.php:672
+#: adminpages/orders.php:701
+#: adminpages/orders.php:805
+#: adminpages/orders.php:836
+#: adminpages/orders.php:847
+#: adminpages/orders.php:934
 #: adminpages/orders.php:989
 msgid "Send Email"
 msgstr ""
 
-#: adminpages/license.php:19 adminpages/license.php:19 includes/license.php:51
+#: adminpages/license.php:19
+#: includes/license.php:51
 #: includes/license.php:54
 msgid "Your license key has been validated."
 msgstr ""
 
-#: adminpages/license.php:43 adminpages/license.php:43 includes/license.php:81
-#: includes/license.php:83 includes/license.php:84
+#: adminpages/license.php:43
+#: includes/license.php:81
+#: includes/license.php:83
+#: includes/license.php:84
 msgid "Paid Memberships Pro Support License"
 msgstr ""
 
-#: adminpages/license.php:47 adminpages/license.php:47 includes/license.php:91
-msgid ""
-"Enter your support license key.</strong> Your license key can be found in "
-"your membership email receipt or in your <a href=\"https://www."
-"paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F"
-"%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign"
-"%3Dmembership-account%26utm_content%3Dno-key\" target=\"_blank\">Membership "
-"Account</a>."
+#: adminpages/license.php:47
+#: includes/license.php:91
+msgid "Enter your support license key.</strong> Your license key can be found in your membership email receipt or in your <a href=\"https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dno-key\" target=\"_blank\">Membership Account</a>."
 msgstr ""
 
-#: adminpages/license.php:49 adminpages/license.php:49 includes/license.php:93
-msgid ""
-"Visit the PMPro <a href=\"https://www.paidmembershipspro.com/login/?"
-"redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium"
-"%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dkey-not-"
-"valid\" target=\"_blank\">Membership Account</a> page to confirm that your "
-"account is active and to find your license key."
+#: adminpages/license.php:49
+#: includes/license.php:93
+msgid "Visit the PMPro <a href=\"https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dkey-not-valid\" target=\"_blank\">Membership Account</a> page to confirm that your account is active and to find your license key."
 msgstr ""
 
-#: adminpages/license.php:59 adminpages/license.php:59 includes/license.php:100
-#: includes/license.php:102 includes/license.php:103
+#: adminpages/license.php:59
+#: includes/license.php:100
+#: includes/license.php:102
+#: includes/license.php:103
 msgid "Enter license key here..."
 msgstr ""
 
-#: adminpages/license.php:61 adminpages/license.php:61
+#: adminpages/license.php:61
 msgid "Validate Key"
 msgstr ""
 
-#: adminpages/license.php:95 adminpages/license.php:95
+#: adminpages/license.php:95
 #, php-format
-msgid ""
-"Paid Memberships Pro and our Add Ons are distributed under the <a href=\"%s"
-"\" title=\"GPLv2 license\" target=\"_blank\">GPLv2 license</a>. This means, "
-"among other things, that you may use the software on this site or any other "
-"site free of charge."
+msgid "Paid Memberships Pro and our Add Ons are distributed under the <a href=\"%s\" title=\"GPLv2 license\" target=\"_blank\">GPLv2 license</a>. This means, among other things, that you may use the software on this site or any other site free of charge."
 msgstr ""
 
-#: adminpages/license.php:99 adminpages/license.php:99
-msgid ""
-"<strong>Paid Memberships Pro offers plans for automatic updates of Add Ons "
-"and premium support.</strong> These plans include a Plus license key which "
-"we recommend for all public websites running Paid Memberships Pro. A Plus "
-"license key allows you to automatically install new Add Ons and update  "
-"active Add Ons when a new security, bug fix, or feature enhancement is "
-"released."
+#: adminpages/license.php:99
+msgid "<strong>Paid Memberships Pro offers plans for automatic updates of Add Ons and premium support.</strong> These plans include a Plus license key which we recommend for all public websites running Paid Memberships Pro. A Plus license key allows you to automatically install new Add Ons and update  active Add Ons when a new security, bug fix, or feature enhancement is released."
 msgstr ""
 
-#: adminpages/license.php:103 adminpages/license.php:103
-msgid ""
-"<strong>Need help?</strong> Your license allows you to open new tickets in "
-"our private support area. Purchases are backed by a 30 day, no questions "
-"asked refund policy."
+#: adminpages/license.php:103
+msgid "<strong>Need help?</strong> Your license allows you to open new tickets in our private support area. Purchases are backed by a 30 day, no questions asked refund policy."
 msgstr ""
 
-#: adminpages/membershiplevels.php:150 adminpages/membershiplevels.php:137
-#: adminpages/membershiplevels.php:141 adminpages/membershiplevels.php:143
-#: adminpages/membershiplevels.php:146 adminpages/membershiplevels.php:150
+#: adminpages/membershiplevels.php:150
+#: adminpages/membershiplevels.php:137
+#: adminpages/membershiplevels.php:141
+#: adminpages/membershiplevels.php:143
+#: adminpages/membershiplevels.php:146
 msgid "Membership level added successfully."
 msgstr ""
 
-#: adminpages/membershiplevels.php:153 adminpages/membershiplevels.php:140
-#: adminpages/membershiplevels.php:146 adminpages/membershiplevels.php:148
-#: adminpages/membershiplevels.php:149 adminpages/membershiplevels.php:153
+#: adminpages/membershiplevels.php:153
+#: adminpages/membershiplevels.php:140
+#: adminpages/membershiplevels.php:146
+#: adminpages/membershiplevels.php:148
+#: adminpages/membershiplevels.php:149
 msgid "Error adding membership level."
 msgstr ""
 
-#: adminpages/membershiplevels.php:161 adminpages/membershiplevels.php:118
-#: adminpages/membershiplevels.php:120 adminpages/membershiplevels.php:148
-#: adminpages/membershiplevels.php:157 adminpages/membershiplevels.php:161
+#: adminpages/membershiplevels.php:161
+#: adminpages/membershiplevels.php:118
+#: adminpages/membershiplevels.php:120
+#: adminpages/membershiplevels.php:148
+#: adminpages/membershiplevels.php:157
 msgid "Membership level updated successfully."
 msgstr ""
 
-#: adminpages/membershiplevels.php:164 adminpages/membershiplevels.php:124
-#: adminpages/membershiplevels.php:126 adminpages/membershiplevels.php:152
-#: adminpages/membershiplevels.php:161 adminpages/membershiplevels.php:164
+#: adminpages/membershiplevels.php:164
+#: adminpages/membershiplevels.php:124
+#: adminpages/membershiplevels.php:126
+#: adminpages/membershiplevels.php:152
+#: adminpages/membershiplevels.php:161
 msgid "Error updating membership level."
 msgstr ""
 
-#: adminpages/membershiplevels.php:219 classes/class-pmpro-levels.php:232
-#: adminpages/membershiplevels.php:179 adminpages/membershiplevels.php:181
-#: adminpages/membershiplevels.php:183 adminpages/membershiplevels.php:193
-#: adminpages/membershiplevels.php:202 adminpages/membershiplevels.php:219
+#: adminpages/membershiplevels.php:219
 #: classes/class-pmpro-levels.php:232
+#: adminpages/membershiplevels.php:179
+#: adminpages/membershiplevels.php:181
+#: adminpages/membershiplevels.php:183
+#: adminpages/membershiplevels.php:193
+#: adminpages/membershiplevels.php:202
 #, php-format
-msgid ""
-"There was an error canceling the subscription for user with ID=%d. You will "
-"want to check your payment gateway to see if their subscription is still "
-"active."
+msgid "There was an error canceling the subscription for user with ID=%d. You will want to check your payment gateway to see if their subscription is still active."
 msgstr ""
 
-#: adminpages/membershiplevels.php:227 classes/class-pmpro-levels.php:240
-#: adminpages/membershiplevels.php:182 adminpages/membershiplevels.php:184
-#: adminpages/membershiplevels.php:186 adminpages/membershiplevels.php:201
-#: adminpages/membershiplevels.php:210 adminpages/membershiplevels.php:227
+#: adminpages/membershiplevels.php:227
 #: classes/class-pmpro-levels.php:240
+#: adminpages/membershiplevels.php:182
+#: adminpages/membershiplevels.php:184
+#: adminpages/membershiplevels.php:186
+#: adminpages/membershiplevels.php:201
+#: adminpages/membershiplevels.php:210
 msgid "Last Invoice"
 msgstr ""
 
-#: adminpages/membershiplevels.php:244 adminpages/membershiplevels.php:196
-#: adminpages/membershiplevels.php:198 adminpages/membershiplevels.php:200
-#: adminpages/membershiplevels.php:218 adminpages/membershiplevels.php:227
 #: adminpages/membershiplevels.php:244
+#: adminpages/membershiplevels.php:196
+#: adminpages/membershiplevels.php:198
+#: adminpages/membershiplevels.php:200
+#: adminpages/membershiplevels.php:218
+#: adminpages/membershiplevels.php:227
 msgid "Membership level deleted successfully."
 msgstr ""
 
-#: adminpages/membershiplevels.php:247 adminpages/membershiplevels.php:252
-#: adminpages/membershiplevels.php:201 adminpages/membershiplevels.php:203
-#: adminpages/membershiplevels.php:205 adminpages/membershiplevels.php:207
-#: adminpages/membershiplevels.php:209 adminpages/membershiplevels.php:211
-#: adminpages/membershiplevels.php:221 adminpages/membershiplevels.php:226
-#: adminpages/membershiplevels.php:230 adminpages/membershiplevels.php:235
-#: adminpages/membershiplevels.php:247 adminpages/membershiplevels.php:252
+#: adminpages/membershiplevels.php:247
+#: adminpages/membershiplevels.php:252
+#: adminpages/membershiplevels.php:201
+#: adminpages/membershiplevels.php:203
+#: adminpages/membershiplevels.php:205
+#: adminpages/membershiplevels.php:207
+#: adminpages/membershiplevels.php:209
+#: adminpages/membershiplevels.php:211
+#: adminpages/membershiplevels.php:221
+#: adminpages/membershiplevels.php:226
+#: adminpages/membershiplevels.php:230
+#: adminpages/membershiplevels.php:235
 msgid "Error deleting membership level."
 msgstr ""
 
-#: adminpages/membershiplevels.php:266 adminpages/membershiplevels.php:222
-#: adminpages/membershiplevels.php:224 adminpages/membershiplevels.php:226
-#: adminpages/membershiplevels.php:240 adminpages/membershiplevels.php:249
 #: adminpages/membershiplevels.php:266
+#: adminpages/membershiplevels.php:222
+#: adminpages/membershiplevels.php:224
+#: adminpages/membershiplevels.php:226
+#: adminpages/membershiplevels.php:240
+#: adminpages/membershiplevels.php:249
 msgid "Edit Membership Level"
 msgstr ""
 
-#: adminpages/membershiplevels.php:268 adminpages/membershiplevels.php:224
-#: adminpages/membershiplevels.php:226 adminpages/membershiplevels.php:228
-#: adminpages/membershiplevels.php:242 adminpages/membershiplevels.php:251
 #: adminpages/membershiplevels.php:268
+#: adminpages/membershiplevels.php:224
+#: adminpages/membershiplevels.php:226
+#: adminpages/membershiplevels.php:228
+#: adminpages/membershiplevels.php:242
+#: adminpages/membershiplevels.php:251
 msgid "Add New Membership Level"
 msgstr ""
 
-#: adminpages/membershiplevels.php:354 adminpages/membershiplevels.php:776
-#: adminpages/reports/login.php:180 adminpages/membershiplevels.php:291
-#: adminpages/membershiplevels.php:293 adminpages/membershiplevels.php:295
-#: adminpages/membershiplevels.php:319 adminpages/membershiplevels.php:329
-#: adminpages/membershiplevels.php:351 adminpages/membershiplevels.php:353
-#: adminpages/membershiplevels.php:354 adminpages/membershiplevels.php:506
-#: adminpages/membershiplevels.php:512 adminpages/membershiplevels.php:514
-#: adminpages/membershiplevels.php:541 adminpages/membershiplevels.php:542
-#: adminpages/membershiplevels.php:584 adminpages/membershiplevels.php:630
-#: adminpages/membershiplevels.php:632 adminpages/membershiplevels.php:637
-#: adminpages/membershiplevels.php:638 adminpages/membershiplevels.php:642
-#: adminpages/membershiplevels.php:654 adminpages/membershiplevels.php:664
-#: adminpages/membershiplevels.php:714 adminpages/membershiplevels.php:716
-#: adminpages/membershiplevels.php:742 adminpages/membershiplevels.php:759
-#: adminpages/membershiplevels.php:764 adminpages/membershiplevels.php:769
-#: adminpages/membershiplevels.php:774 adminpages/membershiplevels.php:776
-#: adminpages/reports/login.php:142 adminpages/reports/login.php:144
-#: adminpages/reports/login.php:160 adminpages/reports/login.php:164
+#: adminpages/membershiplevels.php:354
+#: adminpages/membershiplevels.php:776
 #: adminpages/reports/login.php:180
+#: adminpages/membershiplevels.php:291
+#: adminpages/membershiplevels.php:293
+#: adminpages/membershiplevels.php:295
+#: adminpages/membershiplevels.php:319
+#: adminpages/membershiplevels.php:329
+#: adminpages/membershiplevels.php:351
+#: adminpages/membershiplevels.php:353
+#: adminpages/membershiplevels.php:506
+#: adminpages/membershiplevels.php:512
+#: adminpages/membershiplevels.php:514
+#: adminpages/membershiplevels.php:541
+#: adminpages/membershiplevels.php:542
+#: adminpages/membershiplevels.php:584
+#: adminpages/membershiplevels.php:630
+#: adminpages/membershiplevels.php:632
+#: adminpages/membershiplevels.php:637
+#: adminpages/membershiplevels.php:638
+#: adminpages/membershiplevels.php:642
+#: adminpages/membershiplevels.php:654
+#: adminpages/membershiplevels.php:664
+#: adminpages/membershiplevels.php:714
+#: adminpages/membershiplevels.php:716
+#: adminpages/membershiplevels.php:742
+#: adminpages/membershiplevels.php:759
+#: adminpages/membershiplevels.php:764
+#: adminpages/membershiplevels.php:769
+#: adminpages/membershiplevels.php:774
+#: adminpages/reports/login.php:142
+#: adminpages/reports/login.php:144
+#: adminpages/reports/login.php:160
+#: adminpages/reports/login.php:164
 msgid "Name"
 msgstr ""
 
-#: adminpages/membershiplevels.php:377 adminpages/membershiplevels.php:314
-#: adminpages/membershiplevels.php:316 adminpages/membershiplevels.php:318
-#: adminpages/membershiplevels.php:342 adminpages/membershiplevels.php:352
-#: adminpages/membershiplevels.php:374 adminpages/membershiplevels.php:376
 #: adminpages/membershiplevels.php:377
+#: adminpages/membershiplevels.php:314
+#: adminpages/membershiplevels.php:316
+#: adminpages/membershiplevels.php:318
+#: adminpages/membershiplevels.php:342
+#: adminpages/membershiplevels.php:352
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
 msgid "Confirmation Message"
 msgstr ""
 
-#: adminpages/membershiplevels.php:391 adminpages/membershiplevels.php:388
-#: adminpages/membershiplevels.php:390 adminpages/membershiplevels.php:391
+#: adminpages/membershiplevels.php:391
+#: adminpages/membershiplevels.php:388
+#: adminpages/membershiplevels.php:390
 msgid "Check to include this message in the membership confirmation email."
 msgstr ""
 
-#: adminpages/membershiplevels.php:397 adminpages/membershiplevels.php:777
-#: adminpages/membershiplevels.php:333 adminpages/membershiplevels.php:335
-#: adminpages/membershiplevels.php:337 adminpages/membershiplevels.php:338
-#: adminpages/membershiplevels.php:361 adminpages/membershiplevels.php:371
-#: adminpages/membershiplevels.php:394 adminpages/membershiplevels.php:396
-#: adminpages/membershiplevels.php:397 adminpages/membershiplevels.php:543
-#: adminpages/membershiplevels.php:585 adminpages/membershiplevels.php:631
-#: adminpages/membershiplevels.php:633 adminpages/membershiplevels.php:638
-#: adminpages/membershiplevels.php:639 adminpages/membershiplevels.php:643
-#: adminpages/membershiplevels.php:655 adminpages/membershiplevels.php:665
-#: adminpages/membershiplevels.php:715 adminpages/membershiplevels.php:717
-#: adminpages/membershiplevels.php:743 adminpages/membershiplevels.php:760
-#: adminpages/membershiplevels.php:765 adminpages/membershiplevels.php:770
-#: adminpages/membershiplevels.php:775 adminpages/membershiplevels.php:777
+#: adminpages/membershiplevels.php:397
+#: adminpages/membershiplevels.php:777
+#: adminpages/membershiplevels.php:333
+#: adminpages/membershiplevels.php:335
+#: adminpages/membershiplevels.php:337
+#: adminpages/membershiplevels.php:338
+#: adminpages/membershiplevels.php:361
+#: adminpages/membershiplevels.php:371
+#: adminpages/membershiplevels.php:394
+#: adminpages/membershiplevels.php:396
+#: adminpages/membershiplevels.php:543
+#: adminpages/membershiplevels.php:585
+#: adminpages/membershiplevels.php:631
+#: adminpages/membershiplevels.php:633
+#: adminpages/membershiplevels.php:638
+#: adminpages/membershiplevels.php:639
+#: adminpages/membershiplevels.php:643
+#: adminpages/membershiplevels.php:655
+#: adminpages/membershiplevels.php:665
+#: adminpages/membershiplevels.php:715
+#: adminpages/membershiplevels.php:717
+#: adminpages/membershiplevels.php:743
+#: adminpages/membershiplevels.php:760
+#: adminpages/membershiplevels.php:765
+#: adminpages/membershiplevels.php:770
+#: adminpages/membershiplevels.php:775
 msgid "Billing Details"
 msgstr ""
 
-#: adminpages/membershiplevels.php:454 adminpages/membershiplevels.php:372
-#: adminpages/membershiplevels.php:374 adminpages/membershiplevels.php:393
-#: adminpages/membershiplevels.php:395 adminpages/membershiplevels.php:396
-#: adminpages/membershiplevels.php:417 adminpages/membershiplevels.php:427
-#: adminpages/membershiplevels.php:448 adminpages/membershiplevels.php:450
-#: adminpages/membershiplevels.php:451 adminpages/membershiplevels.php:452
 #: adminpages/membershiplevels.php:454
-msgid ""
-"After saving this level, make note of the ID and create a \"Plan\" in your "
-"Braintree dashboard with the same settings and the \"Plan ID\" set to "
-"<em>pmpro_#</em>, where # is the level ID."
+#: adminpages/membershiplevels.php:372
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:393
+#: adminpages/membershiplevels.php:395
+#: adminpages/membershiplevels.php:396
+#: adminpages/membershiplevels.php:417
+#: adminpages/membershiplevels.php:427
+#: adminpages/membershiplevels.php:448
+#: adminpages/membershiplevels.php:450
+#: adminpages/membershiplevels.php:451
+#: adminpages/membershiplevels.php:452
+msgid "After saving this level, make note of the ID and create a \"Plan\" in your Braintree dashboard with the same settings and the \"Plan ID\" set to <em>pmpro_#</em>, where # is the level ID."
 msgstr ""
 
-#: adminpages/membershiplevels.php:454 adminpages/membershiplevels.php:459
+#: adminpages/membershiplevels.php:454
+#: adminpages/membershiplevels.php:459
 #: classes/gateways/class.pmprogateway_cybersource.php:89
-#: adminpages/membershiplevels.php:372 adminpages/membershiplevels.php:374
-#: adminpages/membershiplevels.php:376 adminpages/membershiplevels.php:393
-#: adminpages/membershiplevels.php:395 adminpages/membershiplevels.php:396
-#: adminpages/membershiplevels.php:397 adminpages/membershiplevels.php:398
-#: adminpages/membershiplevels.php:417 adminpages/membershiplevels.php:419
-#: adminpages/membershiplevels.php:427 adminpages/membershiplevels.php:429
-#: adminpages/membershiplevels.php:432 adminpages/membershiplevels.php:448
-#: adminpages/membershiplevels.php:450 adminpages/membershiplevels.php:451
-#: adminpages/membershiplevels.php:452 adminpages/membershiplevels.php:453
-#: adminpages/membershiplevels.php:454 adminpages/membershiplevels.php:455
-#: adminpages/membershiplevels.php:456 adminpages/membershiplevels.php:457
-#: adminpages/membershiplevels.php:459 adminpages/paymentsettings.php:170
-#: adminpages/paymentsettings.php:174 adminpages/paymentsettings.php:179
+#: adminpages/membershiplevels.php:372
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:393
+#: adminpages/membershiplevels.php:395
+#: adminpages/membershiplevels.php:396
+#: adminpages/membershiplevels.php:397
+#: adminpages/membershiplevels.php:398
+#: adminpages/membershiplevels.php:417
+#: adminpages/membershiplevels.php:419
+#: adminpages/membershiplevels.php:427
+#: adminpages/membershiplevels.php:429
+#: adminpages/membershiplevels.php:432
+#: adminpages/membershiplevels.php:448
+#: adminpages/membershiplevels.php:450
+#: adminpages/membershiplevels.php:451
+#: adminpages/membershiplevels.php:452
+#: adminpages/membershiplevels.php:453
+#: adminpages/membershiplevels.php:455
+#: adminpages/membershiplevels.php:456
+#: adminpages/membershiplevels.php:457
+#: adminpages/paymentsettings.php:170
+#: adminpages/paymentsettings.php:174
+#: adminpages/paymentsettings.php:179
 #: classes/gateways/class.pmprogateway_cybersource.php:88
-#: classes/gateways/class.pmprogateway_cybersource.php:89
 #: classes/gateways/class.pmprogateway_cybersource.php:101
 #: classes/gateways/class.pmprogateway_paypal.php:118
 #: classes/gateways/class.pmprogateway_paypal.php:130
@@ -3252,160 +4437,217 @@ msgstr ""
 msgid "Note"
 msgstr ""
 
-#: adminpages/membershiplevels.php:459 adminpages/membershiplevels.php:432
-#: adminpages/membershiplevels.php:453 adminpages/membershiplevels.php:455
-#: adminpages/membershiplevels.php:456 adminpages/membershiplevels.php:457
 #: adminpages/membershiplevels.php:459
+#: adminpages/membershiplevels.php:432
+#: adminpages/membershiplevels.php:453
+#: adminpages/membershiplevels.php:455
+#: adminpages/membershiplevels.php:456
+#: adminpages/membershiplevels.php:457
 #, php-format
-msgid ""
-"You will need to create a \"Plan\" in your Braintree dashboard with the same "
-"settings and the \"Plan ID\" set to %s."
+msgid "You will need to create a \"Plan\" in your Braintree dashboard with the same settings and the \"Plan ID\" set to %s."
 msgstr ""
 
-#: adminpages/membershiplevels.php:506 adminpages/membershiplevels.php:492
-#: adminpages/membershiplevels.php:493 adminpages/membershiplevels.php:503
-#: adminpages/membershiplevels.php:504 adminpages/membershiplevels.php:506
+#: adminpages/membershiplevels.php:506
+#: adminpages/membershiplevels.php:492
+#: adminpages/membershiplevels.php:493
+#: adminpages/membershiplevels.php:503
+#: adminpages/membershiplevels.php:504
 #, php-format
-msgid ""
-"Optional: Allow more customizable trial periods and renewal dates using the "
-"<a href=\"%s\" title=\"Paid Memberships Pro - Subscription Delays Add On\" "
-"target=\"_blank\">Subscription Delays Add On</a>."
+msgid "Optional: Allow more customizable trial periods and renewal dates using the <a href=\"%s\" title=\"Paid Memberships Pro - Subscription Delays Add On\" target=\"_blank\">Subscription Delays Add On</a>."
 msgstr ""
 
-#: adminpages/membershiplevels.php:541 adminpages/membershiplevels.php:426
-#: adminpages/membershiplevels.php:432 adminpages/membershiplevels.php:434
-#: adminpages/membershiplevels.php:461 adminpages/membershiplevels.php:462
-#: adminpages/membershiplevels.php:464 adminpages/membershiplevels.php:465
-#: adminpages/membershiplevels.php:486 adminpages/membershiplevels.php:496
-#: adminpages/membershiplevels.php:520 adminpages/membershiplevels.php:522
-#: adminpages/membershiplevels.php:528 adminpages/membershiplevels.php:533
-#: adminpages/membershiplevels.php:538 adminpages/membershiplevels.php:539
 #: adminpages/membershiplevels.php:541
+#: adminpages/membershiplevels.php:426
+#: adminpages/membershiplevels.php:432
+#: adminpages/membershiplevels.php:434
+#: adminpages/membershiplevels.php:461
+#: adminpages/membershiplevels.php:462
+#: adminpages/membershiplevels.php:464
+#: adminpages/membershiplevels.php:465
+#: adminpages/membershiplevels.php:486
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:520
+#: adminpages/membershiplevels.php:522
+#: adminpages/membershiplevels.php:528
+#: adminpages/membershiplevels.php:533
+#: adminpages/membershiplevels.php:538
+#: adminpages/membershiplevels.php:539
 msgid "Disable New Signups"
 msgstr ""
 
-#: adminpages/membershiplevels.php:542 adminpages/membershiplevels.php:427
-#: adminpages/membershiplevels.php:433 adminpages/membershiplevels.php:435
-#: adminpages/membershiplevels.php:462 adminpages/membershiplevels.php:463
-#: adminpages/membershiplevels.php:465 adminpages/membershiplevels.php:466
-#: adminpages/membershiplevels.php:487 adminpages/membershiplevels.php:497
-#: adminpages/membershiplevels.php:521 adminpages/membershiplevels.php:523
-#: adminpages/membershiplevels.php:529 adminpages/membershiplevels.php:534
-#: adminpages/membershiplevels.php:539 adminpages/membershiplevels.php:540
 #: adminpages/membershiplevels.php:542
-msgid ""
-"Check to hide this level from the membership levels page and disable "
-"registration."
+#: adminpages/membershiplevels.php:427
+#: adminpages/membershiplevels.php:433
+#: adminpages/membershiplevels.php:435
+#: adminpages/membershiplevels.php:462
+#: adminpages/membershiplevels.php:463
+#: adminpages/membershiplevels.php:465
+#: adminpages/membershiplevels.php:466
+#: adminpages/membershiplevels.php:487
+#: adminpages/membershiplevels.php:497
+#: adminpages/membershiplevels.php:521
+#: adminpages/membershiplevels.php:523
+#: adminpages/membershiplevels.php:529
+#: adminpages/membershiplevels.php:534
+#: adminpages/membershiplevels.php:539
+#: adminpages/membershiplevels.php:540
+msgid "Check to hide this level from the membership levels page and disable registration."
 msgstr ""
 
-#: adminpages/membershiplevels.php:558 adminpages/membershiplevels.php:545
-#: adminpages/membershiplevels.php:550 adminpages/membershiplevels.php:555
-#: adminpages/membershiplevels.php:556 adminpages/membershiplevels.php:558
+#: adminpages/membershiplevels.php:558
+#: adminpages/membershiplevels.php:545
+#: adminpages/membershiplevels.php:550
+#: adminpages/membershiplevels.php:555
+#: adminpages/membershiplevels.php:556
 #, php-format
-msgid ""
-"Optional: Allow more customizable expiration dates using the <a href=\"%s\" "
-"title=\"Paid Memberships Pro - Set Expiration Date Add On\" target=\"_blank"
-"\">Set Expiration Date Add On</a>."
+msgid "Optional: Allow more customizable expiration dates using the <a href=\"%s\" title=\"Paid Memberships Pro - Set Expiration Date Add On\" target=\"_blank\">Set Expiration Date Add On</a>."
 msgstr ""
 
-#: adminpages/membershiplevels.php:578 adminpages/membershiplevels.php:546
-#: adminpages/membershiplevels.php:548 adminpages/membershiplevels.php:565
-#: adminpages/membershiplevels.php:570 adminpages/membershiplevels.php:575
-#: adminpages/membershiplevels.php:576 adminpages/membershiplevels.php:578
+#: adminpages/membershiplevels.php:578
+#: adminpages/membershiplevels.php:546
+#: adminpages/membershiplevels.php:548
+#: adminpages/membershiplevels.php:565
+#: adminpages/membershiplevels.php:570
+#: adminpages/membershiplevels.php:575
+#: adminpages/membershiplevels.php:576
 #, php-format
-msgid ""
-"WARNING: This level is set with both a recurring billing amount and an "
-"expiration date. You only need to set one of these unless you really want "
-"this membership to expire after a certain number of payments. For more "
-"information, <a target=\"_blank\" href=\"%s\">see our post here</a>."
+msgid "WARNING: This level is set with both a recurring billing amount and an expiration date. You only need to set one of these unless you really want this membership to expire after a certain number of payments. For more information, <a target=\"_blank\" href=\"%s\">see our post here</a>."
 msgstr ""
 
-#: adminpages/membershiplevels.php:620 adminpages/membershiplevels.php:588
-#: adminpages/membershiplevels.php:605 adminpages/membershiplevels.php:610
-#: adminpages/membershiplevels.php:615 adminpages/membershiplevels.php:618
 #: adminpages/membershiplevels.php:620
+#: adminpages/membershiplevels.php:588
+#: adminpages/membershiplevels.php:605
+#: adminpages/membershiplevels.php:610
+#: adminpages/membershiplevels.php:615
+#: adminpages/membershiplevels.php:618
 #, php-format
-msgid ""
-"Non-members will not see posts in these categories. You can <a href=\"%s\" "
-"title=\"Advanced Settings\" target=\"_blank\">update this setting here</a>."
+msgid "Non-members will not see posts in these categories. You can <a href=\"%s\" title=\"Advanced Settings\" target=\"_blank\">update this setting here</a>."
 msgstr ""
 
-#: adminpages/membershiplevels.php:624 adminpages/membershiplevels.php:592
-#: adminpages/membershiplevels.php:609 adminpages/membershiplevels.php:614
-#: adminpages/membershiplevels.php:619 adminpages/membershiplevels.php:622
 #: adminpages/membershiplevels.php:624
+#: adminpages/membershiplevels.php:592
+#: adminpages/membershiplevels.php:609
+#: adminpages/membershiplevels.php:614
+#: adminpages/membershiplevels.php:619
+#: adminpages/membershiplevels.php:622
 #, php-format
-msgid ""
-"Non-members will see the title and excerpt for posts in these categories. "
-"You can <a href=\"%s\" title=\"Advanced Settings\" target=\"_blank\">update "
-"this setting here</a>."
+msgid "Non-members will see the title and excerpt for posts in these categories. You can <a href=\"%s\" title=\"Advanced Settings\" target=\"_blank\">update this setting here</a>."
 msgstr ""
 
-#: adminpages/membershiplevels.php:627 adminpages/membershiplevels.php:595
-#: adminpages/membershiplevels.php:612 adminpages/membershiplevels.php:617
-#: adminpages/membershiplevels.php:622 adminpages/membershiplevels.php:625
 #: adminpages/membershiplevels.php:627
+#: adminpages/membershiplevels.php:595
+#: adminpages/membershiplevels.php:612
+#: adminpages/membershiplevels.php:617
+#: adminpages/membershiplevels.php:622
+#: adminpages/membershiplevels.php:625
 #, php-format
-msgid ""
-"Non-members will see the title only for posts in these categories. You can "
-"<a href=\"%s\" title=\"Advanced Settings\" target=\"_blank\">update this "
-"setting here</a>."
+msgid "Non-members will see the title only for posts in these categories. You can <a href=\"%s\" title=\"Advanced Settings\" target=\"_blank\">update this setting here</a>."
 msgstr ""
 
-#: adminpages/membershiplevels.php:634 adminpages/membershiplevels.php:461
-#: adminpages/membershiplevels.php:467 adminpages/membershiplevels.php:469
-#: adminpages/membershiplevels.php:496 adminpages/membershiplevels.php:497
-#: adminpages/membershiplevels.php:499 adminpages/membershiplevels.php:500
-#: adminpages/membershiplevels.php:521 adminpages/membershiplevels.php:531
-#: adminpages/membershiplevels.php:574 adminpages/membershiplevels.php:576
-#: adminpages/membershiplevels.php:602 adminpages/membershiplevels.php:619
-#: adminpages/membershiplevels.php:624 adminpages/membershiplevels.php:629
-#: adminpages/membershiplevels.php:632 adminpages/membershiplevels.php:634
+#: adminpages/membershiplevels.php:634
+#: adminpages/membershiplevels.php:461
+#: adminpages/membershiplevels.php:467
+#: adminpages/membershiplevels.php:469
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:497
+#: adminpages/membershiplevels.php:499
+#: adminpages/membershiplevels.php:500
+#: adminpages/membershiplevels.php:521
+#: adminpages/membershiplevels.php:531
+#: adminpages/membershiplevels.php:574
+#: adminpages/membershiplevels.php:576
+#: adminpages/membershiplevels.php:602
+#: adminpages/membershiplevels.php:619
+#: adminpages/membershiplevels.php:624
+#: adminpages/membershiplevels.php:629
+#: adminpages/membershiplevels.php:632
 msgid "Categories"
 msgstr ""
 
-#: adminpages/membershiplevels.php:642 adminpages/membershiplevels.php:505
-#: adminpages/membershiplevels.php:507 adminpages/membershiplevels.php:516
-#: adminpages/membershiplevels.php:517 adminpages/membershiplevels.php:529
-#: adminpages/membershiplevels.php:539 adminpages/membershiplevels.php:582
-#: adminpages/membershiplevels.php:584 adminpages/membershiplevels.php:610
-#: adminpages/membershiplevels.php:627 adminpages/membershiplevels.php:632
-#: adminpages/membershiplevels.php:637 adminpages/membershiplevels.php:640
 #: adminpages/membershiplevels.php:642
+#: adminpages/membershiplevels.php:505
+#: adminpages/membershiplevels.php:507
+#: adminpages/membershiplevels.php:516
+#: adminpages/membershiplevels.php:517
+#: adminpages/membershiplevels.php:529
+#: adminpages/membershiplevels.php:539
+#: adminpages/membershiplevels.php:582
+#: adminpages/membershiplevels.php:584
+#: adminpages/membershiplevels.php:610
+#: adminpages/membershiplevels.php:627
+#: adminpages/membershiplevels.php:632
+#: adminpages/membershiplevels.php:637
+#: adminpages/membershiplevels.php:640
 msgid "Save Level"
 msgstr ""
 
-#: adminpages/membershiplevels.php:643 adminpages/orders.php:950
-#: includes/profile.php:546 includes/profile.php:670 pages/billing.php:414
-#: pages/cancel.php:86 shortcodes/pmpro_account.php:106
-#: adminpages/membershiplevels.php:506 adminpages/membershiplevels.php:508
-#: adminpages/membershiplevels.php:517 adminpages/membershiplevels.php:518
-#: adminpages/membershiplevels.php:530 adminpages/membershiplevels.php:540
-#: adminpages/membershiplevels.php:583 adminpages/membershiplevels.php:585
-#: adminpages/membershiplevels.php:611 adminpages/membershiplevels.php:628
-#: adminpages/membershiplevels.php:633 adminpages/membershiplevels.php:638
-#: adminpages/membershiplevels.php:641 adminpages/membershiplevels.php:643
-#: adminpages/orders.php:511 adminpages/orders.php:561
-#: adminpages/orders.php:633 adminpages/orders.php:662
-#: adminpages/orders.php:765 adminpages/orders.php:796
-#: adminpages/orders.php:807 adminpages/orders.php:894
-#: adminpages/orders.php:930 adminpages/orders.php:934
-#: adminpages/orders.php:939 adminpages/orders.php:940
-#: adminpages/orders.php:949 includes/profile.php:529 includes/profile.php:538
-#: includes/profile.php:547 includes/profile.php:567 pages/account.php:44
-#: pages/billing.php:295 pages/billing.php:299 pages/billing.php:330
-#: pages/billing.php:339 pages/billing.php:342 pages/billing.php:344
-#: pages/billing.php:348 pages/billing.php:363 pages/billing.php:364
-#: pages/billing.php:365 pages/billing.php:371 pages/billing.php:372
-#: pages/billing.php:380 pages/billing.php:390 pages/billing.php:392
-#: pages/billing.php:397 pages/billing.php:401 pages/billing.php:406
-#: pages/billing.php:414 pages/cancel.php:71 pages/cancel.php:83
-#: pages/cancel.php:84 pages/cancel.php:86 shortcodes/pmpro_account.php:70
-#: shortcodes/pmpro_account.php:72 shortcodes/pmpro_account.php:73
+#: adminpages/membershiplevels.php:643
+#: adminpages/orders.php:950
+#: includes/profile.php:546
+#: includes/profile.php:670
+#: pages/billing.php:414
+#: pages/cancel.php:86
+#: shortcodes/pmpro_account.php:106
+#: adminpages/membershiplevels.php:506
+#: adminpages/membershiplevels.php:508
+#: adminpages/membershiplevels.php:517
+#: adminpages/membershiplevels.php:518
+#: adminpages/membershiplevels.php:530
+#: adminpages/membershiplevels.php:540
+#: adminpages/membershiplevels.php:583
+#: adminpages/membershiplevels.php:585
+#: adminpages/membershiplevels.php:611
+#: adminpages/membershiplevels.php:628
+#: adminpages/membershiplevels.php:633
+#: adminpages/membershiplevels.php:638
+#: adminpages/membershiplevels.php:641
+#: adminpages/orders.php:511
+#: adminpages/orders.php:561
+#: adminpages/orders.php:633
+#: adminpages/orders.php:662
+#: adminpages/orders.php:765
+#: adminpages/orders.php:796
+#: adminpages/orders.php:807
+#: adminpages/orders.php:894
+#: adminpages/orders.php:930
+#: adminpages/orders.php:934
+#: adminpages/orders.php:939
+#: adminpages/orders.php:940
+#: adminpages/orders.php:949
+#: includes/profile.php:529
+#: includes/profile.php:538
+#: includes/profile.php:547
+#: includes/profile.php:567
+#: pages/account.php:44
+#: pages/billing.php:295
+#: pages/billing.php:299
+#: pages/billing.php:330
+#: pages/billing.php:339
+#: pages/billing.php:342
+#: pages/billing.php:344
+#: pages/billing.php:348
+#: pages/billing.php:363
+#: pages/billing.php:364
+#: pages/billing.php:365
+#: pages/billing.php:371
+#: pages/billing.php:372
+#: pages/billing.php:380
+#: pages/billing.php:390
+#: pages/billing.php:392
+#: pages/billing.php:397
+#: pages/billing.php:401
+#: pages/billing.php:406
+#: pages/cancel.php:71
+#: pages/cancel.php:83
+#: pages/cancel.php:84
+#: shortcodes/pmpro_account.php:70
+#: shortcodes/pmpro_account.php:72
+#: shortcodes/pmpro_account.php:73
 msgid "Cancel"
 msgstr ""
 
-#: adminpages/membershiplevels.php:746 adminpages/membershiplevels.php:787
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:787
 msgid "No Membership Levels Found"
 msgstr ""
 
@@ -3413,398 +4655,655 @@ msgstr ""
 msgid "Video: Membership Levels"
 msgstr ""
 
-#: adminpages/membershiplevels.php:754 adminpages/membershiplevels.php:757
-#: adminpages/membershiplevels.php:493 adminpages/membershiplevels.php:496
-#: adminpages/membershiplevels.php:499 adminpages/membershiplevels.php:501
-#: adminpages/membershiplevels.php:502 adminpages/membershiplevels.php:504
-#: adminpages/membershiplevels.php:528 adminpages/membershiplevels.php:529
-#: adminpages/membershiplevels.php:531 adminpages/membershiplevels.php:532
-#: adminpages/membershiplevels.php:572 adminpages/membershiplevels.php:575
-#: adminpages/membershiplevels.php:610 adminpages/membershiplevels.php:612
-#: adminpages/membershiplevels.php:613 adminpages/membershiplevels.php:615
-#: adminpages/membershiplevels.php:621 adminpages/membershiplevels.php:622
-#: adminpages/membershiplevels.php:624 adminpages/membershiplevels.php:625
-#: adminpages/membershiplevels.php:634 adminpages/membershiplevels.php:637
-#: adminpages/membershiplevels.php:644 adminpages/membershiplevels.php:647
-#: adminpages/membershiplevels.php:694 adminpages/membershiplevels.php:696
-#: adminpages/membershiplevels.php:697 adminpages/membershiplevels.php:699
-#: adminpages/membershiplevels.php:722 adminpages/membershiplevels.php:725
-#: adminpages/membershiplevels.php:739 adminpages/membershiplevels.php:742
-#: adminpages/membershiplevels.php:744 adminpages/membershiplevels.php:747
-#: adminpages/membershiplevels.php:749 adminpages/membershiplevels.php:752
-#: adminpages/membershiplevels.php:754 adminpages/membershiplevels.php:755
+#: adminpages/membershiplevels.php:754
 #: adminpages/membershiplevels.php:757
+#: adminpages/membershiplevels.php:493
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:499
+#: adminpages/membershiplevels.php:501
+#: adminpages/membershiplevels.php:502
+#: adminpages/membershiplevels.php:504
+#: adminpages/membershiplevels.php:528
+#: adminpages/membershiplevels.php:529
+#: adminpages/membershiplevels.php:531
+#: adminpages/membershiplevels.php:532
+#: adminpages/membershiplevels.php:572
+#: adminpages/membershiplevels.php:575
+#: adminpages/membershiplevels.php:610
+#: adminpages/membershiplevels.php:612
+#: adminpages/membershiplevels.php:613
+#: adminpages/membershiplevels.php:615
+#: adminpages/membershiplevels.php:621
+#: adminpages/membershiplevels.php:622
+#: adminpages/membershiplevels.php:624
+#: adminpages/membershiplevels.php:625
+#: adminpages/membershiplevels.php:634
+#: adminpages/membershiplevels.php:637
+#: adminpages/membershiplevels.php:644
+#: adminpages/membershiplevels.php:647
+#: adminpages/membershiplevels.php:694
+#: adminpages/membershiplevels.php:696
+#: adminpages/membershiplevels.php:697
+#: adminpages/membershiplevels.php:699
+#: adminpages/membershiplevels.php:722
+#: adminpages/membershiplevels.php:725
+#: adminpages/membershiplevels.php:739
+#: adminpages/membershiplevels.php:742
+#: adminpages/membershiplevels.php:744
+#: adminpages/membershiplevels.php:747
+#: adminpages/membershiplevels.php:749
+#: adminpages/membershiplevels.php:752
+#: adminpages/membershiplevels.php:755
 msgid "Search Levels"
 msgstr ""
 
-#: adminpages/membershiplevels.php:761 adminpages/membershiplevels.php:490
-#: adminpages/membershiplevels.php:496 adminpages/membershiplevels.php:498
-#: adminpages/membershiplevels.php:525 adminpages/membershiplevels.php:526
-#: adminpages/membershiplevels.php:569 adminpages/membershiplevels.php:607
-#: adminpages/membershiplevels.php:609 adminpages/membershiplevels.php:618
-#: adminpages/membershiplevels.php:619 adminpages/membershiplevels.php:631
-#: adminpages/membershiplevels.php:641 adminpages/membershiplevels.php:700
-#: adminpages/membershiplevels.php:702 adminpages/membershiplevels.php:728
-#: adminpages/membershiplevels.php:745 adminpages/membershiplevels.php:750
+#: adminpages/membershiplevels.php:761
+#: adminpages/membershiplevels.php:490
+#: adminpages/membershiplevels.php:496
+#: adminpages/membershiplevels.php:498
+#: adminpages/membershiplevels.php:525
+#: adminpages/membershiplevels.php:526
+#: adminpages/membershiplevels.php:569
+#: adminpages/membershiplevels.php:607
+#: adminpages/membershiplevels.php:609
+#: adminpages/membershiplevels.php:618
+#: adminpages/membershiplevels.php:619
+#: adminpages/membershiplevels.php:631
+#: adminpages/membershiplevels.php:641
+#: adminpages/membershiplevels.php:700
+#: adminpages/membershiplevels.php:702
+#: adminpages/membershiplevels.php:728
+#: adminpages/membershiplevels.php:745
+#: adminpages/membershiplevels.php:750
 #: adminpages/membershiplevels.php:755
 msgid "Add New Level"
 msgstr ""
 
-#: adminpages/membershiplevels.php:765 adminpages/membershiplevels.php:579
-#: adminpages/membershiplevels.php:619 adminpages/membershiplevels.php:621
-#: adminpages/membershiplevels.php:630 adminpages/membershiplevels.php:631
-#: adminpages/membershiplevels.php:643 adminpages/membershiplevels.php:653
-#: adminpages/membershiplevels.php:703 adminpages/membershiplevels.php:705
-#: adminpages/membershiplevels.php:731 adminpages/membershiplevels.php:748
-#: adminpages/membershiplevels.php:753 adminpages/membershiplevels.php:758
-#: adminpages/membershiplevels.php:763 adminpages/membershiplevels.php:765
+#: adminpages/membershiplevels.php:765
+#: adminpages/membershiplevels.php:579
+#: adminpages/membershiplevels.php:619
+#: adminpages/membershiplevels.php:621
+#: adminpages/membershiplevels.php:630
+#: adminpages/membershiplevels.php:631
+#: adminpages/membershiplevels.php:643
+#: adminpages/membershiplevels.php:653
+#: adminpages/membershiplevels.php:703
+#: adminpages/membershiplevels.php:705
+#: adminpages/membershiplevels.php:731
+#: adminpages/membershiplevels.php:748
+#: adminpages/membershiplevels.php:753
+#: adminpages/membershiplevels.php:758
+#: adminpages/membershiplevels.php:763
 msgid "Drag and drop membership levels to reorder them on the Levels page."
 msgstr ""
 
-#: adminpages/membershiplevels.php:778 pages/billing.php:88 pages/cancel.php:61
-#: pages/confirmation.php:83 pages/invoice.php:73
-#: shortcodes/pmpro_account.php:44 adminpages/membershiplevels.php:510
-#: adminpages/membershiplevels.php:516 adminpages/membershiplevels.php:518
-#: adminpages/membershiplevels.php:544 adminpages/membershiplevels.php:545
-#: adminpages/membershiplevels.php:586 adminpages/membershiplevels.php:632
-#: adminpages/membershiplevels.php:634 adminpages/membershiplevels.php:639
-#: adminpages/membershiplevels.php:640 adminpages/membershiplevels.php:644
-#: adminpages/membershiplevels.php:656 adminpages/membershiplevels.php:666
-#: adminpages/membershiplevels.php:716 adminpages/membershiplevels.php:718
-#: adminpages/membershiplevels.php:744 adminpages/membershiplevels.php:761
-#: adminpages/membershiplevels.php:766 adminpages/membershiplevels.php:771
-#: adminpages/membershiplevels.php:776 adminpages/membershiplevels.php:778
-#: pages/account.php:20 pages/billing.php:88 pages/cancel.php:53
-#: pages/cancel.php:61 pages/cancel.php:62 pages/confirmation.php:80
-#: pages/confirmation.php:81 pages/confirmation.php:82
-#: pages/confirmation.php:83 pages/confirmation.php:84
-#: pages/confirmation.php:89 pages/invoice.php:62 pages/invoice.php:63
-#: pages/invoice.php:64 pages/invoice.php:68 pages/invoice.php:70
-#: pages/invoice.php:72 pages/invoice.php:73 shortcodes/pmpro_account.php:44
-#: shortcodes/pmpro_account.php:45 shortcodes/pmpro_account.php:46
+#: adminpages/membershiplevels.php:778
+#: pages/billing.php:88
+#: pages/cancel.php:61
+#: pages/confirmation.php:83
+#: pages/invoice.php:73
+#: shortcodes/pmpro_account.php:44
+#: adminpages/membershiplevels.php:510
+#: adminpages/membershiplevels.php:516
+#: adminpages/membershiplevels.php:518
+#: adminpages/membershiplevels.php:544
+#: adminpages/membershiplevels.php:545
+#: adminpages/membershiplevels.php:586
+#: adminpages/membershiplevels.php:632
+#: adminpages/membershiplevels.php:634
+#: adminpages/membershiplevels.php:639
+#: adminpages/membershiplevels.php:640
+#: adminpages/membershiplevels.php:644
+#: adminpages/membershiplevels.php:656
+#: adminpages/membershiplevels.php:666
+#: adminpages/membershiplevels.php:716
+#: adminpages/membershiplevels.php:718
+#: adminpages/membershiplevels.php:744
+#: adminpages/membershiplevels.php:761
+#: adminpages/membershiplevels.php:766
+#: adminpages/membershiplevels.php:771
+#: adminpages/membershiplevels.php:776
+#: pages/account.php:20
+#: pages/cancel.php:53
+#: pages/cancel.php:62
+#: pages/confirmation.php:80
+#: pages/confirmation.php:81
+#: pages/confirmation.php:82
+#: pages/confirmation.php:84
+#: pages/confirmation.php:89
+#: pages/invoice.php:62
+#: pages/invoice.php:63
+#: pages/invoice.php:64
+#: pages/invoice.php:68
+#: pages/invoice.php:70
+#: pages/invoice.php:72
+#: shortcodes/pmpro_account.php:45
+#: shortcodes/pmpro_account.php:46
 msgid "Expiration"
 msgstr ""
 
-#: adminpages/membershiplevels.php:779 adminpages/membershiplevels.php:511
-#: adminpages/membershiplevels.php:517 adminpages/membershiplevels.php:519
-#: adminpages/membershiplevels.php:545 adminpages/membershiplevels.php:546
-#: adminpages/membershiplevels.php:587 adminpages/membershiplevels.php:633
-#: adminpages/membershiplevels.php:635 adminpages/membershiplevels.php:640
-#: adminpages/membershiplevels.php:641 adminpages/membershiplevels.php:645
-#: adminpages/membershiplevels.php:657 adminpages/membershiplevels.php:667
-#: adminpages/membershiplevels.php:717 adminpages/membershiplevels.php:719
-#: adminpages/membershiplevels.php:745 adminpages/membershiplevels.php:762
-#: adminpages/membershiplevels.php:767 adminpages/membershiplevels.php:772
-#: adminpages/membershiplevels.php:777 adminpages/membershiplevels.php:779
+#: adminpages/membershiplevels.php:779
+#: adminpages/membershiplevels.php:511
+#: adminpages/membershiplevels.php:517
+#: adminpages/membershiplevels.php:519
+#: adminpages/membershiplevels.php:545
+#: adminpages/membershiplevels.php:546
+#: adminpages/membershiplevels.php:587
+#: adminpages/membershiplevels.php:633
+#: adminpages/membershiplevels.php:635
+#: adminpages/membershiplevels.php:640
+#: adminpages/membershiplevels.php:641
+#: adminpages/membershiplevels.php:645
+#: adminpages/membershiplevels.php:657
+#: adminpages/membershiplevels.php:667
+#: adminpages/membershiplevels.php:717
+#: adminpages/membershiplevels.php:719
+#: adminpages/membershiplevels.php:745
+#: adminpages/membershiplevels.php:762
+#: adminpages/membershiplevels.php:767
+#: adminpages/membershiplevels.php:772
+#: adminpages/membershiplevels.php:777
 msgid "Allow Signups"
 msgstr ""
 
-#: adminpages/membershiplevels.php:803 adminpages/membershiplevels.php:566
-#: adminpages/membershiplevels.php:572 adminpages/membershiplevels.php:574
-#: adminpages/membershiplevels.php:580 adminpages/membershiplevels.php:601
-#: adminpages/membershiplevels.php:660 adminpages/membershiplevels.php:662
-#: adminpages/membershiplevels.php:664 adminpages/membershiplevels.php:669
-#: adminpages/membershiplevels.php:670 adminpages/membershiplevels.php:674
-#: adminpages/membershiplevels.php:686 adminpages/membershiplevels.php:696
-#: adminpages/membershiplevels.php:746 adminpages/membershiplevels.php:748
-#: adminpages/membershiplevels.php:762 adminpages/membershiplevels.php:779
-#: adminpages/membershiplevels.php:784 adminpages/membershiplevels.php:789
-#: adminpages/membershiplevels.php:794 adminpages/membershiplevels.php:801
 #: adminpages/membershiplevels.php:803
+#: adminpages/membershiplevels.php:566
+#: adminpages/membershiplevels.php:572
+#: adminpages/membershiplevels.php:574
+#: adminpages/membershiplevels.php:580
+#: adminpages/membershiplevels.php:601
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:662
+#: adminpages/membershiplevels.php:664
+#: adminpages/membershiplevels.php:669
+#: adminpages/membershiplevels.php:670
+#: adminpages/membershiplevels.php:674
+#: adminpages/membershiplevels.php:686
+#: adminpages/membershiplevels.php:696
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:748
+#: adminpages/membershiplevels.php:762
+#: adminpages/membershiplevels.php:779
+#: adminpages/membershiplevels.php:784
+#: adminpages/membershiplevels.php:789
+#: adminpages/membershiplevels.php:794
+#: adminpages/membershiplevels.php:801
 #, php-format
-msgid ""
-"Are you sure you want to delete membership level %s? All subscriptions will "
-"be cancelled."
+msgid "Are you sure you want to delete membership level %s? All subscriptions will be cancelled."
 msgstr ""
 
-#: adminpages/membershiplevels.php:808 adminpages/membershiplevels.php:534
-#: adminpages/membershiplevels.php:540 adminpages/membershiplevels.php:542
-#: adminpages/membershiplevels.php:566 adminpages/membershiplevels.php:569
-#: adminpages/membershiplevels.php:646 adminpages/membershiplevels.php:648
-#: adminpages/membershiplevels.php:650 adminpages/membershiplevels.php:655
-#: adminpages/membershiplevels.php:656 adminpages/membershiplevels.php:660
-#: adminpages/membershiplevels.php:672 adminpages/membershiplevels.php:682
-#: adminpages/membershiplevels.php:732 adminpages/membershiplevels.php:734
-#: adminpages/membershiplevels.php:767 adminpages/membershiplevels.php:784
-#: adminpages/membershiplevels.php:789 adminpages/membershiplevels.php:794
-#: adminpages/membershiplevels.php:799 adminpages/membershiplevels.php:806
 #: adminpages/membershiplevels.php:808
+#: adminpages/membershiplevels.php:534
+#: adminpages/membershiplevels.php:540
+#: adminpages/membershiplevels.php:542
+#: adminpages/membershiplevels.php:566
+#: adminpages/membershiplevels.php:569
+#: adminpages/membershiplevels.php:646
+#: adminpages/membershiplevels.php:648
+#: adminpages/membershiplevels.php:650
+#: adminpages/membershiplevels.php:655
+#: adminpages/membershiplevels.php:656
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:672
+#: adminpages/membershiplevels.php:682
+#: adminpages/membershiplevels.php:732
+#: adminpages/membershiplevels.php:734
+#: adminpages/membershiplevels.php:767
+#: adminpages/membershiplevels.php:784
+#: adminpages/membershiplevels.php:789
+#: adminpages/membershiplevels.php:794
+#: adminpages/membershiplevels.php:799
+#: adminpages/membershiplevels.php:806
 msgid "FREE"
 msgstr ""
 
-#: adminpages/membershiplevels.php:817 adminpages/membershiplevels.php:560
-#: adminpages/membershiplevels.php:566 adminpages/membershiplevels.php:568
-#: adminpages/membershiplevels.php:575 adminpages/membershiplevels.php:595
-#: adminpages/membershiplevels.php:655 adminpages/membershiplevels.php:657
-#: adminpages/membershiplevels.php:659 adminpages/membershiplevels.php:664
-#: adminpages/membershiplevels.php:665 adminpages/membershiplevels.php:669
-#: adminpages/membershiplevels.php:681 adminpages/membershiplevels.php:691
-#: adminpages/membershiplevels.php:741 adminpages/membershiplevels.php:743
-#: adminpages/membershiplevels.php:776 adminpages/membershiplevels.php:793
-#: adminpages/membershiplevels.php:798 adminpages/membershiplevels.php:803
-#: adminpages/membershiplevels.php:808 adminpages/membershiplevels.php:815
 #: adminpages/membershiplevels.php:817
+#: adminpages/membershiplevels.php:560
+#: adminpages/membershiplevels.php:566
+#: adminpages/membershiplevels.php:568
+#: adminpages/membershiplevels.php:575
+#: adminpages/membershiplevels.php:595
+#: adminpages/membershiplevels.php:655
+#: adminpages/membershiplevels.php:657
+#: adminpages/membershiplevels.php:659
+#: adminpages/membershiplevels.php:664
+#: adminpages/membershiplevels.php:665
+#: adminpages/membershiplevels.php:669
+#: adminpages/membershiplevels.php:681
+#: adminpages/membershiplevels.php:691
+#: adminpages/membershiplevels.php:741
+#: adminpages/membershiplevels.php:743
+#: adminpages/membershiplevels.php:776
+#: adminpages/membershiplevels.php:793
+#: adminpages/membershiplevels.php:798
+#: adminpages/membershiplevels.php:803
+#: adminpages/membershiplevels.php:808
+#: adminpages/membershiplevels.php:815
 msgid "After"
 msgstr ""
 
-#: adminpages/memberslist.php:20 adminpages/memberslist.php:25
-#: includes/adminpages.php:15 includes/adminpages.php:53
-#: includes/adminpages.php:54 includes/adminpages.php:74
-#: includes/adminpages.php:142 includes/adminpages.php:149
-#: includes/adminpages.php:153 includes/adminpages.php:158
+#: adminpages/memberslist.php:20
+#: adminpages/memberslist.php:25
+#: includes/adminpages.php:15
+#: includes/adminpages.php:53
+#: includes/adminpages.php:54
+#: includes/adminpages.php:74
+#: includes/adminpages.php:142
+#: includes/adminpages.php:149
+#: includes/adminpages.php:153
+#: includes/adminpages.php:158
 msgid "Members List"
 msgstr ""
 
-#: adminpages/memberslist.php:21 adminpages/orders.php:982
-#: adminpages/memberslist.php:26 adminpages/orders.php:522
-#: adminpages/orders.php:591 adminpages/orders.php:698
-#: adminpages/orders.php:727 adminpages/orders.php:833
-#: adminpages/orders.php:864 adminpages/orders.php:875
-#: adminpages/orders.php:962 adminpages/orders.php:968
-#: adminpages/orders.php:972 adminpages/orders.php:973
+#: adminpages/memberslist.php:21
+#: adminpages/orders.php:982
+#: adminpages/memberslist.php:26
+#: adminpages/orders.php:522
+#: adminpages/orders.php:591
+#: adminpages/orders.php:698
+#: adminpages/orders.php:727
+#: adminpages/orders.php:833
+#: adminpages/orders.php:864
+#: adminpages/orders.php:875
+#: adminpages/orders.php:962
+#: adminpages/orders.php:968
+#: adminpages/orders.php:972
+#: adminpages/orders.php:973
 #: adminpages/orders.php:1018
 msgid "Export to CSV"
 msgstr ""
 
-#: adminpages/memberslist.php:28 adminpages/memberslist.php:28
-#: adminpages/memberslist.php:46 adminpages/memberslist.php:47
-#: adminpages/memberslist.php:49 adminpages/memberslist.php:50
+#: adminpages/memberslist.php:28
+#: adminpages/memberslist.php:46
+#: adminpages/memberslist.php:47
+#: adminpages/memberslist.php:49
+#: adminpages/memberslist.php:50
 #: adminpages/memberslist.php:52
 msgid "Search Members"
 msgstr ""
 
-#: adminpages/memberslist.php:41 adminpages/memberslist.php:41
-#: adminpages/memberslist.php:302 adminpages/memberslist.php:306
+#: adminpages/memberslist.php:41
+#: adminpages/memberslist.php:302
+#: adminpages/memberslist.php:306
 #, php-format
-msgid ""
-"Optional: Capture additional member profile fields using the <a href=\"%s\" "
-"title=\"Paid Memberships Pro - Register Helper Add On\" target=\"_blank"
-"\">Register Helper Add On</a>."
+msgid "Optional: Capture additional member profile fields using the <a href=\"%s\" title=\"Paid Memberships Pro - Register Helper Add On\" target=\"_blank\">Register Helper Add On</a>."
 msgstr ""
 
-#: adminpages/orders.php:161 adminpages/orders.php:26 adminpages/orders.php:67
-#: adminpages/orders.php:156 adminpages/orders.php:161
-#: adminpages/orders.php:162 adminpages/orders.php:174
+#: adminpages/orders.php:161
+#: adminpages/orders.php:26
+#: adminpages/orders.php:67
+#: adminpages/orders.php:156
+#: adminpages/orders.php:162
+#: adminpages/orders.php:174
 #: adminpages/orders.php:175
 msgid "Order deleted successfully."
 msgstr ""
 
-#: adminpages/orders.php:164 adminpages/orders.php:31 adminpages/orders.php:72
-#: adminpages/orders.php:159 adminpages/orders.php:164
-#: adminpages/orders.php:165 adminpages/orders.php:177
+#: adminpages/orders.php:164
+#: adminpages/orders.php:31
+#: adminpages/orders.php:72
+#: adminpages/orders.php:159
+#: adminpages/orders.php:165
+#: adminpages/orders.php:177
 #: adminpages/orders.php:180
 msgid "Error deleting order."
 msgstr ""
 
-#: adminpages/orders.php:304 adminpages/orders.php:119
-#: adminpages/orders.php:169 adminpages/orders.php:270
-#: adminpages/orders.php:284 adminpages/orders.php:285
-#: adminpages/orders.php:295 adminpages/orders.php:296
-#: adminpages/orders.php:297 adminpages/orders.php:298
-#: adminpages/orders.php:301 adminpages/orders.php:314
+#: adminpages/orders.php:304
+#: adminpages/orders.php:119
+#: adminpages/orders.php:169
+#: adminpages/orders.php:270
+#: adminpages/orders.php:284
+#: adminpages/orders.php:285
+#: adminpages/orders.php:295
+#: adminpages/orders.php:296
+#: adminpages/orders.php:297
+#: adminpages/orders.php:298
+#: adminpages/orders.php:301
+#: adminpages/orders.php:314
 msgid "Order saved successfully."
 msgstr ""
 
-#: adminpages/orders.php:307 adminpages/orders.php:124
-#: adminpages/orders.php:174 adminpages/orders.php:275
-#: adminpages/orders.php:287 adminpages/orders.php:288
-#: adminpages/orders.php:298 adminpages/orders.php:299
-#: adminpages/orders.php:300 adminpages/orders.php:301
-#: adminpages/orders.php:304 adminpages/orders.php:317
+#: adminpages/orders.php:307
+#: adminpages/orders.php:124
+#: adminpages/orders.php:174
+#: adminpages/orders.php:275
+#: adminpages/orders.php:287
+#: adminpages/orders.php:288
+#: adminpages/orders.php:298
+#: adminpages/orders.php:299
+#: adminpages/orders.php:300
+#: adminpages/orders.php:301
+#: adminpages/orders.php:304
+#: adminpages/orders.php:317
 msgid "Error updating order timestamp."
 msgstr ""
 
-#: adminpages/orders.php:311 adminpages/orders.php:130
-#: adminpages/orders.php:180 adminpages/orders.php:281
-#: adminpages/orders.php:291 adminpages/orders.php:292
-#: adminpages/orders.php:302 adminpages/orders.php:303
-#: adminpages/orders.php:304 adminpages/orders.php:305
-#: adminpages/orders.php:308 adminpages/orders.php:321
+#: adminpages/orders.php:311
+#: adminpages/orders.php:130
+#: adminpages/orders.php:180
+#: adminpages/orders.php:281
+#: adminpages/orders.php:291
+#: adminpages/orders.php:292
+#: adminpages/orders.php:302
+#: adminpages/orders.php:303
+#: adminpages/orders.php:304
+#: adminpages/orders.php:305
+#: adminpages/orders.php:308
+#: adminpages/orders.php:321
 msgid "Error saving order."
 msgstr ""
 
-#: adminpages/orders.php:382 classes/class-pmpro-admin-activity-email.php:219
-#: classes/class.memberorder.php:947 adminpages/orders.php:195
-#: adminpages/orders.php:245 adminpages/orders.php:317
-#: adminpages/orders.php:321 adminpages/orders.php:346
-#: adminpages/orders.php:352 adminpages/orders.php:362
-#: adminpages/orders.php:364 adminpages/orders.php:370
-#: adminpages/orders.php:382 classes/class-pmpro-admin-activity-email.php:217
-#: classes/class.memberorder.php:743 classes/class.memberorder.php:746
-#: classes/class.memberorder.php:763 classes/class.memberorder.php:814
-#: classes/class.memberorder.php:859 classes/class.memberorder.php:860
-#: classes/class.memberorder.php:872 classes/class.memberorder.php:945
+#: adminpages/orders.php:382
+#: classes/class-pmpro-admin-activity-email.php:219
+#: classes/class.memberorder.php:947
+#: adminpages/orders.php:195
+#: adminpages/orders.php:245
+#: adminpages/orders.php:317
+#: adminpages/orders.php:321
+#: adminpages/orders.php:346
+#: adminpages/orders.php:352
+#: adminpages/orders.php:362
+#: adminpages/orders.php:364
+#: adminpages/orders.php:370
+#: classes/class-pmpro-admin-activity-email.php:217
+#: classes/class.memberorder.php:743
+#: classes/class.memberorder.php:746
+#: classes/class.memberorder.php:763
+#: classes/class.memberorder.php:814
+#: classes/class.memberorder.php:859
+#: classes/class.memberorder.php:860
+#: classes/class.memberorder.php:872
+#: classes/class.memberorder.php:945
 msgid "Order"
 msgstr ""
 
-#: adminpages/orders.php:383 adminpages/orders.php:1365
-#: pages/confirmation.php:49 pages/invoice.php:22 adminpages/orders.php:370
-#: adminpages/orders.php:371 adminpages/orders.php:375
-#: adminpages/orders.php:1341 adminpages/orders.php:1346
-#: adminpages/orders.php:1347 adminpages/orders.php:1356
-#: adminpages/orders.php:1361 pages/confirmation.php:43
-#: pages/confirmation.php:48 pages/confirmation.php:49 pages/invoice.php:22
+#: adminpages/orders.php:383
+#: adminpages/orders.php:1365
+#: pages/confirmation.php:49
+#: pages/invoice.php:22
+#: adminpages/orders.php:370
+#: adminpages/orders.php:371
+#: adminpages/orders.php:375
+#: adminpages/orders.php:1341
+#: adminpages/orders.php:1346
+#: adminpages/orders.php:1347
+#: adminpages/orders.php:1356
+#: adminpages/orders.php:1361
+#: pages/confirmation.php:43
+#: pages/confirmation.php:48
 #: pages/invoice.php:24
 msgid "Print"
 msgstr ""
 
-#: adminpages/orders.php:386 adminpages/orders.php:197
-#: adminpages/orders.php:247 adminpages/orders.php:319
-#: adminpages/orders.php:323 adminpages/orders.php:348
-#: adminpages/orders.php:354 adminpages/orders.php:364
-#: adminpages/orders.php:366 adminpages/orders.php:374
+#: adminpages/orders.php:386
+#: adminpages/orders.php:197
+#: adminpages/orders.php:247
+#: adminpages/orders.php:319
+#: adminpages/orders.php:323
+#: adminpages/orders.php:348
+#: adminpages/orders.php:354
+#: adminpages/orders.php:364
+#: adminpages/orders.php:366
+#: adminpages/orders.php:374
 #: adminpages/orders.php:384
 msgid "New Order"
 msgstr ""
 
-#: adminpages/orders.php:432 adminpages/orders.php:220
-#: adminpages/orders.php:270 adminpages/orders.php:342
-#: adminpages/orders.php:359 adminpages/orders.php:371
-#: adminpages/orders.php:390 adminpages/orders.php:401
-#: adminpages/orders.php:413 adminpages/orders.php:419
-#: adminpages/orders.php:420 adminpages/orders.php:421
-#: adminpages/orders.php:424 adminpages/orders.php:431
+#: adminpages/orders.php:432
+#: adminpages/orders.php:220
+#: adminpages/orders.php:270
+#: adminpages/orders.php:342
+#: adminpages/orders.php:359
+#: adminpages/orders.php:371
+#: adminpages/orders.php:390
+#: adminpages/orders.php:401
+#: adminpages/orders.php:413
+#: adminpages/orders.php:419
+#: adminpages/orders.php:420
+#: adminpages/orders.php:421
+#: adminpages/orders.php:424
+#: adminpages/orders.php:431
 msgid "Randomly generated for you."
 msgstr ""
 
-#: adminpages/orders.php:437 adminpages/orders.php:225
-#: adminpages/orders.php:275 adminpages/orders.php:347
-#: adminpages/orders.php:364 adminpages/orders.php:376
-#: adminpages/orders.php:395 adminpages/orders.php:406
-#: adminpages/orders.php:418 adminpages/orders.php:424
-#: adminpages/orders.php:425 adminpages/orders.php:426
-#: adminpages/orders.php:429 adminpages/orders.php:431
+#: adminpages/orders.php:437
+#: adminpages/orders.php:225
+#: adminpages/orders.php:275
+#: adminpages/orders.php:347
+#: adminpages/orders.php:364
+#: adminpages/orders.php:376
+#: adminpages/orders.php:395
+#: adminpages/orders.php:406
+#: adminpages/orders.php:418
+#: adminpages/orders.php:424
+#: adminpages/orders.php:425
+#: adminpages/orders.php:426
+#: adminpages/orders.php:429
+#: adminpages/orders.php:431
 #: adminpages/orders.php:436
 msgid "User ID"
 msgstr ""
 
-#: adminpages/orders.php:450 adminpages/orders.php:234
-#: adminpages/orders.php:284 adminpages/orders.php:356
-#: adminpages/orders.php:376 adminpages/orders.php:385
-#: adminpages/orders.php:407 adminpages/orders.php:418
-#: adminpages/orders.php:432 adminpages/orders.php:437
-#: adminpages/orders.php:439 adminpages/orders.php:440
-#: adminpages/orders.php:442 adminpages/orders.php:450
+#: adminpages/orders.php:450
+#: adminpages/orders.php:234
+#: adminpages/orders.php:284
+#: adminpages/orders.php:356
+#: adminpages/orders.php:376
+#: adminpages/orders.php:385
+#: adminpages/orders.php:407
+#: adminpages/orders.php:418
+#: adminpages/orders.php:432
+#: adminpages/orders.php:437
+#: adminpages/orders.php:439
+#: adminpages/orders.php:440
+#: adminpages/orders.php:442
 msgid "Membership Level ID"
 msgstr ""
 
-#: adminpages/orders.php:463 includes/privacy.php:245 adminpages/orders.php:243
-#: adminpages/orders.php:293 adminpages/orders.php:365
-#: adminpages/orders.php:389 adminpages/orders.php:394
-#: adminpages/orders.php:420 adminpages/orders.php:431
-#: adminpages/orders.php:447 adminpages/orders.php:450
-#: adminpages/orders.php:454 adminpages/orders.php:455
-#: adminpages/orders.php:465 includes/privacy.php:245
+#: adminpages/orders.php:463
+#: includes/privacy.php:245
+#: adminpages/orders.php:243
+#: adminpages/orders.php:293
+#: adminpages/orders.php:365
+#: adminpages/orders.php:389
+#: adminpages/orders.php:394
+#: adminpages/orders.php:420
+#: adminpages/orders.php:431
+#: adminpages/orders.php:447
+#: adminpages/orders.php:450
+#: adminpages/orders.php:454
+#: adminpages/orders.php:455
+#: adminpages/orders.php:465
 msgid "Billing Name"
 msgstr ""
 
-#: adminpages/orders.php:477 includes/privacy.php:249 adminpages/orders.php:251
-#: adminpages/orders.php:301 adminpages/orders.php:373
-#: adminpages/orders.php:401 adminpages/orders.php:402
-#: adminpages/orders.php:432 adminpages/orders.php:443
-#: adminpages/orders.php:461 adminpages/orders.php:464
-#: adminpages/orders.php:468 adminpages/orders.php:469
-#: adminpages/orders.php:479 includes/privacy.php:249
+#: adminpages/orders.php:477
+#: includes/privacy.php:249
+#: adminpages/orders.php:251
+#: adminpages/orders.php:301
+#: adminpages/orders.php:373
+#: adminpages/orders.php:401
+#: adminpages/orders.php:402
+#: adminpages/orders.php:432
+#: adminpages/orders.php:443
+#: adminpages/orders.php:461
+#: adminpages/orders.php:464
+#: adminpages/orders.php:468
+#: adminpages/orders.php:469
+#: adminpages/orders.php:479
 msgid "Billing Street"
 msgstr ""
 
-#: adminpages/orders.php:490 includes/privacy.php:253 includes/privacy.php:358
-#: adminpages/orders.php:258 adminpages/orders.php:308
-#: adminpages/orders.php:380 adminpages/orders.php:409
-#: adminpages/orders.php:412 adminpages/orders.php:443
-#: adminpages/orders.php:454 adminpages/orders.php:474
-#: adminpages/orders.php:477 adminpages/orders.php:481
-#: adminpages/orders.php:482 adminpages/orders.php:492 includes/privacy.php:253
+#: adminpages/orders.php:490
+#: includes/privacy.php:253
 #: includes/privacy.php:358
+#: adminpages/orders.php:258
+#: adminpages/orders.php:308
+#: adminpages/orders.php:380
+#: adminpages/orders.php:409
+#: adminpages/orders.php:412
+#: adminpages/orders.php:443
+#: adminpages/orders.php:454
+#: adminpages/orders.php:474
+#: adminpages/orders.php:477
+#: adminpages/orders.php:481
+#: adminpages/orders.php:482
+#: adminpages/orders.php:492
 msgid "Billing City"
 msgstr ""
 
-#: adminpages/orders.php:503 includes/privacy.php:257 adminpages/orders.php:265
-#: adminpages/orders.php:315 adminpages/orders.php:387
-#: adminpages/orders.php:416 adminpages/orders.php:423
-#: adminpages/orders.php:454 adminpages/orders.php:465
-#: adminpages/orders.php:487 adminpages/orders.php:490
-#: adminpages/orders.php:494 adminpages/orders.php:495
-#: adminpages/orders.php:505 includes/privacy.php:257
+#: adminpages/orders.php:503
+#: includes/privacy.php:257
+#: adminpages/orders.php:265
+#: adminpages/orders.php:315
+#: adminpages/orders.php:387
+#: adminpages/orders.php:416
+#: adminpages/orders.php:423
+#: adminpages/orders.php:454
+#: adminpages/orders.php:465
+#: adminpages/orders.php:487
+#: adminpages/orders.php:490
+#: adminpages/orders.php:494
+#: adminpages/orders.php:495
+#: adminpages/orders.php:505
 msgid "Billing State"
 msgstr ""
 
-#: adminpages/orders.php:516 includes/privacy.php:261 includes/privacy.php:360
-#: adminpages/orders.php:272 adminpages/orders.php:322
-#: adminpages/orders.php:394 adminpages/orders.php:423
-#: adminpages/orders.php:434 adminpages/orders.php:465
-#: adminpages/orders.php:476 adminpages/orders.php:500
-#: adminpages/orders.php:503 adminpages/orders.php:507
-#: adminpages/orders.php:508 adminpages/orders.php:518 includes/privacy.php:261
+#: adminpages/orders.php:516
+#: includes/privacy.php:261
 #: includes/privacy.php:360
+#: adminpages/orders.php:272
+#: adminpages/orders.php:322
+#: adminpages/orders.php:394
+#: adminpages/orders.php:423
+#: adminpages/orders.php:434
+#: adminpages/orders.php:465
+#: adminpages/orders.php:476
+#: adminpages/orders.php:500
+#: adminpages/orders.php:503
+#: adminpages/orders.php:507
+#: adminpages/orders.php:508
+#: adminpages/orders.php:518
 msgid "Billing Postal Code"
 msgstr ""
 
-#: adminpages/orders.php:529 includes/privacy.php:265 includes/privacy.php:362
-#: adminpages/orders.php:279 adminpages/orders.php:329
-#: adminpages/orders.php:401 adminpages/orders.php:430
-#: adminpages/orders.php:445 adminpages/orders.php:476
-#: adminpages/orders.php:487 adminpages/orders.php:513
-#: adminpages/orders.php:516 adminpages/orders.php:520
-#: adminpages/orders.php:521 adminpages/orders.php:531 includes/privacy.php:265
+#: adminpages/orders.php:529
+#: includes/privacy.php:265
 #: includes/privacy.php:362
+#: adminpages/orders.php:279
+#: adminpages/orders.php:329
+#: adminpages/orders.php:401
+#: adminpages/orders.php:430
+#: adminpages/orders.php:445
+#: adminpages/orders.php:476
+#: adminpages/orders.php:487
+#: adminpages/orders.php:513
+#: adminpages/orders.php:516
+#: adminpages/orders.php:520
+#: adminpages/orders.php:521
+#: adminpages/orders.php:531
 msgid "Billing Country"
 msgstr ""
 
-#: adminpages/orders.php:543 includes/privacy.php:269 adminpages/orders.php:287
-#: adminpages/orders.php:337 adminpages/orders.php:409
-#: adminpages/orders.php:438 adminpages/orders.php:457
-#: adminpages/orders.php:488 adminpages/orders.php:499
-#: adminpages/orders.php:527 adminpages/orders.php:530
-#: adminpages/orders.php:534 adminpages/orders.php:535
-#: adminpages/orders.php:545 includes/privacy.php:269
+#: adminpages/orders.php:543
+#: includes/privacy.php:269
+#: adminpages/orders.php:287
+#: adminpages/orders.php:337
+#: adminpages/orders.php:409
+#: adminpages/orders.php:438
+#: adminpages/orders.php:457
+#: adminpages/orders.php:488
+#: adminpages/orders.php:499
+#: adminpages/orders.php:527
+#: adminpages/orders.php:530
+#: adminpages/orders.php:534
+#: adminpages/orders.php:535
+#: adminpages/orders.php:545
 msgid "Billing Phone"
 msgstr ""
 
-#: adminpages/orders.php:573 adminpages/orders.php:1332
-#: classes/class.pmproemail.php:313 classes/class.pmproemail.php:322
-#: classes/class.pmproemail.php:331 classes/class.pmproemail.php:413
-#: classes/class.pmproemail.php:422 classes/class.pmproemail.php:740
+#: adminpages/orders.php:573
+#: adminpages/orders.php:1332
+#: classes/class.pmproemail.php:313
+#: classes/class.pmproemail.php:322
+#: classes/class.pmproemail.php:331
+#: classes/class.pmproemail.php:413
+#: classes/class.pmproemail.php:422
+#: classes/class.pmproemail.php:740
 #: classes/class.pmproemail.php:742
 #: classes/gateways/class.pmprogateway_braintree.php:509
-#: classes/gateways/class.pmprogateway_stripe.php:1099 pages/checkout.php:86
-#: pages/checkout.php:92 pages/checkout.php:429 pages/confirmation.php:58
-#: pages/invoice.php:40 adminpages/orders.php:560 adminpages/orders.php:564
-#: adminpages/orders.php:565 adminpages/orders.php:575
-#: adminpages/orders.php:1307 adminpages/orders.php:1313
-#: adminpages/orders.php:1318 adminpages/orders.php:1322
-#: adminpages/orders.php:1363 classes/class.pmproemail.php:216
-#: classes/class.pmproemail.php:218 classes/class.pmproemail.php:225
-#: classes/class.pmproemail.php:227 classes/class.pmproemail.php:228
-#: classes/class.pmproemail.php:231 classes/class.pmproemail.php:234
-#: classes/class.pmproemail.php:236 classes/class.pmproemail.php:237
-#: classes/class.pmproemail.php:240 classes/class.pmproemail.php:246
-#: classes/class.pmproemail.php:249 classes/class.pmproemail.php:258
-#: classes/class.pmproemail.php:260 classes/class.pmproemail.php:269
-#: classes/class.pmproemail.php:276 classes/class.pmproemail.php:278
-#: classes/class.pmproemail.php:284 classes/class.pmproemail.php:285
-#: classes/class.pmproemail.php:287 classes/class.pmproemail.php:293
-#: classes/class.pmproemail.php:294 classes/class.pmproemail.php:302
-#: classes/class.pmproemail.php:303 classes/class.pmproemail.php:304
-#: classes/class.pmproemail.php:307 classes/class.pmproemail.php:313
-#: classes/class.pmproemail.php:316 classes/class.pmproemail.php:322
-#: classes/class.pmproemail.php:325 classes/class.pmproemail.php:328
-#: classes/class.pmproemail.php:331 classes/class.pmproemail.php:334
-#: classes/class.pmproemail.php:337 classes/class.pmproemail.php:346
-#: classes/class.pmproemail.php:357 classes/class.pmproemail.php:366
-#: classes/class.pmproemail.php:369 classes/class.pmproemail.php:376
-#: classes/class.pmproemail.php:378 classes/class.pmproemail.php:384
-#: classes/class.pmproemail.php:385 classes/class.pmproemail.php:393
-#: classes/class.pmproemail.php:394 classes/class.pmproemail.php:413
-#: classes/class.pmproemail.php:422 classes/class.pmproemail.php:532
-#: classes/class.pmproemail.php:580 classes/class.pmproemail.php:645
-#: classes/class.pmproemail.php:648 classes/class.pmproemail.php:657
-#: classes/class.pmproemail.php:659 classes/class.pmproemail.php:679
-#: classes/class.pmproemail.php:696 classes/class.pmproemail.php:698
-#: classes/class.pmproemail.php:703 classes/class.pmproemail.php:705
-#: classes/class.pmproemail.php:711 classes/class.pmproemail.php:712
-#: classes/class.pmproemail.php:713 classes/class.pmproemail.php:714
-#: classes/class.pmproemail.php:740 classes/class.pmproemail.php:742
+#: classes/gateways/class.pmprogateway_stripe.php:1099
+#: pages/checkout.php:86
+#: pages/checkout.php:92
+#: pages/checkout.php:429
+#: pages/confirmation.php:58
+#: pages/invoice.php:40
+#: adminpages/orders.php:560
+#: adminpages/orders.php:564
+#: adminpages/orders.php:565
+#: adminpages/orders.php:575
+#: adminpages/orders.php:1307
+#: adminpages/orders.php:1313
+#: adminpages/orders.php:1318
+#: adminpages/orders.php:1322
+#: adminpages/orders.php:1363
+#: classes/class.pmproemail.php:216
+#: classes/class.pmproemail.php:218
+#: classes/class.pmproemail.php:225
+#: classes/class.pmproemail.php:227
+#: classes/class.pmproemail.php:228
+#: classes/class.pmproemail.php:231
+#: classes/class.pmproemail.php:234
+#: classes/class.pmproemail.php:236
+#: classes/class.pmproemail.php:237
+#: classes/class.pmproemail.php:240
+#: classes/class.pmproemail.php:246
+#: classes/class.pmproemail.php:249
+#: classes/class.pmproemail.php:258
+#: classes/class.pmproemail.php:260
+#: classes/class.pmproemail.php:269
+#: classes/class.pmproemail.php:276
+#: classes/class.pmproemail.php:278
+#: classes/class.pmproemail.php:284
+#: classes/class.pmproemail.php:285
+#: classes/class.pmproemail.php:287
+#: classes/class.pmproemail.php:293
+#: classes/class.pmproemail.php:294
+#: classes/class.pmproemail.php:302
+#: classes/class.pmproemail.php:303
+#: classes/class.pmproemail.php:304
+#: classes/class.pmproemail.php:307
+#: classes/class.pmproemail.php:316
+#: classes/class.pmproemail.php:325
+#: classes/class.pmproemail.php:328
+#: classes/class.pmproemail.php:334
+#: classes/class.pmproemail.php:337
+#: classes/class.pmproemail.php:346
+#: classes/class.pmproemail.php:357
+#: classes/class.pmproemail.php:366
+#: classes/class.pmproemail.php:369
+#: classes/class.pmproemail.php:376
+#: classes/class.pmproemail.php:378
+#: classes/class.pmproemail.php:384
+#: classes/class.pmproemail.php:385
+#: classes/class.pmproemail.php:393
+#: classes/class.pmproemail.php:394
+#: classes/class.pmproemail.php:532
+#: classes/class.pmproemail.php:580
+#: classes/class.pmproemail.php:645
+#: classes/class.pmproemail.php:648
+#: classes/class.pmproemail.php:657
+#: classes/class.pmproemail.php:659
+#: classes/class.pmproemail.php:679
+#: classes/class.pmproemail.php:696
+#: classes/class.pmproemail.php:698
+#: classes/class.pmproemail.php:703
+#: classes/class.pmproemail.php:705
+#: classes/class.pmproemail.php:711
+#: classes/class.pmproemail.php:712
+#: classes/class.pmproemail.php:713
+#: classes/class.pmproemail.php:714
 #: classes/gateways/class.pmprogateway_braintree.php:349
 #: classes/gateways/class.pmprogateway_braintree.php:362
 #: classes/gateways/class.pmprogateway_braintree.php:364
@@ -3816,7 +5315,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:464
 #: classes/gateways/class.pmprogateway_braintree.php:489
 #: classes/gateways/class.pmprogateway_braintree.php:508
-#: classes/gateways/class.pmprogateway_braintree.php:509
 #: classes/gateways/class.pmprogateway_braintree.php:510
 #: classes/gateways/class.pmprogateway_braintree.php:515
 #: classes/gateways/class.pmprogateway_braintree.php:516
@@ -3844,108 +5342,201 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:661
 #: classes/gateways/class.pmprogateway_stripe.php:944
 #: classes/gateways/class.pmprogateway_stripe.php:1014
-#: classes/gateways/class.pmprogateway_stripe.php:1088 pages/checkout.php:66
-#: pages/checkout.php:67 pages/checkout.php:68 pages/checkout.php:70
-#: pages/checkout.php:75 pages/checkout.php:76 pages/checkout.php:77
-#: pages/checkout.php:78 pages/checkout.php:81 pages/checkout.php:83
-#: pages/checkout.php:85 pages/checkout.php:86 pages/checkout.php:89
-#: pages/checkout.php:93 pages/checkout.php:96 pages/checkout.php:426
-#: pages/checkout.php:498 pages/checkout.php:506 pages/checkout.php:549
-#: pages/checkout.php:565 pages/checkout.php:566 pages/checkout.php:573
-#: pages/checkout.php:594 pages/checkout.php:603 pages/checkout.php:612
-#: pages/checkout.php:616 pages/checkout.php:617 pages/checkout.php:619
-#: pages/checkout.php:622 pages/confirmation.php:51 pages/confirmation.php:52
-#: pages/confirmation.php:57 pages/confirmation.php:58 pages/invoice.php:32
-#: pages/invoice.php:33 pages/invoice.php:34 pages/invoice.php:40
+#: classes/gateways/class.pmprogateway_stripe.php:1088
+#: pages/checkout.php:66
+#: pages/checkout.php:67
+#: pages/checkout.php:68
+#: pages/checkout.php:70
+#: pages/checkout.php:75
+#: pages/checkout.php:76
+#: pages/checkout.php:77
+#: pages/checkout.php:78
+#: pages/checkout.php:81
+#: pages/checkout.php:83
+#: pages/checkout.php:85
+#: pages/checkout.php:89
+#: pages/checkout.php:93
+#: pages/checkout.php:96
+#: pages/checkout.php:426
+#: pages/checkout.php:498
+#: pages/checkout.php:506
+#: pages/checkout.php:549
+#: pages/checkout.php:565
+#: pages/checkout.php:566
+#: pages/checkout.php:573
+#: pages/checkout.php:594
+#: pages/checkout.php:603
+#: pages/checkout.php:612
+#: pages/checkout.php:616
+#: pages/checkout.php:617
+#: pages/checkout.php:619
+#: pages/checkout.php:622
+#: pages/confirmation.php:51
+#: pages/confirmation.php:52
+#: pages/confirmation.php:57
+#: pages/invoice.php:32
+#: pages/invoice.php:33
+#: pages/invoice.php:34
 msgid "Discount Code"
 msgstr ""
 
-#: adminpages/orders.php:584 classes/class.pmproemail.php:865
-#: classes/class.pmproemail.php:915 includes/init.php:198
-#: includes/profile.php:34 adminpages/orders.php:571 adminpages/orders.php:575
-#: adminpages/orders.php:576 adminpages/orders.php:578
-#: adminpages/orders.php:586 classes/class.pmproemail.php:865
-#: classes/class.pmproemail.php:868 classes/class.pmproemail.php:876
-#: classes/class.pmproemail.php:877 classes/class.pmproemail.php:905
-#: classes/class.pmproemail.php:915 includes/init.php:193 includes/init.php:198
-#: includes/init.php:229 includes/init.php:232 includes/init.php:233
-#: includes/init.php:235 includes/init.php:237 includes/init.php:245
-#: includes/init.php:253 includes/init.php:258 includes/init.php:259
-#: includes/init.php:264 includes/init.php:265 includes/init.php:266
-#: includes/init.php:280 includes/init.php:284 includes/profile.php:34
-#: includes/profile.php:37 includes/profile.php:39 includes/profile.php:42
-#: includes/profile.php:43 includes/profile.php:48
+#: adminpages/orders.php:584
+#: classes/class.pmproemail.php:865
+#: classes/class.pmproemail.php:915
+#: includes/init.php:198
+#: includes/profile.php:34
+#: adminpages/orders.php:571
+#: adminpages/orders.php:575
+#: adminpages/orders.php:576
+#: adminpages/orders.php:578
+#: adminpages/orders.php:586
+#: classes/class.pmproemail.php:868
+#: classes/class.pmproemail.php:876
+#: classes/class.pmproemail.php:877
+#: classes/class.pmproemail.php:905
+#: includes/init.php:193
+#: includes/init.php:229
+#: includes/init.php:232
+#: includes/init.php:233
+#: includes/init.php:235
+#: includes/init.php:237
+#: includes/init.php:245
+#: includes/init.php:253
+#: includes/init.php:258
+#: includes/init.php:259
+#: includes/init.php:264
+#: includes/init.php:265
+#: includes/init.php:266
+#: includes/init.php:280
+#: includes/init.php:284
+#: includes/profile.php:37
+#: includes/profile.php:39
+#: includes/profile.php:42
+#: includes/profile.php:43
+#: includes/profile.php:48
 msgid "None"
 msgstr ""
 
-#: adminpages/orders.php:595 includes/privacy.php:273 adminpages/orders.php:296
-#: adminpages/orders.php:346 adminpages/orders.php:418
-#: adminpages/orders.php:447 adminpages/orders.php:470
-#: adminpages/orders.php:501 adminpages/orders.php:512
-#: adminpages/orders.php:542 adminpages/orders.php:582
-#: adminpages/orders.php:586 adminpages/orders.php:587
-#: adminpages/orders.php:589 adminpages/orders.php:597 includes/privacy.php:273
+#: adminpages/orders.php:595
+#: includes/privacy.php:273
+#: adminpages/orders.php:296
+#: adminpages/orders.php:346
+#: adminpages/orders.php:418
+#: adminpages/orders.php:447
+#: adminpages/orders.php:470
+#: adminpages/orders.php:501
+#: adminpages/orders.php:512
+#: adminpages/orders.php:542
+#: adminpages/orders.php:582
+#: adminpages/orders.php:586
+#: adminpages/orders.php:587
+#: adminpages/orders.php:589
+#: adminpages/orders.php:597
 msgid "Sub Total"
 msgstr ""
 
-#: adminpages/orders.php:608 adminpages/templates/orders-email.php:60
-#: adminpages/templates/orders-print.php:89 includes/privacy.php:277
-#: pages/confirmation.php:95 pages/invoice.php:85 adminpages/orders.php:304
-#: adminpages/orders.php:354 adminpages/orders.php:426
-#: adminpages/orders.php:455 adminpages/orders.php:481
-#: adminpages/orders.php:512 adminpages/orders.php:523
-#: adminpages/orders.php:555 adminpages/orders.php:595
-#: adminpages/orders.php:599 adminpages/orders.php:600
-#: adminpages/orders.php:610 adminpages/templates/orders-email.php:60
-#: adminpages/templates/orders-print.php:89 includes/privacy.php:277
-#: pages/confirmation.php:91 pages/confirmation.php:92
-#: pages/confirmation.php:94 pages/confirmation.php:95 pages/invoice.php:73
-#: pages/invoice.php:74 pages/invoice.php:75 pages/invoice.php:76
-#: pages/invoice.php:78 pages/invoice.php:80 pages/invoice.php:84
+#: adminpages/orders.php:608
+#: adminpages/templates/orders-email.php:60
+#: adminpages/templates/orders-print.php:89
+#: includes/privacy.php:277
+#: pages/confirmation.php:95
 #: pages/invoice.php:85
+#: adminpages/orders.php:304
+#: adminpages/orders.php:354
+#: adminpages/orders.php:426
+#: adminpages/orders.php:455
+#: adminpages/orders.php:481
+#: adminpages/orders.php:512
+#: adminpages/orders.php:523
+#: adminpages/orders.php:555
+#: adminpages/orders.php:595
+#: adminpages/orders.php:599
+#: adminpages/orders.php:600
+#: adminpages/orders.php:610
+#: pages/confirmation.php:91
+#: pages/confirmation.php:92
+#: pages/confirmation.php:94
+#: pages/invoice.php:73
+#: pages/invoice.php:74
+#: pages/invoice.php:75
+#: pages/invoice.php:76
+#: pages/invoice.php:78
+#: pages/invoice.php:80
+#: pages/invoice.php:84
 msgid "Tax"
 msgstr ""
 
-#: adminpages/orders.php:625 includes/privacy.php:281 adminpages/orders.php:312
-#: adminpages/orders.php:362 adminpages/orders.php:434
-#: adminpages/orders.php:463 adminpages/orders.php:492
-#: adminpages/orders.php:523 adminpages/orders.php:534
-#: adminpages/orders.php:568 adminpages/orders.php:608
-#: adminpages/orders.php:612 adminpages/orders.php:613
-#: adminpages/orders.php:623 includes/privacy.php:281
+#: adminpages/orders.php:625
+#: includes/privacy.php:281
+#: adminpages/orders.php:312
+#: adminpages/orders.php:362
+#: adminpages/orders.php:434
+#: adminpages/orders.php:463
+#: adminpages/orders.php:492
+#: adminpages/orders.php:523
+#: adminpages/orders.php:534
+#: adminpages/orders.php:568
+#: adminpages/orders.php:608
+#: adminpages/orders.php:612
+#: adminpages/orders.php:613
+#: adminpages/orders.php:623
 msgid "Coupon Amount"
 msgstr ""
 
-#: adminpages/orders.php:657 includes/privacy.php:289 adminpages/orders.php:330
-#: adminpages/orders.php:380 adminpages/orders.php:452
-#: adminpages/orders.php:481 adminpages/orders.php:518
-#: adminpages/orders.php:549 adminpages/orders.php:560
-#: adminpages/orders.php:598 adminpages/orders.php:637
-#: adminpages/orders.php:641 adminpages/orders.php:642
-#: adminpages/orders.php:643 adminpages/orders.php:653 includes/privacy.php:289
+#: adminpages/orders.php:657
+#: includes/privacy.php:289
+#: adminpages/orders.php:330
+#: adminpages/orders.php:380
+#: adminpages/orders.php:452
+#: adminpages/orders.php:481
+#: adminpages/orders.php:518
+#: adminpages/orders.php:549
+#: adminpages/orders.php:560
+#: adminpages/orders.php:598
+#: adminpages/orders.php:637
+#: adminpages/orders.php:641
+#: adminpages/orders.php:642
+#: adminpages/orders.php:643
+#: adminpages/orders.php:653
 msgid "Payment Type"
 msgstr ""
 
-#: adminpages/orders.php:668 adminpages/orders.php:335
-#: adminpages/orders.php:385 adminpages/orders.php:457
-#: adminpages/orders.php:486 adminpages/orders.php:528
-#: adminpages/orders.php:559 adminpages/orders.php:570
-#: adminpages/orders.php:610 adminpages/orders.php:648
-#: adminpages/orders.php:652 adminpages/orders.php:653
-#: adminpages/orders.php:655 adminpages/orders.php:665
+#: adminpages/orders.php:668
+#: adminpages/orders.php:335
+#: adminpages/orders.php:385
+#: adminpages/orders.php:457
+#: adminpages/orders.php:486
+#: adminpages/orders.php:528
+#: adminpages/orders.php:559
+#: adminpages/orders.php:570
+#: adminpages/orders.php:610
+#: adminpages/orders.php:648
+#: adminpages/orders.php:652
+#: adminpages/orders.php:653
+#: adminpages/orders.php:655
+#: adminpages/orders.php:665
 msgid "e.g. PayPal Express, PayPal Standard, Credit Card."
 msgstr ""
 
 #: adminpages/orders.php:672
 #: classes/gateways/class.pmprogateway_braintree.php:466
-#: classes/gateways/class.pmprogateway_stripe.php:1069 includes/privacy.php:293
-#: pages/billing.php:321 pages/checkout.php:377 adminpages/orders.php:339
-#: adminpages/orders.php:389 adminpages/orders.php:461
-#: adminpages/orders.php:490 adminpages/orders.php:532
-#: adminpages/orders.php:563 adminpages/orders.php:574
-#: adminpages/orders.php:614 adminpages/orders.php:652
-#: adminpages/orders.php:656 adminpages/orders.php:657
-#: adminpages/orders.php:659 adminpages/orders.php:669
+#: classes/gateways/class.pmprogateway_stripe.php:1069
+#: includes/privacy.php:293
+#: pages/billing.php:321
+#: pages/checkout.php:377
+#: adminpages/orders.php:339
+#: adminpages/orders.php:389
+#: adminpages/orders.php:461
+#: adminpages/orders.php:490
+#: adminpages/orders.php:532
+#: adminpages/orders.php:563
+#: adminpages/orders.php:574
+#: adminpages/orders.php:614
+#: adminpages/orders.php:652
+#: adminpages/orders.php:656
+#: adminpages/orders.php:657
+#: adminpages/orders.php:659
+#: adminpages/orders.php:669
 #: classes/gateways/class.pmprogateway_braintree.php:291
 #: classes/gateways/class.pmprogateway_braintree.php:304
 #: classes/gateways/class.pmprogateway_braintree.php:306
@@ -3957,7 +5548,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:441
 #: classes/gateways/class.pmprogateway_braintree.php:446
 #: classes/gateways/class.pmprogateway_braintree.php:465
-#: classes/gateways/class.pmprogateway_braintree.php:466
 #: classes/gateways/class.pmprogateway_braintree.php:467
 #: classes/gateways/class.pmprogateway_braintree.php:472
 #: classes/gateways/class.pmprogateway_braintree.php:473
@@ -3985,195 +5575,336 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:590
 #: classes/gateways/class.pmprogateway_stripe.php:914
 #: classes/gateways/class.pmprogateway_stripe.php:984
-#: classes/gateways/class.pmprogateway_stripe.php:1058 includes/privacy.php:293
-#: pages/billing.php:234 pages/billing.php:238 pages/billing.php:247
-#: pages/billing.php:250 pages/billing.php:253 pages/billing.php:262
-#: pages/billing.php:268 pages/billing.php:271 pages/billing.php:274
-#: pages/billing.php:275 pages/billing.php:279 pages/billing.php:280
-#: pages/billing.php:288 pages/billing.php:294 pages/billing.php:297
-#: pages/billing.php:321 pages/checkout.php:374 pages/checkout.php:423
-#: pages/checkout.php:431 pages/checkout.php:493 pages/checkout.php:507
-#: pages/checkout.php:510 pages/checkout.php:516 pages/checkout.php:517
-#: pages/checkout.php:525 pages/checkout.php:527 pages/checkout.php:534
+#: classes/gateways/class.pmprogateway_stripe.php:1058
+#: pages/billing.php:234
+#: pages/billing.php:238
+#: pages/billing.php:247
+#: pages/billing.php:250
+#: pages/billing.php:253
+#: pages/billing.php:262
+#: pages/billing.php:268
+#: pages/billing.php:271
+#: pages/billing.php:274
+#: pages/billing.php:275
+#: pages/billing.php:279
+#: pages/billing.php:280
+#: pages/billing.php:288
+#: pages/billing.php:294
+#: pages/billing.php:297
+#: pages/checkout.php:374
+#: pages/checkout.php:423
+#: pages/checkout.php:431
+#: pages/checkout.php:493
+#: pages/checkout.php:507
+#: pages/checkout.php:510
+#: pages/checkout.php:516
+#: pages/checkout.php:517
+#: pages/checkout.php:525
+#: pages/checkout.php:527
+#: pages/checkout.php:534
 #: pages/checkout.php:537
 msgid "Card Type"
 msgstr ""
 
-#: adminpages/orders.php:682 adminpages/orders.php:344
-#: adminpages/orders.php:394 adminpages/orders.php:466
-#: adminpages/orders.php:495 adminpages/orders.php:540
-#: adminpages/orders.php:571 adminpages/orders.php:582
-#: adminpages/orders.php:624 adminpages/orders.php:662
-#: adminpages/orders.php:666 adminpages/orders.php:667
-#: adminpages/orders.php:669 adminpages/orders.php:679
+#: adminpages/orders.php:682
+#: adminpages/orders.php:344
+#: adminpages/orders.php:394
+#: adminpages/orders.php:466
+#: adminpages/orders.php:495
+#: adminpages/orders.php:540
+#: adminpages/orders.php:571
+#: adminpages/orders.php:582
+#: adminpages/orders.php:624
+#: adminpages/orders.php:662
+#: adminpages/orders.php:666
+#: adminpages/orders.php:667
+#: adminpages/orders.php:669
+#: adminpages/orders.php:679
 msgid "e.g. Visa, MasterCard, AMEX, etc"
 msgstr ""
 
 #: adminpages/orders.php:686
 #: classes/gateways/class.pmprogateway_twocheckout.php:138
-#: includes/privacy.php:297 adminpages/orders.php:348 adminpages/orders.php:398
-#: adminpages/orders.php:470 adminpages/orders.php:499
-#: adminpages/orders.php:544 adminpages/orders.php:575
-#: adminpages/orders.php:586 adminpages/orders.php:628
-#: adminpages/orders.php:666 adminpages/orders.php:670
-#: adminpages/orders.php:671 adminpages/orders.php:673
-#: adminpages/orders.php:683 adminpages/paymentsettings.php:347
+#: includes/privacy.php:297
+#: adminpages/orders.php:348
+#: adminpages/orders.php:398
+#: adminpages/orders.php:470
+#: adminpages/orders.php:499
+#: adminpages/orders.php:544
+#: adminpages/orders.php:575
+#: adminpages/orders.php:586
+#: adminpages/orders.php:628
+#: adminpages/orders.php:666
+#: adminpages/orders.php:670
+#: adminpages/orders.php:671
+#: adminpages/orders.php:673
+#: adminpages/orders.php:683
+#: adminpages/paymentsettings.php:347
 #: adminpages/paymentsettings.php:352
 #: classes/gateways/class.pmprogateway_twocheckout.php:129
 #: classes/gateways/class.pmprogateway_twocheckout.php:137
-#: classes/gateways/class.pmprogateway_twocheckout.php:138
 #: classes/gateways/class.pmprogateway_twocheckout.php:148
-#: includes/privacy.php:297
 msgid "Account Number"
 msgstr ""
 
-#: adminpages/orders.php:697 adminpages/orders.php:353
-#: adminpages/orders.php:403 adminpages/orders.php:475
-#: adminpages/orders.php:504 adminpages/orders.php:553
-#: adminpages/orders.php:584 adminpages/orders.php:595
-#: adminpages/orders.php:639 adminpages/orders.php:677
-#: adminpages/orders.php:681 adminpages/orders.php:682
-#: adminpages/orders.php:684 adminpages/orders.php:694
+#: adminpages/orders.php:697
+#: adminpages/orders.php:353
+#: adminpages/orders.php:403
+#: adminpages/orders.php:475
+#: adminpages/orders.php:504
+#: adminpages/orders.php:553
+#: adminpages/orders.php:584
+#: adminpages/orders.php:595
+#: adminpages/orders.php:639
+#: adminpages/orders.php:677
+#: adminpages/orders.php:681
+#: adminpages/orders.php:682
+#: adminpages/orders.php:684
+#: adminpages/orders.php:694
 msgid "Obscure all but last 4 digits."
 msgstr ""
 
-#: adminpages/orders.php:706 adminpages/orders.php:717 includes/privacy.php:301
-#: adminpages/orders.php:358 adminpages/orders.php:408
-#: adminpages/orders.php:480 adminpages/orders.php:509
-#: adminpages/orders.php:561 adminpages/orders.php:592
-#: adminpages/orders.php:603 adminpages/orders.php:649
-#: adminpages/orders.php:687 adminpages/orders.php:691
-#: adminpages/orders.php:692 adminpages/orders.php:694
-#: adminpages/orders.php:704 includes/privacy.php:301
+#: adminpages/orders.php:706
+#: adminpages/orders.php:717
+#: includes/privacy.php:301
+#: adminpages/orders.php:358
+#: adminpages/orders.php:408
+#: adminpages/orders.php:480
+#: adminpages/orders.php:509
+#: adminpages/orders.php:561
+#: adminpages/orders.php:592
+#: adminpages/orders.php:603
+#: adminpages/orders.php:649
+#: adminpages/orders.php:687
+#: adminpages/orders.php:691
+#: adminpages/orders.php:692
+#: adminpages/orders.php:694
+#: adminpages/orders.php:704
 msgid "Expiration Month"
 msgstr ""
 
-#: adminpages/orders.php:725 includes/privacy.php:305 adminpages/orders.php:365
-#: adminpages/orders.php:415 adminpages/orders.php:487
-#: adminpages/orders.php:516 adminpages/orders.php:569
-#: adminpages/orders.php:600 adminpages/orders.php:611
-#: adminpages/orders.php:657 adminpages/orders.php:695
-#: adminpages/orders.php:699 adminpages/orders.php:700
-#: adminpages/orders.php:702 adminpages/orders.php:712 includes/privacy.php:305
+#: adminpages/orders.php:725
+#: includes/privacy.php:305
+#: adminpages/orders.php:365
+#: adminpages/orders.php:415
+#: adminpages/orders.php:487
+#: adminpages/orders.php:516
+#: adminpages/orders.php:569
+#: adminpages/orders.php:600
+#: adminpages/orders.php:611
+#: adminpages/orders.php:657
+#: adminpages/orders.php:695
+#: adminpages/orders.php:699
+#: adminpages/orders.php:700
+#: adminpages/orders.php:702
+#: adminpages/orders.php:712
 msgid "Expiration Year"
 msgstr ""
 
-#: adminpages/orders.php:757 adminpages/orders.php:1328
-#: classes/class.memberorder.php:948 includes/privacy.php:313
-#: adminpages/orders.php:394 adminpages/orders.php:444
-#: adminpages/orders.php:516 adminpages/orders.php:545
-#: adminpages/orders.php:604 adminpages/orders.php:612
-#: adminpages/orders.php:643 adminpages/orders.php:654
-#: adminpages/orders.php:689 adminpages/orders.php:727
-#: adminpages/orders.php:731 adminpages/orders.php:732
-#: adminpages/orders.php:734 adminpages/orders.php:744
-#: adminpages/orders.php:907 adminpages/orders.php:917
-#: adminpages/orders.php:944 adminpages/orders.php:973
-#: adminpages/orders.php:1110 adminpages/orders.php:1141
-#: adminpages/orders.php:1147 adminpages/orders.php:1238
-#: adminpages/orders.php:1303 adminpages/orders.php:1309
-#: adminpages/orders.php:1314 adminpages/orders.php:1318
-#: adminpages/orders.php:1359 classes/class.memberorder.php:744
-#: classes/class.memberorder.php:747 classes/class.memberorder.php:764
-#: classes/class.memberorder.php:815 classes/class.memberorder.php:860
-#: classes/class.memberorder.php:861 classes/class.memberorder.php:873
-#: classes/class.memberorder.php:946 includes/privacy.php:313
+#: adminpages/orders.php:757
+#: adminpages/orders.php:1328
+#: classes/class.memberorder.php:948
+#: includes/privacy.php:313
+#: adminpages/orders.php:394
+#: adminpages/orders.php:444
+#: adminpages/orders.php:516
+#: adminpages/orders.php:545
+#: adminpages/orders.php:604
+#: adminpages/orders.php:612
+#: adminpages/orders.php:643
+#: adminpages/orders.php:654
+#: adminpages/orders.php:689
+#: adminpages/orders.php:727
+#: adminpages/orders.php:731
+#: adminpages/orders.php:732
+#: adminpages/orders.php:734
+#: adminpages/orders.php:744
+#: adminpages/orders.php:907
+#: adminpages/orders.php:917
+#: adminpages/orders.php:944
+#: adminpages/orders.php:973
+#: adminpages/orders.php:1110
+#: adminpages/orders.php:1141
+#: adminpages/orders.php:1147
+#: adminpages/orders.php:1238
+#: adminpages/orders.php:1303
+#: adminpages/orders.php:1309
+#: adminpages/orders.php:1314
+#: adminpages/orders.php:1318
+#: adminpages/orders.php:1359
+#: classes/class.memberorder.php:744
+#: classes/class.memberorder.php:747
+#: classes/class.memberorder.php:764
+#: classes/class.memberorder.php:815
+#: classes/class.memberorder.php:860
+#: classes/class.memberorder.php:861
+#: classes/class.memberorder.php:873
+#: classes/class.memberorder.php:946
 msgid "Gateway"
 msgstr ""
 
-#: adminpages/orders.php:780 adminpages/paymentsettings.php:148
-#: includes/privacy.php:317 adminpages/orders.php:411 adminpages/orders.php:461
-#: adminpages/orders.php:462 adminpages/orders.php:534
-#: adminpages/orders.php:563 adminpages/orders.php:633
-#: adminpages/orders.php:664 adminpages/orders.php:675
-#: adminpages/orders.php:712 adminpages/orders.php:750
-#: adminpages/orders.php:754 adminpages/orders.php:755
-#: adminpages/orders.php:757 adminpages/orders.php:767
-#: adminpages/paymentsettings.php:124 adminpages/paymentsettings.php:141
-#: adminpages/paymentsettings.php:144 adminpages/paymentsettings.php:145
-#: adminpages/paymentsettings.php:146 adminpages/paymentsettings.php:148
-#: adminpages/paymentsettings.php:175 adminpages/paymentsettings.php:179
-#: adminpages/paymentsettings.php:184 includes/privacy.php:317
+#: adminpages/orders.php:780
+#: adminpages/paymentsettings.php:148
+#: includes/privacy.php:317
+#: adminpages/orders.php:411
+#: adminpages/orders.php:461
+#: adminpages/orders.php:462
+#: adminpages/orders.php:534
+#: adminpages/orders.php:563
+#: adminpages/orders.php:633
+#: adminpages/orders.php:664
+#: adminpages/orders.php:675
+#: adminpages/orders.php:712
+#: adminpages/orders.php:750
+#: adminpages/orders.php:754
+#: adminpages/orders.php:755
+#: adminpages/orders.php:757
+#: adminpages/orders.php:767
+#: adminpages/paymentsettings.php:124
+#: adminpages/paymentsettings.php:141
+#: adminpages/paymentsettings.php:144
+#: adminpages/paymentsettings.php:145
+#: adminpages/paymentsettings.php:146
+#: adminpages/paymentsettings.php:175
+#: adminpages/paymentsettings.php:179
+#: adminpages/paymentsettings.php:184
 msgid "Gateway Environment"
 msgstr ""
 
-#: adminpages/orders.php:788 adminpages/paymentsettings.php:152
-#: adminpages/orders.php:415 adminpages/orders.php:465
-#: adminpages/orders.php:466 adminpages/orders.php:538
-#: adminpages/orders.php:567 adminpages/orders.php:640
-#: adminpages/orders.php:671 adminpages/orders.php:682
-#: adminpages/orders.php:724 adminpages/orders.php:762
-#: adminpages/orders.php:766 adminpages/orders.php:767
-#: adminpages/orders.php:769 adminpages/orders.php:779
-#: adminpages/paymentsettings.php:128 adminpages/paymentsettings.php:145
-#: adminpages/paymentsettings.php:148 adminpages/paymentsettings.php:149
-#: adminpages/paymentsettings.php:150 adminpages/paymentsettings.php:152
-#: adminpages/paymentsettings.php:179 adminpages/paymentsettings.php:183
+#: adminpages/orders.php:788
+#: adminpages/paymentsettings.php:152
+#: adminpages/orders.php:415
+#: adminpages/orders.php:465
+#: adminpages/orders.php:466
+#: adminpages/orders.php:538
+#: adminpages/orders.php:567
+#: adminpages/orders.php:640
+#: adminpages/orders.php:671
+#: adminpages/orders.php:682
+#: adminpages/orders.php:724
+#: adminpages/orders.php:762
+#: adminpages/orders.php:766
+#: adminpages/orders.php:767
+#: adminpages/orders.php:769
+#: adminpages/orders.php:779
+#: adminpages/paymentsettings.php:128
+#: adminpages/paymentsettings.php:145
+#: adminpages/paymentsettings.php:148
+#: adminpages/paymentsettings.php:149
+#: adminpages/paymentsettings.php:150
+#: adminpages/paymentsettings.php:179
+#: adminpages/paymentsettings.php:183
 #: adminpages/paymentsettings.php:188
 msgid "Sandbox/Testing"
 msgstr ""
 
-#: adminpages/orders.php:789 adminpages/paymentsettings.php:153
-#: adminpages/orders.php:416 adminpages/orders.php:466
-#: adminpages/orders.php:467 adminpages/orders.php:539
-#: adminpages/orders.php:568 adminpages/orders.php:642
-#: adminpages/orders.php:673 adminpages/orders.php:684
-#: adminpages/orders.php:729 adminpages/orders.php:767
-#: adminpages/orders.php:771 adminpages/orders.php:772
-#: adminpages/orders.php:774 adminpages/orders.php:784
-#: adminpages/paymentsettings.php:129 adminpages/paymentsettings.php:146
-#: adminpages/paymentsettings.php:149 adminpages/paymentsettings.php:150
-#: adminpages/paymentsettings.php:151 adminpages/paymentsettings.php:153
-#: adminpages/paymentsettings.php:180 adminpages/paymentsettings.php:184
+#: adminpages/orders.php:789
+#: adminpages/paymentsettings.php:153
+#: adminpages/orders.php:416
+#: adminpages/orders.php:466
+#: adminpages/orders.php:467
+#: adminpages/orders.php:539
+#: adminpages/orders.php:568
+#: adminpages/orders.php:642
+#: adminpages/orders.php:673
+#: adminpages/orders.php:684
+#: adminpages/orders.php:729
+#: adminpages/orders.php:767
+#: adminpages/orders.php:771
+#: adminpages/orders.php:772
+#: adminpages/orders.php:774
+#: adminpages/orders.php:784
+#: adminpages/paymentsettings.php:129
+#: adminpages/paymentsettings.php:146
+#: adminpages/paymentsettings.php:149
+#: adminpages/paymentsettings.php:150
+#: adminpages/paymentsettings.php:151
+#: adminpages/paymentsettings.php:180
+#: adminpages/paymentsettings.php:184
 #: adminpages/paymentsettings.php:189
 msgid "Live/Production"
 msgstr ""
 
-#: adminpages/orders.php:797 includes/privacy.php:321 adminpages/orders.php:423
-#: adminpages/orders.php:473 adminpages/orders.php:474
-#: adminpages/orders.php:546 adminpages/orders.php:575
-#: adminpages/orders.php:650 adminpages/orders.php:681
-#: adminpages/orders.php:692 adminpages/orders.php:737
-#: adminpages/orders.php:775 adminpages/orders.php:779
-#: adminpages/orders.php:780 adminpages/orders.php:782
-#: adminpages/orders.php:783 adminpages/orders.php:792 includes/privacy.php:321
+#: adminpages/orders.php:797
+#: includes/privacy.php:321
+#: adminpages/orders.php:423
+#: adminpages/orders.php:473
+#: adminpages/orders.php:474
+#: adminpages/orders.php:546
+#: adminpages/orders.php:575
+#: adminpages/orders.php:650
+#: adminpages/orders.php:681
+#: adminpages/orders.php:692
+#: adminpages/orders.php:737
+#: adminpages/orders.php:775
+#: adminpages/orders.php:779
+#: adminpages/orders.php:780
+#: adminpages/orders.php:782
+#: adminpages/orders.php:783
+#: adminpages/orders.php:792
 msgid "Payment Transaction ID"
 msgstr ""
 
-#: adminpages/orders.php:807 adminpages/orders.php:428
-#: adminpages/orders.php:478 adminpages/orders.php:479
-#: adminpages/orders.php:551 adminpages/orders.php:580
-#: adminpages/orders.php:659 adminpages/orders.php:690
-#: adminpages/orders.php:701 adminpages/orders.php:748
-#: adminpages/orders.php:785 adminpages/orders.php:789
-#: adminpages/orders.php:790 adminpages/orders.php:793
+#: adminpages/orders.php:807
+#: adminpages/orders.php:428
+#: adminpages/orders.php:478
+#: adminpages/orders.php:479
+#: adminpages/orders.php:551
+#: adminpages/orders.php:580
+#: adminpages/orders.php:659
+#: adminpages/orders.php:690
+#: adminpages/orders.php:701
+#: adminpages/orders.php:748
+#: adminpages/orders.php:785
+#: adminpages/orders.php:789
+#: adminpages/orders.php:790
+#: adminpages/orders.php:793
 #: adminpages/orders.php:803
 msgid "Generated by the gateway. Useful to cross reference orders."
 msgstr ""
 
-#: adminpages/orders.php:812 classes/class.memberorder.php:949
-#: includes/privacy.php:325 adminpages/orders.php:432 adminpages/orders.php:482
-#: adminpages/orders.php:483 adminpages/orders.php:555
-#: adminpages/orders.php:584 adminpages/orders.php:664
-#: adminpages/orders.php:695 adminpages/orders.php:706
-#: adminpages/orders.php:753 adminpages/orders.php:790
-#: adminpages/orders.php:794 adminpages/orders.php:795
-#: adminpages/orders.php:798 adminpages/orders.php:808
-#: classes/class.memberorder.php:745 classes/class.memberorder.php:748
-#: classes/class.memberorder.php:765 classes/class.memberorder.php:816
-#: classes/class.memberorder.php:861 classes/class.memberorder.php:862
-#: classes/class.memberorder.php:874 classes/class.memberorder.php:947
+#: adminpages/orders.php:812
+#: classes/class.memberorder.php:949
 #: includes/privacy.php:325
+#: adminpages/orders.php:432
+#: adminpages/orders.php:482
+#: adminpages/orders.php:483
+#: adminpages/orders.php:555
+#: adminpages/orders.php:584
+#: adminpages/orders.php:664
+#: adminpages/orders.php:695
+#: adminpages/orders.php:706
+#: adminpages/orders.php:753
+#: adminpages/orders.php:790
+#: adminpages/orders.php:794
+#: adminpages/orders.php:795
+#: adminpages/orders.php:798
+#: adminpages/orders.php:808
+#: classes/class.memberorder.php:745
+#: classes/class.memberorder.php:748
+#: classes/class.memberorder.php:765
+#: classes/class.memberorder.php:816
+#: classes/class.memberorder.php:861
+#: classes/class.memberorder.php:862
+#: classes/class.memberorder.php:874
+#: classes/class.memberorder.php:947
 msgid "Subscription Transaction ID"
 msgstr ""
 
-#: adminpages/orders.php:823 adminpages/orders.php:437
-#: adminpages/orders.php:487 adminpages/orders.php:488
-#: adminpages/orders.php:560 adminpages/orders.php:589
-#: adminpages/orders.php:674 adminpages/orders.php:705
-#: adminpages/orders.php:716 adminpages/orders.php:765
-#: adminpages/orders.php:801 adminpages/orders.php:805
-#: adminpages/orders.php:806 adminpages/orders.php:810
+#: adminpages/orders.php:823
+#: adminpages/orders.php:437
+#: adminpages/orders.php:487
+#: adminpages/orders.php:488
+#: adminpages/orders.php:560
+#: adminpages/orders.php:589
+#: adminpages/orders.php:674
+#: adminpages/orders.php:705
+#: adminpages/orders.php:716
+#: adminpages/orders.php:765
+#: adminpages/orders.php:801
+#: adminpages/orders.php:805
+#: adminpages/orders.php:806
+#: adminpages/orders.php:810
 #: adminpages/orders.php:820
 msgid "Generated by the gateway. Useful to cross reference subscriptions."
 msgstr ""
@@ -4182,184 +5913,285 @@ msgstr ""
 msgid "at"
 msgstr ""
 
-#: adminpages/orders.php:873 adminpages/orders.php:477
-#: adminpages/orders.php:527 adminpages/orders.php:599
-#: adminpages/orders.php:628 adminpages/orders.php:716
-#: adminpages/orders.php:747 adminpages/orders.php:758
-#: adminpages/orders.php:812 adminpages/orders.php:848
-#: adminpages/orders.php:852 adminpages/orders.php:857
-#: adminpages/orders.php:858 adminpages/orders.php:867
+#: adminpages/orders.php:873
+#: adminpages/orders.php:477
+#: adminpages/orders.php:527
+#: adminpages/orders.php:599
+#: adminpages/orders.php:628
+#: adminpages/orders.php:716
+#: adminpages/orders.php:747
+#: adminpages/orders.php:758
+#: adminpages/orders.php:812
+#: adminpages/orders.php:848
+#: adminpages/orders.php:852
+#: adminpages/orders.php:857
+#: adminpages/orders.php:858
+#: adminpages/orders.php:867
 msgid "Affiliate ID"
 msgstr ""
 
-#: adminpages/orders.php:886 adminpages/orders.php:485
-#: adminpages/orders.php:535 adminpages/orders.php:607
-#: adminpages/orders.php:636 adminpages/orders.php:728
-#: adminpages/orders.php:759 adminpages/orders.php:770
-#: adminpages/orders.php:826 adminpages/orders.php:862
-#: adminpages/orders.php:866 adminpages/orders.php:871
-#: adminpages/orders.php:872 adminpages/orders.php:881
+#: adminpages/orders.php:886
+#: adminpages/orders.php:485
+#: adminpages/orders.php:535
+#: adminpages/orders.php:607
+#: adminpages/orders.php:636
+#: adminpages/orders.php:728
+#: adminpages/orders.php:759
+#: adminpages/orders.php:770
+#: adminpages/orders.php:826
+#: adminpages/orders.php:862
+#: adminpages/orders.php:866
+#: adminpages/orders.php:871
+#: adminpages/orders.php:872
+#: adminpages/orders.php:881
 msgid "Affiliate SubID"
 msgstr ""
 
-#: adminpages/orders.php:907 adminpages/orders.php:848
-#: adminpages/orders.php:884 adminpages/orders.php:888
-#: adminpages/orders.php:893 adminpages/orders.php:894
+#: adminpages/orders.php:907
+#: adminpages/orders.php:848
+#: adminpages/orders.php:884
+#: adminpages/orders.php:888
+#: adminpages/orders.php:893
+#: adminpages/orders.php:894
 #: adminpages/orders.php:903
 msgid "TOS Consent"
 msgstr ""
 
-#: adminpages/orders.php:922 adminpages/orders.php:495
-#: adminpages/orders.php:545 adminpages/orders.php:617
-#: adminpages/orders.php:646 adminpages/orders.php:742
-#: adminpages/orders.php:773 adminpages/orders.php:784
-#: adminpages/orders.php:865 adminpages/orders.php:901
-#: adminpages/orders.php:905 adminpages/orders.php:910
-#: adminpages/orders.php:911 adminpages/orders.php:920
+#: adminpages/orders.php:922
+#: adminpages/orders.php:495
+#: adminpages/orders.php:545
+#: adminpages/orders.php:617
+#: adminpages/orders.php:646
+#: adminpages/orders.php:742
+#: adminpages/orders.php:773
+#: adminpages/orders.php:784
+#: adminpages/orders.php:865
+#: adminpages/orders.php:901
+#: adminpages/orders.php:905
+#: adminpages/orders.php:910
+#: adminpages/orders.php:911
+#: adminpages/orders.php:920
 msgid "Notes"
 msgstr ""
 
-#: adminpages/orders.php:949 adminpages/orders.php:510
-#: adminpages/orders.php:560 adminpages/orders.php:632
-#: adminpages/orders.php:661 adminpages/orders.php:764
-#: adminpages/orders.php:795 adminpages/orders.php:806
-#: adminpages/orders.php:893 adminpages/orders.php:929
-#: adminpages/orders.php:933 adminpages/orders.php:938
-#: adminpages/orders.php:939 adminpages/orders.php:948
+#: adminpages/orders.php:949
+#: adminpages/orders.php:510
+#: adminpages/orders.php:560
+#: adminpages/orders.php:632
+#: adminpages/orders.php:661
+#: adminpages/orders.php:764
+#: adminpages/orders.php:795
+#: adminpages/orders.php:806
+#: adminpages/orders.php:893
+#: adminpages/orders.php:929
+#: adminpages/orders.php:933
+#: adminpages/orders.php:938
+#: adminpages/orders.php:939
+#: adminpages/orders.php:948
 msgid "Save Order"
 msgstr ""
 
-#: adminpages/orders.php:961 adminpages/orders.php:521
-#: adminpages/orders.php:571 adminpages/orders.php:678
-#: adminpages/orders.php:707 adminpages/orders.php:812
-#: adminpages/orders.php:843 adminpages/orders.php:854
-#: adminpages/orders.php:941 adminpages/orders.php:946
-#: adminpages/orders.php:951 adminpages/orders.php:996
+#: adminpages/orders.php:961
+#: adminpages/orders.php:521
+#: adminpages/orders.php:571
+#: adminpages/orders.php:678
+#: adminpages/orders.php:707
+#: adminpages/orders.php:812
+#: adminpages/orders.php:843
+#: adminpages/orders.php:854
+#: adminpages/orders.php:941
+#: adminpages/orders.php:946
+#: adminpages/orders.php:951
+#: adminpages/orders.php:996
 msgid "Add New Order"
 msgstr ""
 
-#: adminpages/orders.php:1002 adminpages/reports/login.php:103
-#: adminpages/reports/memberships.php:349 adminpages/reports/sales.php:288
-#: classes/class-pmpro-members-list-table.php:623 adminpages/memberslist.php:30
-#: adminpages/orders.php:603 adminpages/orders.php:710
-#: adminpages/orders.php:739 adminpages/orders.php:848
-#: adminpages/orders.php:879 adminpages/orders.php:890
-#: adminpages/orders.php:981 adminpages/orders.php:982
-#: adminpages/orders.php:987 adminpages/orders.php:992
-#: adminpages/orders.php:1037 adminpages/reports/login.php:65
-#: adminpages/reports/login.php:67 adminpages/reports/login.php:83
-#: adminpages/reports/login.php:87 adminpages/reports/login.php:103
+#: adminpages/orders.php:1002
+#: adminpages/reports/login.php:103
+#: adminpages/reports/memberships.php:349
+#: adminpages/reports/sales.php:288
+#: classes/class-pmpro-members-list-table.php:623
+#: adminpages/memberslist.php:30
+#: adminpages/orders.php:603
+#: adminpages/orders.php:710
+#: adminpages/orders.php:739
+#: adminpages/orders.php:848
+#: adminpages/orders.php:879
+#: adminpages/orders.php:890
+#: adminpages/orders.php:981
+#: adminpages/orders.php:982
+#: adminpages/orders.php:987
+#: adminpages/orders.php:992
+#: adminpages/orders.php:1037
+#: adminpages/reports/login.php:65
+#: adminpages/reports/login.php:67
+#: adminpages/reports/login.php:83
+#: adminpages/reports/login.php:87
 #: adminpages/reports/memberships.php:256
 #: adminpages/reports/memberships.php:263
 #: adminpages/reports/memberships.php:276
 #: adminpages/reports/memberships.php:292
 #: adminpages/reports/memberships.php:304
 #: adminpages/reports/memberships.php:328
-#: adminpages/reports/memberships.php:349 adminpages/reports/sales.php:185
-#: adminpages/reports/sales.php:193 adminpages/reports/sales.php:194
-#: adminpages/reports/sales.php:202 adminpages/reports/sales.php:203
-#: adminpages/reports/sales.php:219 adminpages/reports/sales.php:288
+#: adminpages/reports/sales.php:185
+#: adminpages/reports/sales.php:193
+#: adminpages/reports/sales.php:194
+#: adminpages/reports/sales.php:202
+#: adminpages/reports/sales.php:203
+#: adminpages/reports/sales.php:219
 #: classes/class-pmpro-members-list-table.php:532
 #: classes/class-pmpro-members-list-table.php:592
 #: classes/class-pmpro-members-list-table.php:600
 #: classes/class-pmpro-members-list-table.php:616
-#: classes/class-pmpro-members-list-table.php:623
 #: classes/class-pmpro-members-list-table.php:660
 msgid "Show"
 msgstr ""
 
-#: adminpages/orders.php:1006 adminpages/orders.php:606
-#: adminpages/orders.php:713 adminpages/orders.php:742
-#: adminpages/orders.php:852 adminpages/orders.php:883
-#: adminpages/orders.php:894 adminpages/orders.php:985
-#: adminpages/orders.php:986 adminpages/orders.php:991
-#: adminpages/orders.php:996 adminpages/orders.php:1041
+#: adminpages/orders.php:1006
+#: adminpages/orders.php:606
+#: adminpages/orders.php:713
+#: adminpages/orders.php:742
+#: adminpages/orders.php:852
+#: adminpages/orders.php:883
+#: adminpages/orders.php:894
+#: adminpages/orders.php:985
+#: adminpages/orders.php:986
+#: adminpages/orders.php:991
+#: adminpages/orders.php:996
+#: adminpages/orders.php:1041
 msgid "Within a Date Range"
 msgstr ""
 
-#: adminpages/orders.php:1008 adminpages/orders.php:607
-#: adminpages/orders.php:714 adminpages/orders.php:743
-#: adminpages/orders.php:854 adminpages/orders.php:885
-#: adminpages/orders.php:896 adminpages/orders.php:987
-#: adminpages/orders.php:988 adminpages/orders.php:993
-#: adminpages/orders.php:998 adminpages/orders.php:1043
+#: adminpages/orders.php:1008
+#: adminpages/orders.php:607
+#: adminpages/orders.php:714
+#: adminpages/orders.php:743
+#: adminpages/orders.php:854
+#: adminpages/orders.php:885
+#: adminpages/orders.php:896
+#: adminpages/orders.php:987
+#: adminpages/orders.php:988
+#: adminpages/orders.php:993
+#: adminpages/orders.php:998
+#: adminpages/orders.php:1043
 msgid "Predefined Date Range"
 msgstr ""
 
-#: adminpages/orders.php:1010 adminpages/orders.php:608
-#: adminpages/orders.php:715 adminpages/orders.php:744
-#: adminpages/orders.php:856 adminpages/orders.php:887
-#: adminpages/orders.php:898 adminpages/orders.php:989
-#: adminpages/orders.php:990 adminpages/orders.php:995
-#: adminpages/orders.php:1000 adminpages/orders.php:1045
+#: adminpages/orders.php:1010
+#: adminpages/orders.php:608
+#: adminpages/orders.php:715
+#: adminpages/orders.php:744
+#: adminpages/orders.php:856
+#: adminpages/orders.php:887
+#: adminpages/orders.php:898
+#: adminpages/orders.php:989
+#: adminpages/orders.php:990
+#: adminpages/orders.php:995
+#: adminpages/orders.php:1000
+#: adminpages/orders.php:1045
 msgid "Within a Level"
 msgstr ""
 
-#: adminpages/orders.php:1012 adminpages/orders.php:992
-#: adminpages/orders.php:997 adminpages/orders.php:1002
+#: adminpages/orders.php:1012
+#: adminpages/orders.php:992
+#: adminpages/orders.php:997
+#: adminpages/orders.php:1002
 #: adminpages/orders.php:1047
 msgid "With a Discount Code"
 msgstr ""
 
-#: adminpages/orders.php:1014 adminpages/orders.php:609
-#: adminpages/orders.php:716 adminpages/orders.php:745
-#: adminpages/orders.php:858 adminpages/orders.php:889
-#: adminpages/orders.php:900 adminpages/orders.php:991
-#: adminpages/orders.php:994 adminpages/orders.php:999
-#: adminpages/orders.php:1004 adminpages/orders.php:1049
+#: adminpages/orders.php:1014
+#: adminpages/orders.php:609
+#: adminpages/orders.php:716
+#: adminpages/orders.php:745
+#: adminpages/orders.php:858
+#: adminpages/orders.php:889
+#: adminpages/orders.php:900
+#: adminpages/orders.php:991
+#: adminpages/orders.php:994
+#: adminpages/orders.php:999
+#: adminpages/orders.php:1004
+#: adminpages/orders.php:1049
 msgid "Within a Status"
 msgstr ""
 
-#: adminpages/orders.php:1016 adminpages/orders.php:996
-#: adminpages/orders.php:1001 adminpages/orders.php:1006
+#: adminpages/orders.php:1016
+#: adminpages/orders.php:996
+#: adminpages/orders.php:1001
+#: adminpages/orders.php:1006
 #: adminpages/orders.php:1051
 msgid "Only Paid Orders"
 msgstr ""
 
-#: adminpages/orders.php:1018 adminpages/orders.php:998
-#: adminpages/orders.php:1003 adminpages/orders.php:1008
+#: adminpages/orders.php:1018
+#: adminpages/orders.php:998
+#: adminpages/orders.php:1003
+#: adminpages/orders.php:1008
 #: adminpages/orders.php:1053
 msgid "Only Free Orders"
 msgstr ""
 
-#: adminpages/orders.php:1026 adminpages/orders.php:612
-#: adminpages/orders.php:719 adminpages/orders.php:748
-#: adminpages/orders.php:861 adminpages/orders.php:892
-#: adminpages/orders.php:903 adminpages/orders.php:994
-#: adminpages/orders.php:1001 adminpages/orders.php:1006
-#: adminpages/orders.php:1011 adminpages/orders.php:1016
+#: adminpages/orders.php:1026
+#: adminpages/orders.php:612
+#: adminpages/orders.php:719
+#: adminpages/orders.php:748
+#: adminpages/orders.php:861
+#: adminpages/orders.php:892
+#: adminpages/orders.php:903
+#: adminpages/orders.php:994
+#: adminpages/orders.php:1001
+#: adminpages/orders.php:1006
+#: adminpages/orders.php:1011
+#: adminpages/orders.php:1016
 #: adminpages/orders.php:1056
 msgid "From"
 msgstr ""
 
-#: adminpages/orders.php:1041 adminpages/orders.php:624
-#: adminpages/orders.php:731 adminpages/orders.php:760
-#: adminpages/orders.php:876 adminpages/orders.php:907
-#: adminpages/orders.php:918 adminpages/orders.php:1009
-#: adminpages/orders.php:1016 adminpages/orders.php:1021
-#: adminpages/orders.php:1026 adminpages/orders.php:1031
+#: adminpages/orders.php:1041
+#: adminpages/orders.php:624
+#: adminpages/orders.php:731
+#: adminpages/orders.php:760
+#: adminpages/orders.php:876
+#: adminpages/orders.php:907
+#: adminpages/orders.php:918
+#: adminpages/orders.php:1009
+#: adminpages/orders.php:1016
+#: adminpages/orders.php:1021
+#: adminpages/orders.php:1026
+#: adminpages/orders.php:1031
 #: adminpages/orders.php:1071
 msgid "To"
 msgstr ""
 
-#: adminpages/orders.php:1054 adminpages/orders.php:636
-#: adminpages/orders.php:743 adminpages/orders.php:772
-#: adminpages/orders.php:889 adminpages/orders.php:920
-#: adminpages/orders.php:931 adminpages/orders.php:1022
-#: adminpages/orders.php:1029 adminpages/orders.php:1034
-#: adminpages/orders.php:1039 adminpages/orders.php:1044
+#: adminpages/orders.php:1054
+#: adminpages/orders.php:636
+#: adminpages/orders.php:743
+#: adminpages/orders.php:772
+#: adminpages/orders.php:889
+#: adminpages/orders.php:920
+#: adminpages/orders.php:931
+#: adminpages/orders.php:1022
+#: adminpages/orders.php:1029
+#: adminpages/orders.php:1034
+#: adminpages/orders.php:1039
+#: adminpages/orders.php:1044
 #: adminpages/orders.php:1084
 msgid "filter by "
 msgstr ""
 
-#: adminpages/orders.php:1059 adminpages/reports/login.php:50
-#: adminpages/reports/memberships.php:68 adminpages/reports/sales.php:51
-#: adminpages/reports/login.php:44 adminpages/reports/login.php:50
-#: adminpages/reports/memberships.php:47 adminpages/reports/memberships.php:48
-#: adminpages/reports/memberships.php:58 adminpages/reports/memberships.php:68
-#: adminpages/reports/memberships.php:69 adminpages/reports/memberships.php:77
-#: adminpages/reports/sales.php:51 adminpages/reports/sales.php:52
-#: adminpages/reports/sales.php:56 adminpages/reports/sales.php:57
+#: adminpages/orders.php:1059
+#: adminpages/reports/login.php:50
+#: adminpages/reports/memberships.php:68
+#: adminpages/reports/sales.php:51
+#: adminpages/reports/login.php:44
+#: adminpages/reports/memberships.php:47
+#: adminpages/reports/memberships.php:48
+#: adminpages/reports/memberships.php:58
+#: adminpages/reports/memberships.php:69
+#: adminpages/reports/memberships.php:77
+#: adminpages/reports/sales.php:52
+#: adminpages/reports/sales.php:56
+#: adminpages/reports/sales.php:57
 msgid "This Month"
 msgstr ""
 
@@ -4367,12 +6199,16 @@ msgstr ""
 msgid "Last Month"
 msgstr ""
 
-#: adminpages/orders.php:1063 adminpages/reports/memberships.php:69
-#: adminpages/reports/sales.php:52 adminpages/reports/memberships.php:48
-#: adminpages/reports/memberships.php:53 adminpages/reports/memberships.php:54
-#: adminpages/reports/memberships.php:69 adminpages/reports/memberships.php:70
-#: adminpages/reports/memberships.php:73 adminpages/reports/sales.php:52
-#: adminpages/reports/sales.php:53 adminpages/reports/sales.php:61
+#: adminpages/orders.php:1063
+#: adminpages/reports/memberships.php:69
+#: adminpages/reports/sales.php:52
+#: adminpages/reports/memberships.php:48
+#: adminpages/reports/memberships.php:53
+#: adminpages/reports/memberships.php:54
+#: adminpages/reports/memberships.php:70
+#: adminpages/reports/memberships.php:73
+#: adminpages/reports/sales.php:53
+#: adminpages/reports/sales.php:61
 #: adminpages/reports/sales.php:62
 msgid "This Year"
 msgstr ""
@@ -4381,219 +6217,329 @@ msgstr ""
 msgid "Last Year"
 msgstr ""
 
-#: adminpages/orders.php:1104 adminpages/orders.php:674
-#: adminpages/orders.php:780 adminpages/orders.php:809
-#: adminpages/orders.php:932 adminpages/orders.php:963
-#: adminpages/orders.php:969 adminpages/orders.php:1060
-#: adminpages/orders.php:1079 adminpages/orders.php:1085
-#: adminpages/orders.php:1090 adminpages/orders.php:1094
+#: adminpages/orders.php:1104
+#: adminpages/orders.php:674
+#: adminpages/orders.php:780
+#: adminpages/orders.php:809
+#: adminpages/orders.php:932
+#: adminpages/orders.php:963
+#: adminpages/orders.php:969
+#: adminpages/orders.php:1060
+#: adminpages/orders.php:1079
+#: adminpages/orders.php:1085
+#: adminpages/orders.php:1090
+#: adminpages/orders.php:1094
 #: adminpages/orders.php:1135
 msgid "Filter"
 msgstr ""
 
-#: adminpages/orders.php:1238 adminpages/orders.php:1241
-#: adminpages/orders.php:535 adminpages/orders.php:538
-#: adminpages/orders.php:777 adminpages/orders.php:780
-#: adminpages/orders.php:883 adminpages/orders.php:886
-#: adminpages/orders.php:912 adminpages/orders.php:915
-#: adminpages/orders.php:1029 adminpages/orders.php:1032
-#: adminpages/orders.php:1060 adminpages/orders.php:1063
-#: adminpages/orders.php:1066 adminpages/orders.php:1069
-#: adminpages/orders.php:1157 adminpages/orders.php:1160
-#: adminpages/orders.php:1213 adminpages/orders.php:1216
-#: adminpages/orders.php:1219 adminpages/orders.php:1222
-#: adminpages/orders.php:1224 adminpages/orders.php:1227
-#: adminpages/orders.php:1228 adminpages/orders.php:1231
-#: adminpages/orders.php:1269 adminpages/orders.php:1272
+#: adminpages/orders.php:1238
+#: adminpages/orders.php:1241
+#: adminpages/orders.php:535
+#: adminpages/orders.php:538
+#: adminpages/orders.php:777
+#: adminpages/orders.php:780
+#: adminpages/orders.php:883
+#: adminpages/orders.php:886
+#: adminpages/orders.php:912
+#: adminpages/orders.php:915
+#: adminpages/orders.php:1029
+#: adminpages/orders.php:1032
+#: adminpages/orders.php:1060
+#: adminpages/orders.php:1063
+#: adminpages/orders.php:1066
+#: adminpages/orders.php:1069
+#: adminpages/orders.php:1157
+#: adminpages/orders.php:1160
+#: adminpages/orders.php:1213
+#: adminpages/orders.php:1216
+#: adminpages/orders.php:1219
+#: adminpages/orders.php:1222
+#: adminpages/orders.php:1224
+#: adminpages/orders.php:1227
+#: adminpages/orders.php:1228
+#: adminpages/orders.php:1231
+#: adminpages/orders.php:1269
+#: adminpages/orders.php:1272
 msgid "Search Orders"
 msgstr ""
 
-#: adminpages/orders.php:1314 adminpages/orders.php:590
-#: adminpages/orders.php:893 adminpages/orders.php:903
-#: adminpages/orders.php:930 adminpages/orders.php:959
-#: adminpages/orders.php:1096 adminpages/orders.php:1127
-#: adminpages/orders.php:1133 adminpages/orders.php:1224
-#: adminpages/orders.php:1289 adminpages/orders.php:1295
-#: adminpages/orders.php:1300 adminpages/orders.php:1304
+#: adminpages/orders.php:1314
+#: adminpages/orders.php:590
+#: adminpages/orders.php:893
+#: adminpages/orders.php:903
+#: adminpages/orders.php:930
+#: adminpages/orders.php:959
+#: adminpages/orders.php:1096
+#: adminpages/orders.php:1127
+#: adminpages/orders.php:1133
+#: adminpages/orders.php:1224
+#: adminpages/orders.php:1289
+#: adminpages/orders.php:1295
+#: adminpages/orders.php:1300
+#: adminpages/orders.php:1304
 #: adminpages/orders.php:1345
 #, php-format
 msgid "%d orders found."
 msgstr ""
 
-#: adminpages/orders.php:1327 adminpages/orders.php:1449
-#: adminpages/orders.php:603 adminpages/orders.php:651
-#: adminpages/orders.php:906 adminpages/orders.php:916
-#: adminpages/orders.php:943 adminpages/orders.php:954
-#: adminpages/orders.php:972 adminpages/orders.php:982
-#: adminpages/orders.php:1011 adminpages/orders.php:1040
-#: adminpages/orders.php:1109 adminpages/orders.php:1140
-#: adminpages/orders.php:1146 adminpages/orders.php:1186
-#: adminpages/orders.php:1220 adminpages/orders.php:1226
-#: adminpages/orders.php:1237 adminpages/orders.php:1302
-#: adminpages/orders.php:1308 adminpages/orders.php:1313
-#: adminpages/orders.php:1317 adminpages/orders.php:1335
-#: adminpages/orders.php:1358 adminpages/orders.php:1419
-#: adminpages/orders.php:1424 adminpages/orders.php:1425
-#: adminpages/orders.php:1440 adminpages/orders.php:1457
+#: adminpages/orders.php:1327
+#: adminpages/orders.php:1449
+#: adminpages/orders.php:603
+#: adminpages/orders.php:651
+#: adminpages/orders.php:906
+#: adminpages/orders.php:916
+#: adminpages/orders.php:943
+#: adminpages/orders.php:954
+#: adminpages/orders.php:972
+#: adminpages/orders.php:982
+#: adminpages/orders.php:1011
+#: adminpages/orders.php:1040
+#: adminpages/orders.php:1109
+#: adminpages/orders.php:1140
+#: adminpages/orders.php:1146
+#: adminpages/orders.php:1186
+#: adminpages/orders.php:1220
+#: adminpages/orders.php:1226
+#: adminpages/orders.php:1237
+#: adminpages/orders.php:1302
+#: adminpages/orders.php:1308
+#: adminpages/orders.php:1313
+#: adminpages/orders.php:1317
+#: adminpages/orders.php:1335
+#: adminpages/orders.php:1358
+#: adminpages/orders.php:1419
+#: adminpages/orders.php:1424
+#: adminpages/orders.php:1425
+#: adminpages/orders.php:1440
+#: adminpages/orders.php:1457
 msgid "Payment"
 msgstr ""
 
-#: adminpages/orders.php:1329 adminpages/orders.php:605
-#: adminpages/orders.php:908 adminpages/orders.php:918
-#: adminpages/orders.php:945 adminpages/orders.php:974
-#: adminpages/orders.php:1111 adminpages/orders.php:1142
-#: adminpages/orders.php:1148 adminpages/orders.php:1239
-#: adminpages/orders.php:1304 adminpages/orders.php:1310
-#: adminpages/orders.php:1315 adminpages/orders.php:1319
+#: adminpages/orders.php:1329
+#: adminpages/orders.php:605
+#: adminpages/orders.php:908
+#: adminpages/orders.php:918
+#: adminpages/orders.php:945
+#: adminpages/orders.php:974
+#: adminpages/orders.php:1111
+#: adminpages/orders.php:1142
+#: adminpages/orders.php:1148
+#: adminpages/orders.php:1239
+#: adminpages/orders.php:1304
+#: adminpages/orders.php:1310
+#: adminpages/orders.php:1315
+#: adminpages/orders.php:1319
 #: adminpages/orders.php:1360
 msgid "Transaction IDs"
 msgstr ""
 
-#: adminpages/orders.php:1360 adminpages/orders.php:664
-#: adminpages/orders.php:967 adminpages/orders.php:985
-#: adminpages/orders.php:995 adminpages/orders.php:998
-#: adminpages/orders.php:1027 adminpages/orders.php:1056
-#: adminpages/orders.php:1211 adminpages/orders.php:1245
-#: adminpages/orders.php:1251 adminpages/orders.php:1338
-#: adminpages/orders.php:1343 adminpages/orders.php:1344
-#: adminpages/orders.php:1346 adminpages/orders.php:1347
-#: adminpages/orders.php:1353 adminpages/orders.php:1358
-#: adminpages/orders.php:1366 adminpages/orders.php:1495
+#: adminpages/orders.php:1360
+#: adminpages/orders.php:664
+#: adminpages/orders.php:967
+#: adminpages/orders.php:985
+#: adminpages/orders.php:995
+#: adminpages/orders.php:998
+#: adminpages/orders.php:1027
+#: adminpages/orders.php:1056
+#: adminpages/orders.php:1211
+#: adminpages/orders.php:1245
+#: adminpages/orders.php:1251
+#: adminpages/orders.php:1338
+#: adminpages/orders.php:1343
+#: adminpages/orders.php:1344
+#: adminpages/orders.php:1346
+#: adminpages/orders.php:1347
+#: adminpages/orders.php:1353
+#: adminpages/orders.php:1358
+#: adminpages/orders.php:1366
+#: adminpages/orders.php:1495
 #, php-format
-msgid ""
-"Deleting orders is permanent and can affect active users. Are you sure you "
-"want to delete order %s?"
+msgid "Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?"
 msgstr ""
 
-#: adminpages/orders.php:1458 adminpages/orders.php:653
-#: adminpages/orders.php:956 adminpages/orders.php:974
-#: adminpages/orders.php:984 adminpages/orders.php:1013
-#: adminpages/orders.php:1042 adminpages/orders.php:1192
-#: adminpages/orders.php:1226 adminpages/orders.php:1232
-#: adminpages/orders.php:1344 adminpages/orders.php:1428
-#: adminpages/orders.php:1433 adminpages/orders.php:1434
-#: adminpages/orders.php:1449 adminpages/orders.php:1466
+#: adminpages/orders.php:1458
+#: adminpages/orders.php:653
+#: adminpages/orders.php:956
+#: adminpages/orders.php:974
+#: adminpages/orders.php:984
+#: adminpages/orders.php:1013
+#: adminpages/orders.php:1042
+#: adminpages/orders.php:1192
+#: adminpages/orders.php:1226
+#: adminpages/orders.php:1232
+#: adminpages/orders.php:1344
+#: adminpages/orders.php:1428
+#: adminpages/orders.php:1433
+#: adminpages/orders.php:1434
+#: adminpages/orders.php:1449
+#: adminpages/orders.php:1466
 msgid "Subscription"
 msgstr ""
 
-#: adminpages/orders.php:1475 adminpages/discountcodes.php:614
-#: adminpages/discountcodes.php:619 adminpages/discountcodes.php:647
-#: adminpages/discountcodes.php:648 adminpages/discountcodes.php:649
-#: adminpages/discountcodes.php:650 adminpages/discountcodes.php:655
-#: adminpages/discountcodes.php:735 adminpages/discountcodes.php:789
-#: adminpages/discountcodes.php:803 adminpages/membershiplevels.php:564
-#: adminpages/membershiplevels.php:570 adminpages/membershiplevels.php:572
-#: adminpages/membershiplevels.php:580 adminpages/membershiplevels.php:599
-#: adminpages/membershiplevels.php:660 adminpages/membershiplevels.php:662
-#: adminpages/membershiplevels.php:664 adminpages/membershiplevels.php:669
-#: adminpages/membershiplevels.php:670 adminpages/membershiplevels.php:674
-#: adminpages/membershiplevels.php:686 adminpages/membershiplevels.php:696
-#: adminpages/membershiplevels.php:746 adminpages/membershiplevels.php:748
-#: adminpages/orders.php:658 adminpages/orders.php:961
-#: adminpages/orders.php:979 adminpages/orders.php:989
-#: adminpages/orders.php:992 adminpages/orders.php:1021
-#: adminpages/orders.php:1050 adminpages/orders.php:1205
-#: adminpages/orders.php:1239 adminpages/orders.php:1245
-#: adminpages/orders.php:1360 adminpages/orders.php:1445
-#: adminpages/orders.php:1450 adminpages/orders.php:1451
-#: adminpages/orders.php:1466 adminpages/orders.php:1483
+#: adminpages/orders.php:1475
+#: adminpages/discountcodes.php:614
+#: adminpages/discountcodes.php:619
+#: adminpages/discountcodes.php:647
+#: adminpages/discountcodes.php:648
+#: adminpages/discountcodes.php:649
+#: adminpages/discountcodes.php:650
+#: adminpages/discountcodes.php:655
+#: adminpages/discountcodes.php:735
+#: adminpages/discountcodes.php:789
+#: adminpages/discountcodes.php:803
+#: adminpages/membershiplevels.php:564
+#: adminpages/membershiplevels.php:570
+#: adminpages/membershiplevels.php:572
+#: adminpages/membershiplevels.php:580
+#: adminpages/membershiplevels.php:599
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:662
+#: adminpages/membershiplevels.php:664
+#: adminpages/membershiplevels.php:669
+#: adminpages/membershiplevels.php:670
+#: adminpages/membershiplevels.php:674
+#: adminpages/membershiplevels.php:686
+#: adminpages/membershiplevels.php:696
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:748
+#: adminpages/orders.php:658
+#: adminpages/orders.php:961
+#: adminpages/orders.php:979
+#: adminpages/orders.php:989
+#: adminpages/orders.php:992
+#: adminpages/orders.php:1021
+#: adminpages/orders.php:1050
+#: adminpages/orders.php:1205
+#: adminpages/orders.php:1239
+#: adminpages/orders.php:1245
+#: adminpages/orders.php:1360
+#: adminpages/orders.php:1445
+#: adminpages/orders.php:1450
+#: adminpages/orders.php:1451
+#: adminpages/orders.php:1466
+#: adminpages/orders.php:1483
 #: adminpages/orders.php:1489
 msgid "edit"
 msgstr ""
 
-#: adminpages/pagesettings.php:66 adminpages/pagesettings.php:54
-#: adminpages/pagesettings.php:55 adminpages/pagesettings.php:62
 #: adminpages/pagesettings.php:66
+#: adminpages/pagesettings.php:54
+#: adminpages/pagesettings.php:55
+#: adminpages/pagesettings.php:62
 msgid "Your page settings have been updated."
 msgstr ""
 
-#: adminpages/pagesettings.php:86 adminpages/pagesettings.php:100
-#: adminpages/pagesettings.php:86 adminpages/pagesettings.php:100
+#: adminpages/pagesettings.php:86
+#: adminpages/pagesettings.php:100
 msgid "Your Profile"
 msgstr ""
 
-#: adminpages/pagesettings.php:92 adminpages/pagesettings.php:51
-#: adminpages/pagesettings.php:64 adminpages/pagesettings.php:65
-#: adminpages/pagesettings.php:79 adminpages/pagesettings.php:92
+#: adminpages/pagesettings.php:92
+#: adminpages/pagesettings.php:51
+#: adminpages/pagesettings.php:64
+#: adminpages/pagesettings.php:65
+#: adminpages/pagesettings.php:79
 msgid "Membership Account"
 msgstr ""
 
-#: adminpages/pagesettings.php:93 adminpages/pagesettings.php:54
-#: adminpages/pagesettings.php:65 adminpages/pagesettings.php:66
-#: adminpages/pagesettings.php:80 adminpages/pagesettings.php:93
+#: adminpages/pagesettings.php:93
+#: adminpages/pagesettings.php:54
+#: adminpages/pagesettings.php:65
+#: adminpages/pagesettings.php:66
+#: adminpages/pagesettings.php:80
 msgid "Membership Billing"
 msgstr ""
 
-#: adminpages/pagesettings.php:94 adminpages/pagesettings.php:57
-#: adminpages/pagesettings.php:66 adminpages/pagesettings.php:67
-#: adminpages/pagesettings.php:81 adminpages/pagesettings.php:94
+#: adminpages/pagesettings.php:94
+#: adminpages/pagesettings.php:57
+#: adminpages/pagesettings.php:66
+#: adminpages/pagesettings.php:67
+#: adminpages/pagesettings.php:81
 msgid "Membership Cancel"
 msgstr ""
 
-#: adminpages/pagesettings.php:95 adminpages/pagesettings.php:60
-#: adminpages/pagesettings.php:67 adminpages/pagesettings.php:68
-#: adminpages/pagesettings.php:82 adminpages/pagesettings.php:95
+#: adminpages/pagesettings.php:95
+#: adminpages/pagesettings.php:60
+#: adminpages/pagesettings.php:67
+#: adminpages/pagesettings.php:68
+#: adminpages/pagesettings.php:82
 msgid "Membership Checkout"
 msgstr ""
 
-#: adminpages/pagesettings.php:96 adminpages/pagesettings.php:63
-#: adminpages/pagesettings.php:68 adminpages/pagesettings.php:69
-#: adminpages/pagesettings.php:83 adminpages/pagesettings.php:96
+#: adminpages/pagesettings.php:96
+#: adminpages/pagesettings.php:63
+#: adminpages/pagesettings.php:68
+#: adminpages/pagesettings.php:69
+#: adminpages/pagesettings.php:83
 msgid "Membership Confirmation"
 msgstr ""
 
-#: adminpages/pagesettings.php:97 adminpages/pagesettings.php:66
-#: adminpages/pagesettings.php:69 adminpages/pagesettings.php:70
-#: adminpages/pagesettings.php:84 adminpages/pagesettings.php:97
+#: adminpages/pagesettings.php:97
+#: adminpages/pagesettings.php:66
+#: adminpages/pagesettings.php:69
+#: adminpages/pagesettings.php:70
+#: adminpages/pagesettings.php:84
 msgid "Membership Invoice"
 msgstr ""
 
-#: adminpages/pagesettings.php:99 includes/login.php:707 includes/menus.php:66
-#: includes/menus.php:70 includes/menus.php:160 adminpages/pagesettings.php:99
-#: includes/menus.php:66 includes/menus.php:70 includes/menus.php:160
+#: adminpages/pagesettings.php:99
+#: includes/login.php:707
+#: includes/menus.php:66
+#: includes/menus.php:70
+#: includes/menus.php:160
 msgid "Log In"
 msgstr ""
 
-#: adminpages/pagesettings.php:114 adminpages/pagesettings.php:114
+#: adminpages/pagesettings.php:114
 #, php-format
 msgid "Found an existing version of the %s page and used that one."
 msgstr ""
 
-#: adminpages/pagesettings.php:117 adminpages/pagesettings.php:117
+#: adminpages/pagesettings.php:117
 #, php-format
-msgid ""
-"Error generating the %s page. You will have to choose or create one manually."
+msgid "Error generating the %s page. You will have to choose or create one manually."
 msgstr ""
 
-#: adminpages/pagesettings.php:138 adminpages/pagesettings.php:83
-#: adminpages/pagesettings.php:84 adminpages/pagesettings.php:98
-#: adminpages/pagesettings.php:111 adminpages/pagesettings.php:138
+#: adminpages/pagesettings.php:138
+#: adminpages/pagesettings.php:83
+#: adminpages/pagesettings.php:84
+#: adminpages/pagesettings.php:98
+#: adminpages/pagesettings.php:111
 msgid "The following pages have been created for you"
 msgstr ""
 
-#: adminpages/pagesettings.php:167 adminpages/pagesettings.php:97
-#: adminpages/pagesettings.php:98 adminpages/pagesettings.php:112
-#: adminpages/pagesettings.php:113 adminpages/pagesettings.php:124
-#: adminpages/pagesettings.php:126 adminpages/pagesettings.php:167
-msgid ""
-"Manage the WordPress pages assigned to each required Paid Memberships Pro "
-"page."
+#: adminpages/pagesettings.php:167
+#: adminpages/pagesettings.php:97
+#: adminpages/pagesettings.php:98
+#: adminpages/pagesettings.php:112
+#: adminpages/pagesettings.php:113
+#: adminpages/pagesettings.php:124
+#: adminpages/pagesettings.php:126
+msgid "Manage the WordPress pages assigned to each required Paid Memberships Pro page."
 msgstr ""
 
-#: adminpages/pagesettings.php:169 adminpages/pagesettings.php:101
-#: adminpages/pagesettings.php:102 adminpages/pagesettings.php:104
-#: adminpages/pagesettings.php:114 adminpages/pagesettings.php:117
-#: adminpages/pagesettings.php:126 adminpages/pagesettings.php:128
-#: adminpages/pagesettings.php:132 adminpages/pagesettings.php:169
-msgid ""
-"Assign the WordPress pages for each required Paid Memberships Pro page or"
+#: adminpages/pagesettings.php:169
+#: adminpages/pagesettings.php:101
+#: adminpages/pagesettings.php:102
+#: adminpages/pagesettings.php:104
+#: adminpages/pagesettings.php:114
+#: adminpages/pagesettings.php:117
+#: adminpages/pagesettings.php:126
+#: adminpages/pagesettings.php:128
+#: adminpages/pagesettings.php:132
+msgid "Assign the WordPress pages for each required Paid Memberships Pro page or"
 msgstr ""
 
-#: adminpages/pagesettings.php:170 adminpages/pagesettings.php:102
-#: adminpages/pagesettings.php:103 adminpages/pagesettings.php:104
-#: adminpages/pagesettings.php:115 adminpages/pagesettings.php:118
-#: adminpages/pagesettings.php:127 adminpages/pagesettings.php:129
-#: adminpages/pagesettings.php:132 adminpages/pagesettings.php:170
+#: adminpages/pagesettings.php:170
+#: adminpages/pagesettings.php:102
+#: adminpages/pagesettings.php:103
+#: adminpages/pagesettings.php:104
+#: adminpages/pagesettings.php:115
+#: adminpages/pagesettings.php:118
+#: adminpages/pagesettings.php:127
+#: adminpages/pagesettings.php:129
+#: adminpages/pagesettings.php:132
 msgid "click here to let us generate them for you"
 msgstr ""
 
@@ -4613,304 +6559,470 @@ msgstr ""
 msgid "Create Pages Manually"
 msgstr ""
 
-#: adminpages/pagesettings.php:186 adminpages/pagesettings.php:111
-#: adminpages/pagesettings.php:112 adminpages/pagesettings.php:127
-#: adminpages/pagesettings.php:131 adminpages/pagesettings.php:140
-#: adminpages/pagesettings.php:143 adminpages/pagesettings.php:145
 #: adminpages/pagesettings.php:186
+#: adminpages/pagesettings.php:111
+#: adminpages/pagesettings.php:112
+#: adminpages/pagesettings.php:127
+#: adminpages/pagesettings.php:131
+#: adminpages/pagesettings.php:140
+#: adminpages/pagesettings.php:143
+#: adminpages/pagesettings.php:145
 msgid "Account Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:190 adminpages/pagesettings.php:207
-#: adminpages/pagesettings.php:224 adminpages/pagesettings.php:242
-#: adminpages/pagesettings.php:260 adminpages/pagesettings.php:278
-#: adminpages/pagesettings.php:296 adminpages/pagesettings.php:414
-#: adminpages/pagesettings.php:115 adminpages/pagesettings.php:116
-#: adminpages/pagesettings.php:131 adminpages/pagesettings.php:133
-#: adminpages/pagesettings.php:134 adminpages/pagesettings.php:135
-#: adminpages/pagesettings.php:144 adminpages/pagesettings.php:147
-#: adminpages/pagesettings.php:149 adminpages/pagesettings.php:151
-#: adminpages/pagesettings.php:152 adminpages/pagesettings.php:153
-#: adminpages/pagesettings.php:159 adminpages/pagesettings.php:162
-#: adminpages/pagesettings.php:164 adminpages/pagesettings.php:165
-#: adminpages/pagesettings.php:166 adminpages/pagesettings.php:167
-#: adminpages/pagesettings.php:170 adminpages/pagesettings.php:171
-#: adminpages/pagesettings.php:174 adminpages/pagesettings.php:177
-#: adminpages/pagesettings.php:181 adminpages/pagesettings.php:183
-#: adminpages/pagesettings.php:186 adminpages/pagesettings.php:189
-#: adminpages/pagesettings.php:190 adminpages/pagesettings.php:193
-#: adminpages/pagesettings.php:199 adminpages/pagesettings.php:201
-#: adminpages/pagesettings.php:202 adminpages/pagesettings.php:205
-#: adminpages/pagesettings.php:206 adminpages/pagesettings.php:207
-#: adminpages/pagesettings.php:209 adminpages/pagesettings.php:210
-#: adminpages/pagesettings.php:217 adminpages/pagesettings.php:219
-#: adminpages/pagesettings.php:221 adminpages/pagesettings.php:222
-#: adminpages/pagesettings.php:224 adminpages/pagesettings.php:225
-#: adminpages/pagesettings.php:228 adminpages/pagesettings.php:229
-#: adminpages/pagesettings.php:235 adminpages/pagesettings.php:237
-#: adminpages/pagesettings.php:238 adminpages/pagesettings.php:241
-#: adminpages/pagesettings.php:242 adminpages/pagesettings.php:244
-#: adminpages/pagesettings.php:248 adminpages/pagesettings.php:253
-#: adminpages/pagesettings.php:255 adminpages/pagesettings.php:260
-#: adminpages/pagesettings.php:268 adminpages/pagesettings.php:269
-#: adminpages/pagesettings.php:278 adminpages/pagesettings.php:284
-#: adminpages/pagesettings.php:289 adminpages/pagesettings.php:296
-#: adminpages/pagesettings.php:304 adminpages/pagesettings.php:306
-#: adminpages/pagesettings.php:312 adminpages/pagesettings.php:414
+#: adminpages/pagesettings.php:190
+#: adminpages/pagesettings.php:207
+#: adminpages/pagesettings.php:224
+#: adminpages/pagesettings.php:242
+#: adminpages/pagesettings.php:260
+#: adminpages/pagesettings.php:278
+#: adminpages/pagesettings.php:296
+#: adminpages/pagesettings.php:414
+#: adminpages/pagesettings.php:115
+#: adminpages/pagesettings.php:116
+#: adminpages/pagesettings.php:131
+#: adminpages/pagesettings.php:133
+#: adminpages/pagesettings.php:134
+#: adminpages/pagesettings.php:135
+#: adminpages/pagesettings.php:144
+#: adminpages/pagesettings.php:147
+#: adminpages/pagesettings.php:149
+#: adminpages/pagesettings.php:151
+#: adminpages/pagesettings.php:152
+#: adminpages/pagesettings.php:153
+#: adminpages/pagesettings.php:159
+#: adminpages/pagesettings.php:162
+#: adminpages/pagesettings.php:164
+#: adminpages/pagesettings.php:165
+#: adminpages/pagesettings.php:166
+#: adminpages/pagesettings.php:167
+#: adminpages/pagesettings.php:170
+#: adminpages/pagesettings.php:171
+#: adminpages/pagesettings.php:174
+#: adminpages/pagesettings.php:177
+#: adminpages/pagesettings.php:181
+#: adminpages/pagesettings.php:183
+#: adminpages/pagesettings.php:186
+#: adminpages/pagesettings.php:189
+#: adminpages/pagesettings.php:193
+#: adminpages/pagesettings.php:199
+#: adminpages/pagesettings.php:201
+#: adminpages/pagesettings.php:202
+#: adminpages/pagesettings.php:205
+#: adminpages/pagesettings.php:206
+#: adminpages/pagesettings.php:209
+#: adminpages/pagesettings.php:210
+#: adminpages/pagesettings.php:217
+#: adminpages/pagesettings.php:219
+#: adminpages/pagesettings.php:221
+#: adminpages/pagesettings.php:222
+#: adminpages/pagesettings.php:225
+#: adminpages/pagesettings.php:228
+#: adminpages/pagesettings.php:229
+#: adminpages/pagesettings.php:235
+#: adminpages/pagesettings.php:237
+#: adminpages/pagesettings.php:238
+#: adminpages/pagesettings.php:241
+#: adminpages/pagesettings.php:244
+#: adminpages/pagesettings.php:248
+#: adminpages/pagesettings.php:253
+#: adminpages/pagesettings.php:255
+#: adminpages/pagesettings.php:268
+#: adminpages/pagesettings.php:269
+#: adminpages/pagesettings.php:284
+#: adminpages/pagesettings.php:289
+#: adminpages/pagesettings.php:304
+#: adminpages/pagesettings.php:306
+#: adminpages/pagesettings.php:312
 msgid "Choose One"
 msgstr ""
 
-#: adminpages/pagesettings.php:194 adminpages/pagesettings.php:211
-#: adminpages/pagesettings.php:228 adminpages/pagesettings.php:246
-#: adminpages/pagesettings.php:264 adminpages/pagesettings.php:282
-#: adminpages/pagesettings.php:300 adminpages/pagesettings.php:336
-#: adminpages/pagesettings.php:364 adminpages/pagesettings.php:420
-#: adminpages/pagesettings.php:119 adminpages/pagesettings.php:120
-#: adminpages/pagesettings.php:132 adminpages/pagesettings.php:134
-#: adminpages/pagesettings.php:135 adminpages/pagesettings.php:137
-#: adminpages/pagesettings.php:138 adminpages/pagesettings.php:139
-#: adminpages/pagesettings.php:145 adminpages/pagesettings.php:147
-#: adminpages/pagesettings.php:149 adminpages/pagesettings.php:150
-#: adminpages/pagesettings.php:151 adminpages/pagesettings.php:153
-#: adminpages/pagesettings.php:155 adminpages/pagesettings.php:156
-#: adminpages/pagesettings.php:157 adminpages/pagesettings.php:159
-#: adminpages/pagesettings.php:162 adminpages/pagesettings.php:165
-#: adminpages/pagesettings.php:168 adminpages/pagesettings.php:169
-#: adminpages/pagesettings.php:170 adminpages/pagesettings.php:171
-#: adminpages/pagesettings.php:173 adminpages/pagesettings.php:174
-#: adminpages/pagesettings.php:175 adminpages/pagesettings.php:177
-#: adminpages/pagesettings.php:180 adminpages/pagesettings.php:181
-#: adminpages/pagesettings.php:185 adminpages/pagesettings.php:187
-#: adminpages/pagesettings.php:190 adminpages/pagesettings.php:193
-#: adminpages/pagesettings.php:194 adminpages/pagesettings.php:196
-#: adminpages/pagesettings.php:197 adminpages/pagesettings.php:201
-#: adminpages/pagesettings.php:203 adminpages/pagesettings.php:205
-#: adminpages/pagesettings.php:206 adminpages/pagesettings.php:209
-#: adminpages/pagesettings.php:211 adminpages/pagesettings.php:212
-#: adminpages/pagesettings.php:213 adminpages/pagesettings.php:214
-#: adminpages/pagesettings.php:221 adminpages/pagesettings.php:223
-#: adminpages/pagesettings.php:225 adminpages/pagesettings.php:228
-#: adminpages/pagesettings.php:229 adminpages/pagesettings.php:232
-#: adminpages/pagesettings.php:233 adminpages/pagesettings.php:239
-#: adminpages/pagesettings.php:241 adminpages/pagesettings.php:244
-#: adminpages/pagesettings.php:245 adminpages/pagesettings.php:246
-#: adminpages/pagesettings.php:248 adminpages/pagesettings.php:252
-#: adminpages/pagesettings.php:257 adminpages/pagesettings.php:259
-#: adminpages/pagesettings.php:264 adminpages/pagesettings.php:274
-#: adminpages/pagesettings.php:275 adminpages/pagesettings.php:282
-#: adminpages/pagesettings.php:290 adminpages/pagesettings.php:295
-#: adminpages/pagesettings.php:300 adminpages/pagesettings.php:310
-#: adminpages/pagesettings.php:312 adminpages/pagesettings.php:318
-#: adminpages/pagesettings.php:336 adminpages/pagesettings.php:364
+#: adminpages/pagesettings.php:194
+#: adminpages/pagesettings.php:211
+#: adminpages/pagesettings.php:228
+#: adminpages/pagesettings.php:246
+#: adminpages/pagesettings.php:264
+#: adminpages/pagesettings.php:282
+#: adminpages/pagesettings.php:300
+#: adminpages/pagesettings.php:336
+#: adminpages/pagesettings.php:364
 #: adminpages/pagesettings.php:420
+#: adminpages/pagesettings.php:119
+#: adminpages/pagesettings.php:120
+#: adminpages/pagesettings.php:132
+#: adminpages/pagesettings.php:134
+#: adminpages/pagesettings.php:135
+#: adminpages/pagesettings.php:137
+#: adminpages/pagesettings.php:138
+#: adminpages/pagesettings.php:139
+#: adminpages/pagesettings.php:145
+#: adminpages/pagesettings.php:147
+#: adminpages/pagesettings.php:149
+#: adminpages/pagesettings.php:150
+#: adminpages/pagesettings.php:151
+#: adminpages/pagesettings.php:153
+#: adminpages/pagesettings.php:155
+#: adminpages/pagesettings.php:156
+#: adminpages/pagesettings.php:157
+#: adminpages/pagesettings.php:159
+#: adminpages/pagesettings.php:162
+#: adminpages/pagesettings.php:165
+#: adminpages/pagesettings.php:168
+#: adminpages/pagesettings.php:169
+#: adminpages/pagesettings.php:170
+#: adminpages/pagesettings.php:171
+#: adminpages/pagesettings.php:173
+#: adminpages/pagesettings.php:174
+#: adminpages/pagesettings.php:175
+#: adminpages/pagesettings.php:177
+#: adminpages/pagesettings.php:180
+#: adminpages/pagesettings.php:181
+#: adminpages/pagesettings.php:185
+#: adminpages/pagesettings.php:187
+#: adminpages/pagesettings.php:190
+#: adminpages/pagesettings.php:193
+#: adminpages/pagesettings.php:196
+#: adminpages/pagesettings.php:197
+#: adminpages/pagesettings.php:201
+#: adminpages/pagesettings.php:203
+#: adminpages/pagesettings.php:205
+#: adminpages/pagesettings.php:206
+#: adminpages/pagesettings.php:209
+#: adminpages/pagesettings.php:212
+#: adminpages/pagesettings.php:213
+#: adminpages/pagesettings.php:214
+#: adminpages/pagesettings.php:221
+#: adminpages/pagesettings.php:223
+#: adminpages/pagesettings.php:225
+#: adminpages/pagesettings.php:229
+#: adminpages/pagesettings.php:232
+#: adminpages/pagesettings.php:233
+#: adminpages/pagesettings.php:239
+#: adminpages/pagesettings.php:241
+#: adminpages/pagesettings.php:244
+#: adminpages/pagesettings.php:245
+#: adminpages/pagesettings.php:248
+#: adminpages/pagesettings.php:252
+#: adminpages/pagesettings.php:257
+#: adminpages/pagesettings.php:259
+#: adminpages/pagesettings.php:274
+#: adminpages/pagesettings.php:275
+#: adminpages/pagesettings.php:290
+#: adminpages/pagesettings.php:295
+#: adminpages/pagesettings.php:310
+#: adminpages/pagesettings.php:312
+#: adminpages/pagesettings.php:318
 msgid "edit page"
 msgstr ""
 
-#: adminpages/pagesettings.php:197 adminpages/pagesettings.php:214
-#: adminpages/pagesettings.php:231 adminpages/pagesettings.php:249
-#: adminpages/pagesettings.php:267 adminpages/pagesettings.php:285
-#: adminpages/pagesettings.php:303 adminpages/pagesettings.php:339
-#: adminpages/pagesettings.php:367 adminpages/pagesettings.php:423
-#: adminpages/pagesettings.php:121 adminpages/pagesettings.php:122
-#: adminpages/pagesettings.php:123 adminpages/pagesettings.php:136
-#: adminpages/pagesettings.php:138 adminpages/pagesettings.php:140
-#: adminpages/pagesettings.php:141 adminpages/pagesettings.php:142
-#: adminpages/pagesettings.php:149 adminpages/pagesettings.php:151
-#: adminpages/pagesettings.php:152 adminpages/pagesettings.php:154
-#: adminpages/pagesettings.php:156 adminpages/pagesettings.php:158
-#: adminpages/pagesettings.php:159 adminpages/pagesettings.php:160
-#: adminpages/pagesettings.php:164 adminpages/pagesettings.php:167
-#: adminpages/pagesettings.php:171 adminpages/pagesettings.php:172
-#: adminpages/pagesettings.php:173 adminpages/pagesettings.php:174
-#: adminpages/pagesettings.php:177 adminpages/pagesettings.php:178
-#: adminpages/pagesettings.php:179 adminpages/pagesettings.php:182
-#: adminpages/pagesettings.php:183 adminpages/pagesettings.php:188
-#: adminpages/pagesettings.php:190 adminpages/pagesettings.php:193
-#: adminpages/pagesettings.php:195 adminpages/pagesettings.php:196
-#: adminpages/pagesettings.php:197 adminpages/pagesettings.php:198
-#: adminpages/pagesettings.php:199 adminpages/pagesettings.php:206
-#: adminpages/pagesettings.php:208 adminpages/pagesettings.php:209
-#: adminpages/pagesettings.php:211 adminpages/pagesettings.php:212
-#: adminpages/pagesettings.php:214 adminpages/pagesettings.php:215
-#: adminpages/pagesettings.php:216 adminpages/pagesettings.php:217
-#: adminpages/pagesettings.php:224 adminpages/pagesettings.php:226
-#: adminpages/pagesettings.php:227 adminpages/pagesettings.php:228
-#: adminpages/pagesettings.php:230 adminpages/pagesettings.php:231
-#: adminpages/pagesettings.php:232 adminpages/pagesettings.php:235
-#: adminpages/pagesettings.php:236 adminpages/pagesettings.php:242
-#: adminpages/pagesettings.php:243 adminpages/pagesettings.php:244
-#: adminpages/pagesettings.php:246 adminpages/pagesettings.php:248
-#: adminpages/pagesettings.php:249 adminpages/pagesettings.php:251
-#: adminpages/pagesettings.php:255 adminpages/pagesettings.php:260
-#: adminpages/pagesettings.php:262 adminpages/pagesettings.php:267
-#: adminpages/pagesettings.php:277 adminpages/pagesettings.php:278
-#: adminpages/pagesettings.php:285 adminpages/pagesettings.php:293
-#: adminpages/pagesettings.php:298 adminpages/pagesettings.php:303
-#: adminpages/pagesettings.php:313 adminpages/pagesettings.php:315
-#: adminpages/pagesettings.php:321 adminpages/pagesettings.php:339
-#: adminpages/pagesettings.php:367 adminpages/pagesettings.php:423
+#: adminpages/pagesettings.php:197
+#: adminpages/pagesettings.php:214
+#: adminpages/pagesettings.php:231
+#: adminpages/pagesettings.php:249
+#: adminpages/pagesettings.php:267
+#: adminpages/pagesettings.php:285
+#: adminpages/pagesettings.php:303
+#: adminpages/pagesettings.php:339
+#: adminpages/pagesettings.php:367
+#: adminpages/pagesettings.php:423
+#: adminpages/pagesettings.php:121
+#: adminpages/pagesettings.php:122
+#: adminpages/pagesettings.php:123
+#: adminpages/pagesettings.php:136
+#: adminpages/pagesettings.php:138
+#: adminpages/pagesettings.php:140
+#: adminpages/pagesettings.php:141
+#: adminpages/pagesettings.php:142
+#: adminpages/pagesettings.php:149
+#: adminpages/pagesettings.php:151
+#: adminpages/pagesettings.php:152
+#: adminpages/pagesettings.php:154
+#: adminpages/pagesettings.php:156
+#: adminpages/pagesettings.php:158
+#: adminpages/pagesettings.php:159
+#: adminpages/pagesettings.php:160
+#: adminpages/pagesettings.php:164
+#: adminpages/pagesettings.php:167
+#: adminpages/pagesettings.php:171
+#: adminpages/pagesettings.php:172
+#: adminpages/pagesettings.php:173
+#: adminpages/pagesettings.php:174
+#: adminpages/pagesettings.php:177
+#: adminpages/pagesettings.php:178
+#: adminpages/pagesettings.php:179
+#: adminpages/pagesettings.php:182
+#: adminpages/pagesettings.php:183
+#: adminpages/pagesettings.php:188
+#: adminpages/pagesettings.php:190
+#: adminpages/pagesettings.php:193
+#: adminpages/pagesettings.php:195
+#: adminpages/pagesettings.php:196
+#: adminpages/pagesettings.php:198
+#: adminpages/pagesettings.php:199
+#: adminpages/pagesettings.php:206
+#: adminpages/pagesettings.php:208
+#: adminpages/pagesettings.php:209
+#: adminpages/pagesettings.php:211
+#: adminpages/pagesettings.php:212
+#: adminpages/pagesettings.php:215
+#: adminpages/pagesettings.php:216
+#: adminpages/pagesettings.php:217
+#: adminpages/pagesettings.php:224
+#: adminpages/pagesettings.php:226
+#: adminpages/pagesettings.php:227
+#: adminpages/pagesettings.php:228
+#: adminpages/pagesettings.php:230
+#: adminpages/pagesettings.php:232
+#: adminpages/pagesettings.php:235
+#: adminpages/pagesettings.php:236
+#: adminpages/pagesettings.php:242
+#: adminpages/pagesettings.php:243
+#: adminpages/pagesettings.php:244
+#: adminpages/pagesettings.php:246
+#: adminpages/pagesettings.php:248
+#: adminpages/pagesettings.php:251
+#: adminpages/pagesettings.php:255
+#: adminpages/pagesettings.php:260
+#: adminpages/pagesettings.php:262
+#: adminpages/pagesettings.php:277
+#: adminpages/pagesettings.php:278
+#: adminpages/pagesettings.php:293
+#: adminpages/pagesettings.php:298
+#: adminpages/pagesettings.php:313
+#: adminpages/pagesettings.php:315
+#: adminpages/pagesettings.php:321
 msgid "view page"
 msgstr ""
 
-#: adminpages/pagesettings.php:199 adminpages/pagesettings.php:216
-#: adminpages/pagesettings.php:233 adminpages/pagesettings.php:251
-#: adminpages/pagesettings.php:269 adminpages/pagesettings.php:287
-#: adminpages/pagesettings.php:305 adminpages/pagesettings.php:121
-#: adminpages/pagesettings.php:123 adminpages/pagesettings.php:125
-#: adminpages/pagesettings.php:126 adminpages/pagesettings.php:134
-#: adminpages/pagesettings.php:138 adminpages/pagesettings.php:141
-#: adminpages/pagesettings.php:143 adminpages/pagesettings.php:144
-#: adminpages/pagesettings.php:145 adminpages/pagesettings.php:147
-#: adminpages/pagesettings.php:151 adminpages/pagesettings.php:153
-#: adminpages/pagesettings.php:154 adminpages/pagesettings.php:156
-#: adminpages/pagesettings.php:157 adminpages/pagesettings.php:158
-#: adminpages/pagesettings.php:159 adminpages/pagesettings.php:161
-#: adminpages/pagesettings.php:162 adminpages/pagesettings.php:163
-#: adminpages/pagesettings.php:166 adminpages/pagesettings.php:169
-#: adminpages/pagesettings.php:173 adminpages/pagesettings.php:175
-#: adminpages/pagesettings.php:177 adminpages/pagesettings.php:180
-#: adminpages/pagesettings.php:181 adminpages/pagesettings.php:184
-#: adminpages/pagesettings.php:185 adminpages/pagesettings.php:189
-#: adminpages/pagesettings.php:190 adminpages/pagesettings.php:192
-#: adminpages/pagesettings.php:193 adminpages/pagesettings.php:196
-#: adminpages/pagesettings.php:197 adminpages/pagesettings.php:199
-#: adminpages/pagesettings.php:200 adminpages/pagesettings.php:201
-#: adminpages/pagesettings.php:203 adminpages/pagesettings.php:208
-#: adminpages/pagesettings.php:210 adminpages/pagesettings.php:212
-#: adminpages/pagesettings.php:213 adminpages/pagesettings.php:215
-#: adminpages/pagesettings.php:216 adminpages/pagesettings.php:217
-#: adminpages/pagesettings.php:219 adminpages/pagesettings.php:220
-#: adminpages/pagesettings.php:226 adminpages/pagesettings.php:228
-#: adminpages/pagesettings.php:229 adminpages/pagesettings.php:231
-#: adminpages/pagesettings.php:232 adminpages/pagesettings.php:233
-#: adminpages/pagesettings.php:235 adminpages/pagesettings.php:238
-#: adminpages/pagesettings.php:239 adminpages/pagesettings.php:244
-#: adminpages/pagesettings.php:245 adminpages/pagesettings.php:246
-#: adminpages/pagesettings.php:248 adminpages/pagesettings.php:251
-#: adminpages/pagesettings.php:254 adminpages/pagesettings.php:258
-#: adminpages/pagesettings.php:262 adminpages/pagesettings.php:264
-#: adminpages/pagesettings.php:269 adminpages/pagesettings.php:270
-#: adminpages/pagesettings.php:287 adminpages/pagesettings.php:305
+#: adminpages/pagesettings.php:199
+#: adminpages/pagesettings.php:216
+#: adminpages/pagesettings.php:233
+#: adminpages/pagesettings.php:251
+#: adminpages/pagesettings.php:269
+#: adminpages/pagesettings.php:287
+#: adminpages/pagesettings.php:305
+#: adminpages/pagesettings.php:121
+#: adminpages/pagesettings.php:123
+#: adminpages/pagesettings.php:125
+#: adminpages/pagesettings.php:126
+#: adminpages/pagesettings.php:134
+#: adminpages/pagesettings.php:138
+#: adminpages/pagesettings.php:141
+#: adminpages/pagesettings.php:143
+#: adminpages/pagesettings.php:144
+#: adminpages/pagesettings.php:145
+#: adminpages/pagesettings.php:147
+#: adminpages/pagesettings.php:151
+#: adminpages/pagesettings.php:153
+#: adminpages/pagesettings.php:154
+#: adminpages/pagesettings.php:156
+#: adminpages/pagesettings.php:157
+#: adminpages/pagesettings.php:158
+#: adminpages/pagesettings.php:159
+#: adminpages/pagesettings.php:161
+#: adminpages/pagesettings.php:162
+#: adminpages/pagesettings.php:163
+#: adminpages/pagesettings.php:166
+#: adminpages/pagesettings.php:169
+#: adminpages/pagesettings.php:173
+#: adminpages/pagesettings.php:175
+#: adminpages/pagesettings.php:177
+#: adminpages/pagesettings.php:180
+#: adminpages/pagesettings.php:181
+#: adminpages/pagesettings.php:184
+#: adminpages/pagesettings.php:185
+#: adminpages/pagesettings.php:189
+#: adminpages/pagesettings.php:190
+#: adminpages/pagesettings.php:192
+#: adminpages/pagesettings.php:193
+#: adminpages/pagesettings.php:196
+#: adminpages/pagesettings.php:197
+#: adminpages/pagesettings.php:200
+#: adminpages/pagesettings.php:201
+#: adminpages/pagesettings.php:203
+#: adminpages/pagesettings.php:208
+#: adminpages/pagesettings.php:210
+#: adminpages/pagesettings.php:212
+#: adminpages/pagesettings.php:213
+#: adminpages/pagesettings.php:215
+#: adminpages/pagesettings.php:217
+#: adminpages/pagesettings.php:219
+#: adminpages/pagesettings.php:220
+#: adminpages/pagesettings.php:226
+#: adminpages/pagesettings.php:228
+#: adminpages/pagesettings.php:229
+#: adminpages/pagesettings.php:231
+#: adminpages/pagesettings.php:232
+#: adminpages/pagesettings.php:235
+#: adminpages/pagesettings.php:238
+#: adminpages/pagesettings.php:239
+#: adminpages/pagesettings.php:244
+#: adminpages/pagesettings.php:245
+#: adminpages/pagesettings.php:246
+#: adminpages/pagesettings.php:248
+#: adminpages/pagesettings.php:254
+#: adminpages/pagesettings.php:258
+#: adminpages/pagesettings.php:262
+#: adminpages/pagesettings.php:264
+#: adminpages/pagesettings.php:270
 msgid "Include the shortcode"
 msgstr ""
 
-#: adminpages/pagesettings.php:199 adminpages/pagesettings.php:156
-#: adminpages/pagesettings.php:158 adminpages/pagesettings.php:199
+#: adminpages/pagesettings.php:199
+#: adminpages/pagesettings.php:156
+#: adminpages/pagesettings.php:158
 msgid "or the Membership Account block"
 msgstr ""
 
-#: adminpages/pagesettings.php:203 adminpages/pagesettings.php:125
-#: adminpages/pagesettings.php:127 adminpages/pagesettings.php:129
-#: adminpages/pagesettings.php:130 adminpages/pagesettings.php:145
-#: adminpages/pagesettings.php:149 adminpages/pagesettings.php:155
-#: adminpages/pagesettings.php:158 adminpages/pagesettings.php:160
-#: adminpages/pagesettings.php:161 adminpages/pagesettings.php:162
 #: adminpages/pagesettings.php:203
+#: adminpages/pagesettings.php:125
+#: adminpages/pagesettings.php:127
+#: adminpages/pagesettings.php:129
+#: adminpages/pagesettings.php:130
+#: adminpages/pagesettings.php:145
+#: adminpages/pagesettings.php:149
+#: adminpages/pagesettings.php:155
+#: adminpages/pagesettings.php:158
+#: adminpages/pagesettings.php:160
+#: adminpages/pagesettings.php:161
+#: adminpages/pagesettings.php:162
 msgid "Billing Information Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:216 adminpages/pagesettings.php:173
-#: adminpages/pagesettings.php:175 adminpages/pagesettings.php:216
+#: adminpages/pagesettings.php:216
+#: adminpages/pagesettings.php:173
+#: adminpages/pagesettings.php:175
 msgid "or the Membership Billing block"
 msgstr ""
 
-#: adminpages/pagesettings.php:220 adminpages/pagesettings.php:138
-#: adminpages/pagesettings.php:142 adminpages/pagesettings.php:147
-#: adminpages/pagesettings.php:148 adminpages/pagesettings.php:163
-#: adminpages/pagesettings.php:167 adminpages/pagesettings.php:170
-#: adminpages/pagesettings.php:173 adminpages/pagesettings.php:177
-#: adminpages/pagesettings.php:179 adminpages/pagesettings.php:220
+#: adminpages/pagesettings.php:220
+#: adminpages/pagesettings.php:138
+#: adminpages/pagesettings.php:142
+#: adminpages/pagesettings.php:147
+#: adminpages/pagesettings.php:148
+#: adminpages/pagesettings.php:163
+#: adminpages/pagesettings.php:167
+#: adminpages/pagesettings.php:170
+#: adminpages/pagesettings.php:173
+#: adminpages/pagesettings.php:177
+#: adminpages/pagesettings.php:179
 msgid "Cancel Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:233 adminpages/pagesettings.php:190
-#: adminpages/pagesettings.php:192 adminpages/pagesettings.php:233
+#: adminpages/pagesettings.php:233
+#: adminpages/pagesettings.php:190
+#: adminpages/pagesettings.php:192
 msgid "or the Membership Cancel block"
 msgstr ""
 
-#: adminpages/pagesettings.php:238 adminpages/pagesettings.php:152
-#: adminpages/pagesettings.php:158 adminpages/pagesettings.php:166
-#: adminpages/pagesettings.php:167 adminpages/pagesettings.php:182
-#: adminpages/pagesettings.php:186 adminpages/pagesettings.php:189
-#: adminpages/pagesettings.php:195 adminpages/pagesettings.php:197
-#: adminpages/pagesettings.php:198 adminpages/pagesettings.php:238
+#: adminpages/pagesettings.php:238
+#: adminpages/pagesettings.php:152
+#: adminpages/pagesettings.php:158
+#: adminpages/pagesettings.php:166
+#: adminpages/pagesettings.php:167
+#: adminpages/pagesettings.php:182
+#: adminpages/pagesettings.php:186
+#: adminpages/pagesettings.php:189
+#: adminpages/pagesettings.php:195
+#: adminpages/pagesettings.php:197
+#: adminpages/pagesettings.php:198
 msgid "Checkout Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:251 adminpages/pagesettings.php:208
-#: adminpages/pagesettings.php:210 adminpages/pagesettings.php:251
+#: adminpages/pagesettings.php:251
+#: adminpages/pagesettings.php:208
+#: adminpages/pagesettings.php:210
 msgid "or the Membership Checkout block"
 msgstr ""
 
-#: adminpages/pagesettings.php:256 adminpages/pagesettings.php:166
-#: adminpages/pagesettings.php:174 adminpages/pagesettings.php:185
-#: adminpages/pagesettings.php:186 adminpages/pagesettings.php:201
-#: adminpages/pagesettings.php:202 adminpages/pagesettings.php:205
-#: adminpages/pagesettings.php:213 adminpages/pagesettings.php:215
-#: adminpages/pagesettings.php:217 adminpages/pagesettings.php:256
+#: adminpages/pagesettings.php:256
+#: adminpages/pagesettings.php:166
+#: adminpages/pagesettings.php:174
+#: adminpages/pagesettings.php:185
+#: adminpages/pagesettings.php:186
+#: adminpages/pagesettings.php:201
+#: adminpages/pagesettings.php:202
+#: adminpages/pagesettings.php:205
+#: adminpages/pagesettings.php:213
+#: adminpages/pagesettings.php:215
+#: adminpages/pagesettings.php:217
 msgid "Confirmation Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:269 adminpages/pagesettings.php:226
-#: adminpages/pagesettings.php:228 adminpages/pagesettings.php:269
+#: adminpages/pagesettings.php:269
+#: adminpages/pagesettings.php:226
+#: adminpages/pagesettings.php:228
 msgid "or the Membership Confirmation block"
 msgstr ""
 
-#: adminpages/pagesettings.php:274 adminpages/pagesettings.php:180
-#: adminpages/pagesettings.php:190 adminpages/pagesettings.php:205
-#: adminpages/pagesettings.php:206 adminpages/pagesettings.php:218
-#: adminpages/pagesettings.php:221 adminpages/pagesettings.php:225
-#: adminpages/pagesettings.php:231 adminpages/pagesettings.php:233
-#: adminpages/pagesettings.php:237 adminpages/pagesettings.php:274
+#: adminpages/pagesettings.php:274
+#: adminpages/pagesettings.php:180
+#: adminpages/pagesettings.php:190
+#: adminpages/pagesettings.php:205
+#: adminpages/pagesettings.php:206
+#: adminpages/pagesettings.php:218
+#: adminpages/pagesettings.php:221
+#: adminpages/pagesettings.php:225
+#: adminpages/pagesettings.php:231
+#: adminpages/pagesettings.php:233
+#: adminpages/pagesettings.php:237
 msgid "Invoice Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:287 adminpages/pagesettings.php:244
-#: adminpages/pagesettings.php:246 adminpages/pagesettings.php:287
+#: adminpages/pagesettings.php:287
+#: adminpages/pagesettings.php:244
+#: adminpages/pagesettings.php:246
 msgid "or the Membership Invoice block"
 msgstr ""
 
-#: adminpages/pagesettings.php:292 adminpages/pagesettings.php:194
-#: adminpages/pagesettings.php:206 adminpages/pagesettings.php:224
-#: adminpages/pagesettings.php:225 adminpages/pagesettings.php:234
-#: adminpages/pagesettings.php:237 adminpages/pagesettings.php:240
-#: adminpages/pagesettings.php:244 adminpages/pagesettings.php:249
-#: adminpages/pagesettings.php:251 adminpages/pagesettings.php:256
 #: adminpages/pagesettings.php:292
+#: adminpages/pagesettings.php:194
+#: adminpages/pagesettings.php:206
+#: adminpages/pagesettings.php:224
+#: adminpages/pagesettings.php:225
+#: adminpages/pagesettings.php:234
+#: adminpages/pagesettings.php:237
+#: adminpages/pagesettings.php:240
+#: adminpages/pagesettings.php:244
+#: adminpages/pagesettings.php:249
+#: adminpages/pagesettings.php:251
+#: adminpages/pagesettings.php:256
 msgid "Levels Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:305 adminpages/pagesettings.php:262
-#: adminpages/pagesettings.php:264 adminpages/pagesettings.php:305
+#: adminpages/pagesettings.php:305
+#: adminpages/pagesettings.php:262
+#: adminpages/pagesettings.php:264
 msgid "or the Membership Levels block"
 msgstr ""
 
-#: adminpages/pagesettings.php:315 adminpages/pagesettings.php:272
-#: adminpages/pagesettings.php:274 adminpages/pagesettings.php:280
 #: adminpages/pagesettings.php:315
+#: adminpages/pagesettings.php:272
+#: adminpages/pagesettings.php:274
+#: adminpages/pagesettings.php:280
 #, php-format
-msgid ""
-"Optional: Customize your Membership Levels page using the <a href=\"%s\" "
-"title=\"Paid Memberships Pro - Advanced Levels Page Add On\" target=\"_blank"
-"\">Advanced Levels Page Add On</a>."
+msgid "Optional: Customize your Membership Levels page using the <a href=\"%s\" title=\"Paid Memberships Pro - Advanced Levels Page Add On\" target=\"_blank\">Advanced Levels Page Add On</a>."
 msgstr ""
 
 #: adminpages/pagesettings.php:321
 msgid "Log In Page"
 msgstr ""
 
-#: adminpages/pagesettings.php:328 adminpages/pagesettings.php:356
-#: adminpages/pagesettings.php:328 adminpages/pagesettings.php:356
+#: adminpages/pagesettings.php:328
+#: adminpages/pagesettings.php:356
 msgid "Use WordPress Default"
 msgstr ""
 
-#: adminpages/pagesettings.php:342 adminpages/pagesettings.php:370
-#: adminpages/pagesettings.php:426 adminpages/pagesettings.php:280
-#: adminpages/pagesettings.php:281 adminpages/pagesettings.php:296
-#: adminpages/pagesettings.php:301 adminpages/pagesettings.php:316
-#: adminpages/pagesettings.php:318 adminpages/pagesettings.php:324
-#: adminpages/pagesettings.php:342 adminpages/pagesettings.php:370
+#: adminpages/pagesettings.php:342
+#: adminpages/pagesettings.php:370
 #: adminpages/pagesettings.php:426
+#: adminpages/pagesettings.php:280
+#: adminpages/pagesettings.php:281
+#: adminpages/pagesettings.php:296
+#: adminpages/pagesettings.php:301
+#: adminpages/pagesettings.php:316
+#: adminpages/pagesettings.php:318
+#: adminpages/pagesettings.php:324
 msgid "Generate Page"
 msgstr ""
 
@@ -4919,7 +7031,7 @@ msgstr ""
 msgid "Include the shortcode %s or the Log In Form block."
 msgstr ""
 
-#: adminpages/pagesettings.php:349 includes/adminpages.php:351
+#: adminpages/pagesettings.php:349
 #: includes/adminpages.php:351
 msgid "Member Profile Edit Page"
 msgstr ""
@@ -4929,472 +7041,573 @@ msgstr ""
 msgid "Include the shortcode %s or the Member Profile Edit block."
 msgstr ""
 
-#: adminpages/pagesettings.php:382 adminpages/pagesettings.php:382
+#: adminpages/pagesettings.php:382
 #, php-format
-msgid ""
-"Optional: Collect additional member fields at checkout, on the profile, or "
-"for admin-use only using the <a href=\"%s\" title=\"Paid Memberships Pro - "
-"Register Helper Add On\" target=\"_blank\">Register Helper Add On</a>."
+msgid "Optional: Collect additional member fields at checkout, on the profile, or for admin-use only using the <a href=\"%s\" title=\"Paid Memberships Pro - Register Helper Add On\" target=\"_blank\">Register Helper Add On</a>."
 msgstr ""
 
-#: adminpages/pagesettings.php:391 adminpages/pagesettings.php:245
-#: adminpages/pagesettings.php:246 adminpages/pagesettings.php:261
-#: adminpages/pagesettings.php:266 adminpages/pagesettings.php:281
-#: adminpages/pagesettings.php:283 adminpages/pagesettings.php:289
 #: adminpages/pagesettings.php:391
+#: adminpages/pagesettings.php:245
+#: adminpages/pagesettings.php:246
+#: adminpages/pagesettings.php:261
+#: adminpages/pagesettings.php:266
+#: adminpages/pagesettings.php:281
+#: adminpages/pagesettings.php:283
+#: adminpages/pagesettings.php:289
 msgid "Additional Page Settings"
 msgstr ""
 
-#: adminpages/paymentsettings.php:66 adminpages/paymentsettings.php:49
-#: adminpages/paymentsettings.php:64 adminpages/paymentsettings.php:66
-#: adminpages/paymentsettings.php:77 adminpages/paymentsettings.php:82
+#: adminpages/paymentsettings.php:66
+#: adminpages/paymentsettings.php:49
+#: adminpages/paymentsettings.php:64
+#: adminpages/paymentsettings.php:77
+#: adminpages/paymentsettings.php:82
 msgid "Your payment settings have been updated."
 msgstr ""
 
-#: adminpages/paymentsettings.php:112 adminpages/paymentsettings.php:127
-#: adminpages/paymentsettings.php:93 adminpages/paymentsettings.php:106
-#: adminpages/paymentsettings.php:110 adminpages/paymentsettings.php:123
-#: adminpages/paymentsettings.php:124 adminpages/paymentsettings.php:125
-#: adminpages/paymentsettings.php:127 adminpages/paymentsettings.php:144
-#: adminpages/paymentsettings.php:146 adminpages/paymentsettings.php:152
+#: adminpages/paymentsettings.php:112
+#: adminpages/paymentsettings.php:127
+#: adminpages/paymentsettings.php:93
+#: adminpages/paymentsettings.php:106
+#: adminpages/paymentsettings.php:110
+#: adminpages/paymentsettings.php:123
+#: adminpages/paymentsettings.php:124
+#: adminpages/paymentsettings.php:125
+#: adminpages/paymentsettings.php:144
+#: adminpages/paymentsettings.php:146
+#: adminpages/paymentsettings.php:152
 #: adminpages/paymentsettings.php:154
 msgid "Payment Gateway"
 msgstr ""
 
-#: adminpages/paymentsettings.php:112 adminpages/paymentsettings.php:241
-#: adminpages/paymentsettings.php:93 adminpages/paymentsettings.php:110
-#: adminpages/paymentsettings.php:144 adminpages/paymentsettings.php:146
-#: adminpages/paymentsettings.php:201 adminpages/paymentsettings.php:218
-#: adminpages/paymentsettings.php:235 adminpages/paymentsettings.php:238
-#: adminpages/paymentsettings.php:239 adminpages/paymentsettings.php:241
+#: adminpages/paymentsettings.php:112
+#: adminpages/paymentsettings.php:241
+#: adminpages/paymentsettings.php:93
+#: adminpages/paymentsettings.php:110
+#: adminpages/paymentsettings.php:144
+#: adminpages/paymentsettings.php:146
+#: adminpages/paymentsettings.php:201
+#: adminpages/paymentsettings.php:218
+#: adminpages/paymentsettings.php:235
+#: adminpages/paymentsettings.php:238
+#: adminpages/paymentsettings.php:239
 msgid "SSL Settings"
 msgstr ""
 
-#: adminpages/paymentsettings.php:115 adminpages/paymentsettings.php:112
-#: adminpages/paymentsettings.php:113 adminpages/paymentsettings.php:115
-msgid ""
-"Learn more about <a title=\"Paid Memberships Pro - SSL Settings\" target="
-"\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-"
-"plugin-setup/ssl/?utm_source=plugin&utm_medium=pmpro-"
-"paymentsettings&utm_campaign=documentation&utm_content=ssl&utm_term=link1\">SSL</"
-"a> or <a title=\"Paid Memberships Pro - Payment Gateway Settings\" target="
-"\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-"
-"plugin-setup/step-3-payment-gateway-security/?"
-"utm_source=plugin&utm_medium=pmpro-"
-"paymentsettings&utm_campaign=documentation&utm_content=step-3-payment-"
-"gateway-security\">Payment Gateway Settings</a>."
+#: adminpages/paymentsettings.php:115
+#: adminpages/paymentsettings.php:112
+#: adminpages/paymentsettings.php:113
+msgid "Learn more about <a title=\"Paid Memberships Pro - SSL Settings\" target=\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-plugin-setup/ssl/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=ssl&utm_term=link1\">SSL</a> or <a title=\"Paid Memberships Pro - Payment Gateway Settings\" target=\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-plugin-setup/step-3-payment-gateway-security/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=step-3-payment-gateway-security\">Payment Gateway Settings</a>."
 msgstr ""
 
-#: adminpages/paymentsettings.php:122 adminpages/paymentsettings.php:101
-#: adminpages/paymentsettings.php:118 adminpages/paymentsettings.php:119
-#: adminpages/paymentsettings.php:120 adminpages/paymentsettings.php:122
+#: adminpages/paymentsettings.php:122
+#: adminpages/paymentsettings.php:101
+#: adminpages/paymentsettings.php:118
+#: adminpages/paymentsettings.php:119
+#: adminpages/paymentsettings.php:120
 msgid "Choose a Gateway"
 msgstr ""
 
-#: adminpages/paymentsettings.php:142 adminpages/paymentsettings.php:138
-#: adminpages/paymentsettings.php:139 adminpages/paymentsettings.php:140
 #: adminpages/paymentsettings.php:142
-msgid ""
-"It is not connected to a live gateway environment and cannot accept payments."
+#: adminpages/paymentsettings.php:138
+#: adminpages/paymentsettings.php:139
+#: adminpages/paymentsettings.php:140
+msgid "It is not connected to a live gateway environment and cannot accept payments."
 msgstr ""
 
-#: adminpages/paymentsettings.php:142 adminpages/paymentsettings.php:138
-#: adminpages/paymentsettings.php:139 adminpages/paymentsettings.php:140
 #: adminpages/paymentsettings.php:142
-msgid ""
-"This gateway is for membership sites with Free levels or for sites that "
-"accept payment offline."
+#: adminpages/paymentsettings.php:138
+#: adminpages/paymentsettings.php:139
+#: adminpages/paymentsettings.php:140
+msgid "This gateway is for membership sites with Free levels or for sites that accept payment offline."
 msgstr ""
 
-#: adminpages/paymentsettings.php:187 adminpages/paymentsettings.php:148
-#: adminpages/paymentsettings.php:165 adminpages/paymentsettings.php:182
-#: adminpages/paymentsettings.php:184 adminpages/paymentsettings.php:185
 #: adminpages/paymentsettings.php:187
+#: adminpages/paymentsettings.php:148
+#: adminpages/paymentsettings.php:165
+#: adminpages/paymentsettings.php:182
+#: adminpages/paymentsettings.php:184
+#: adminpages/paymentsettings.php:185
 msgid "Currency and Tax Settings"
 msgstr ""
 
-#: adminpages/paymentsettings.php:192 adminpages/paymentsettings.php:153
-#: adminpages/paymentsettings.php:170 adminpages/paymentsettings.php:187
-#: adminpages/paymentsettings.php:189 adminpages/paymentsettings.php:190
-#: adminpages/paymentsettings.php:192 adminpages/paymentsettings.php:327
-#: adminpages/paymentsettings.php:337 adminpages/paymentsettings.php:356
-#: adminpages/paymentsettings.php:381 adminpages/paymentsettings.php:386
+#: adminpages/paymentsettings.php:192
+#: adminpages/paymentsettings.php:153
+#: adminpages/paymentsettings.php:170
+#: adminpages/paymentsettings.php:187
+#: adminpages/paymentsettings.php:189
+#: adminpages/paymentsettings.php:190
+#: adminpages/paymentsettings.php:327
+#: adminpages/paymentsettings.php:337
+#: adminpages/paymentsettings.php:356
+#: adminpages/paymentsettings.php:381
+#: adminpages/paymentsettings.php:386
 msgid "Currency"
 msgstr ""
 
-#: adminpages/paymentsettings.php:208 adminpages/paymentsettings.php:169
-#: adminpages/paymentsettings.php:186 adminpages/paymentsettings.php:203
-#: adminpages/paymentsettings.php:205 adminpages/paymentsettings.php:206
-#: adminpages/paymentsettings.php:208 adminpages/paymentsettings.php:400
+#: adminpages/paymentsettings.php:208
+#: adminpages/paymentsettings.php:169
+#: adminpages/paymentsettings.php:186
+#: adminpages/paymentsettings.php:203
+#: adminpages/paymentsettings.php:205
+#: adminpages/paymentsettings.php:206
+#: adminpages/paymentsettings.php:400
 #: adminpages/paymentsettings.php:402
-msgid ""
-"Not all currencies will be supported by every gateway. Please check with "
-"your gateway."
+msgid "Not all currencies will be supported by every gateway. Please check with your gateway."
 msgstr ""
 
-#: adminpages/paymentsettings.php:213 adminpages/paymentsettings.php:174
-#: adminpages/paymentsettings.php:191 adminpages/paymentsettings.php:208
-#: adminpages/paymentsettings.php:210 adminpages/paymentsettings.php:211
-#: adminpages/paymentsettings.php:213 adminpages/paymentsettings.php:375
-#: adminpages/paymentsettings.php:401 adminpages/paymentsettings.php:406
+#: adminpages/paymentsettings.php:213
+#: adminpages/paymentsettings.php:174
+#: adminpages/paymentsettings.php:191
+#: adminpages/paymentsettings.php:208
+#: adminpages/paymentsettings.php:210
+#: adminpages/paymentsettings.php:211
+#: adminpages/paymentsettings.php:375
+#: adminpages/paymentsettings.php:401
+#: adminpages/paymentsettings.php:406
 #: adminpages/paymentsettings.php:408
 msgid "Accepted Credit Card Types"
 msgstr ""
 
-#: adminpages/paymentsettings.php:227 adminpages/paymentsettings.php:188
-#: adminpages/paymentsettings.php:205 adminpages/paymentsettings.php:222
-#: adminpages/paymentsettings.php:224 adminpages/paymentsettings.php:225
-#: adminpages/paymentsettings.php:227 adminpages/paymentsettings.php:398
-#: adminpages/paymentsettings.php:438 adminpages/paymentsettings.php:443
+#: adminpages/paymentsettings.php:227
+#: adminpages/paymentsettings.php:188
+#: adminpages/paymentsettings.php:205
+#: adminpages/paymentsettings.php:222
+#: adminpages/paymentsettings.php:224
+#: adminpages/paymentsettings.php:225
+#: adminpages/paymentsettings.php:398
+#: adminpages/paymentsettings.php:438
+#: adminpages/paymentsettings.php:443
 #: adminpages/paymentsettings.php:445
 msgid "Sales Tax"
 msgstr ""
 
-#: adminpages/paymentsettings.php:227 pages/billing.php:167
-#: adminpages/paymentsettings.php:188 adminpages/paymentsettings.php:205
-#: adminpages/paymentsettings.php:222 adminpages/paymentsettings.php:224
-#: adminpages/paymentsettings.php:225 adminpages/paymentsettings.php:227
-#: adminpages/paymentsettings.php:398 adminpages/paymentsettings.php:438
-#: adminpages/paymentsettings.php:443 adminpages/paymentsettings.php:445
-#: pages/billing.php:78 pages/billing.php:82 pages/billing.php:91
-#: pages/billing.php:94 pages/billing.php:96 pages/billing.php:97
-#: pages/billing.php:100 pages/billing.php:117 pages/billing.php:120
-#: pages/billing.php:121 pages/billing.php:123 pages/billing.php:125
-#: pages/billing.php:126 pages/billing.php:134 pages/billing.php:143
+#: adminpages/paymentsettings.php:227
 #: pages/billing.php:167
+#: adminpages/paymentsettings.php:188
+#: adminpages/paymentsettings.php:205
+#: adminpages/paymentsettings.php:222
+#: adminpages/paymentsettings.php:224
+#: adminpages/paymentsettings.php:225
+#: adminpages/paymentsettings.php:398
+#: adminpages/paymentsettings.php:438
+#: adminpages/paymentsettings.php:443
+#: adminpages/paymentsettings.php:445
+#: pages/billing.php:78
+#: pages/billing.php:82
+#: pages/billing.php:91
+#: pages/billing.php:94
+#: pages/billing.php:96
+#: pages/billing.php:97
+#: pages/billing.php:100
+#: pages/billing.php:117
+#: pages/billing.php:120
+#: pages/billing.php:121
+#: pages/billing.php:123
+#: pages/billing.php:125
+#: pages/billing.php:126
+#: pages/billing.php:134
+#: pages/billing.php:143
 msgid "optional"
 msgstr ""
 
-#: adminpages/paymentsettings.php:230 adminpages/paymentsettings.php:191
-#: adminpages/paymentsettings.php:208 adminpages/paymentsettings.php:225
-#: adminpages/paymentsettings.php:227 adminpages/paymentsettings.php:228
-#: adminpages/paymentsettings.php:230 adminpages/paymentsettings.php:401
-#: adminpages/paymentsettings.php:441 adminpages/paymentsettings.php:446
+#: adminpages/paymentsettings.php:230
+#: adminpages/paymentsettings.php:191
+#: adminpages/paymentsettings.php:208
+#: adminpages/paymentsettings.php:225
+#: adminpages/paymentsettings.php:227
+#: adminpages/paymentsettings.php:228
+#: adminpages/paymentsettings.php:401
+#: adminpages/paymentsettings.php:441
+#: adminpages/paymentsettings.php:446
 #: adminpages/paymentsettings.php:448
 msgid "Tax State"
 msgstr ""
 
-#: adminpages/paymentsettings.php:231 adminpages/paymentsettings.php:192
-#: adminpages/paymentsettings.php:209 adminpages/paymentsettings.php:226
-#: adminpages/paymentsettings.php:228 adminpages/paymentsettings.php:229
-#: adminpages/paymentsettings.php:231 adminpages/paymentsettings.php:402
-#: adminpages/paymentsettings.php:442 adminpages/paymentsettings.php:447
+#: adminpages/paymentsettings.php:231
+#: adminpages/paymentsettings.php:192
+#: adminpages/paymentsettings.php:209
+#: adminpages/paymentsettings.php:226
+#: adminpages/paymentsettings.php:228
+#: adminpages/paymentsettings.php:229
+#: adminpages/paymentsettings.php:402
+#: adminpages/paymentsettings.php:442
+#: adminpages/paymentsettings.php:447
 #: adminpages/paymentsettings.php:449
 msgid "abbreviation, e.g. \"PA\""
 msgstr ""
 
-#: adminpages/paymentsettings.php:232 adminpages/paymentsettings.php:193
-#: adminpages/paymentsettings.php:210 adminpages/paymentsettings.php:227
-#: adminpages/paymentsettings.php:229 adminpages/paymentsettings.php:230
 #: adminpages/paymentsettings.php:232
+#: adminpages/paymentsettings.php:193
+#: adminpages/paymentsettings.php:210
+#: adminpages/paymentsettings.php:227
+#: adminpages/paymentsettings.php:229
+#: adminpages/paymentsettings.php:230
 msgid "Tax Rate"
 msgstr ""
 
-#: adminpages/paymentsettings.php:233 adminpages/paymentsettings.php:194
-#: adminpages/paymentsettings.php:211 adminpages/paymentsettings.php:228
-#: adminpages/paymentsettings.php:230 adminpages/paymentsettings.php:231
-#: adminpages/paymentsettings.php:233 adminpages/paymentsettings.php:404
-#: adminpages/paymentsettings.php:444 adminpages/paymentsettings.php:449
+#: adminpages/paymentsettings.php:233
+#: adminpages/paymentsettings.php:194
+#: adminpages/paymentsettings.php:211
+#: adminpages/paymentsettings.php:228
+#: adminpages/paymentsettings.php:230
+#: adminpages/paymentsettings.php:231
+#: adminpages/paymentsettings.php:404
+#: adminpages/paymentsettings.php:444
+#: adminpages/paymentsettings.php:449
 #: adminpages/paymentsettings.php:451
 msgid "decimal, e.g. \"0.06\""
 msgstr ""
 
-#: adminpages/paymentsettings.php:234 adminpages/paymentsettings.php:229
-#: adminpages/paymentsettings.php:231 adminpages/paymentsettings.php:232
 #: adminpages/paymentsettings.php:234
-msgid ""
-"US only. If values are given, tax will be applied for any members ordering "
-"from the selected state.<br />For non-US or more complex tax rules, use the "
-"<a target=\"_blank\" href=\"https://www.paidmembershipspro.com/non-us-taxes-"
-"paid-memberships-pro/?utm_source=plugin&utm_medium=pmpro-"
-"paymentsettings&utm_campaign=blog&utm_content=non-us-taxes-paid-memberships-"
-"pro\">pmpro_tax filter</a>."
+#: adminpages/paymentsettings.php:229
+#: adminpages/paymentsettings.php:231
+#: adminpages/paymentsettings.php:232
+msgid "US only. If values are given, tax will be applied for any members ordering from the selected state.<br />For non-US or more complex tax rules, use the <a target=\"_blank\" href=\"https://www.paidmembershipspro.com/non-us-taxes-paid-memberships-pro/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=blog&utm_content=non-us-taxes-paid-memberships-pro\">pmpro_tax filter</a>."
 msgstr ""
 
-#: adminpages/paymentsettings.php:246 adminpages/paymentsettings.php:206
-#: adminpages/paymentsettings.php:223 adminpages/paymentsettings.php:240
-#: adminpages/paymentsettings.php:243 adminpages/paymentsettings.php:244
-#: adminpages/paymentsettings.php:246 adminpages/paymentsettings.php:450
-#: adminpages/paymentsettings.php:455 adminpages/paymentsettings.php:457
+#: adminpages/paymentsettings.php:246
+#: adminpages/paymentsettings.php:206
+#: adminpages/paymentsettings.php:223
+#: adminpages/paymentsettings.php:240
+#: adminpages/paymentsettings.php:243
+#: adminpages/paymentsettings.php:244
+#: adminpages/paymentsettings.php:450
+#: adminpages/paymentsettings.php:455
+#: adminpages/paymentsettings.php:457
 msgid "Force SSL"
 msgstr ""
 
-#: adminpages/paymentsettings.php:253 adminpages/paymentsettings.php:213
-#: adminpages/paymentsettings.php:230 adminpages/paymentsettings.php:247
-#: adminpages/paymentsettings.php:250 adminpages/paymentsettings.php:251
 #: adminpages/paymentsettings.php:253
-msgid ""
-"Your Site URL starts with https:// and so PMPro will allow your entire site "
-"to be served over HTTPS."
+#: adminpages/paymentsettings.php:213
+#: adminpages/paymentsettings.php:230
+#: adminpages/paymentsettings.php:247
+#: adminpages/paymentsettings.php:250
+#: adminpages/paymentsettings.php:251
+msgid "Your Site URL starts with https:// and so PMPro will allow your entire site to be served over HTTPS."
 msgstr ""
 
-#: adminpages/paymentsettings.php:261 adminpages/paymentsettings.php:212
-#: adminpages/paymentsettings.php:221 adminpages/paymentsettings.php:238
-#: adminpages/paymentsettings.php:255 adminpages/paymentsettings.php:258
-#: adminpages/paymentsettings.php:259 adminpages/paymentsettings.php:261
-#: adminpages/paymentsettings.php:456 adminpages/paymentsettings.php:461
+#: adminpages/paymentsettings.php:261
+#: adminpages/paymentsettings.php:212
+#: adminpages/paymentsettings.php:221
+#: adminpages/paymentsettings.php:238
+#: adminpages/paymentsettings.php:255
+#: adminpages/paymentsettings.php:258
+#: adminpages/paymentsettings.php:259
+#: adminpages/paymentsettings.php:456
+#: adminpages/paymentsettings.php:461
 #: adminpages/paymentsettings.php:463
 msgid "Yes (with JavaScript redirects)"
 msgstr ""
 
-#: adminpages/paymentsettings.php:263 adminpages/paymentsettings.php:214
-#: adminpages/paymentsettings.php:223 adminpages/paymentsettings.php:240
-#: adminpages/paymentsettings.php:257 adminpages/paymentsettings.php:260
-#: adminpages/paymentsettings.php:261 adminpages/paymentsettings.php:263
-msgid ""
-"Recommended: Yes. Try the JavaScript redirects setting if you are having "
-"issues with infinite redirect loops."
+#: adminpages/paymentsettings.php:263
+#: adminpages/paymentsettings.php:214
+#: adminpages/paymentsettings.php:223
+#: adminpages/paymentsettings.php:240
+#: adminpages/paymentsettings.php:257
+#: adminpages/paymentsettings.php:260
+#: adminpages/paymentsettings.php:261
+msgid "Recommended: Yes. Try the JavaScript redirects setting if you are having issues with infinite redirect loops."
 msgstr ""
 
-#: adminpages/paymentsettings.php:271 adminpages/paymentsettings.php:219
-#: adminpages/paymentsettings.php:231 adminpages/paymentsettings.php:248
-#: adminpages/paymentsettings.php:265 adminpages/paymentsettings.php:268
-#: adminpages/paymentsettings.php:269 adminpages/paymentsettings.php:271
-#: adminpages/paymentsettings.php:430 adminpages/paymentsettings.php:463
-#: adminpages/paymentsettings.php:468 adminpages/paymentsettings.php:470
+#: adminpages/paymentsettings.php:271
+#: adminpages/paymentsettings.php:219
+#: adminpages/paymentsettings.php:231
+#: adminpages/paymentsettings.php:248
+#: adminpages/paymentsettings.php:265
+#: adminpages/paymentsettings.php:268
+#: adminpages/paymentsettings.php:269
+#: adminpages/paymentsettings.php:430
+#: adminpages/paymentsettings.php:463
+#: adminpages/paymentsettings.php:468
+#: adminpages/paymentsettings.php:470
 msgid "SSL Seal Code"
 msgstr ""
 
-#: adminpages/paymentsettings.php:275 adminpages/paymentsettings.php:272
-#: adminpages/paymentsettings.php:273 adminpages/paymentsettings.php:275
-msgid ""
-"Your <strong><a target=\"_blank\" href=\"https://www.paidmembershipspro.com/"
-"documentation/initial-plugin-setup/ssl/?utm_source=plugin&utm_medium=pmpro-"
-"paymentsettings&utm_campaign=documentation&utm_content=ssl&utm_term=link2\">SSL "
-"Certificate</a></strong> must be installed by your web host. Use this field "
-"to display your seal or other trusted merchant images. This field does not "
-"accept JavaScript."
+#: adminpages/paymentsettings.php:275
+#: adminpages/paymentsettings.php:272
+#: adminpages/paymentsettings.php:273
+msgid "Your <strong><a target=\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-plugin-setup/ssl/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=ssl&utm_term=link2\">SSL Certificate</a></strong> must be installed by your web host. Use this field to display your seal or other trusted merchant images. This field does not accept JavaScript."
 msgstr ""
 
-#: adminpages/paymentsettings.php:280 adminpages/paymentsettings.php:228
-#: adminpages/paymentsettings.php:240 adminpages/paymentsettings.php:257
-#: adminpages/paymentsettings.php:274 adminpages/paymentsettings.php:277
-#: adminpages/paymentsettings.php:278 adminpages/paymentsettings.php:280
+#: adminpages/paymentsettings.php:280
+#: adminpages/paymentsettings.php:228
+#: adminpages/paymentsettings.php:240
+#: adminpages/paymentsettings.php:257
+#: adminpages/paymentsettings.php:274
+#: adminpages/paymentsettings.php:277
+#: adminpages/paymentsettings.php:278
 msgid "Extra HTTPS URL Filter"
 msgstr ""
 
-#: adminpages/paymentsettings.php:283 adminpages/paymentsettings.php:231
-#: adminpages/paymentsettings.php:243 adminpages/paymentsettings.php:260
-#: adminpages/paymentsettings.php:277 adminpages/paymentsettings.php:280
-#: adminpages/paymentsettings.php:281 adminpages/paymentsettings.php:283
-msgid ""
-"Pass all generated HTML through a URL filter to add HTTPS to URLs used on "
-"secure pages. Check this if you are using SSL and have warnings on your "
-"checkout pages."
+#: adminpages/paymentsettings.php:283
+#: adminpages/paymentsettings.php:231
+#: adminpages/paymentsettings.php:243
+#: adminpages/paymentsettings.php:260
+#: adminpages/paymentsettings.php:277
+#: adminpages/paymentsettings.php:280
+#: adminpages/paymentsettings.php:281
+msgid "Pass all generated HTML through a URL filter to add HTTPS to URLs used on secure pages. Check this if you are using SSL and have warnings on your checkout pages."
 msgstr ""
 
-#: adminpages/reports.php:19 adminpages/reports.php:19
-#: adminpages/reports.php:61 adminpages/reports.php:63
+#: adminpages/reports.php:19
+#: adminpages/reports.php:61
+#: adminpages/reports.php:63
 msgid "Back to Reports Dashboard"
 msgstr ""
 
-#: adminpages/reports/login.php:31 adminpages/reports/login.php:31
+#: adminpages/reports/login.php:31
 msgid "Visits"
 msgstr ""
 
-#: adminpages/reports/login.php:32 adminpages/reports/login.php:32
+#: adminpages/reports/login.php:32
 msgid "Views"
 msgstr ""
 
-#: adminpages/reports/login.php:33 adminpages/reports/login.php:33
+#: adminpages/reports/login.php:33
 msgid "Logins"
 msgstr ""
 
-#: adminpages/reports/login.php:38 adminpages/reports/memberships.php:67
-#: adminpages/reports/sales.php:50 adminpages/reports/login.php:38
-#: adminpages/reports/memberships.php:43 adminpages/reports/memberships.php:46
-#: adminpages/reports/memberships.php:62 adminpages/reports/memberships.php:67
-#: adminpages/reports/memberships.php:68 adminpages/reports/memberships.php:81
-#: adminpages/reports/sales.php:50 adminpages/reports/sales.php:51
+#: adminpages/reports/login.php:38
+#: adminpages/reports/memberships.php:67
+#: adminpages/reports/sales.php:50
+#: adminpages/reports/memberships.php:43
+#: adminpages/reports/memberships.php:46
+#: adminpages/reports/memberships.php:62
+#: adminpages/reports/memberships.php:68
+#: adminpages/reports/memberships.php:81
+#: adminpages/reports/sales.php:51
 #: adminpages/reports/sales.php:52
 msgid "Today"
 msgstr ""
 
-#: adminpages/reports/login.php:44 adminpages/reports/login.php:44
+#: adminpages/reports/login.php:44
 msgid "This Week"
 msgstr ""
 
-#: adminpages/reports/login.php:56 adminpages/reports/login.php:56
+#: adminpages/reports/login.php:56
 msgid "Year to Date"
 msgstr ""
 
-#: adminpages/reports/login.php:62 adminpages/reports/memberships.php:70
-#: adminpages/reports/sales.php:53 adminpages/reports/login.php:50
-#: adminpages/reports/login.php:62 adminpages/reports/memberships.php:49
-#: adminpages/reports/memberships.php:50 adminpages/reports/memberships.php:58
-#: adminpages/reports/memberships.php:69 adminpages/reports/memberships.php:70
-#: adminpages/reports/memberships.php:71 adminpages/reports/sales.php:53
-#: adminpages/reports/sales.php:54 adminpages/reports/sales.php:66
+#: adminpages/reports/login.php:62
+#: adminpages/reports/memberships.php:70
+#: adminpages/reports/sales.php:53
+#: adminpages/reports/login.php:50
+#: adminpages/reports/memberships.php:49
+#: adminpages/reports/memberships.php:50
+#: adminpages/reports/memberships.php:58
+#: adminpages/reports/memberships.php:69
+#: adminpages/reports/memberships.php:71
+#: adminpages/reports/sales.php:54
+#: adminpages/reports/sales.php:66
 #: adminpages/reports/sales.php:67
 msgid "All Time"
 msgstr ""
 
-#: adminpages/reports/login.php:71 adminpages/reports/memberships.php:114
-#: adminpages/reports/sales.php:99 adminpages/reports.php:26
-#: adminpages/reports.php:37 adminpages/reports.php:40
-#: adminpages/reports.php:41 adminpages/reports/login.php:71
-#: adminpages/reports/memberships.php:114 adminpages/reports/sales.php:99
+#: adminpages/reports/login.php:71
+#: adminpages/reports/memberships.php:114
+#: adminpages/reports/sales.php:99
+#: adminpages/reports.php:26
+#: adminpages/reports.php:37
+#: adminpages/reports.php:40
+#: adminpages/reports.php:41
 msgid "Details"
 msgstr ""
 
-#: adminpages/reports/login.php:99 adminpages/reports/login.php:61
-#: adminpages/reports/login.php:63 adminpages/reports/login.php:79
-#: adminpages/reports/login.php:83 adminpages/reports/login.php:99
+#: adminpages/reports/login.php:99
+#: adminpages/reports/login.php:61
+#: adminpages/reports/login.php:63
+#: adminpages/reports/login.php:79
+#: adminpages/reports/login.php:83
 msgid "Visits, Views, and Logins Report"
 msgstr ""
 
 #: adminpages/reports/login.php:104
 #: classes/class-pmpro-members-list-table.php:234
-#: adminpages/memberslist.php:279 adminpages/memberslist.php:283
-#: adminpages/reports/login.php:66 adminpages/reports/login.php:68
-#: adminpages/reports/login.php:84 adminpages/reports/login.php:88
-#: adminpages/reports/login.php:104
-#: classes/class-pmpro-members-list-table.php:234
+#: adminpages/memberslist.php:279
+#: adminpages/memberslist.php:283
+#: adminpages/reports/login.php:66
+#: adminpages/reports/login.php:68
+#: adminpages/reports/login.php:84
+#: adminpages/reports/login.php:88
 #: classes/class-pmpro-members-list-table.php:260
 #: classes/class-pmpro-members-list-table.php:265
 msgid "All Users"
 msgstr ""
 
-#: adminpages/reports/login.php:105 adminpages/reports/memberships.php:373
+#: adminpages/reports/login.php:105
+#: adminpages/reports/memberships.php:373
 #: adminpages/reports/sales.php:311
 #: classes/class-pmpro-members-list-table.php:625
-#: classes/class.pmproemail.php:182 classes/class.pmproemail.php:227
-#: adminpages/memberslist.php:32 adminpages/reports/login.php:67
-#: adminpages/reports/login.php:69 adminpages/reports/login.php:85
-#: adminpages/reports/login.php:89 adminpages/reports/login.php:105
+#: classes/class.pmproemail.php:182
+#: classes/class.pmproemail.php:227
+#: adminpages/memberslist.php:32
+#: adminpages/reports/login.php:67
+#: adminpages/reports/login.php:69
+#: adminpages/reports/login.php:85
+#: adminpages/reports/login.php:89
 #: adminpages/reports/memberships.php:281
 #: adminpages/reports/memberships.php:290
 #: adminpages/reports/memberships.php:303
 #: adminpages/reports/memberships.php:317
 #: adminpages/reports/memberships.php:331
 #: adminpages/reports/memberships.php:355
-#: adminpages/reports/memberships.php:373 adminpages/reports/sales.php:208
-#: adminpages/reports/sales.php:216 adminpages/reports/sales.php:217
-#: adminpages/reports/sales.php:225 adminpages/reports/sales.php:226
-#: adminpages/reports/sales.php:242 adminpages/reports/sales.php:311
+#: adminpages/reports/sales.php:208
+#: adminpages/reports/sales.php:216
+#: adminpages/reports/sales.php:217
+#: adminpages/reports/sales.php:225
+#: adminpages/reports/sales.php:226
+#: adminpages/reports/sales.php:242
 #: classes/class-pmpro-members-list-table.php:538
 #: classes/class-pmpro-members-list-table.php:594
 #: classes/class-pmpro-members-list-table.php:606
 #: classes/class-pmpro-members-list-table.php:618
-#: classes/class-pmpro-members-list-table.php:625
 #: classes/class-pmpro-members-list-table.php:662
-#: classes/class.pmproemail.php:145 classes/class.pmproemail.php:147
-#: classes/class.pmproemail.php:154 classes/class.pmproemail.php:182
-#: classes/class.pmproemail.php:189 classes/class.pmproemail.php:192
-#: classes/class.pmproemail.php:199 classes/class.pmproemail.php:227
+#: classes/class.pmproemail.php:145
+#: classes/class.pmproemail.php:147
+#: classes/class.pmproemail.php:154
+#: classes/class.pmproemail.php:189
+#: classes/class.pmproemail.php:192
+#: classes/class.pmproemail.php:199
 msgid "All Levels"
 msgstr ""
 
-#: adminpages/reports/login.php:184 adminpages/reports/login.php:146
-#: adminpages/reports/login.php:148 adminpages/reports/login.php:164
-#: adminpages/reports/login.php:168 adminpages/reports/login.php:184
+#: adminpages/reports/login.php:184
+#: adminpages/reports/login.php:146
+#: adminpages/reports/login.php:148
+#: adminpages/reports/login.php:164
+#: adminpages/reports/login.php:168
 msgid "Last Visit"
 msgstr ""
 
-#: adminpages/reports/login.php:185 adminpages/reports/login.php:185
+#: adminpages/reports/login.php:185
 msgid "Visits This Week"
 msgstr ""
 
-#: adminpages/reports/login.php:186 adminpages/reports/login.php:27
-#: adminpages/reports/login.php:28 adminpages/reports/login.php:147
-#: adminpages/reports/login.php:149 adminpages/reports/login.php:165
-#: adminpages/reports/login.php:169 adminpages/reports/login.php:186
+#: adminpages/reports/login.php:186
+#: adminpages/reports/login.php:27
+#: adminpages/reports/login.php:28
+#: adminpages/reports/login.php:147
+#: adminpages/reports/login.php:149
+#: adminpages/reports/login.php:165
+#: adminpages/reports/login.php:169
 msgid "Visits This Month"
 msgstr ""
 
-#: adminpages/reports/login.php:187 adminpages/reports/login.php:187
+#: adminpages/reports/login.php:187
 msgid "Visits This Year"
 msgstr ""
 
-#: adminpages/reports/login.php:188 adminpages/reports/login.php:28
-#: adminpages/reports/login.php:29 adminpages/reports/login.php:188
+#: adminpages/reports/login.php:188
+#: adminpages/reports/login.php:28
+#: adminpages/reports/login.php:29
 msgid "Visits All Time"
 msgstr ""
 
-#: adminpages/reports/login.php:189 adminpages/reports/login.php:189
+#: adminpages/reports/login.php:189
 msgid "Views This Week"
 msgstr ""
 
-#: adminpages/reports/login.php:190 adminpages/reports/login.php:32
-#: adminpages/reports/login.php:33 adminpages/reports/login.php:149
-#: adminpages/reports/login.php:151 adminpages/reports/login.php:167
-#: adminpages/reports/login.php:171 adminpages/reports/login.php:190
+#: adminpages/reports/login.php:190
+#: adminpages/reports/login.php:32
+#: adminpages/reports/login.php:33
+#: adminpages/reports/login.php:149
+#: adminpages/reports/login.php:151
+#: adminpages/reports/login.php:167
+#: adminpages/reports/login.php:171
 msgid "Views This Month"
 msgstr ""
 
-#: adminpages/reports/login.php:191 adminpages/reports/login.php:191
+#: adminpages/reports/login.php:191
 msgid "Views This Year"
 msgstr ""
 
-#: adminpages/reports/login.php:192 adminpages/reports/login.php:33
-#: adminpages/reports/login.php:34 adminpages/reports/login.php:192
+#: adminpages/reports/login.php:192
+#: adminpages/reports/login.php:33
+#: adminpages/reports/login.php:34
 msgid "Views All Time"
 msgstr ""
 
-#: adminpages/reports/login.php:193 adminpages/reports/login.php:151
-#: adminpages/reports/login.php:153 adminpages/reports/login.php:169
-#: adminpages/reports/login.php:173 adminpages/reports/login.php:193
+#: adminpages/reports/login.php:193
+#: adminpages/reports/login.php:151
+#: adminpages/reports/login.php:153
+#: adminpages/reports/login.php:169
+#: adminpages/reports/login.php:173
 msgid "Last Login"
 msgstr ""
 
-#: adminpages/reports/login.php:194 adminpages/reports/login.php:194
+#: adminpages/reports/login.php:194
 msgid "Logins This Week"
 msgstr ""
 
-#: adminpages/reports/login.php:195 adminpages/reports/login.php:37
-#: adminpages/reports/login.php:38 adminpages/reports/login.php:152
-#: adminpages/reports/login.php:154 adminpages/reports/login.php:170
-#: adminpages/reports/login.php:174 adminpages/reports/login.php:195
+#: adminpages/reports/login.php:195
+#: adminpages/reports/login.php:37
+#: adminpages/reports/login.php:38
+#: adminpages/reports/login.php:152
+#: adminpages/reports/login.php:154
+#: adminpages/reports/login.php:170
+#: adminpages/reports/login.php:174
 msgid "Logins This Month"
 msgstr ""
 
-#: adminpages/reports/login.php:196 adminpages/reports/login.php:196
+#: adminpages/reports/login.php:196
 msgid "Logins This Year"
 msgstr ""
 
-#: adminpages/reports/login.php:197 adminpages/reports/login.php:38
-#: adminpages/reports/login.php:39 adminpages/reports/login.php:197
+#: adminpages/reports/login.php:197
+#: adminpages/reports/login.php:38
+#: adminpages/reports/login.php:39
 msgid "Logins All Time"
 msgstr ""
 
 #: adminpages/reports/login.php:261
 #: classes/class-pmpro-members-list-table.php:228
-#: adminpages/memberslist.php:195 adminpages/memberslist.php:223
-#: adminpages/memberslist.php:251 adminpages/memberslist.php:261
-#: adminpages/memberslist.php:262 adminpages/memberslist.php:266
-#: adminpages/memberslist.php:270 adminpages/memberslist.php:274
-#: adminpages/reports/login.php:210 adminpages/reports/login.php:212
-#: adminpages/reports/login.php:228 adminpages/reports/login.php:232
-#: adminpages/reports/login.php:261
-#: classes/class-pmpro-members-list-table.php:228
+#: adminpages/memberslist.php:195
+#: adminpages/memberslist.php:223
+#: adminpages/memberslist.php:251
+#: adminpages/memberslist.php:261
+#: adminpages/memberslist.php:262
+#: adminpages/memberslist.php:266
+#: adminpages/memberslist.php:270
+#: adminpages/memberslist.php:274
+#: adminpages/reports/login.php:210
+#: adminpages/reports/login.php:212
+#: adminpages/reports/login.php:228
+#: adminpages/reports/login.php:232
 #: classes/class-pmpro-members-list-table.php:254
 #: classes/class-pmpro-members-list-table.php:259
 msgid "Search all levels"
 msgstr ""
 
-#: adminpages/reports/memberships.php:61 adminpages/reports/memberships.php:37
-#: adminpages/reports/memberships.php:40 adminpages/reports/memberships.php:48
-#: adminpages/reports/memberships.php:61 adminpages/reports/memberships.php:62
+#: adminpages/reports/memberships.php:61
+#: adminpages/reports/memberships.php:37
+#: adminpages/reports/memberships.php:40
+#: adminpages/reports/memberships.php:48
+#: adminpages/reports/memberships.php:62
 msgid "Signups"
 msgstr ""
 
-#: adminpages/reports/memberships.php:62 adminpages/reports/memberships.php:38
-#: adminpages/reports/memberships.php:41 adminpages/reports/memberships.php:62
+#: adminpages/reports/memberships.php:62
+#: adminpages/reports/memberships.php:38
+#: adminpages/reports/memberships.php:41
 #: adminpages/reports/memberships.php:63
 msgid "All Cancellations"
 msgstr ""
 
-#: adminpages/reports/memberships.php:353 adminpages/reports/sales.php:292
+#: adminpages/reports/memberships.php:353
+#: adminpages/reports/sales.php:292
 #: adminpages/reports/memberships.php:260
 #: adminpages/reports/memberships.php:267
 #: adminpages/reports/memberships.php:280
 #: adminpages/reports/memberships.php:296
 #: adminpages/reports/memberships.php:308
 #: adminpages/reports/memberships.php:332
-#: adminpages/reports/memberships.php:353 adminpages/reports/sales.php:189
-#: adminpages/reports/sales.php:197 adminpages/reports/sales.php:198
-#: adminpages/reports/sales.php:206 adminpages/reports/sales.php:207
-#: adminpages/reports/sales.php:223 adminpages/reports/sales.php:292
+#: adminpages/reports/sales.php:189
+#: adminpages/reports/sales.php:197
+#: adminpages/reports/sales.php:198
+#: adminpages/reports/sales.php:206
+#: adminpages/reports/sales.php:207
+#: adminpages/reports/sales.php:223
 msgid "Annual"
 msgstr ""
 
@@ -5403,7 +7616,6 @@ msgstr ""
 #: adminpages/reports/memberships.php:283
 #: adminpages/reports/memberships.php:311
 #: adminpages/reports/memberships.php:335
-#: adminpages/reports/memberships.php:356
 msgid "Signups vs. All Cancellations"
 msgstr ""
 
@@ -5414,7 +7626,6 @@ msgstr ""
 #: adminpages/reports/memberships.php:299
 #: adminpages/reports/memberships.php:312
 #: adminpages/reports/memberships.php:336
-#: adminpages/reports/memberships.php:357
 msgid "Signups vs. Cancellations"
 msgstr ""
 
@@ -5423,16 +7634,20 @@ msgstr ""
 #: adminpages/reports/memberships.php:285
 #: adminpages/reports/memberships.php:313
 #: adminpages/reports/memberships.php:337
-#: adminpages/reports/memberships.php:358
 msgid "Signups vs. Expirations"
 msgstr ""
 
 #: adminpages/reports/memberships.php:360
-#: adminpages/reports/memberships.php:371 adminpages/reports/sales.php:298
-#: adminpages/reports/sales.php:309 adminpages/membershiplevels.php:545
-#: adminpages/membershiplevels.php:551 adminpages/membershiplevels.php:553
-#: adminpages/membershiplevels.php:559 adminpages/membershiplevels.php:561
-#: adminpages/membershiplevels.php:580 adminpages/membershiplevels.php:588
+#: adminpages/reports/memberships.php:371
+#: adminpages/reports/sales.php:298
+#: adminpages/reports/sales.php:309
+#: adminpages/membershiplevels.php:545
+#: adminpages/membershiplevels.php:551
+#: adminpages/membershiplevels.php:553
+#: adminpages/membershiplevels.php:559
+#: adminpages/membershiplevels.php:561
+#: adminpages/membershiplevels.php:580
+#: adminpages/membershiplevels.php:588
 #: adminpages/reports/memberships.php:268
 #: adminpages/reports/memberships.php:277
 #: adminpages/reports/memberships.php:279
@@ -5445,81 +7660,90 @@ msgstr ""
 #: adminpages/reports/memberships.php:329
 #: adminpages/reports/memberships.php:342
 #: adminpages/reports/memberships.php:353
-#: adminpages/reports/memberships.php:360
-#: adminpages/reports/memberships.php:371 adminpages/reports/sales.php:195
-#: adminpages/reports/sales.php:203 adminpages/reports/sales.php:204
-#: adminpages/reports/sales.php:206 adminpages/reports/sales.php:212
-#: adminpages/reports/sales.php:213 adminpages/reports/sales.php:214
-#: adminpages/reports/sales.php:215 adminpages/reports/sales.php:223
-#: adminpages/reports/sales.php:224 adminpages/reports/sales.php:229
-#: adminpages/reports/sales.php:240 adminpages/reports/sales.php:298
-#: adminpages/reports/sales.php:309
+#: adminpages/reports/sales.php:195
+#: adminpages/reports/sales.php:203
+#: adminpages/reports/sales.php:204
+#: adminpages/reports/sales.php:206
+#: adminpages/reports/sales.php:212
+#: adminpages/reports/sales.php:213
+#: adminpages/reports/sales.php:214
+#: adminpages/reports/sales.php:215
+#: adminpages/reports/sales.php:223
+#: adminpages/reports/sales.php:224
+#: adminpages/reports/sales.php:229
+#: adminpages/reports/sales.php:240
 msgid "for"
 msgstr ""
 
-#: adminpages/reports/memberships.php:374
 #: adminpages/reports/memberships.php:374
 msgid "All Paid Levels"
 msgstr ""
 
 #: adminpages/reports/memberships.php:375
-#: adminpages/reports/memberships.php:375
 msgid "All Free Levels"
 msgstr ""
 
-#: adminpages/reports/memberships.php:394 adminpages/reports/sales.php:328
-#: adminpages/reports/memberships.php:394 adminpages/reports/sales.php:328
+#: adminpages/reports/memberships.php:394
+#: adminpages/reports/sales.php:328
 msgid "All Codes"
 msgstr ""
 
-#: adminpages/reports/memberships.php:402 adminpages/reports/sales.php:336
+#: adminpages/reports/memberships.php:402
+#: adminpages/reports/sales.php:336
 #: adminpages/reports/memberships.php:295
 #: adminpages/reports/memberships.php:304
 #: adminpages/reports/memberships.php:317
 #: adminpages/reports/memberships.php:331
 #: adminpages/reports/memberships.php:345
 #: adminpages/reports/memberships.php:369
-#: adminpages/reports/memberships.php:402 adminpages/reports/sales.php:222
-#: adminpages/reports/sales.php:230 adminpages/reports/sales.php:231
-#: adminpages/reports/sales.php:239 adminpages/reports/sales.php:240
-#: adminpages/reports/sales.php:256 adminpages/reports/sales.php:336
+#: adminpages/reports/sales.php:222
+#: adminpages/reports/sales.php:230
+#: adminpages/reports/sales.php:231
+#: adminpages/reports/sales.php:239
+#: adminpages/reports/sales.php:240
+#: adminpages/reports/sales.php:256
 msgid "Generate Report"
 msgstr ""
 
-#: adminpages/reports/sales.php:18 adminpages/reports/sales.php:18
+#: adminpages/reports/sales.php:18
 msgid "Sales and Revenue (Testing/Sandbox)"
 msgstr ""
 
-#: adminpages/reports/sales.php:44 adminpages/reports/sales.php:296
-#: adminpages/reports/sales.php:44 adminpages/reports/sales.php:45
-#: adminpages/reports/sales.php:46 adminpages/reports/sales.php:193
-#: adminpages/reports/sales.php:201 adminpages/reports/sales.php:202
-#: adminpages/reports/sales.php:210 adminpages/reports/sales.php:211
-#: adminpages/reports/sales.php:227 adminpages/reports/sales.php:296
+#: adminpages/reports/sales.php:44
+#: adminpages/reports/sales.php:296
+#: adminpages/reports/sales.php:45
+#: adminpages/reports/sales.php:46
+#: adminpages/reports/sales.php:193
+#: adminpages/reports/sales.php:201
+#: adminpages/reports/sales.php:202
+#: adminpages/reports/sales.php:210
+#: adminpages/reports/sales.php:211
+#: adminpages/reports/sales.php:227
 msgid "Sales"
 msgstr ""
 
-#: adminpages/reports/sales.php:45 adminpages/reports/sales.php:295
-#: adminpages/reports/sales.php:45 adminpages/reports/sales.php:46
-#: adminpages/reports/sales.php:47 adminpages/reports/sales.php:192
-#: adminpages/reports/sales.php:200 adminpages/reports/sales.php:201
-#: adminpages/reports/sales.php:209 adminpages/reports/sales.php:210
-#: adminpages/reports/sales.php:226 adminpages/reports/sales.php:295
+#: adminpages/reports/sales.php:45
+#: adminpages/reports/sales.php:295
+#: adminpages/reports/sales.php:46
+#: adminpages/reports/sales.php:47
+#: adminpages/reports/sales.php:192
+#: adminpages/reports/sales.php:200
+#: adminpages/reports/sales.php:201
+#: adminpages/reports/sales.php:209
+#: adminpages/reports/sales.php:210
+#: adminpages/reports/sales.php:226
 msgid "Revenue"
 msgstr ""
 
-#: adminpages/reports/sales.php:339 adminpages/reports/sales.php:339
-msgid ""
-"Average line calculated using data prior to current day, month, or year."
+#: adminpages/reports/sales.php:339
+msgid "Average line calculated using data prior to current day, month, or year."
 msgstr ""
 
-#: adminpages/reports/sales.php:382 adminpages/reports/sales.php:381
 #: adminpages/reports/sales.php:382
+#: adminpages/reports/sales.php:381
 msgid "Average*"
 msgstr ""
 
-#: adminpages/templates/orders-email.php:14
-#: adminpages/templates/orders-print.php:50
 #: adminpages/templates/orders-email.php:14
 #: adminpages/templates/orders-print.php:50
 msgid "Invoice #: "
@@ -5527,93 +7751,101 @@ msgstr ""
 
 #: adminpages/templates/orders-email.php:18
 #: adminpages/templates/orders-print.php:54
-#: adminpages/templates/orders-email.php:18
-#: adminpages/templates/orders-print.php:54
 msgid "Date:"
 msgstr ""
 
-#: adminpages/templates/orders-email.php:24
 #: adminpages/templates/orders-email.php:24
 msgid "Bill to:"
 msgstr ""
 
 #: adminpages/templates/orders-email.php:47
 #: adminpages/templates/orders-print.php:76
-#: adminpages/templates/orders-email.php:47
-#: adminpages/templates/orders-print.php:76
 msgid "Item"
 msgstr ""
 
 #: adminpages/templates/orders-email.php:48
-#: adminpages/templates/orders-print.php:77 pages/levels.php:36
-#: adminpages/templates/orders-email.php:48
-#: adminpages/templates/orders-print.php:77 pages/levels.php:14
+#: adminpages/templates/orders-print.php:77
 #: pages/levels.php:36
+#: pages/levels.php:14
 msgid "Price"
 msgstr ""
 
 #: adminpages/templates/orders-email.php:56
-#: adminpages/templates/orders-print.php:85 pages/confirmation.php:94
-#: pages/invoice.php:84 adminpages/templates/orders-email.php:56
-#: adminpages/templates/orders-print.php:85 pages/confirmation.php:90
-#: pages/confirmation.php:91 pages/confirmation.php:93
-#: pages/confirmation.php:94 pages/invoice.php:72 pages/invoice.php:73
-#: pages/invoice.php:74 pages/invoice.php:75 pages/invoice.php:77
-#: pages/invoice.php:79 pages/invoice.php:83 pages/invoice.php:84
+#: adminpages/templates/orders-print.php:85
+#: pages/confirmation.php:94
+#: pages/invoice.php:84
+#: pages/confirmation.php:90
+#: pages/confirmation.php:91
+#: pages/confirmation.php:93
+#: pages/invoice.php:72
+#: pages/invoice.php:73
+#: pages/invoice.php:74
+#: pages/invoice.php:75
+#: pages/invoice.php:77
+#: pages/invoice.php:79
+#: pages/invoice.php:83
 msgid "Subtotal"
 msgstr ""
 
-#: adminpages/updates.php:14 adminpages/updates.php:11
 #: adminpages/updates.php:14
+#: adminpages/updates.php:11
 msgid "Updating Paid Memberships Pro"
 msgstr ""
 
-#: adminpages/updates.php:21 adminpages/updates.php:18
 #: adminpages/updates.php:21
+#: adminpages/updates.php:18
 msgid "Updates are processing. This may take a few minutes to complete."
 msgstr ""
 
-#: adminpages/updates.php:27 adminpages/updates.php:23
 #: adminpages/updates.php:27
+#: adminpages/updates.php:23
 msgid "Update complete."
 msgstr ""
 
-#: blocks/blocks.php:37 classes/class-pmpro-admin-activity-email.php:355
-#: includes/compatibility/divi.php:19 includes/compatibility/divi.php:23
-#: includes/compatibility/elementor/class-pmpro-elementor.php:65
-#: includes/menus.php:34 includes/menus.php:104 blocks/blocks.php:35
-#: blocks/blocks.php:37 includes/compatibility/divi.php:19
+#. Plugin Name of the plugin
+#: blocks/blocks.php:37
+#: classes/class-pmpro-admin-activity-email.php:355
+#: includes/compatibility/divi.php:19
 #: includes/compatibility/divi.php:23
-#: includes/compatibility/elementor/class-pmpro-elementor.php:61
 #: includes/compatibility/elementor/class-pmpro-elementor.php:65
-#: includes/menus.php:34 includes/menus.php:104
+#: includes/menus.php:34
+#: includes/menus.php:104
+#: blocks/blocks.php:35
+#: includes/compatibility/elementor/class-pmpro-elementor.php:61
+#: blocks/account-invoices-section/block.js:38
+#: blocks/account-links-section/block.js:38
+#: blocks/account-membership-section/block.js:38
+#: blocks/account-page/block.js:58
+#: blocks/account-profile-section/block.js:39
+#: blocks/billing-page/block.js:38
+#: blocks/cancel-page/block.js:38
+#: blocks/checkout-page/block.js:51
+#: blocks/confirmation-page/block.js:38
+#: blocks/invoice-page/block.js:38
+#: blocks/levels-page/block.js:38
+#: blocks/login/block.js:46
+#: blocks/member-profile-edit/block.js:33
 msgid "Paid Memberships Pro"
 msgstr ""
 
-#: blocks/checkout-button/block.php:54 blocks/checkout-button/block.php:54
+#: blocks/checkout-button/block.php:54
 msgid "Buy Now"
 msgstr ""
 
 #: classes/class-deny-network-activation.php:41
-#: classes/class-deny-network-activation.php:41
 #: classes/class-deny-network-activation.php:45
 #, php-format
-msgid ""
-"The %s plugin should not be network activated. Activate on each individual "
-"site's plugin page."
+msgid "The %s plugin should not be network activated. Activate on each individual site's plugin page."
 msgstr ""
 
-#: classes/class-pmpro-admin-activity-email.php:43
 #: classes/class-pmpro-admin-activity-email.php:43
 msgid "yesterday"
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:44
-#: classes/class-pmpro-admin-activity-email.php:44
 msgid "last week"
 msgstr ""
 
-#: classes/class-pmpro-admin-activity-email.php:45
 #: classes/class-pmpro-admin-activity-email.php:45
 msgid "last month"
 msgstr ""
@@ -5655,16 +7887,13 @@ msgstr ""
 #: classes/class-pmpro-admin-activity-email.php:206
 #: classes/class-pmpro-admin-activity-email.php:204
 #, php-format
-msgid ""
-"<strong>%1$d order</strong> used a <a %2$s>Discount Code</a> at checkout:"
+msgid "<strong>%1$d order</strong> used a <a %2$s>Discount Code</a> at checkout:"
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:208
 #: classes/class-pmpro-admin-activity-email.php:206
 #, php-format
-msgid ""
-"<strong>%1$d orders</strong> used a <a %2$s>Discount Code</a> at checkout. "
-"Here is a breakdown of your most used codes:"
+msgid "<strong>%1$d orders</strong> used a <a %2$s>Discount Code</a> at checkout. Here is a breakdown of your most used codes:"
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:228
@@ -5692,11 +7921,7 @@ msgstr ""
 #: classes/class-pmpro-admin-activity-email.php:275
 #: classes/class-pmpro-admin-activity-email.php:273
 #, php-format
-msgid ""
-"It is important to keep all Add Ons up to date to take advantage of security "
-"improvements, bug fixes, and expanded features. Add On updates can be made "
-"<a href=\"%s\" style=\"color:#2997c8;\" target=\"_blank\">via the WordPress "
-"Dashboard</a>."
+msgid "It is important to keep all Add Ons up to date to take advantage of security improvements, bug fixes, and expanded features. Add On updates can be made <a href=\"%s\" style=\"color:#2997c8;\" target=\"_blank\">via the WordPress Dashboard</a>."
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:284
@@ -5714,9 +7939,7 @@ msgid "Membership Managers"
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:308
-msgid ""
-"Note: It is important to review users with access to your membership site "
-"data since they control settings and can modify member accounts."
+msgid "Note: It is important to review users with access to your membership site data since they control settings and can modify member accounts."
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:315
@@ -5726,11 +7949,7 @@ msgstr ""
 #: classes/class-pmpro-admin-activity-email.php:316
 #: classes/class-pmpro-admin-activity-email.php:314
 #, php-format
-msgid ""
-"...and that is perfectly OK! PMPro is free to use for as long as you want "
-"for membership sites of all sizes. Interested in unlimited support, access "
-"to over 70 featured-enhancing Add Ons and instant installs and updates? <a "
-"%s>Check out our paid plans to learn more</a>."
+msgid "...and that is perfectly OK! PMPro is free to use for as long as you want for membership sites of all sizes. Interested in unlimited support, access to over 70 featured-enhancing Add Ons and instant installs and updates? <a %s>Check out our paid plans to learn more</a>."
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:331
@@ -5751,18 +7970,13 @@ msgid "Subscribe to our YouTube Channel"
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:371
-msgid ""
-"This email is automatically generated by your WordPress site and sent to "
-"your Administration Email Address set under Settings > General in your "
-"WordPress dashboard."
+msgid "This email is automatically generated by your WordPress site and sent to your Administration Email Address set under Settings > General in your WordPress dashboard."
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:372
 #: classes/class-pmpro-admin-activity-email.php:370
 #, php-format
-msgid ""
-"To adjust the frequency of this message or disable these emails completely, "
-"you can <a %s>update the \"Activity Email Frequency\" setting here</a>."
+msgid "To adjust the frequency of this message or disable these emails completely, you can <a %s>update the \"Activity Email Frequency\" setting here</a>."
 msgstr ""
 
 #: classes/class-pmpro-admin-activity-email.php:410
@@ -5772,54 +7986,54 @@ msgid "[%1$s] PMPro Activity for %2$s: %3$s"
 msgstr ""
 
 #: classes/class-pmpro-members-list-table.php:232
-#: adminpages/memberslist.php:274 adminpages/memberslist.php:278
-#: classes/class-pmpro-members-list-table.php:232
+#: adminpages/memberslist.php:274
+#: adminpages/memberslist.php:278
 #: classes/class-pmpro-members-list-table.php:258
 #: classes/class-pmpro-members-list-table.php:263
 msgid "You can also try searching:"
 msgstr ""
 
 #: classes/class-pmpro-members-list-table.php:235
-#: classes/class-pmpro-members-list-table.php:635 adminpages/memberslist.php:42
-#: adminpages/memberslist.php:276 adminpages/memberslist.php:280
-#: classes/class-pmpro-members-list-table.php:235
+#: classes/class-pmpro-members-list-table.php:635
+#: adminpages/memberslist.php:42
+#: adminpages/memberslist.php:276
+#: adminpages/memberslist.php:280
 #: classes/class-pmpro-members-list-table.php:261
 #: classes/class-pmpro-members-list-table.php:266
 #: classes/class-pmpro-members-list-table.php:561
 #: classes/class-pmpro-members-list-table.php:604
 #: classes/class-pmpro-members-list-table.php:628
 #: classes/class-pmpro-members-list-table.php:629
-#: classes/class-pmpro-members-list-table.php:635
 #: classes/class-pmpro-members-list-table.php:672
 msgid "Cancelled Members"
 msgstr ""
 
 #: classes/class-pmpro-members-list-table.php:236
-#: classes/class-pmpro-members-list-table.php:636 adminpages/memberslist.php:43
-#: adminpages/memberslist.php:277 adminpages/memberslist.php:281
-#: classes/class-pmpro-members-list-table.php:236
+#: classes/class-pmpro-members-list-table.php:636
+#: adminpages/memberslist.php:43
+#: adminpages/memberslist.php:277
+#: adminpages/memberslist.php:281
 #: classes/class-pmpro-members-list-table.php:262
 #: classes/class-pmpro-members-list-table.php:267
 #: classes/class-pmpro-members-list-table.php:566
 #: classes/class-pmpro-members-list-table.php:605
 #: classes/class-pmpro-members-list-table.php:629
 #: classes/class-pmpro-members-list-table.php:634
-#: classes/class-pmpro-members-list-table.php:636
 #: classes/class-pmpro-members-list-table.php:673
 msgid "Expired Members"
 msgstr ""
 
 #: classes/class-pmpro-members-list-table.php:237
-#: classes/class-pmpro-members-list-table.php:637 adminpages/memberslist.php:42
-#: adminpages/memberslist.php:44 adminpages/memberslist.php:278
+#: classes/class-pmpro-members-list-table.php:637
+#: adminpages/memberslist.php:42
+#: adminpages/memberslist.php:44
+#: adminpages/memberslist.php:278
 #: adminpages/memberslist.php:282
-#: classes/class-pmpro-members-list-table.php:237
 #: classes/class-pmpro-members-list-table.php:263
 #: classes/class-pmpro-members-list-table.php:268
 #: classes/class-pmpro-members-list-table.php:571
 #: classes/class-pmpro-members-list-table.php:606
 #: classes/class-pmpro-members-list-table.php:630
-#: classes/class-pmpro-members-list-table.php:637
 #: classes/class-pmpro-members-list-table.php:639
 #: classes/class-pmpro-members-list-table.php:674
 msgid "Old Members"
@@ -5829,332 +8043,489 @@ msgstr ""
 msgid "&#8212;"
 msgstr ""
 
-#: classes/class.memberorder.php:943 classes/class.memberorder.php:553
-#: classes/class.memberorder.php:561 classes/class.memberorder.php:564
-#: classes/class.memberorder.php:573 classes/class.memberorder.php:644
-#: classes/class.memberorder.php:697 classes/class.memberorder.php:699
-#: classes/class.memberorder.php:706 classes/class.memberorder.php:716
-#: classes/class.memberorder.php:719 classes/class.memberorder.php:720
-#: classes/class.memberorder.php:729 classes/class.memberorder.php:740
-#: classes/class.memberorder.php:743 classes/class.memberorder.php:760
-#: classes/class.memberorder.php:811 classes/class.memberorder.php:856
-#: classes/class.memberorder.php:868 classes/class.memberorder.php:941
+#: classes/class.memberorder.php:943
+#: classes/class.memberorder.php:553
+#: classes/class.memberorder.php:561
+#: classes/class.memberorder.php:564
+#: classes/class.memberorder.php:573
+#: classes/class.memberorder.php:644
+#: classes/class.memberorder.php:697
+#: classes/class.memberorder.php:699
+#: classes/class.memberorder.php:706
+#: classes/class.memberorder.php:716
+#: classes/class.memberorder.php:719
+#: classes/class.memberorder.php:720
+#: classes/class.memberorder.php:729
+#: classes/class.memberorder.php:740
+#: classes/class.memberorder.php:743
+#: classes/class.memberorder.php:760
+#: classes/class.memberorder.php:811
+#: classes/class.memberorder.php:856
+#: classes/class.memberorder.php:868
+#: classes/class.memberorder.php:941
 #: includes/cleanup.php:24
 #, php-format
-msgid ""
-"There was an error canceling the subscription for user with ID=%s. You will "
-"want to check your payment gateway to see if their subscription is still "
-"active."
+msgid "There was an error canceling the subscription for user with ID=%s. You will want to check your payment gateway to see if their subscription is still active."
 msgstr ""
 
-#: classes/class.memberorder.php:944 classes/class.memberorder.php:741
-#: classes/class.memberorder.php:744 classes/class.memberorder.php:761
-#: classes/class.memberorder.php:812 classes/class.memberorder.php:857
-#: classes/class.memberorder.php:869 classes/class.memberorder.php:942
+#: classes/class.memberorder.php:944
+#: classes/class.memberorder.php:741
+#: classes/class.memberorder.php:744
+#: classes/class.memberorder.php:761
+#: classes/class.memberorder.php:812
+#: classes/class.memberorder.php:857
+#: classes/class.memberorder.php:869
+#: classes/class.memberorder.php:942
 msgid "User Email"
 msgstr ""
 
-#: classes/class.memberorder.php:946 classes/class.memberorder.php:742
-#: classes/class.memberorder.php:745 classes/class.memberorder.php:762
-#: classes/class.memberorder.php:813 classes/class.memberorder.php:858
-#: classes/class.memberorder.php:859 classes/class.memberorder.php:871
+#: classes/class.memberorder.php:946
+#: classes/class.memberorder.php:742
+#: classes/class.memberorder.php:745
+#: classes/class.memberorder.php:762
+#: classes/class.memberorder.php:813
+#: classes/class.memberorder.php:858
+#: classes/class.memberorder.php:859
+#: classes/class.memberorder.php:871
 #: classes/class.memberorder.php:944
 msgid "User Display Name"
 msgstr ""
 
-#: classes/class.memberorder.php:951 classes/class.memberorder.php:864
-#: classes/class.memberorder.php:876 classes/class.memberorder.php:949
+#: classes/class.memberorder.php:951
+#: classes/class.memberorder.php:864
+#: classes/class.memberorder.php:876
+#: classes/class.memberorder.php:949
 msgid "Edit User"
 msgstr ""
 
-#: classes/class.memberorder.php:952 classes/class.memberorder.php:865
-#: classes/class.memberorder.php:877 classes/class.memberorder.php:950
+#: classes/class.memberorder.php:952
+#: classes/class.memberorder.php:865
+#: classes/class.memberorder.php:877
+#: classes/class.memberorder.php:950
 msgid "Edit Order"
 msgstr ""
 
-#: classes/class.pmproemail.php:37 classes/class.pmproemail.php:37
+#: classes/class.pmproemail.php:37
 #, php-format
 msgid "An Email From %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:171 classes/class.pmproemail.php:120
-#: classes/class.pmproemail.php:122 classes/class.pmproemail.php:125
-#: classes/class.pmproemail.php:134 classes/class.pmproemail.php:136
-#: classes/class.pmproemail.php:143 classes/class.pmproemail.php:171
+#: classes/class.pmproemail.php:171
+#: classes/class.pmproemail.php:120
+#: classes/class.pmproemail.php:122
+#: classes/class.pmproemail.php:125
+#: classes/class.pmproemail.php:134
+#: classes/class.pmproemail.php:136
+#: classes/class.pmproemail.php:143
 #, php-format
 msgid "Your membership at %s has been CANCELLED"
 msgstr ""
 
-#: classes/class.pmproemail.php:204 classes/class.pmproemail.php:142
-#: classes/class.pmproemail.php:144 classes/class.pmproemail.php:147
-#: classes/class.pmproemail.php:156 classes/class.pmproemail.php:166
-#: classes/class.pmproemail.php:169 classes/class.pmproemail.php:176
 #: classes/class.pmproemail.php:204
+#: classes/class.pmproemail.php:142
+#: classes/class.pmproemail.php:144
+#: classes/class.pmproemail.php:147
+#: classes/class.pmproemail.php:156
+#: classes/class.pmproemail.php:166
+#: classes/class.pmproemail.php:169
+#: classes/class.pmproemail.php:176
 #, php-format
 msgid "Membership for %s at %s has been CANCELLED"
 msgstr ""
 
-#: classes/class.pmproemail.php:254 classes/class.pmproemail.php:172
-#: classes/class.pmproemail.php:173 classes/class.pmproemail.php:175
-#: classes/class.pmproemail.php:178 classes/class.pmproemail.php:187
-#: classes/class.pmproemail.php:207 classes/class.pmproemail.php:212
-#: classes/class.pmproemail.php:219 classes/class.pmproemail.php:226
 #: classes/class.pmproemail.php:254
+#: classes/class.pmproemail.php:172
+#: classes/class.pmproemail.php:173
+#: classes/class.pmproemail.php:175
+#: classes/class.pmproemail.php:178
+#: classes/class.pmproemail.php:187
+#: classes/class.pmproemail.php:207
+#: classes/class.pmproemail.php:212
+#: classes/class.pmproemail.php:219
+#: classes/class.pmproemail.php:226
 #, php-format
 msgid "Your membership confirmation for %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:338 classes/class.pmproemail.php:434
-#: classes/class.pmproemail.php:749 classes/class.pmproemail.php:241
-#: classes/class.pmproemail.php:243 classes/class.pmproemail.php:253
-#: classes/class.pmproemail.php:256 classes/class.pmproemail.php:265
-#: classes/class.pmproemail.php:285 classes/class.pmproemail.php:294
-#: classes/class.pmproemail.php:301 classes/class.pmproemail.php:309
-#: classes/class.pmproemail.php:310 classes/class.pmproemail.php:325
-#: classes/class.pmproemail.php:328 classes/class.pmproemail.php:338
-#: classes/class.pmproemail.php:346 classes/class.pmproemail.php:349
-#: classes/class.pmproemail.php:358 classes/class.pmproemail.php:378
-#: classes/class.pmproemail.php:390 classes/class.pmproemail.php:397
-#: classes/class.pmproemail.php:405 classes/class.pmproemail.php:406
-#: classes/class.pmproemail.php:434 classes/class.pmproemail.php:538
-#: classes/class.pmproemail.php:586 classes/class.pmproemail.php:651
-#: classes/class.pmproemail.php:654 classes/class.pmproemail.php:663
-#: classes/class.pmproemail.php:665 classes/class.pmproemail.php:685
-#: classes/class.pmproemail.php:705 classes/class.pmproemail.php:712
-#: classes/class.pmproemail.php:720 classes/class.pmproemail.php:721
+#: classes/class.pmproemail.php:338
+#: classes/class.pmproemail.php:434
 #: classes/class.pmproemail.php:749
+#: classes/class.pmproemail.php:241
+#: classes/class.pmproemail.php:243
+#: classes/class.pmproemail.php:253
+#: classes/class.pmproemail.php:256
+#: classes/class.pmproemail.php:265
+#: classes/class.pmproemail.php:285
+#: classes/class.pmproemail.php:294
+#: classes/class.pmproemail.php:301
+#: classes/class.pmproemail.php:309
+#: classes/class.pmproemail.php:310
+#: classes/class.pmproemail.php:325
+#: classes/class.pmproemail.php:328
+#: classes/class.pmproemail.php:346
+#: classes/class.pmproemail.php:349
+#: classes/class.pmproemail.php:358
+#: classes/class.pmproemail.php:378
+#: classes/class.pmproemail.php:390
+#: classes/class.pmproemail.php:397
+#: classes/class.pmproemail.php:405
+#: classes/class.pmproemail.php:406
+#: classes/class.pmproemail.php:538
+#: classes/class.pmproemail.php:586
+#: classes/class.pmproemail.php:651
+#: classes/class.pmproemail.php:654
+#: classes/class.pmproemail.php:663
+#: classes/class.pmproemail.php:665
+#: classes/class.pmproemail.php:685
+#: classes/class.pmproemail.php:705
+#: classes/class.pmproemail.php:712
+#: classes/class.pmproemail.php:720
+#: classes/class.pmproemail.php:721
 #, php-format
 msgid "This membership will expire on %s."
 msgstr ""
 
-#: classes/class.pmproemail.php:360 classes/class.pmproemail.php:263
-#: classes/class.pmproemail.php:265 classes/class.pmproemail.php:275
-#: classes/class.pmproemail.php:278 classes/class.pmproemail.php:287
-#: classes/class.pmproemail.php:307 classes/class.pmproemail.php:316
-#: classes/class.pmproemail.php:323 classes/class.pmproemail.php:331
-#: classes/class.pmproemail.php:332 classes/class.pmproemail.php:360
+#: classes/class.pmproemail.php:360
+#: classes/class.pmproemail.php:263
+#: classes/class.pmproemail.php:265
+#: classes/class.pmproemail.php:275
+#: classes/class.pmproemail.php:278
+#: classes/class.pmproemail.php:287
+#: classes/class.pmproemail.php:307
+#: classes/class.pmproemail.php:316
+#: classes/class.pmproemail.php:323
+#: classes/class.pmproemail.php:331
+#: classes/class.pmproemail.php:332
 #, php-format
 msgid "Member Checkout for %s at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:451 classes/class.pmproemail.php:375
-#: classes/class.pmproemail.php:395 classes/class.pmproemail.php:407
-#: classes/class.pmproemail.php:414 classes/class.pmproemail.php:422
-#: classes/class.pmproemail.php:423 classes/class.pmproemail.php:451
+#: classes/class.pmproemail.php:451
+#: classes/class.pmproemail.php:375
+#: classes/class.pmproemail.php:395
+#: classes/class.pmproemail.php:407
+#: classes/class.pmproemail.php:414
+#: classes/class.pmproemail.php:422
+#: classes/class.pmproemail.php:423
 #, php-format
 msgid "Your billing information has been updated at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:505 classes/class.pmproemail.php:428
-#: classes/class.pmproemail.php:448 classes/class.pmproemail.php:461
-#: classes/class.pmproemail.php:468 classes/class.pmproemail.php:476
-#: classes/class.pmproemail.php:477 classes/class.pmproemail.php:505
+#: classes/class.pmproemail.php:505
+#: classes/class.pmproemail.php:428
+#: classes/class.pmproemail.php:448
+#: classes/class.pmproemail.php:461
+#: classes/class.pmproemail.php:468
+#: classes/class.pmproemail.php:476
+#: classes/class.pmproemail.php:477
 #, php-format
 msgid "Billing information has been updated for %s at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:554 classes/class.pmproemail.php:425
-#: classes/class.pmproemail.php:430 classes/class.pmproemail.php:464
-#: classes/class.pmproemail.php:467 classes/class.pmproemail.php:476
-#: classes/class.pmproemail.php:496 classes/class.pmproemail.php:510
-#: classes/class.pmproemail.php:517 classes/class.pmproemail.php:525
-#: classes/class.pmproemail.php:526 classes/class.pmproemail.php:554
+#: classes/class.pmproemail.php:554
+#: classes/class.pmproemail.php:425
+#: classes/class.pmproemail.php:430
+#: classes/class.pmproemail.php:464
+#: classes/class.pmproemail.php:467
+#: classes/class.pmproemail.php:476
+#: classes/class.pmproemail.php:496
+#: classes/class.pmproemail.php:510
+#: classes/class.pmproemail.php:517
+#: classes/class.pmproemail.php:525
+#: classes/class.pmproemail.php:526
 #, php-format
 msgid "Membership Payment Failed at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:601 classes/class.pmproemail.php:462
-#: classes/class.pmproemail.php:468 classes/class.pmproemail.php:510
-#: classes/class.pmproemail.php:513 classes/class.pmproemail.php:522
-#: classes/class.pmproemail.php:542 classes/class.pmproemail.php:557
-#: classes/class.pmproemail.php:564 classes/class.pmproemail.php:572
-#: classes/class.pmproemail.php:573 classes/class.pmproemail.php:601
+#: classes/class.pmproemail.php:601
+#: classes/class.pmproemail.php:462
+#: classes/class.pmproemail.php:468
+#: classes/class.pmproemail.php:510
+#: classes/class.pmproemail.php:513
+#: classes/class.pmproemail.php:522
+#: classes/class.pmproemail.php:542
+#: classes/class.pmproemail.php:557
+#: classes/class.pmproemail.php:564
+#: classes/class.pmproemail.php:572
+#: classes/class.pmproemail.php:573
 #, php-format
 msgid "Membership Payment Failed For %s at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:649 classes/class.pmproemail.php:508
-#: classes/class.pmproemail.php:557 classes/class.pmproemail.php:560
-#: classes/class.pmproemail.php:569 classes/class.pmproemail.php:589
-#: classes/class.pmproemail.php:605 classes/class.pmproemail.php:612
-#: classes/class.pmproemail.php:620 classes/class.pmproemail.php:621
 #: classes/class.pmproemail.php:649
+#: classes/class.pmproemail.php:508
+#: classes/class.pmproemail.php:557
+#: classes/class.pmproemail.php:560
+#: classes/class.pmproemail.php:569
+#: classes/class.pmproemail.php:589
+#: classes/class.pmproemail.php:605
+#: classes/class.pmproemail.php:612
+#: classes/class.pmproemail.php:620
+#: classes/class.pmproemail.php:621
 #, php-format
 msgid "Credit Card on File Expiring Soon at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:700 classes/class.pmproemail.php:501
-#: classes/class.pmproemail.php:548 classes/class.pmproemail.php:605
-#: classes/class.pmproemail.php:608 classes/class.pmproemail.php:617
-#: classes/class.pmproemail.php:619 classes/class.pmproemail.php:639
-#: classes/class.pmproemail.php:656 classes/class.pmproemail.php:663
-#: classes/class.pmproemail.php:671 classes/class.pmproemail.php:672
 #: classes/class.pmproemail.php:700
+#: classes/class.pmproemail.php:501
+#: classes/class.pmproemail.php:548
+#: classes/class.pmproemail.php:605
+#: classes/class.pmproemail.php:608
+#: classes/class.pmproemail.php:617
+#: classes/class.pmproemail.php:619
+#: classes/class.pmproemail.php:639
+#: classes/class.pmproemail.php:656
+#: classes/class.pmproemail.php:663
+#: classes/class.pmproemail.php:671
+#: classes/class.pmproemail.php:672
 #, php-format
 msgid "INVOICE for %s membership"
 msgstr ""
 
-#: classes/class.pmproemail.php:777 classes/class.pmproemail.php:563
-#: classes/class.pmproemail.php:611 classes/class.pmproemail.php:676
-#: classes/class.pmproemail.php:679 classes/class.pmproemail.php:688
-#: classes/class.pmproemail.php:690 classes/class.pmproemail.php:710
-#: classes/class.pmproemail.php:733 classes/class.pmproemail.php:740
-#: classes/class.pmproemail.php:748 classes/class.pmproemail.php:749
 #: classes/class.pmproemail.php:777
+#: classes/class.pmproemail.php:563
+#: classes/class.pmproemail.php:611
+#: classes/class.pmproemail.php:676
+#: classes/class.pmproemail.php:679
+#: classes/class.pmproemail.php:688
+#: classes/class.pmproemail.php:690
+#: classes/class.pmproemail.php:710
+#: classes/class.pmproemail.php:733
+#: classes/class.pmproemail.php:740
+#: classes/class.pmproemail.php:748
+#: classes/class.pmproemail.php:749
 #, php-format
 msgid "Your trial at %s is ending soon"
 msgstr ""
 
-#: classes/class.pmproemail.php:813 classes/class.pmproemail.php:596
-#: classes/class.pmproemail.php:645 classes/class.pmproemail.php:710
-#: classes/class.pmproemail.php:713 classes/class.pmproemail.php:722
-#: classes/class.pmproemail.php:724 classes/class.pmproemail.php:744
-#: classes/class.pmproemail.php:769 classes/class.pmproemail.php:776
-#: classes/class.pmproemail.php:784 classes/class.pmproemail.php:785
 #: classes/class.pmproemail.php:813
+#: classes/class.pmproemail.php:596
+#: classes/class.pmproemail.php:645
+#: classes/class.pmproemail.php:710
+#: classes/class.pmproemail.php:713
+#: classes/class.pmproemail.php:722
+#: classes/class.pmproemail.php:724
+#: classes/class.pmproemail.php:744
+#: classes/class.pmproemail.php:769
+#: classes/class.pmproemail.php:776
+#: classes/class.pmproemail.php:784
+#: classes/class.pmproemail.php:785
 #, php-format
 msgid "Your membership at %s has ended"
 msgstr ""
 
-#: classes/class.pmproemail.php:840 classes/class.pmproemail.php:621
-#: classes/class.pmproemail.php:670 classes/class.pmproemail.php:735
-#: classes/class.pmproemail.php:738 classes/class.pmproemail.php:747
-#: classes/class.pmproemail.php:749 classes/class.pmproemail.php:769
-#: classes/class.pmproemail.php:796 classes/class.pmproemail.php:803
-#: classes/class.pmproemail.php:811 classes/class.pmproemail.php:812
 #: classes/class.pmproemail.php:840
+#: classes/class.pmproemail.php:621
+#: classes/class.pmproemail.php:670
+#: classes/class.pmproemail.php:735
+#: classes/class.pmproemail.php:738
+#: classes/class.pmproemail.php:747
+#: classes/class.pmproemail.php:749
+#: classes/class.pmproemail.php:769
+#: classes/class.pmproemail.php:796
+#: classes/class.pmproemail.php:803
+#: classes/class.pmproemail.php:811
+#: classes/class.pmproemail.php:812
 #, php-format
 msgid "Your membership at %s will end soon"
 msgstr ""
 
-#: classes/class.pmproemail.php:870 classes/class.pmproemail.php:641
-#: classes/class.pmproemail.php:690 classes/class.pmproemail.php:755
-#: classes/class.pmproemail.php:758 classes/class.pmproemail.php:767
-#: classes/class.pmproemail.php:769 classes/class.pmproemail.php:789
-#: classes/class.pmproemail.php:818 classes/class.pmproemail.php:825
-#: classes/class.pmproemail.php:833 classes/class.pmproemail.php:834
-#: classes/class.pmproemail.php:862 classes/class.pmproemail.php:870
+#: classes/class.pmproemail.php:870
+#: classes/class.pmproemail.php:641
+#: classes/class.pmproemail.php:690
+#: classes/class.pmproemail.php:755
+#: classes/class.pmproemail.php:758
+#: classes/class.pmproemail.php:767
+#: classes/class.pmproemail.php:769
+#: classes/class.pmproemail.php:789
+#: classes/class.pmproemail.php:818
+#: classes/class.pmproemail.php:825
+#: classes/class.pmproemail.php:833
+#: classes/class.pmproemail.php:834
+#: classes/class.pmproemail.php:862
 #, php-format
 msgid "Your membership at %s has been changed"
 msgstr ""
 
-#: classes/class.pmproemail.php:875 classes/class.pmproemail.php:925
-#: classes/class.pmproemail.php:759 classes/class.pmproemail.php:762
-#: classes/class.pmproemail.php:771 classes/class.pmproemail.php:773
-#: classes/class.pmproemail.php:793 classes/class.pmproemail.php:800
-#: classes/class.pmproemail.php:809 classes/class.pmproemail.php:810
-#: classes/class.pmproemail.php:811 classes/class.pmproemail.php:823
-#: classes/class.pmproemail.php:830 classes/class.pmproemail.php:838
-#: classes/class.pmproemail.php:839 classes/class.pmproemail.php:863
-#: classes/class.pmproemail.php:867 classes/class.pmproemail.php:870
-#: classes/class.pmproemail.php:875 classes/class.pmproemail.php:877
-#: classes/class.pmproemail.php:885 classes/class.pmproemail.php:886
-#: classes/class.pmproemail.php:914 classes/class.pmproemail.php:925
+#: classes/class.pmproemail.php:875
+#: classes/class.pmproemail.php:925
+#: classes/class.pmproemail.php:759
+#: classes/class.pmproemail.php:762
+#: classes/class.pmproemail.php:771
+#: classes/class.pmproemail.php:773
+#: classes/class.pmproemail.php:793
+#: classes/class.pmproemail.php:800
+#: classes/class.pmproemail.php:809
+#: classes/class.pmproemail.php:810
+#: classes/class.pmproemail.php:811
+#: classes/class.pmproemail.php:823
+#: classes/class.pmproemail.php:830
+#: classes/class.pmproemail.php:838
+#: classes/class.pmproemail.php:839
+#: classes/class.pmproemail.php:863
+#: classes/class.pmproemail.php:867
+#: classes/class.pmproemail.php:870
+#: classes/class.pmproemail.php:877
+#: classes/class.pmproemail.php:885
+#: classes/class.pmproemail.php:886
+#: classes/class.pmproemail.php:914
 #, php-format
 msgid "The new level is %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:877 classes/class.pmproemail.php:647
-#: classes/class.pmproemail.php:696 classes/class.pmproemail.php:761
-#: classes/class.pmproemail.php:764 classes/class.pmproemail.php:773
-#: classes/class.pmproemail.php:775 classes/class.pmproemail.php:795
-#: classes/class.pmproemail.php:825 classes/class.pmproemail.php:832
-#: classes/class.pmproemail.php:840 classes/class.pmproemail.php:841
-#: classes/class.pmproemail.php:869 classes/class.pmproemail.php:877
+#: classes/class.pmproemail.php:877
+#: classes/class.pmproemail.php:647
+#: classes/class.pmproemail.php:696
+#: classes/class.pmproemail.php:761
+#: classes/class.pmproemail.php:764
+#: classes/class.pmproemail.php:773
+#: classes/class.pmproemail.php:775
+#: classes/class.pmproemail.php:795
+#: classes/class.pmproemail.php:825
+#: classes/class.pmproemail.php:832
+#: classes/class.pmproemail.php:840
+#: classes/class.pmproemail.php:841
+#: classes/class.pmproemail.php:869
 msgid "Your membership has been cancelled"
 msgstr ""
 
-#: classes/class.pmproemail.php:882 classes/class.pmproemail.php:932
-#: classes/class.pmproemail.php:651 classes/class.pmproemail.php:689
-#: classes/class.pmproemail.php:700 classes/class.pmproemail.php:738
-#: classes/class.pmproemail.php:765 classes/class.pmproemail.php:768
-#: classes/class.pmproemail.php:777 classes/class.pmproemail.php:778
-#: classes/class.pmproemail.php:779 classes/class.pmproemail.php:798
-#: classes/class.pmproemail.php:803 classes/class.pmproemail.php:806
-#: classes/class.pmproemail.php:815 classes/class.pmproemail.php:816
-#: classes/class.pmproemail.php:817 classes/class.pmproemail.php:829
-#: classes/class.pmproemail.php:836 classes/class.pmproemail.php:844
-#: classes/class.pmproemail.php:845 classes/class.pmproemail.php:869
-#: classes/class.pmproemail.php:873 classes/class.pmproemail.php:876
-#: classes/class.pmproemail.php:882 classes/class.pmproemail.php:884
-#: classes/class.pmproemail.php:892 classes/class.pmproemail.php:893
-#: classes/class.pmproemail.php:921 classes/class.pmproemail.php:932
+#: classes/class.pmproemail.php:882
+#: classes/class.pmproemail.php:932
+#: classes/class.pmproemail.php:651
+#: classes/class.pmproemail.php:689
+#: classes/class.pmproemail.php:700
+#: classes/class.pmproemail.php:738
+#: classes/class.pmproemail.php:765
+#: classes/class.pmproemail.php:768
+#: classes/class.pmproemail.php:777
+#: classes/class.pmproemail.php:778
+#: classes/class.pmproemail.php:779
+#: classes/class.pmproemail.php:798
+#: classes/class.pmproemail.php:803
+#: classes/class.pmproemail.php:806
+#: classes/class.pmproemail.php:815
+#: classes/class.pmproemail.php:816
+#: classes/class.pmproemail.php:817
+#: classes/class.pmproemail.php:829
+#: classes/class.pmproemail.php:836
+#: classes/class.pmproemail.php:844
+#: classes/class.pmproemail.php:845
+#: classes/class.pmproemail.php:869
+#: classes/class.pmproemail.php:873
+#: classes/class.pmproemail.php:876
+#: classes/class.pmproemail.php:884
+#: classes/class.pmproemail.php:892
+#: classes/class.pmproemail.php:893
+#: classes/class.pmproemail.php:921
 #, php-format
 msgid "This membership will expire on %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:886 classes/class.pmproemail.php:936
-#: classes/class.pmproemail.php:655 classes/class.pmproemail.php:693
-#: classes/class.pmproemail.php:704 classes/class.pmproemail.php:742
-#: classes/class.pmproemail.php:769 classes/class.pmproemail.php:772
-#: classes/class.pmproemail.php:781 classes/class.pmproemail.php:782
-#: classes/class.pmproemail.php:783 classes/class.pmproemail.php:802
-#: classes/class.pmproemail.php:807 classes/class.pmproemail.php:810
-#: classes/class.pmproemail.php:819 classes/class.pmproemail.php:820
-#: classes/class.pmproemail.php:821 classes/class.pmproemail.php:833
-#: classes/class.pmproemail.php:840 classes/class.pmproemail.php:848
-#: classes/class.pmproemail.php:849 classes/class.pmproemail.php:873
-#: classes/class.pmproemail.php:877 classes/class.pmproemail.php:880
-#: classes/class.pmproemail.php:886 classes/class.pmproemail.php:888
-#: classes/class.pmproemail.php:896 classes/class.pmproemail.php:897
-#: classes/class.pmproemail.php:925 classes/class.pmproemail.php:936
+#: classes/class.pmproemail.php:886
+#: classes/class.pmproemail.php:936
+#: classes/class.pmproemail.php:655
+#: classes/class.pmproemail.php:693
+#: classes/class.pmproemail.php:704
+#: classes/class.pmproemail.php:742
+#: classes/class.pmproemail.php:769
+#: classes/class.pmproemail.php:772
+#: classes/class.pmproemail.php:781
+#: classes/class.pmproemail.php:782
+#: classes/class.pmproemail.php:783
+#: classes/class.pmproemail.php:802
+#: classes/class.pmproemail.php:807
+#: classes/class.pmproemail.php:810
+#: classes/class.pmproemail.php:819
+#: classes/class.pmproemail.php:820
+#: classes/class.pmproemail.php:821
+#: classes/class.pmproemail.php:833
+#: classes/class.pmproemail.php:840
+#: classes/class.pmproemail.php:848
+#: classes/class.pmproemail.php:849
+#: classes/class.pmproemail.php:873
+#: classes/class.pmproemail.php:877
+#: classes/class.pmproemail.php:880
+#: classes/class.pmproemail.php:888
+#: classes/class.pmproemail.php:896
+#: classes/class.pmproemail.php:897
+#: classes/class.pmproemail.php:925
 msgid "This membership does not expire"
 msgstr ""
 
-#: classes/class.pmproemail.php:920 classes/class.pmproemail.php:679
-#: classes/class.pmproemail.php:728 classes/class.pmproemail.php:793
-#: classes/class.pmproemail.php:796 classes/class.pmproemail.php:805
-#: classes/class.pmproemail.php:806 classes/class.pmproemail.php:807
-#: classes/class.pmproemail.php:826 classes/class.pmproemail.php:859
-#: classes/class.pmproemail.php:866 classes/class.pmproemail.php:872
-#: classes/class.pmproemail.php:880 classes/class.pmproemail.php:881
-#: classes/class.pmproemail.php:909 classes/class.pmproemail.php:920
+#: classes/class.pmproemail.php:920
+#: classes/class.pmproemail.php:679
+#: classes/class.pmproemail.php:728
+#: classes/class.pmproemail.php:793
+#: classes/class.pmproemail.php:796
+#: classes/class.pmproemail.php:805
+#: classes/class.pmproemail.php:806
+#: classes/class.pmproemail.php:807
+#: classes/class.pmproemail.php:826
+#: classes/class.pmproemail.php:859
+#: classes/class.pmproemail.php:866
+#: classes/class.pmproemail.php:872
+#: classes/class.pmproemail.php:880
+#: classes/class.pmproemail.php:881
+#: classes/class.pmproemail.php:909
 #, php-format
 msgid "Membership for %s at %s has been changed"
 msgstr ""
 
-#: classes/class.pmproemail.php:927 classes/class.pmproemail.php:799
-#: classes/class.pmproemail.php:802 classes/class.pmproemail.php:811
-#: classes/class.pmproemail.php:812 classes/class.pmproemail.php:813
-#: classes/class.pmproemail.php:832 classes/class.pmproemail.php:865
-#: classes/class.pmproemail.php:872 classes/class.pmproemail.php:879
-#: classes/class.pmproemail.php:887 classes/class.pmproemail.php:888
-#: classes/class.pmproemail.php:916 classes/class.pmproemail.php:927
+#: classes/class.pmproemail.php:927
+#: classes/class.pmproemail.php:799
+#: classes/class.pmproemail.php:802
+#: classes/class.pmproemail.php:811
+#: classes/class.pmproemail.php:812
+#: classes/class.pmproemail.php:813
+#: classes/class.pmproemail.php:832
+#: classes/class.pmproemail.php:865
+#: classes/class.pmproemail.php:872
+#: classes/class.pmproemail.php:879
+#: classes/class.pmproemail.php:887
+#: classes/class.pmproemail.php:888
+#: classes/class.pmproemail.php:916
 msgid "Membership has been cancelled"
 msgstr ""
 
-#: classes/class.pmproemail.php:967 classes/class.pmproemail.php:848
-#: classes/class.pmproemail.php:849 classes/class.pmproemail.php:850
-#: classes/class.pmproemail.php:869 classes/class.pmproemail.php:904
-#: classes/class.pmproemail.php:911 classes/class.pmproemail.php:919
-#: classes/class.pmproemail.php:927 classes/class.pmproemail.php:928
-#: classes/class.pmproemail.php:956 classes/class.pmproemail.php:967
+#: classes/class.pmproemail.php:967
+#: classes/class.pmproemail.php:848
+#: classes/class.pmproemail.php:849
+#: classes/class.pmproemail.php:850
+#: classes/class.pmproemail.php:869
+#: classes/class.pmproemail.php:904
+#: classes/class.pmproemail.php:911
+#: classes/class.pmproemail.php:919
+#: classes/class.pmproemail.php:927
+#: classes/class.pmproemail.php:928
+#: classes/class.pmproemail.php:956
 msgid "Invoice for Order #: "
 msgstr ""
 
-#: classes/class.pmproemail.php:1014 classes/class.pmproemail.php:1003
 #: classes/class.pmproemail.php:1014
+#: classes/class.pmproemail.php:1003
 #, php-format
 msgid "Payment action required for your %s membership"
 msgstr ""
 
-#: classes/class.pmproemail.php:1051 classes/class.pmproemail.php:1040
 #: classes/class.pmproemail.php:1051
+#: classes/class.pmproemail.php:1040
 #, php-format
 msgid "Payment action required: membership for %s at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:1087 classes/class.pmproemail.php:948
-#: classes/class.pmproemail.php:955 classes/class.pmproemail.php:963
-#: classes/class.pmproemail.php:971 classes/class.pmproemail.php:972
-#: classes/class.pmproemail.php:1076 classes/class.pmproemail.php:1087
+#: classes/class.pmproemail.php:1087
+#: classes/class.pmproemail.php:948
+#: classes/class.pmproemail.php:955
+#: classes/class.pmproemail.php:963
+#: classes/class.pmproemail.php:971
+#: classes/class.pmproemail.php:972
+#: classes/class.pmproemail.php:1076
 msgid ""
 "<p>An administrator at !!sitename!! has changed your membership level.</p>\n"
 "\n"
 "<p>!!membership_change!!.</p>\n"
 "\n"
-"<p>If you did not request this membership change and would like more "
-"information please contact us at !!siteemail!!</p>\n"
+"<p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>\n"
 "\n"
 "<p>Log in to your membership account here: !!login_link!!</p>"
 msgstr ""
@@ -6165,30 +8536,24 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_cybersource.php:155
 #: classes/gateways/class.pmprogateway_payflowpro.php:173
 #: classes/gateways/class.pmprogateway_paypal.php:315
-#: classes/gateways/class.pmprogateway.php:55
 #: classes/gateways/class.pmprogateway_authorizenet.php:55
 #: classes/gateways/class.pmprogateway_authorizenet.php:171
 #: classes/gateways/class.pmprogateway_authorizenet.php:172
 #: classes/gateways/class.pmprogateway_authorizenet.php:173
-#: classes/gateways/class.pmprogateway_authorizenet.php:189
 #: classes/gateways/class.pmprogateway_check.php:60
 #: classes/gateways/class.pmprogateway_check.php:193
 #: classes/gateways/class.pmprogateway_check.php:210
-#: classes/gateways/class.pmprogateway_check.php:211
 #: classes/gateways/class.pmprogateway_cybersource.php:57
 #: classes/gateways/class.pmprogateway_cybersource.php:154
-#: classes/gateways/class.pmprogateway_cybersource.php:155
 #: classes/gateways/class.pmprogateway_cybersource.php:171
 #: classes/gateways/class.pmprogateway_payflowpro.php:27
 #: classes/gateways/class.pmprogateway_payflowpro.php:164
-#: classes/gateways/class.pmprogateway_payflowpro.php:173
 #: classes/gateways/class.pmprogateway_paypal.php:27
 #: classes/gateways/class.pmprogateway_paypal.php:247
 #: classes/gateways/class.pmprogateway_paypal.php:249
 #: classes/gateways/class.pmprogateway_paypal.php:272
 #: classes/gateways/class.pmprogateway_paypal.php:302
 #: classes/gateways/class.pmprogateway_paypal.php:314
-#: classes/gateways/class.pmprogateway_paypal.php:315
 msgid "Unknown error: Authorization failed."
 msgstr ""
 
@@ -6207,9 +8572,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_payflowpro.php:196
 #: classes/gateways/class.pmprogateway_payflowpro.php:201
 #: classes/gateways/class.pmprogateway_paypal.php:338
-#: classes/gateways/class.pmprogateway.php:106
-#: classes/gateways/class.pmprogateway.php:111
-#: classes/gateways/class.pmprogateway.php:129
 #: classes/gateways/class.pmprogateway_authorizenet.php:106
 #: classes/gateways/class.pmprogateway_authorizenet.php:111
 #: classes/gateways/class.pmprogateway_authorizenet.php:128
@@ -6219,11 +8581,8 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_authorizenet.php:227
 #: classes/gateways/class.pmprogateway_authorizenet.php:228
 #: classes/gateways/class.pmprogateway_authorizenet.php:229
-#: classes/gateways/class.pmprogateway_authorizenet.php:240
 #: classes/gateways/class.pmprogateway_authorizenet.php:244
-#: classes/gateways/class.pmprogateway_authorizenet.php:245
 #: classes/gateways/class.pmprogateway_authorizenet.php:246
-#: classes/gateways/class.pmprogateway_authorizenet.php:262
 #: classes/gateways/class.pmprogateway_check.php:111
 #: classes/gateways/class.pmprogateway_check.php:116
 #: classes/gateways/class.pmprogateway_check.php:134
@@ -6232,36 +8591,27 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_check.php:249
 #: classes/gateways/class.pmprogateway_check.php:250
 #: classes/gateways/class.pmprogateway_check.php:262
-#: classes/gateways/class.pmprogateway_check.php:263
 #: classes/gateways/class.pmprogateway_check.php:267
-#: classes/gateways/class.pmprogateway_check.php:268
 #: classes/gateways/class.pmprogateway_check.php:285
-#: classes/gateways/class.pmprogateway_check.php:286
 #: classes/gateways/class.pmprogateway_cybersource.php:108
 #: classes/gateways/class.pmprogateway_cybersource.php:113
 #: classes/gateways/class.pmprogateway_cybersource.php:131
 #: classes/gateways/class.pmprogateway_cybersource.php:202
-#: classes/gateways/class.pmprogateway_cybersource.php:203
 #: classes/gateways/class.pmprogateway_cybersource.php:207
-#: classes/gateways/class.pmprogateway_cybersource.php:208
 #: classes/gateways/class.pmprogateway_cybersource.php:222
 #: classes/gateways/class.pmprogateway_cybersource.php:223
-#: classes/gateways/class.pmprogateway_cybersource.php:224
 #: classes/gateways/class.pmprogateway_cybersource.php:227
 #: classes/gateways/class.pmprogateway_cybersource.php:245
 #: classes/gateways/class.pmprogateway_payflowpro.php:50
 #: classes/gateways/class.pmprogateway_payflowpro.php:55
 #: classes/gateways/class.pmprogateway_payflowpro.php:187
 #: classes/gateways/class.pmprogateway_payflowpro.php:192
-#: classes/gateways/class.pmprogateway_payflowpro.php:196
-#: classes/gateways/class.pmprogateway_payflowpro.php:201
 #: classes/gateways/class.pmprogateway_paypal.php:50
 #: classes/gateways/class.pmprogateway_paypal.php:270
 #: classes/gateways/class.pmprogateway_paypal.php:272
 #: classes/gateways/class.pmprogateway_paypal.php:295
 #: classes/gateways/class.pmprogateway_paypal.php:325
 #: classes/gateways/class.pmprogateway_paypal.php:337
-#: classes/gateways/class.pmprogateway_paypal.php:338
 msgid "Unknown error: Payment failed."
 msgstr ""
 
@@ -6269,39 +8619,39 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_authorizenet.php:246
 #: classes/gateways/class.pmprogateway_check.php:270
 #: classes/gateways/class.pmprogateway_cybersource.php:209
-#: classes/gateways/class.pmprogateway.php:113
 #: classes/gateways/class.pmprogateway_authorizenet.php:112
 #: classes/gateways/class.pmprogateway_authorizenet.php:228
 #: classes/gateways/class.pmprogateway_authorizenet.php:229
 #: classes/gateways/class.pmprogateway_authorizenet.php:230
-#: classes/gateways/class.pmprogateway_authorizenet.php:246
 #: classes/gateways/class.pmprogateway_check.php:118
 #: classes/gateways/class.pmprogateway_check.php:251
 #: classes/gateways/class.pmprogateway_check.php:252
 #: classes/gateways/class.pmprogateway_check.php:269
-#: classes/gateways/class.pmprogateway_check.php:270
 #: classes/gateways/class.pmprogateway_cybersource.php:115
 #: classes/gateways/class.pmprogateway_cybersource.php:208
-#: classes/gateways/class.pmprogateway_cybersource.php:209
 #: classes/gateways/class.pmprogateway_cybersource.php:229
-msgid ""
-"A partial payment was made that we could not void. Please contact the site "
-"owner immediately to correct this."
+msgid "A partial payment was made that we could not void. Please contact the site owner immediately to correct this."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_authorizenet.php:55
 #: paid-memberships-pro.php:164
 #: classes/gateways/class.pmprogateway_authorizenet.php:39
-#: classes/gateways/class.pmprogateway_authorizenet.php:55
-#: paid-memberships-pro.php:122 paid-memberships-pro.php:123
-#: paid-memberships-pro.php:130 paid-memberships-pro.php:131
-#: paid-memberships-pro.php:132 paid-memberships-pro.php:133
-#: paid-memberships-pro.php:134 paid-memberships-pro.php:135
-#: paid-memberships-pro.php:136 paid-memberships-pro.php:137
-#: paid-memberships-pro.php:142 paid-memberships-pro.php:147
-#: paid-memberships-pro.php:152 paid-memberships-pro.php:154
-#: paid-memberships-pro.php:155 paid-memberships-pro.php:163
-#: paid-memberships-pro.php:164
+#: paid-memberships-pro.php:122
+#: paid-memberships-pro.php:123
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:136
+#: paid-memberships-pro.php:137
+#: paid-memberships-pro.php:142
+#: paid-memberships-pro.php:147
+#: paid-memberships-pro.php:152
+#: paid-memberships-pro.php:154
+#: paid-memberships-pro.php:155
+#: paid-memberships-pro.php:163
 msgid "Authorize.net"
 msgstr ""
 
@@ -6312,40 +8662,41 @@ msgid "Authorize.net Settings"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_authorizenet.php:115
-#: adminpages/paymentsettings.php:260 adminpages/paymentsettings.php:264
+#: adminpages/paymentsettings.php:260
+#: adminpages/paymentsettings.php:264
 #: adminpages/paymentsettings.php:269
 #: classes/gateways/class.pmprogateway_authorizenet.php:98
 #: classes/gateways/class.pmprogateway_authorizenet.php:99
-#: classes/gateways/class.pmprogateway_authorizenet.php:115
 msgid "Login Name"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_authorizenet.php:123
-#: adminpages/paymentsettings.php:268 adminpages/paymentsettings.php:272
+#: adminpages/paymentsettings.php:268
+#: adminpages/paymentsettings.php:272
 #: adminpages/paymentsettings.php:277
 #: classes/gateways/class.pmprogateway_authorizenet.php:106
 #: classes/gateways/class.pmprogateway_authorizenet.php:107
-#: classes/gateways/class.pmprogateway_authorizenet.php:123
 msgid "Transaction Key"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_authorizenet.php:131
-#: adminpages/paymentsettings.php:454 adminpages/paymentsettings.php:495
-#: adminpages/paymentsettings.php:501 adminpages/paymentsettings.php:503
+#: adminpages/paymentsettings.php:454
+#: adminpages/paymentsettings.php:495
+#: adminpages/paymentsettings.php:501
+#: adminpages/paymentsettings.php:503
 #: classes/gateways/class.pmprogateway_authorizenet.php:114
 #: classes/gateways/class.pmprogateway_authorizenet.php:115
-#: classes/gateways/class.pmprogateway_authorizenet.php:131
 msgid "Silent Post URL"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_authorizenet.php:134
-#: adminpages/paymentsettings.php:457 adminpages/paymentsettings.php:498
-#: adminpages/paymentsettings.php:504 adminpages/paymentsettings.php:506
+#: adminpages/paymentsettings.php:457
+#: adminpages/paymentsettings.php:498
+#: adminpages/paymentsettings.php:504
+#: adminpages/paymentsettings.php:506
 #: classes/gateways/class.pmprogateway_authorizenet.php:117
 #: classes/gateways/class.pmprogateway_authorizenet.php:118
-#: classes/gateways/class.pmprogateway_authorizenet.php:134
-msgid ""
-"To fully integrate with Authorize.net, be sure to set your Silent Post URL to"
+msgid "To fully integrate with Authorize.net, be sure to set your Silent Post URL to"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_authorizenet.php:914
@@ -6360,8 +8711,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_authorizenet.php:910
 #: classes/gateways/class.pmprogateway_authorizenet.php:911
 #: classes/gateways/class.pmprogateway_authorizenet.php:912
-#: classes/gateways/class.pmprogateway_authorizenet.php:914
-#: classes/gateways/class.pmprogateway_authorizenet.php:915
 #: classes/gateways/class.pmprogateway_authorizenet.php:929
 #: classes/gateways/class.pmprogateway_authorizenet.php:930
 msgid "Could not connect to Authorize.net"
@@ -6369,7 +8718,6 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:51
 #: classes/gateways/class.pmprogateway_braintree.php:48
-#: classes/gateways/class.pmprogateway_braintree.php:51
 #, php-format
 msgid "Attempting to load Braintree gateway: %s"
 msgstr ""
@@ -6379,7 +8727,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:49
 #: classes/gateways/class.pmprogateway_braintree.php:62
 #: classes/gateways/class.pmprogateway_braintree.php:84
-#: classes/gateways/class.pmprogateway_braintree.php:87
 #: classes/gateways/class.pmprogateway_stripe.php:58
 #: classes/gateways/class.pmprogateway_stripe.php:81
 #: classes/gateways/class.pmprogateway_stripe.php:83
@@ -6387,15 +8734,12 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:88
 #: classes/gateways/class.pmprogateway_stripe.php:89
 #, php-format
-msgid ""
-"The %s gateway depends on the %s PHP extension. Please enable it, or ask "
-"your hosting provider to enable it."
+msgid "The %s gateway depends on the %s PHP extension. Please enable it, or ask your hosting provider to enable it."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:144
 #: classes/gateways/class.pmprogateway_braintree.php:141
 #: classes/gateways/class.pmprogateway_braintree.php:142
-#: classes/gateways/class.pmprogateway_braintree.php:144
 #, php-format
 msgid "Problem loading plans: %s"
 msgstr ""
@@ -6403,10 +8747,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:146
 #: classes/gateways/class.pmprogateway_braintree.php:143
 #: classes/gateways/class.pmprogateway_braintree.php:144
-#: classes/gateways/class.pmprogateway_braintree.php:146
-msgid ""
-"Problem accessing the Braintree Gateway. Please verify your PMPro Payment "
-"Settings (Keys, etc)."
+msgid "Problem accessing the Braintree Gateway. Please verify your PMPro Payment Settings (Keys, etc)."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:251
@@ -6421,16 +8762,22 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:246
 #: classes/gateways/class.pmprogateway_braintree.php:247
 #: classes/gateways/class.pmprogateway_braintree.php:250
-#: classes/gateways/class.pmprogateway_braintree.php:251
-#: paid-memberships-pro.php:123 paid-memberships-pro.php:124
-#: paid-memberships-pro.php:131 paid-memberships-pro.php:132
-#: paid-memberships-pro.php:133 paid-memberships-pro.php:134
-#: paid-memberships-pro.php:135 paid-memberships-pro.php:136
-#: paid-memberships-pro.php:137 paid-memberships-pro.php:138
-#: paid-memberships-pro.php:143 paid-memberships-pro.php:148
-#: paid-memberships-pro.php:153 paid-memberships-pro.php:155
-#: paid-memberships-pro.php:156 paid-memberships-pro.php:164
-#: paid-memberships-pro.php:165
+#: paid-memberships-pro.php:123
+#: paid-memberships-pro.php:124
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:136
+#: paid-memberships-pro.php:137
+#: paid-memberships-pro.php:138
+#: paid-memberships-pro.php:143
+#: paid-memberships-pro.php:148
+#: paid-memberships-pro.php:153
+#: paid-memberships-pro.php:155
+#: paid-memberships-pro.php:156
+#: paid-memberships-pro.php:164
 msgid "Braintree Payments"
 msgstr ""
 
@@ -6451,8 +8798,10 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:313
 #: classes/gateways/class.pmprogateway_cybersource.php:94
-#: adminpages/paymentsettings.php:294 adminpages/paymentsettings.php:298
-#: adminpages/paymentsettings.php:303 adminpages/paymentsettings.php:364
+#: adminpages/paymentsettings.php:294
+#: adminpages/paymentsettings.php:298
+#: adminpages/paymentsettings.php:303
+#: adminpages/paymentsettings.php:364
 #: adminpages/paymentsettings.php:369
 #: classes/gateways/class.pmprogateway_braintree.php:124
 #: classes/gateways/class.pmprogateway_braintree.php:137
@@ -6465,15 +8814,14 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:308
 #: classes/gateways/class.pmprogateway_braintree.php:311
 #: classes/gateways/class.pmprogateway_braintree.php:312
-#: classes/gateways/class.pmprogateway_braintree.php:313
 #: classes/gateways/class.pmprogateway_cybersource.php:93
-#: classes/gateways/class.pmprogateway_cybersource.php:94
 #: classes/gateways/class.pmprogateway_cybersource.php:106
 msgid "Merchant ID"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:321
-#: adminpages/paymentsettings.php:302 adminpages/paymentsettings.php:306
+#: adminpages/paymentsettings.php:302
+#: adminpages/paymentsettings.php:306
 #: adminpages/paymentsettings.php:311
 #: classes/gateways/class.pmprogateway_braintree.php:132
 #: classes/gateways/class.pmprogateway_braintree.php:145
@@ -6486,12 +8834,12 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:316
 #: classes/gateways/class.pmprogateway_braintree.php:319
 #: classes/gateways/class.pmprogateway_braintree.php:320
-#: classes/gateways/class.pmprogateway_braintree.php:321
 msgid "Public Key"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:329
-#: adminpages/paymentsettings.php:310 adminpages/paymentsettings.php:314
+#: adminpages/paymentsettings.php:310
+#: adminpages/paymentsettings.php:314
 #: adminpages/paymentsettings.php:319
 #: classes/gateways/class.pmprogateway_braintree.php:140
 #: classes/gateways/class.pmprogateway_braintree.php:153
@@ -6504,12 +8852,12 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:324
 #: classes/gateways/class.pmprogateway_braintree.php:327
 #: classes/gateways/class.pmprogateway_braintree.php:328
-#: classes/gateways/class.pmprogateway_braintree.php:329
 msgid "Private Key"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:337
-#: adminpages/paymentsettings.php:318 adminpages/paymentsettings.php:322
+#: adminpages/paymentsettings.php:318
+#: adminpages/paymentsettings.php:322
 #: adminpages/paymentsettings.php:327
 #: classes/gateways/class.pmprogateway_braintree.php:148
 #: classes/gateways/class.pmprogateway_braintree.php:161
@@ -6522,14 +8870,16 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:332
 #: classes/gateways/class.pmprogateway_braintree.php:335
 #: classes/gateways/class.pmprogateway_braintree.php:336
-#: classes/gateways/class.pmprogateway_braintree.php:337
 msgid "Client-Side Encryption Key"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:345
-#: adminpages/paymentsettings.php:462 adminpages/paymentsettings.php:470
-#: adminpages/paymentsettings.php:503 adminpages/paymentsettings.php:509
-#: adminpages/paymentsettings.php:511 adminpages/paymentsettings.php:517
+#: adminpages/paymentsettings.php:462
+#: adminpages/paymentsettings.php:470
+#: adminpages/paymentsettings.php:503
+#: adminpages/paymentsettings.php:509
+#: adminpages/paymentsettings.php:511
+#: adminpages/paymentsettings.php:517
 #: adminpages/paymentsettings.php:519
 #: classes/gateways/class.pmprogateway_braintree.php:156
 #: classes/gateways/class.pmprogateway_braintree.php:169
@@ -6542,7 +8892,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:340
 #: classes/gateways/class.pmprogateway_braintree.php:343
 #: classes/gateways/class.pmprogateway_braintree.php:344
-#: classes/gateways/class.pmprogateway_braintree.php:345
 #: classes/gateways/class.pmprogateway_stripe.php:181
 #: classes/gateways/class.pmprogateway_stripe.php:182
 #: classes/gateways/class.pmprogateway_stripe.php:192
@@ -6565,8 +8914,10 @@ msgid "Web Hook URL"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:348
-#: adminpages/paymentsettings.php:474 adminpages/paymentsettings.php:515
-#: adminpages/paymentsettings.php:521 adminpages/paymentsettings.php:523
+#: adminpages/paymentsettings.php:474
+#: adminpages/paymentsettings.php:515
+#: adminpages/paymentsettings.php:521
+#: adminpages/paymentsettings.php:523
 #: classes/gateways/class.pmprogateway_braintree.php:160
 #: classes/gateways/class.pmprogateway_braintree.php:173
 #: classes/gateways/class.pmprogateway_braintree.php:174
@@ -6577,12 +8928,12 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:343
 #: classes/gateways/class.pmprogateway_braintree.php:344
 #: classes/gateways/class.pmprogateway_braintree.php:347
-#: classes/gateways/class.pmprogateway_braintree.php:348
 msgid "To fully integrate with Braintree, be sure to set your Web Hook URL to"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:454
-#: classes/gateways/class.pmprogateway_stripe.php:1048 pages/checkout.php:365
+#: classes/gateways/class.pmprogateway_stripe.php:1048
+#: pages/checkout.php:365
 #: classes/gateways/class.pmprogateway_braintree.php:270
 #: classes/gateways/class.pmprogateway_braintree.php:283
 #: classes/gateways/class.pmprogateway_braintree.php:285
@@ -6594,7 +8945,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:429
 #: classes/gateways/class.pmprogateway_braintree.php:434
 #: classes/gateways/class.pmprogateway_braintree.php:453
-#: classes/gateways/class.pmprogateway_braintree.php:454
 #: classes/gateways/class.pmprogateway_braintree.php:455
 #: classes/gateways/class.pmprogateway_braintree.php:460
 #: classes/gateways/class.pmprogateway_braintree.php:461
@@ -6622,16 +8972,26 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:578
 #: classes/gateways/class.pmprogateway_stripe.php:902
 #: classes/gateways/class.pmprogateway_stripe.php:972
-#: classes/gateways/class.pmprogateway_stripe.php:1037 pages/checkout.php:362
-#: pages/checkout.php:411 pages/checkout.php:419 pages/checkout.php:476
-#: pages/checkout.php:478 pages/checkout.php:485 pages/checkout.php:493
-#: pages/checkout.php:494 pages/checkout.php:500 pages/checkout.php:501
-#: pages/checkout.php:503 pages/checkout.php:510 pages/checkout.php:513
+#: classes/gateways/class.pmprogateway_stripe.php:1037
+#: pages/checkout.php:362
+#: pages/checkout.php:411
+#: pages/checkout.php:419
+#: pages/checkout.php:476
+#: pages/checkout.php:478
+#: pages/checkout.php:485
+#: pages/checkout.php:493
+#: pages/checkout.php:494
+#: pages/checkout.php:500
+#: pages/checkout.php:501
+#: pages/checkout.php:503
+#: pages/checkout.php:510
+#: pages/checkout.php:513
 msgid "Payment Information"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:455
-#: classes/gateways/class.pmprogateway_stripe.php:1049 pages/checkout.php:366
+#: classes/gateways/class.pmprogateway_stripe.php:1049
+#: pages/checkout.php:366
 #: classes/gateways/class.pmprogateway_braintree.php:270
 #: classes/gateways/class.pmprogateway_braintree.php:283
 #: classes/gateways/class.pmprogateway_braintree.php:285
@@ -6643,7 +9003,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:430
 #: classes/gateways/class.pmprogateway_braintree.php:435
 #: classes/gateways/class.pmprogateway_braintree.php:454
-#: classes/gateways/class.pmprogateway_braintree.php:455
 #: classes/gateways/class.pmprogateway_braintree.php:456
 #: classes/gateways/class.pmprogateway_braintree.php:461
 #: classes/gateways/class.pmprogateway_braintree.php:462
@@ -6671,18 +9030,29 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:579
 #: classes/gateways/class.pmprogateway_stripe.php:903
 #: classes/gateways/class.pmprogateway_stripe.php:973
-#: classes/gateways/class.pmprogateway_stripe.php:1038 pages/checkout.php:363
-#: pages/checkout.php:412 pages/checkout.php:420 pages/checkout.php:476
-#: pages/checkout.php:478 pages/checkout.php:485 pages/checkout.php:493
-#: pages/checkout.php:494 pages/checkout.php:500 pages/checkout.php:502
-#: pages/checkout.php:504 pages/checkout.php:511 pages/checkout.php:514
+#: classes/gateways/class.pmprogateway_stripe.php:1038
+#: pages/checkout.php:363
+#: pages/checkout.php:412
+#: pages/checkout.php:420
+#: pages/checkout.php:476
+#: pages/checkout.php:478
+#: pages/checkout.php:485
+#: pages/checkout.php:493
+#: pages/checkout.php:494
+#: pages/checkout.php:500
+#: pages/checkout.php:502
+#: pages/checkout.php:504
+#: pages/checkout.php:511
+#: pages/checkout.php:514
 #, php-format
 msgid "We Accept %s"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:475
-#: classes/gateways/class.pmprogateway_stripe.php:1082 pages/billing.php:359
-#: pages/checkout.php:388 classes/gateways/class.pmprogateway_braintree.php:303
+#: classes/gateways/class.pmprogateway_stripe.php:1082
+#: pages/billing.php:359
+#: pages/checkout.php:388
+#: classes/gateways/class.pmprogateway_braintree.php:303
 #: classes/gateways/class.pmprogateway_braintree.php:316
 #: classes/gateways/class.pmprogateway_braintree.php:318
 #: classes/gateways/class.pmprogateway_braintree.php:321
@@ -6692,7 +9062,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:418
 #: classes/gateways/class.pmprogateway_braintree.php:455
 #: classes/gateways/class.pmprogateway_braintree.php:474
-#: classes/gateways/class.pmprogateway_braintree.php:475
 #: classes/gateways/class.pmprogateway_braintree.php:476
 #: classes/gateways/class.pmprogateway_braintree.php:481
 #: classes/gateways/class.pmprogateway_braintree.php:482
@@ -6720,21 +9089,41 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:626
 #: classes/gateways/class.pmprogateway_stripe.php:927
 #: classes/gateways/class.pmprogateway_stripe.php:997
-#: classes/gateways/class.pmprogateway_stripe.php:1071 pages/billing.php:244
-#: pages/billing.php:248 pages/billing.php:257 pages/billing.php:260
-#: pages/billing.php:263 pages/billing.php:305 pages/billing.php:309
-#: pages/billing.php:311 pages/billing.php:312 pages/billing.php:313
-#: pages/billing.php:314 pages/billing.php:317 pages/billing.php:318
-#: pages/billing.php:326 pages/billing.php:335 pages/billing.php:337
-#: pages/billing.php:359 pages/checkout.php:385 pages/checkout.php:459
-#: pages/checkout.php:467 pages/checkout.php:503 pages/checkout.php:519
-#: pages/checkout.php:520 pages/checkout.php:527 pages/checkout.php:548
-#: pages/checkout.php:557 pages/checkout.php:566 pages/checkout.php:570
-#: pages/checkout.php:577 pages/checkout.php:580
+#: classes/gateways/class.pmprogateway_stripe.php:1071
+#: pages/billing.php:244
+#: pages/billing.php:248
+#: pages/billing.php:257
+#: pages/billing.php:260
+#: pages/billing.php:263
+#: pages/billing.php:305
+#: pages/billing.php:309
+#: pages/billing.php:311
+#: pages/billing.php:312
+#: pages/billing.php:313
+#: pages/billing.php:314
+#: pages/billing.php:317
+#: pages/billing.php:318
+#: pages/billing.php:326
+#: pages/billing.php:335
+#: pages/billing.php:337
+#: pages/checkout.php:385
+#: pages/checkout.php:459
+#: pages/checkout.php:467
+#: pages/checkout.php:503
+#: pages/checkout.php:519
+#: pages/checkout.php:520
+#: pages/checkout.php:527
+#: pages/checkout.php:548
+#: pages/checkout.php:557
+#: pages/checkout.php:566
+#: pages/checkout.php:570
+#: pages/checkout.php:577
+#: pages/checkout.php:580
 msgid "Card Number"
 msgstr ""
 
-#: classes/gateways/class.pmprogateway_braintree.php:503 pages/billing.php:398
+#: classes/gateways/class.pmprogateway_braintree.php:503
+#: pages/billing.php:398
 #: classes/gateways/class.pmprogateway_braintree.php:340
 #: classes/gateways/class.pmprogateway_braintree.php:353
 #: classes/gateways/class.pmprogateway_braintree.php:355
@@ -6745,7 +9134,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:455
 #: classes/gateways/class.pmprogateway_braintree.php:483
 #: classes/gateways/class.pmprogateway_braintree.php:502
-#: classes/gateways/class.pmprogateway_braintree.php:503
 #: classes/gateways/class.pmprogateway_braintree.php:504
 #: classes/gateways/class.pmprogateway_braintree.php:509
 #: classes/gateways/class.pmprogateway_braintree.php:510
@@ -6760,21 +9148,41 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:553
 #: classes/gateways/class.pmprogateway_stripe.php:564
 #: classes/gateways/class.pmprogateway_stripe.php:602
-#: classes/gateways/class.pmprogateway_stripe.php:629 pages/billing.php:281
-#: pages/billing.php:285 pages/billing.php:294 pages/billing.php:297
-#: pages/billing.php:301 pages/billing.php:343 pages/billing.php:348
-#: pages/billing.php:351 pages/billing.php:352 pages/billing.php:354
-#: pages/billing.php:356 pages/billing.php:357 pages/billing.php:365
-#: pages/billing.php:374 pages/billing.php:380 pages/billing.php:398
-#: pages/checkout.php:540 pages/checkout.php:556 pages/checkout.php:557
-#: pages/checkout.php:564 pages/checkout.php:585 pages/checkout.php:594
-#: pages/checkout.php:603 pages/checkout.php:605 pages/checkout.php:607
-#: pages/checkout.php:608 pages/checkout.php:612 pages/checkout.php:615
+#: classes/gateways/class.pmprogateway_stripe.php:629
+#: pages/billing.php:281
+#: pages/billing.php:285
+#: pages/billing.php:294
+#: pages/billing.php:297
+#: pages/billing.php:301
+#: pages/billing.php:343
+#: pages/billing.php:348
+#: pages/billing.php:351
+#: pages/billing.php:352
+#: pages/billing.php:354
+#: pages/billing.php:356
+#: pages/billing.php:357
+#: pages/billing.php:365
+#: pages/billing.php:374
+#: pages/billing.php:380
+#: pages/checkout.php:540
+#: pages/checkout.php:556
+#: pages/checkout.php:557
+#: pages/checkout.php:564
+#: pages/checkout.php:585
+#: pages/checkout.php:594
+#: pages/checkout.php:603
+#: pages/checkout.php:605
+#: pages/checkout.php:607
+#: pages/checkout.php:608
+#: pages/checkout.php:612
+#: pages/checkout.php:615
 msgid "CVV"
 msgstr ""
 
-#: classes/gateways/class.pmprogateway_braintree.php:504 pages/billing.php:399
-#: pages/checkout.php:424 classes/gateways/class.pmprogateway_braintree.php:341
+#: classes/gateways/class.pmprogateway_braintree.php:504
+#: pages/billing.php:399
+#: pages/checkout.php:424
+#: classes/gateways/class.pmprogateway_braintree.php:341
 #: classes/gateways/class.pmprogateway_braintree.php:354
 #: classes/gateways/class.pmprogateway_braintree.php:356
 #: classes/gateways/class.pmprogateway_braintree.php:359
@@ -6784,7 +9192,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:456
 #: classes/gateways/class.pmprogateway_braintree.php:484
 #: classes/gateways/class.pmprogateway_braintree.php:503
-#: classes/gateways/class.pmprogateway_braintree.php:504
 #: classes/gateways/class.pmprogateway_braintree.php:505
 #: classes/gateways/class.pmprogateway_braintree.php:510
 #: classes/gateways/class.pmprogateway_braintree.php:511
@@ -6805,23 +9212,45 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:647
 #: classes/gateways/class.pmprogateway_stripe.php:654
 #: classes/gateways/class.pmprogateway_stripe.php:655
-#: classes/gateways/class.pmprogateway_stripe.php:656 pages/billing.php:282
-#: pages/billing.php:286 pages/billing.php:295 pages/billing.php:298
-#: pages/billing.php:302 pages/billing.php:344 pages/billing.php:349
-#: pages/billing.php:352 pages/billing.php:353 pages/billing.php:355
-#: pages/billing.php:357 pages/billing.php:358 pages/billing.php:366
-#: pages/billing.php:375 pages/billing.php:381 pages/billing.php:399
-#: pages/checkout.php:421 pages/checkout.php:493 pages/checkout.php:501
-#: pages/checkout.php:541 pages/checkout.php:557 pages/checkout.php:558
-#: pages/checkout.php:565 pages/checkout.php:586 pages/checkout.php:595
-#: pages/checkout.php:604 pages/checkout.php:606 pages/checkout.php:608
-#: pages/checkout.php:609 pages/checkout.php:613 pages/checkout.php:616
+#: classes/gateways/class.pmprogateway_stripe.php:656
+#: pages/billing.php:282
+#: pages/billing.php:286
+#: pages/billing.php:295
+#: pages/billing.php:298
+#: pages/billing.php:302
+#: pages/billing.php:344
+#: pages/billing.php:349
+#: pages/billing.php:352
+#: pages/billing.php:353
+#: pages/billing.php:355
+#: pages/billing.php:357
+#: pages/billing.php:358
+#: pages/billing.php:366
+#: pages/billing.php:375
+#: pages/billing.php:381
+#: pages/checkout.php:421
+#: pages/checkout.php:493
+#: pages/checkout.php:501
+#: pages/checkout.php:541
+#: pages/checkout.php:557
+#: pages/checkout.php:558
+#: pages/checkout.php:565
+#: pages/checkout.php:586
+#: pages/checkout.php:595
+#: pages/checkout.php:604
+#: pages/checkout.php:606
+#: pages/checkout.php:608
+#: pages/checkout.php:609
+#: pages/checkout.php:613
+#: pages/checkout.php:616
 msgid "what's this?"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:511
-#: classes/gateways/class.pmprogateway_stripe.php:1104 pages/checkout.php:94
-#: pages/checkout.php:431 classes/gateways/class.pmprogateway_braintree.php:351
+#: classes/gateways/class.pmprogateway_stripe.php:1104
+#: pages/checkout.php:94
+#: pages/checkout.php:431
+#: classes/gateways/class.pmprogateway_braintree.php:351
 #: classes/gateways/class.pmprogateway_braintree.php:364
 #: classes/gateways/class.pmprogateway_braintree.php:366
 #: classes/gateways/class.pmprogateway_braintree.php:369
@@ -6832,7 +9261,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:466
 #: classes/gateways/class.pmprogateway_braintree.php:491
 #: classes/gateways/class.pmprogateway_braintree.php:510
-#: classes/gateways/class.pmprogateway_braintree.php:511
 #: classes/gateways/class.pmprogateway_braintree.php:512
 #: classes/gateways/class.pmprogateway_braintree.php:517
 #: classes/gateways/class.pmprogateway_braintree.php:518
@@ -6860,14 +9288,29 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:663
 #: classes/gateways/class.pmprogateway_stripe.php:949
 #: classes/gateways/class.pmprogateway_stripe.php:1019
-#: classes/gateways/class.pmprogateway_stripe.php:1093 pages/checkout.php:78
-#: pages/checkout.php:79 pages/checkout.php:80 pages/checkout.php:83
-#: pages/checkout.php:87 pages/checkout.php:88 pages/checkout.php:91
-#: pages/checkout.php:95 pages/checkout.php:98 pages/checkout.php:428
-#: pages/checkout.php:500 pages/checkout.php:508 pages/checkout.php:551
-#: pages/checkout.php:567 pages/checkout.php:568 pages/checkout.php:575
-#: pages/checkout.php:596 pages/checkout.php:605 pages/checkout.php:614
-#: pages/checkout.php:618 pages/checkout.php:619 pages/checkout.php:621
+#: classes/gateways/class.pmprogateway_stripe.php:1093
+#: pages/checkout.php:78
+#: pages/checkout.php:79
+#: pages/checkout.php:80
+#: pages/checkout.php:83
+#: pages/checkout.php:87
+#: pages/checkout.php:88
+#: pages/checkout.php:91
+#: pages/checkout.php:95
+#: pages/checkout.php:98
+#: pages/checkout.php:428
+#: pages/checkout.php:500
+#: pages/checkout.php:508
+#: pages/checkout.php:551
+#: pages/checkout.php:567
+#: pages/checkout.php:568
+#: pages/checkout.php:575
+#: pages/checkout.php:596
+#: pages/checkout.php:605
+#: pages/checkout.php:614
+#: pages/checkout.php:618
+#: pages/checkout.php:619
+#: pages/checkout.php:621
 #: pages/checkout.php:624
 msgid "Apply"
 msgstr ""
@@ -6885,12 +9328,10 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:550
 #: classes/gateways/class.pmprogateway_braintree.php:567
 #: classes/gateways/class.pmprogateway_braintree.php:569
-#: classes/gateways/class.pmprogateway_braintree.php:570
 #: classes/gateways/class.pmprogateway_braintree.php:571
 #: classes/gateways/class.pmprogateway_braintree.php:576
 #: classes/gateways/class.pmprogateway_braintree.php:577
 #: classes/gateways/class.pmprogateway_braintree.php:586
-#: classes/gateways/class.pmprogateway_braintree.php:587
 #: classes/gateways/class.pmprogateway_braintree.php:588
 #: classes/gateways/class.pmprogateway_braintree.php:593
 #: classes/gateways/class.pmprogateway_braintree.php:594
@@ -6898,7 +9339,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:623
 #: classes/gateways/class.pmprogateway_braintree.php:657
 #: classes/gateways/class.pmprogateway_braintree.php:676
-#: classes/gateways/class.pmprogateway_braintree.php:677
 #: classes/gateways/class.pmprogateway_braintree.php:678
 #: classes/gateways/class.pmprogateway_braintree.php:683
 #: classes/gateways/class.pmprogateway_braintree.php:684
@@ -6906,7 +9346,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:782
 #: classes/gateways/class.pmprogateway_braintree.php:822
 #: classes/gateways/class.pmprogateway_braintree.php:848
-#: classes/gateways/class.pmprogateway_braintree.php:849
 #: classes/gateways/class.pmprogateway_braintree.php:850
 #: classes/gateways/class.pmprogateway_braintree.php:856
 #: classes/gateways/class.pmprogateway_braintree.php:886
@@ -6917,12 +9356,10 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:947
 #: classes/gateways/class.pmprogateway_braintree.php:953
 #: classes/gateways/class.pmprogateway_braintree.php:957
-#: classes/gateways/class.pmprogateway_braintree.php:958
 #: classes/gateways/class.pmprogateway_braintree.php:959
 #: classes/gateways/class.pmprogateway_braintree.php:964
 #: classes/gateways/class.pmprogateway_braintree.php:973
 #: classes/gateways/class.pmprogateway_braintree.php:984
-#: classes/gateways/class.pmprogateway_braintree.php:985
 #: classes/gateways/class.pmprogateway_braintree.php:986
 #: classes/gateways/class.pmprogateway_braintree.php:991
 msgid "Payment error: Please contact the webmaster (braintree-load-error)"
@@ -6941,7 +9378,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:528
 #: classes/gateways/class.pmprogateway_braintree.php:554
 #: classes/gateways/class.pmprogateway_braintree.php:573
-#: classes/gateways/class.pmprogateway_braintree.php:574
 #: classes/gateways/class.pmprogateway_braintree.php:575
 #: classes/gateways/class.pmprogateway_braintree.php:580
 #: classes/gateways/class.pmprogateway_braintree.php:581
@@ -6981,7 +9417,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:596
 #: classes/gateways/class.pmprogateway_braintree.php:630
 #: classes/gateways/class.pmprogateway_braintree.php:649
-#: classes/gateways/class.pmprogateway_braintree.php:650
 #: classes/gateways/class.pmprogateway_braintree.php:651
 #: classes/gateways/class.pmprogateway_braintree.php:656
 #: classes/gateways/class.pmprogateway_braintree.php:657
@@ -7001,7 +9436,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:605
 #: classes/gateways/class.pmprogateway_braintree.php:639
 #: classes/gateways/class.pmprogateway_braintree.php:658
-#: classes/gateways/class.pmprogateway_braintree.php:659
 #: classes/gateways/class.pmprogateway_braintree.php:660
 #: classes/gateways/class.pmprogateway_braintree.php:665
 #: classes/gateways/class.pmprogateway_braintree.php:666
@@ -7012,7 +9446,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:690
 #: classes/gateways/class.pmprogateway_braintree.php:731
 #: classes/gateways/class.pmprogateway_braintree.php:750
-#: classes/gateways/class.pmprogateway_braintree.php:751
 #: classes/gateways/class.pmprogateway_braintree.php:752
 #: classes/gateways/class.pmprogateway_braintree.php:757
 #: classes/gateways/class.pmprogateway_braintree.php:758
@@ -7034,7 +9467,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:703
 #: classes/gateways/class.pmprogateway_braintree.php:743
 #: classes/gateways/class.pmprogateway_braintree.php:762
-#: classes/gateways/class.pmprogateway_braintree.php:763
 #: classes/gateways/class.pmprogateway_braintree.php:764
 #: classes/gateways/class.pmprogateway_braintree.php:769
 #: classes/gateways/class.pmprogateway_braintree.php:770
@@ -7055,7 +9487,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:751
 #: classes/gateways/class.pmprogateway_braintree.php:791
 #: classes/gateways/class.pmprogateway_braintree.php:810
-#: classes/gateways/class.pmprogateway_braintree.php:811
 #: classes/gateways/class.pmprogateway_braintree.php:812
 #: classes/gateways/class.pmprogateway_braintree.php:817
 #: classes/gateways/class.pmprogateway_braintree.php:818
@@ -7076,7 +9507,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:758
 #: classes/gateways/class.pmprogateway_braintree.php:798
 #: classes/gateways/class.pmprogateway_braintree.php:817
-#: classes/gateways/class.pmprogateway_braintree.php:818
 #: classes/gateways/class.pmprogateway_braintree.php:819
 #: classes/gateways/class.pmprogateway_braintree.php:824
 #: classes/gateways/class.pmprogateway_braintree.php:825
@@ -7085,7 +9515,6 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:934
 #: classes/gateways/class.pmprogateway_braintree.php:933
-#: classes/gateways/class.pmprogateway_braintree.php:934
 #: classes/gateways/class.pmprogateway_braintree.php:935
 #: classes/gateways/class.pmprogateway_braintree.php:940
 #, php-format
@@ -7094,7 +9523,6 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:949
 #: classes/gateways/class.pmprogateway_braintree.php:948
-#: classes/gateways/class.pmprogateway_braintree.php:949
 #: classes/gateways/class.pmprogateway_braintree.php:950
 #: classes/gateways/class.pmprogateway_braintree.php:955
 #, php-format
@@ -7103,11 +9531,9 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:1019
 #: classes/gateways/class.pmprogateway_braintree.php:1030
-#: classes/gateways/class.pmprogateway_braintree.php:1019
 #: classes/gateways/class.pmprogateway_braintree.php:1020
 #: classes/gateways/class.pmprogateway_braintree.php:1021
 #: classes/gateways/class.pmprogateway_braintree.php:1026
-#: classes/gateways/class.pmprogateway_braintree.php:1030
 #: classes/gateways/class.pmprogateway_braintree.php:1031
 #: classes/gateways/class.pmprogateway_braintree.php:1032
 #: classes/gateways/class.pmprogateway_braintree.php:1037
@@ -7157,7 +9583,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_braintree.php:992
 #: classes/gateways/class.pmprogateway_braintree.php:1005
 #: classes/gateways/class.pmprogateway_braintree.php:1012
-#: classes/gateways/class.pmprogateway_braintree.php:1037
 #: classes/gateways/class.pmprogateway_braintree.php:1038
 #: classes/gateways/class.pmprogateway_braintree.php:1039
 #: classes/gateways/class.pmprogateway_braintree.php:1044
@@ -7174,56 +9599,61 @@ msgid "Could not find the subscription."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_braintree.php:1083
-#: classes/gateways/class.pmprogateway_braintree.php:1083
 msgid "Error getting subscription with Braintree:"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_check.php:49
-#: paid-memberships-pro.php:158 adminpages/orders.php:399
-#: adminpages/orders.php:449 adminpages/paymentsettings.php:157
+#: paid-memberships-pro.php:158
+#: adminpages/orders.php:399
+#: adminpages/orders.php:449
+#: adminpages/paymentsettings.php:157
 #: adminpages/paymentsettings.php:159
 #: classes/gateways/class.pmprogateway_check.php:48
-#: classes/gateways/class.pmprogateway_check.php:49
-#: paid-memberships-pro.php:116 paid-memberships-pro.php:117
-#: paid-memberships-pro.php:124 paid-memberships-pro.php:125
-#: paid-memberships-pro.php:126 paid-memberships-pro.php:127
-#: paid-memberships-pro.php:128 paid-memberships-pro.php:129
-#: paid-memberships-pro.php:130 paid-memberships-pro.php:131
-#: paid-memberships-pro.php:136 paid-memberships-pro.php:141
-#: paid-memberships-pro.php:146 paid-memberships-pro.php:148
-#: paid-memberships-pro.php:149 paid-memberships-pro.php:157
-#: paid-memberships-pro.php:158
+#: paid-memberships-pro.php:116
+#: paid-memberships-pro.php:117
+#: paid-memberships-pro.php:124
+#: paid-memberships-pro.php:125
+#: paid-memberships-pro.php:126
+#: paid-memberships-pro.php:127
+#: paid-memberships-pro.php:128
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:136
+#: paid-memberships-pro.php:141
+#: paid-memberships-pro.php:146
+#: paid-memberships-pro.php:148
+#: paid-memberships-pro.php:149
+#: paid-memberships-pro.php:157
 msgid "Pay by Check"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_check.php:102
 #: classes/gateways/class.pmprogateway_check.php:100
 #: classes/gateways/class.pmprogateway_check.php:101
-#: classes/gateways/class.pmprogateway_check.php:102
 msgid "Pay by Check Settings"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_check.php:107
-#: adminpages/paymentsettings.php:389 adminpages/paymentsettings.php:415
-#: adminpages/paymentsettings.php:420 adminpages/paymentsettings.php:422
+#: adminpages/paymentsettings.php:389
+#: adminpages/paymentsettings.php:415
+#: adminpages/paymentsettings.php:420
+#: adminpages/paymentsettings.php:422
 #: classes/gateways/class.pmprogateway_check.php:105
 #: classes/gateways/class.pmprogateway_check.php:106
-#: classes/gateways/class.pmprogateway_check.php:107
 msgid "Instructions"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_check.php:111
-#: adminpages/paymentsettings.php:393 adminpages/paymentsettings.php:419
-#: adminpages/paymentsettings.php:424 adminpages/paymentsettings.php:426
+#: adminpages/paymentsettings.php:393
+#: adminpages/paymentsettings.php:419
+#: adminpages/paymentsettings.php:424
+#: adminpages/paymentsettings.php:426
 #: classes/gateways/class.pmprogateway_check.php:109
 #: classes/gateways/class.pmprogateway_check.php:110
-#: classes/gateways/class.pmprogateway_check.php:111
-msgid ""
-"Who to write the check out to. Where to mail it. Shown on checkout, "
-"confirmation, and invoice pages."
+msgid "Who to write the check out to. Where to mail it. Shown on checkout, confirmation, and invoice pages."
 msgstr ""
 
-#: classes/gateways/class.pmprogateway_cybersource.php:36
 #: classes/gateways/class.pmprogateway_cybersource.php:36
 #: classes/gateways/class.pmprogateway_cybersource.php:42
 msgid "CyberSource"
@@ -7231,7 +9661,6 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:84
 #: classes/gateways/class.pmprogateway_cybersource.php:83
-#: classes/gateways/class.pmprogateway_cybersource.php:84
 #: classes/gateways/class.pmprogateway_cybersource.php:96
 msgid "CyberSource Settings"
 msgstr ""
@@ -7239,19 +9668,14 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_cybersource.php:89
 #: adminpages/paymentsettings.php:174
 #: classes/gateways/class.pmprogateway_cybersource.php:88
-#: classes/gateways/class.pmprogateway_cybersource.php:89
 #: classes/gateways/class.pmprogateway_cybersource.php:101
-msgid ""
-"This gateway option is in beta. Some functionality may not be available. "
-"Please contact Paid Memberships Pro with any issues you run into. "
-"<strong>Please be sure to upgrade Paid Memberships Pro to the latest "
-"versions when available.</strong>"
+msgid "This gateway option is in beta. Some functionality may not be available. Please contact Paid Memberships Pro with any issues you run into. <strong>Please be sure to upgrade Paid Memberships Pro to the latest versions when available.</strong>"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:102
-#: adminpages/paymentsettings.php:372 adminpages/paymentsettings.php:377
+#: adminpages/paymentsettings.php:372
+#: adminpages/paymentsettings.php:377
 #: classes/gateways/class.pmprogateway_cybersource.php:101
-#: classes/gateways/class.pmprogateway_cybersource.php:102
 #: classes/gateways/class.pmprogateway_cybersource.php:114
 msgid "Transaction Security Key"
 msgstr ""
@@ -7263,17 +9687,9 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_cybersource.php:768
 #: classes/gateways/class.pmprogateway_cybersource.php:769
 #: classes/gateways/class.pmprogateway_cybersource.php:316
-#: classes/gateways/class.pmprogateway_cybersource.php:317
-#: classes/gateways/class.pmprogateway_cybersource.php:318
 #: classes/gateways/class.pmprogateway_cybersource.php:480
-#: classes/gateways/class.pmprogateway_cybersource.php:481
-#: classes/gateways/class.pmprogateway_cybersource.php:482
 #: classes/gateways/class.pmprogateway_cybersource.php:767
-#: classes/gateways/class.pmprogateway_cybersource.php:768
-#: classes/gateways/class.pmprogateway_cybersource.php:769
-msgid ""
-"Error validating credit card type. Make sure your credit card number is "
-"correct and try again."
+msgid "Error validating credit card type. Make sure your credit card number is correct and try again."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:344
@@ -7289,29 +9705,17 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_cybersource.php:834
 #: classes/gateways/class.pmprogateway_cybersource.php:840
 #: classes/gateways/class.pmprogateway_cybersource.php:343
-#: classes/gateways/class.pmprogateway_cybersource.php:344
 #: classes/gateways/class.pmprogateway_cybersource.php:349
-#: classes/gateways/class.pmprogateway_cybersource.php:350
 #: classes/gateways/class.pmprogateway_cybersource.php:395
-#: classes/gateways/class.pmprogateway_cybersource.php:396
 #: classes/gateways/class.pmprogateway_cybersource.php:401
-#: classes/gateways/class.pmprogateway_cybersource.php:402
 #: classes/gateways/class.pmprogateway_cybersource.php:505
-#: classes/gateways/class.pmprogateway_cybersource.php:506
 #: classes/gateways/class.pmprogateway_cybersource.php:511
-#: classes/gateways/class.pmprogateway_cybersource.php:512
 #: classes/gateways/class.pmprogateway_cybersource.php:695
-#: classes/gateways/class.pmprogateway_cybersource.php:696
 #: classes/gateways/class.pmprogateway_cybersource.php:701
-#: classes/gateways/class.pmprogateway_cybersource.php:702
 #: classes/gateways/class.pmprogateway_cybersource.php:779
-#: classes/gateways/class.pmprogateway_cybersource.php:780
 #: classes/gateways/class.pmprogateway_cybersource.php:785
-#: classes/gateways/class.pmprogateway_cybersource.php:786
 #: classes/gateways/class.pmprogateway_cybersource.php:833
-#: classes/gateways/class.pmprogateway_cybersource.php:834
 #: classes/gateways/class.pmprogateway_cybersource.php:839
-#: classes/gateways/class.pmprogateway_cybersource.php:840
 msgid "Error communicating with Cybersource: %"
 msgstr ""
 
@@ -7328,484 +9732,387 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_cybersource.php:835
 #: classes/gateways/class.pmprogateway_cybersource.php:841
 #: classes/gateways/class.pmprogateway_cybersource.php:344
-#: classes/gateways/class.pmprogateway_cybersource.php:345
 #: classes/gateways/class.pmprogateway_cybersource.php:350
-#: classes/gateways/class.pmprogateway_cybersource.php:351
 #: classes/gateways/class.pmprogateway_cybersource.php:396
-#: classes/gateways/class.pmprogateway_cybersource.php:397
 #: classes/gateways/class.pmprogateway_cybersource.php:402
-#: classes/gateways/class.pmprogateway_cybersource.php:403
 #: classes/gateways/class.pmprogateway_cybersource.php:506
-#: classes/gateways/class.pmprogateway_cybersource.php:507
 #: classes/gateways/class.pmprogateway_cybersource.php:512
-#: classes/gateways/class.pmprogateway_cybersource.php:513
 #: classes/gateways/class.pmprogateway_cybersource.php:696
-#: classes/gateways/class.pmprogateway_cybersource.php:697
 #: classes/gateways/class.pmprogateway_cybersource.php:702
-#: classes/gateways/class.pmprogateway_cybersource.php:703
 #: classes/gateways/class.pmprogateway_cybersource.php:780
-#: classes/gateways/class.pmprogateway_cybersource.php:781
 #: classes/gateways/class.pmprogateway_cybersource.php:786
-#: classes/gateways/class.pmprogateway_cybersource.php:787
 #: classes/gateways/class.pmprogateway_cybersource.php:834
-#: classes/gateways/class.pmprogateway_cybersource.php:835
 #: classes/gateways/class.pmprogateway_cybersource.php:840
-#: classes/gateways/class.pmprogateway_cybersource.php:841
 msgid "Error communicating with Cybersource."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:679
 #: classes/gateways/class.pmprogateway_cybersource.php:678
-#: classes/gateways/class.pmprogateway_cybersource.php:679
 msgid "The payment gateway doesn't support this credit/debit card type."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:864
 #: classes/gateways/class.pmprogateway_cybersource.php:863
-#: classes/gateways/class.pmprogateway_cybersource.php:864
 msgid "Successful transaction."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:865
 #: classes/gateways/class.pmprogateway_cybersource.php:864
-#: classes/gateways/class.pmprogateway_cybersource.php:865
 msgid "The request is missing one or more required fields."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:866
 #: classes/gateways/class.pmprogateway_cybersource.php:865
-#: classes/gateways/class.pmprogateway_cybersource.php:866
-msgid ""
-"One or more fields in the request contains invalid data. Check that your "
-"billing address is valid."
+msgid "One or more fields in the request contains invalid data. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:867
 #: classes/gateways/class.pmprogateway_cybersource.php:866
-#: classes/gateways/class.pmprogateway_cybersource.php:867
 msgid "Duplicate order detected."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:868
 #: classes/gateways/class.pmprogateway_cybersource.php:867
-#: classes/gateways/class.pmprogateway_cybersource.php:868
 msgid "Only partial amount was approved."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:869
 #: classes/gateways/class.pmprogateway_cybersource.php:868
-#: classes/gateways/class.pmprogateway_cybersource.php:869
 msgid "Error: General system failure."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:870
 #: classes/gateways/class.pmprogateway_cybersource.php:869
-#: classes/gateways/class.pmprogateway_cybersource.php:870
 msgid "Error: The request was received but there was a server timeout."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:871
 #: classes/gateways/class.pmprogateway_cybersource.php:870
-#: classes/gateways/class.pmprogateway_cybersource.php:871
-msgid ""
-"Error: The request was received, but a service did not finish running in "
-"time. "
+msgid "Error: The request was received, but a service did not finish running in time. "
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:872
 #: classes/gateways/class.pmprogateway_cybersource.php:871
-#: classes/gateways/class.pmprogateway_cybersource.php:872
 msgid "Address Verification Service (AVS) failure."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:873
 #: classes/gateways/class.pmprogateway_cybersource.php:872
-#: classes/gateways/class.pmprogateway_cybersource.php:873
 msgid "Authorization failed."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:874
 #: classes/gateways/class.pmprogateway_cybersource.php:873
-#: classes/gateways/class.pmprogateway_cybersource.php:874
 msgid "Expired card or invalid expiration date."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:875
 #: classes/gateways/class.pmprogateway_cybersource.php:874
-#: classes/gateways/class.pmprogateway_cybersource.php:875
 msgid "The card was declined."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:876
 #: classes/gateways/class.pmprogateway_cybersource.php:875
-#: classes/gateways/class.pmprogateway_cybersource.php:876
 msgid "Insufficient funds in the account."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:877
 #: classes/gateways/class.pmprogateway_cybersource.php:876
-#: classes/gateways/class.pmprogateway_cybersource.php:877
 msgid "Stolen or lost card."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:878
 #: classes/gateways/class.pmprogateway_cybersource.php:877
-#: classes/gateways/class.pmprogateway_cybersource.php:878
 msgid "Issuing bank unavailable."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:879
 #: classes/gateways/class.pmprogateway_cybersource.php:878
-#: classes/gateways/class.pmprogateway_cybersource.php:879
 msgid "Inactive card or card not authorized for card-not-present transactions."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:880
 #: classes/gateways/class.pmprogateway_cybersource.php:879
-#: classes/gateways/class.pmprogateway_cybersource.php:880
 msgid "American Express Card Identification Digits (CID) did not match."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:881
 #: classes/gateways/class.pmprogateway_cybersource.php:880
-#: classes/gateways/class.pmprogateway_cybersource.php:881
 msgid "The card has reached the credit limit. "
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:882
 #: classes/gateways/class.pmprogateway_cybersource.php:881
-#: classes/gateways/class.pmprogateway_cybersource.php:882
 msgid "Invalid card verification number."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:883
 #: classes/gateways/class.pmprogateway_cybersource.php:882
-#: classes/gateways/class.pmprogateway_cybersource.php:883
 msgid "The customer matched an entry on the processors negative file. "
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:884
 #: classes/gateways/class.pmprogateway_cybersource.php:883
-#: classes/gateways/class.pmprogateway_cybersource.php:884
 msgid "Card verification (CV) check failed."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:885
 #: classes/gateways/class.pmprogateway_cybersource.php:884
-#: classes/gateways/class.pmprogateway_cybersource.php:885
 msgid "Invalid account number."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:886
 #: classes/gateways/class.pmprogateway_cybersource.php:885
-#: classes/gateways/class.pmprogateway_cybersource.php:886
 msgid "The card type is not accepted by the payment processor."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:887
 #: classes/gateways/class.pmprogateway_cybersource.php:886
-#: classes/gateways/class.pmprogateway_cybersource.php:887
 msgid "General decline by the processor."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:888
 #: classes/gateways/class.pmprogateway_cybersource.php:887
-#: classes/gateways/class.pmprogateway_cybersource.php:888
 msgid "There is a problem with your CyberSource merchant configuration."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:889
 #: classes/gateways/class.pmprogateway_cybersource.php:888
-#: classes/gateways/class.pmprogateway_cybersource.php:889
 msgid "The requested amount exceeds the originally authorized amount."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:890
 #: classes/gateways/class.pmprogateway_cybersource.php:889
-#: classes/gateways/class.pmprogateway_cybersource.php:890
 msgid "Processor failure."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:891
 #: classes/gateways/class.pmprogateway_cybersource.php:890
-#: classes/gateways/class.pmprogateway_cybersource.php:891
 msgid "The authorization has already been reversed."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:892
 #: classes/gateways/class.pmprogateway_cybersource.php:891
-#: classes/gateways/class.pmprogateway_cybersource.php:892
 msgid "The authorization has already been captured."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:893
 #: classes/gateways/class.pmprogateway_cybersource.php:892
-#: classes/gateways/class.pmprogateway_cybersource.php:893
-msgid ""
-"The requested transaction amount must match the previous transaction amount."
+msgid "The requested transaction amount must match the previous transaction amount."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:894
 #: classes/gateways/class.pmprogateway_cybersource.php:893
-#: classes/gateways/class.pmprogateway_cybersource.php:894
-msgid ""
-"The card type sent is invalid or does not correlate with the credit card "
-"number."
+msgid "The card type sent is invalid or does not correlate with the credit card number."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:895
 #: classes/gateways/class.pmprogateway_cybersource.php:894
-#: classes/gateways/class.pmprogateway_cybersource.php:895
 msgid "The referenced request id is invalid for all follow-on transactions."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:896
 #: classes/gateways/class.pmprogateway_cybersource.php:895
-#: classes/gateways/class.pmprogateway_cybersource.php:896
 msgid "The request ID is invalid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:897
 #: classes/gateways/class.pmprogateway_cybersource.php:896
-#: classes/gateways/class.pmprogateway_cybersource.php:897
 msgid "The transaction has already been settled or reversed."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:898
 #: classes/gateways/class.pmprogateway_cybersource.php:897
-#: classes/gateways/class.pmprogateway_cybersource.php:898
-msgid ""
-"The capture or credit is not voidable because the capture or credit "
-"information has already been submitted to your processor. Or, you requested "
-"a void for a type of transaction that cannot be voided."
+msgid "The capture or credit is not voidable because the capture or credit information has already been submitted to your processor. Or, you requested a void for a type of transaction that cannot be voided."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:899
 #: classes/gateways/class.pmprogateway_cybersource.php:898
-#: classes/gateways/class.pmprogateway_cybersource.php:899
 msgid "You requested a credit for a capture that was previously voided."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:900
 #: classes/gateways/class.pmprogateway_cybersource.php:899
-#: classes/gateways/class.pmprogateway_cybersource.php:900
-msgid ""
-"Error: The request was received, but there was a timeout at the payment "
-"processor."
+msgid "Error: The request was received, but there was a timeout at the payment processor."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:901
 #: classes/gateways/class.pmprogateway_cybersource.php:900
-#: classes/gateways/class.pmprogateway_cybersource.php:901
 msgid "Stand-alone credits are not allowed with this processor."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:902
 #: classes/gateways/class.pmprogateway_cybersource.php:901
-#: classes/gateways/class.pmprogateway_cybersource.php:902
-msgid ""
-"Apartment number missing or not found. Check that your billing address is "
-"valid."
+msgid "Apartment number missing or not found. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:903
 #: classes/gateways/class.pmprogateway_cybersource.php:902
-#: classes/gateways/class.pmprogateway_cybersource.php:903
-msgid ""
-"Insufficient address information. Check that your billing address is valid."
+msgid "Insufficient address information. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:904
 #: classes/gateways/class.pmprogateway_cybersource.php:903
-#: classes/gateways/class.pmprogateway_cybersource.php:904
-msgid ""
-"House/Box number not found on street. Check that your billing address is "
-"valid."
+msgid "House/Box number not found on street. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:905
 #: classes/gateways/class.pmprogateway_cybersource.php:904
-#: classes/gateways/class.pmprogateway_cybersource.php:905
-msgid ""
-"Multiple address matches were found. Check that your billing address is "
-"valid."
+msgid "Multiple address matches were found. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:906
 #: classes/gateways/class.pmprogateway_cybersource.php:905
-#: classes/gateways/class.pmprogateway_cybersource.php:906
-msgid ""
-"P.O. Box identifier not found or out of range.. Check that your billing "
-"address is valid."
+msgid "P.O. Box identifier not found or out of range.. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:907
 #: classes/gateways/class.pmprogateway_cybersource.php:906
-#: classes/gateways/class.pmprogateway_cybersource.php:907
-msgid ""
-"Route service identifier not found or out of range. Check that your billing "
-"address is valid."
+msgid "Route service identifier not found or out of range. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:908
 #: classes/gateways/class.pmprogateway_cybersource.php:907
-#: classes/gateways/class.pmprogateway_cybersource.php:908
-msgid ""
-"Street name not found in Postal code. Check that your billing address is "
-"valid."
+msgid "Street name not found in Postal code. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:909
 #: classes/gateways/class.pmprogateway_cybersource.php:908
-#: classes/gateways/class.pmprogateway_cybersource.php:909
-msgid ""
-"Postal code not found in database. Check that your billing address is valid."
+msgid "Postal code not found in database. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:910
 #: classes/gateways/class.pmprogateway_cybersource.php:909
-#: classes/gateways/class.pmprogateway_cybersource.php:910
-msgid ""
-"Unable to verify or correct address. Check that your billing address is "
-"valid."
+msgid "Unable to verify or correct address. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:911
 #: classes/gateways/class.pmprogateway_cybersource.php:910
-#: classes/gateways/class.pmprogateway_cybersource.php:911
-msgid ""
-"Multiple address matches were found (international). Check that your billing "
-"address is valid."
+msgid "Multiple address matches were found (international). Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:912
 #: classes/gateways/class.pmprogateway_cybersource.php:911
-#: classes/gateways/class.pmprogateway_cybersource.php:912
 msgid "Address match not found. Check that your billing address is valid."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:913
 #: classes/gateways/class.pmprogateway_cybersource.php:912
-#: classes/gateways/class.pmprogateway_cybersource.php:913
-msgid ""
-"Unsupported character set. Verify the character set that you are using to "
-"process transactions."
+msgid "Unsupported character set. Verify the character set that you are using to process transactions."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:914
 #: classes/gateways/class.pmprogateway_cybersource.php:913
-#: classes/gateways/class.pmprogateway_cybersource.php:914
 msgid "Order has been rejected by Decision Manager."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:915
 #: classes/gateways/class.pmprogateway_cybersource.php:914
-#: classes/gateways/class.pmprogateway_cybersource.php:915
 msgid "Smart Authorization failed."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:916
 #: classes/gateways/class.pmprogateway_cybersource.php:915
-#: classes/gateways/class.pmprogateway_cybersource.php:916
 msgid "Your order has been refused."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:922
 #: classes/gateways/class.pmprogateway_cybersource.php:921
-#: classes/gateways/class.pmprogateway_cybersource.php:922
 msgid "Unknown error."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_cybersource.php:927
 #: classes/gateways/class.pmprogateway_cybersource.php:926
-#: classes/gateways/class.pmprogateway_cybersource.php:927
 msgid " Invalid fields:"
 msgstr ""
 
-#: classes/gateways/class.pmprogateway_payflowpro.php:39
 #: classes/gateways/class.pmprogateway_payflowpro.php:39
 msgid "Payflow Pro/PayPal Pro"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:96
 #: classes/gateways/class.pmprogateway_payflowpro.php:95
-#: classes/gateways/class.pmprogateway_payflowpro.php:96
 msgid "Payflow Pro Settings"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:101
-#: adminpages/paymentsettings.php:195 adminpages/paymentsettings.php:199
+#: adminpages/paymentsettings.php:195
+#: adminpages/paymentsettings.php:199
 #: adminpages/paymentsettings.php:204
 #: classes/gateways/class.pmprogateway_payflowpro.php:100
-#: classes/gateways/class.pmprogateway_payflowpro.php:101
 msgid "Partner"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:109
-#: adminpages/paymentsettings.php:203 adminpages/paymentsettings.php:207
+#: adminpages/paymentsettings.php:203
+#: adminpages/paymentsettings.php:207
 #: adminpages/paymentsettings.php:212
 #: classes/gateways/class.pmprogateway_payflowpro.php:108
-#: classes/gateways/class.pmprogateway_payflowpro.php:109
 msgid "Vendor"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:125
-#: pages/checkout.php:130 adminpages/paymentsettings.php:219
-#: adminpages/paymentsettings.php:223 adminpages/paymentsettings.php:228
+#: pages/checkout.php:130
+#: adminpages/paymentsettings.php:219
+#: adminpages/paymentsettings.php:223
+#: adminpages/paymentsettings.php:228
 #: classes/gateways/class.pmprogateway_payflowpro.php:124
-#: classes/gateways/class.pmprogateway_payflowpro.php:125
-#: pages/checkout.php:127 pages/checkout.php:176 pages/checkout.php:177
-#: pages/checkout.php:180 pages/checkout.php:182 pages/checkout.php:184
-#: pages/checkout.php:189 pages/checkout.php:191 pages/checkout.php:193
-#: pages/checkout.php:200 pages/checkout.php:203
+#: pages/checkout.php:127
+#: pages/checkout.php:176
+#: pages/checkout.php:177
+#: pages/checkout.php:180
+#: pages/checkout.php:182
+#: pages/checkout.php:184
+#: pages/checkout.php:189
+#: pages/checkout.php:191
+#: pages/checkout.php:193
+#: pages/checkout.php:200
+#: pages/checkout.php:203
 msgid "Password"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:133
 #: classes/gateways/class.pmprogateway_payflowpro.php:132
-#: classes/gateways/class.pmprogateway_payflowpro.php:133
 msgid "IPN Handler"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:145
-#: classes/gateways/class.pmprogateway_payflowpro.php:145
 #, php-format
-msgid ""
-"Payflow does not use IPN. To sync recurring subscriptions, please see the <a "
-"target=\"_blank\" href=\"%s\" title=\"the Payflow Recurring Orders Add On"
-"\">Payflow Recurring Orders Add On</a>."
+msgid "Payflow does not use IPN. To sync recurring subscriptions, please see the <a target=\"_blank\" href=\"%s\" title=\"the Payflow Recurring Orders Add On\">Payflow Recurring Orders Add On</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:203
 #: classes/gateways/class.pmprogateway_paypal.php:345
 #: classes/gateways/class.pmprogateway_payflowpro.php:57
 #: classes/gateways/class.pmprogateway_payflowpro.php:194
-#: classes/gateways/class.pmprogateway_payflowpro.php:203
 #: classes/gateways/class.pmprogateway_paypal.php:57
 #: classes/gateways/class.pmprogateway_paypal.php:277
 #: classes/gateways/class.pmprogateway_paypal.php:279
 #: classes/gateways/class.pmprogateway_paypal.php:302
 #: classes/gateways/class.pmprogateway_paypal.php:332
 #: classes/gateways/class.pmprogateway_paypal.php:344
-#: classes/gateways/class.pmprogateway_paypal.php:345
-msgid ""
-"A partial payment was made that we could not refund. Please contact the site "
-"owner immediately to correct this."
+msgid "A partial payment was made that we could not refund. Please contact the site owner immediately to correct this."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:68
 #: paid-memberships-pro.php:161
 #: classes/gateways/class.pmprogateway_paypal.php:57
-#: classes/gateways/class.pmprogateway_paypal.php:68
-#: paid-memberships-pro.php:119 paid-memberships-pro.php:120
-#: paid-memberships-pro.php:127 paid-memberships-pro.php:128
-#: paid-memberships-pro.php:129 paid-memberships-pro.php:130
-#: paid-memberships-pro.php:131 paid-memberships-pro.php:132
-#: paid-memberships-pro.php:133 paid-memberships-pro.php:134
-#: paid-memberships-pro.php:139 paid-memberships-pro.php:144
-#: paid-memberships-pro.php:149 paid-memberships-pro.php:151
-#: paid-memberships-pro.php:152 paid-memberships-pro.php:160
-#: paid-memberships-pro.php:161
+#: paid-memberships-pro.php:119
+#: paid-memberships-pro.php:120
+#: paid-memberships-pro.php:127
+#: paid-memberships-pro.php:128
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:139
+#: paid-memberships-pro.php:144
+#: paid-memberships-pro.php:149
+#: paid-memberships-pro.php:151
+#: paid-memberships-pro.php:152
+#: paid-memberships-pro.php:160
 msgid "PayPal Website Payments Pro"
 msgstr ""
 
@@ -7815,47 +10122,35 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypal.php:113
 #: classes/gateways/class.pmprogateway_paypal.php:125
 #: classes/gateways/class.pmprogateway_paypal.php:131
-#: classes/gateways/class.pmprogateway_paypal.php:132
 #: classes/gateways/class.pmprogateway_paypalexpress.php:118
 #: classes/gateways/class.pmprogateway_paypalexpress.php:128
 #: classes/gateways/class.pmprogateway_paypalexpress.php:140
-#: classes/gateways/class.pmprogateway_paypalexpress.php:141
 #: classes/gateways/class.pmprogateway_paypalstandard.php:112
 #: classes/gateways/class.pmprogateway_paypalstandard.php:132
-#: classes/gateways/class.pmprogateway_paypalstandard.php:133
 msgid "PayPal Settings"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:146
 #: classes/gateways/class.pmprogateway_paypalexpress.php:155
 #: classes/gateways/class.pmprogateway_paypalstandard.php:147
-#: classes/gateways/class.pmprogateway_paypal.php:146
-#: classes/gateways/class.pmprogateway_paypalexpress.php:155
-#: classes/gateways/class.pmprogateway_paypalstandard.php:147
 #, php-format
-msgid ""
-"Note: We do not recommend using PayPal Standard. We suggest using PayPal "
-"Express, Website Payments Pro (Legacy), or PayPal Pro (Payflow Pro). <a "
-"target=\"_blank\" href=\"%s\" title=\"More information on why can be found "
-"here\">More information on why can be found here</a>."
+msgid "Note: We do not recommend using PayPal Standard. We suggest using PayPal Express, Website Payments Pro (Legacy), or PayPal Pro (Payflow Pro). <a target=\"_blank\" href=\"%s\" title=\"More information on why can be found here\">More information on why can be found here</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:153
 #: classes/gateways/class.pmprogateway_paypalexpress.php:162
 #: classes/gateways/class.pmprogateway_paypalstandard.php:154
-#: adminpages/paymentsettings.php:227 adminpages/paymentsettings.php:231
+#: adminpages/paymentsettings.php:227
+#: adminpages/paymentsettings.php:231
 #: adminpages/paymentsettings.php:236
 #: classes/gateways/class.pmprogateway_paypal.php:123
 #: classes/gateways/class.pmprogateway_paypal.php:135
 #: classes/gateways/class.pmprogateway_paypal.php:141
-#: classes/gateways/class.pmprogateway_paypal.php:153
 #: classes/gateways/class.pmprogateway_paypalexpress.php:128
 #: classes/gateways/class.pmprogateway_paypalexpress.php:138
 #: classes/gateways/class.pmprogateway_paypalexpress.php:150
-#: classes/gateways/class.pmprogateway_paypalexpress.php:162
 #: classes/gateways/class.pmprogateway_paypalstandard.php:122
 #: classes/gateways/class.pmprogateway_paypalstandard.php:142
-#: classes/gateways/class.pmprogateway_paypalstandard.php:154
 msgid "Gateway Account Email"
 msgstr ""
 
@@ -7863,23 +10158,21 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:170
 #: classes/gateways/class.pmprogateway_paypalstandard.php:162
 #: classes/gateways/class.pmprogateway_twocheckout.php:120
-#: adminpages/paymentsettings.php:235 adminpages/paymentsettings.php:239
-#: adminpages/paymentsettings.php:244 adminpages/paymentsettings.php:331
+#: adminpages/paymentsettings.php:235
+#: adminpages/paymentsettings.php:239
+#: adminpages/paymentsettings.php:244
+#: adminpages/paymentsettings.php:331
 #: adminpages/paymentsettings.php:336
 #: classes/gateways/class.pmprogateway_paypal.php:131
 #: classes/gateways/class.pmprogateway_paypal.php:143
 #: classes/gateways/class.pmprogateway_paypal.php:149
-#: classes/gateways/class.pmprogateway_paypal.php:161
 #: classes/gateways/class.pmprogateway_paypalexpress.php:136
 #: classes/gateways/class.pmprogateway_paypalexpress.php:146
 #: classes/gateways/class.pmprogateway_paypalexpress.php:158
-#: classes/gateways/class.pmprogateway_paypalexpress.php:170
 #: classes/gateways/class.pmprogateway_paypalstandard.php:130
 #: classes/gateways/class.pmprogateway_paypalstandard.php:150
-#: classes/gateways/class.pmprogateway_paypalstandard.php:162
 #: classes/gateways/class.pmprogateway_twocheckout.php:113
 #: classes/gateways/class.pmprogateway_twocheckout.php:119
-#: classes/gateways/class.pmprogateway_twocheckout.php:120
 #: classes/gateways/class.pmprogateway_twocheckout.php:121
 msgid "API Username"
 msgstr ""
@@ -7888,23 +10181,21 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:178
 #: classes/gateways/class.pmprogateway_paypalstandard.php:170
 #: classes/gateways/class.pmprogateway_twocheckout.php:129
-#: adminpages/paymentsettings.php:243 adminpages/paymentsettings.php:247
-#: adminpages/paymentsettings.php:252 adminpages/paymentsettings.php:339
+#: adminpages/paymentsettings.php:243
+#: adminpages/paymentsettings.php:247
+#: adminpages/paymentsettings.php:252
+#: adminpages/paymentsettings.php:339
 #: adminpages/paymentsettings.php:344
 #: classes/gateways/class.pmprogateway_paypal.php:139
 #: classes/gateways/class.pmprogateway_paypal.php:151
 #: classes/gateways/class.pmprogateway_paypal.php:157
-#: classes/gateways/class.pmprogateway_paypal.php:169
 #: classes/gateways/class.pmprogateway_paypalexpress.php:144
 #: classes/gateways/class.pmprogateway_paypalexpress.php:154
 #: classes/gateways/class.pmprogateway_paypalexpress.php:166
-#: classes/gateways/class.pmprogateway_paypalexpress.php:178
 #: classes/gateways/class.pmprogateway_paypalstandard.php:138
 #: classes/gateways/class.pmprogateway_paypalstandard.php:158
-#: classes/gateways/class.pmprogateway_paypalstandard.php:170
 #: classes/gateways/class.pmprogateway_twocheckout.php:121
 #: classes/gateways/class.pmprogateway_twocheckout.php:128
-#: classes/gateways/class.pmprogateway_twocheckout.php:129
 #: classes/gateways/class.pmprogateway_twocheckout.php:130
 msgid "API Password"
 msgstr ""
@@ -7912,19 +10203,17 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypal.php:177
 #: classes/gateways/class.pmprogateway_paypalexpress.php:186
 #: classes/gateways/class.pmprogateway_paypalstandard.php:178
-#: adminpages/paymentsettings.php:251 adminpages/paymentsettings.php:255
+#: adminpages/paymentsettings.php:251
+#: adminpages/paymentsettings.php:255
 #: adminpages/paymentsettings.php:260
 #: classes/gateways/class.pmprogateway_paypal.php:147
 #: classes/gateways/class.pmprogateway_paypal.php:159
 #: classes/gateways/class.pmprogateway_paypal.php:165
-#: classes/gateways/class.pmprogateway_paypal.php:177
 #: classes/gateways/class.pmprogateway_paypalexpress.php:152
 #: classes/gateways/class.pmprogateway_paypalexpress.php:162
 #: classes/gateways/class.pmprogateway_paypalexpress.php:174
-#: classes/gateways/class.pmprogateway_paypalexpress.php:186
 #: classes/gateways/class.pmprogateway_paypalstandard.php:146
 #: classes/gateways/class.pmprogateway_paypalstandard.php:166
-#: classes/gateways/class.pmprogateway_paypalstandard.php:178
 msgid "API Signature"
 msgstr ""
 
@@ -7932,51 +10221,48 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:194
 #: classes/gateways/class.pmprogateway_paypal.php:167
 #: classes/gateways/class.pmprogateway_paypal.php:173
-#: classes/gateways/class.pmprogateway_paypal.php:185
 #: classes/gateways/class.pmprogateway_paypalexpress.php:182
-#: classes/gateways/class.pmprogateway_paypalexpress.php:194
 msgid "Confirmation Step"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:196
 #: classes/gateways/class.pmprogateway_paypalexpress.php:205
 #: classes/gateways/class.pmprogateway_paypalstandard.php:186
-#: adminpages/paymentsettings.php:446 adminpages/paymentsettings.php:479
-#: adminpages/paymentsettings.php:485 adminpages/paymentsettings.php:487
+#: adminpages/paymentsettings.php:446
+#: adminpages/paymentsettings.php:479
+#: adminpages/paymentsettings.php:485
+#: adminpages/paymentsettings.php:487
 #: classes/gateways/class.pmprogateway_paypal.php:155
 #: classes/gateways/class.pmprogateway_paypal.php:178
 #: classes/gateways/class.pmprogateway_paypal.php:184
-#: classes/gateways/class.pmprogateway_paypal.php:196
 #: classes/gateways/class.pmprogateway_paypalexpress.php:160
 #: classes/gateways/class.pmprogateway_paypalexpress.php:170
 #: classes/gateways/class.pmprogateway_paypalexpress.php:193
-#: classes/gateways/class.pmprogateway_paypalexpress.php:205
 #: classes/gateways/class.pmprogateway_paypalstandard.php:154
 #: classes/gateways/class.pmprogateway_paypalstandard.php:174
-#: classes/gateways/class.pmprogateway_paypalstandard.php:186
 msgid "IPN Handler URL"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:199
 #: classes/gateways/class.pmprogateway_paypalexpress.php:208
-#: adminpages/paymentsettings.php:449 adminpages/paymentsettings.php:482
-#: adminpages/paymentsettings.php:488 adminpages/paymentsettings.php:490
-#: classes/gateways/class.pmprogateway_paypal.php:199
+#: adminpages/paymentsettings.php:449
+#: adminpages/paymentsettings.php:482
+#: adminpages/paymentsettings.php:488
+#: adminpages/paymentsettings.php:490
 #: classes/gateways/class.pmprogateway_paypalexpress.php:163
 #: classes/gateways/class.pmprogateway_paypalexpress.php:173
 #: classes/gateways/class.pmprogateway_paypalexpress.php:196
-#: classes/gateways/class.pmprogateway_paypalexpress.php:208
 msgid "To fully integrate with PayPal, be sure to set your IPN Handler URL to "
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:281
 #: classes/gateways/class.pmprogateway_paypalexpress.php:476
 #: classes/gateways/class.pmprogateway_paypalstandard.php:241
-#: pages/checkout.php:217 classes/gateways/class.pmprogateway_paypal.php:178
+#: pages/checkout.php:217
+#: classes/gateways/class.pmprogateway_paypal.php:178
 #: classes/gateways/class.pmprogateway_paypal.php:201
 #: classes/gateways/class.pmprogateway_paypal.php:268
 #: classes/gateways/class.pmprogateway_paypal.php:280
-#: classes/gateways/class.pmprogateway_paypal.php:281
 #: classes/gateways/class.pmprogateway_paypalexpress.php:402
 #: classes/gateways/class.pmprogateway_paypalexpress.php:412
 #: classes/gateways/class.pmprogateway_paypalexpress.php:438
@@ -7984,27 +10270,34 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:444
 #: classes/gateways/class.pmprogateway_paypalexpress.php:463
 #: classes/gateways/class.pmprogateway_paypalexpress.php:475
-#: classes/gateways/class.pmprogateway_paypalexpress.php:476
 #: classes/gateways/class.pmprogateway_paypalstandard.php:201
 #: classes/gateways/class.pmprogateway_paypalstandard.php:202
 #: classes/gateways/class.pmprogateway_paypalstandard.php:229
-#: classes/gateways/class.pmprogateway_paypalstandard.php:241
-#: pages/checkout.php:214 pages/checkout.php:263 pages/checkout.php:271
-#: pages/checkout.php:286 pages/checkout.php:288 pages/checkout.php:295
-#: pages/checkout.php:300 pages/checkout.php:302 pages/checkout.php:309
-#: pages/checkout.php:312 pages/checkout.php:675 pages/checkout.php:682
-#: pages/checkout.php:685 pages/checkout.php:701
+#: pages/checkout.php:214
+#: pages/checkout.php:263
+#: pages/checkout.php:271
+#: pages/checkout.php:286
+#: pages/checkout.php:288
+#: pages/checkout.php:295
+#: pages/checkout.php:300
+#: pages/checkout.php:302
+#: pages/checkout.php:309
+#: pages/checkout.php:312
+#: pages/checkout.php:675
+#: pages/checkout.php:682
+#: pages/checkout.php:685
+#: pages/checkout.php:701
 msgid "Check Out with PayPal"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:287
 #: classes/gateways/class.pmprogateway_paypalexpress.php:481
 #: classes/gateways/class.pmprogateway_paypalstandard.php:246
-#: pages/checkout.php:512 classes/gateways/class.pmprogateway_paypal.php:184
+#: pages/checkout.php:512
+#: classes/gateways/class.pmprogateway_paypal.php:184
 #: classes/gateways/class.pmprogateway_paypal.php:207
 #: classes/gateways/class.pmprogateway_paypal.php:274
 #: classes/gateways/class.pmprogateway_paypal.php:286
-#: classes/gateways/class.pmprogateway_paypal.php:287
 #: classes/gateways/class.pmprogateway_paypalexpress.php:408
 #: classes/gateways/class.pmprogateway_paypalexpress.php:418
 #: classes/gateways/class.pmprogateway_paypalexpress.php:443
@@ -8012,16 +10305,24 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:449
 #: classes/gateways/class.pmprogateway_paypalexpress.php:468
 #: classes/gateways/class.pmprogateway_paypalexpress.php:480
-#: classes/gateways/class.pmprogateway_paypalexpress.php:481
 #: classes/gateways/class.pmprogateway_paypalstandard.php:206
 #: classes/gateways/class.pmprogateway_paypalstandard.php:208
 #: classes/gateways/class.pmprogateway_paypalstandard.php:234
-#: classes/gateways/class.pmprogateway_paypalstandard.php:246
-#: pages/checkout.php:496 pages/checkout.php:509 pages/checkout.php:598
-#: pages/checkout.php:606 pages/checkout.php:681 pages/checkout.php:688
-#: pages/checkout.php:691 pages/checkout.php:704 pages/checkout.php:707
-#: pages/checkout.php:713 pages/checkout.php:718 pages/checkout.php:722
-#: pages/checkout.php:724 pages/checkout.php:725 pages/checkout.php:728
+#: pages/checkout.php:496
+#: pages/checkout.php:509
+#: pages/checkout.php:598
+#: pages/checkout.php:606
+#: pages/checkout.php:681
+#: pages/checkout.php:688
+#: pages/checkout.php:691
+#: pages/checkout.php:704
+#: pages/checkout.php:707
+#: pages/checkout.php:713
+#: pages/checkout.php:718
+#: pages/checkout.php:722
+#: pages/checkout.php:724
+#: pages/checkout.php:725
+#: pages/checkout.php:728
 #: pages/checkout.php:729
 msgid "Submit and Check Out"
 msgstr ""
@@ -8030,11 +10331,11 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:481
 #: classes/gateways/class.pmprogateway_paypalstandard.php:246
 #: classes/gateways/class.pmprogateway_twocheckout.php:205
-#: pages/checkout.php:512 classes/gateways/class.pmprogateway_paypal.php:184
+#: pages/checkout.php:512
+#: classes/gateways/class.pmprogateway_paypal.php:184
 #: classes/gateways/class.pmprogateway_paypal.php:207
 #: classes/gateways/class.pmprogateway_paypal.php:274
 #: classes/gateways/class.pmprogateway_paypal.php:286
-#: classes/gateways/class.pmprogateway_paypal.php:287
 #: classes/gateways/class.pmprogateway_paypalexpress.php:408
 #: classes/gateways/class.pmprogateway_paypalexpress.php:418
 #: classes/gateways/class.pmprogateway_paypalexpress.php:443
@@ -8042,21 +10343,28 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:449
 #: classes/gateways/class.pmprogateway_paypalexpress.php:468
 #: classes/gateways/class.pmprogateway_paypalexpress.php:480
-#: classes/gateways/class.pmprogateway_paypalexpress.php:481
 #: classes/gateways/class.pmprogateway_paypalstandard.php:206
 #: classes/gateways/class.pmprogateway_paypalstandard.php:208
 #: classes/gateways/class.pmprogateway_paypalstandard.php:234
-#: classes/gateways/class.pmprogateway_paypalstandard.php:246
 #: classes/gateways/class.pmprogateway_twocheckout.php:192
 #: classes/gateways/class.pmprogateway_twocheckout.php:203
 #: classes/gateways/class.pmprogateway_twocheckout.php:204
-#: classes/gateways/class.pmprogateway_twocheckout.php:205
 #: classes/gateways/class.pmprogateway_twocheckout.php:214
-#: pages/checkout.php:496 pages/checkout.php:509 pages/checkout.php:598
-#: pages/checkout.php:606 pages/checkout.php:681 pages/checkout.php:688
-#: pages/checkout.php:691 pages/checkout.php:704 pages/checkout.php:707
-#: pages/checkout.php:713 pages/checkout.php:718 pages/checkout.php:722
-#: pages/checkout.php:724 pages/checkout.php:725 pages/checkout.php:728
+#: pages/checkout.php:496
+#: pages/checkout.php:509
+#: pages/checkout.php:598
+#: pages/checkout.php:606
+#: pages/checkout.php:681
+#: pages/checkout.php:688
+#: pages/checkout.php:691
+#: pages/checkout.php:704
+#: pages/checkout.php:707
+#: pages/checkout.php:713
+#: pages/checkout.php:718
+#: pages/checkout.php:722
+#: pages/checkout.php:724
+#: pages/checkout.php:725
+#: pages/checkout.php:728
 #: pages/checkout.php:729
 msgid "Submit and Confirm"
 msgstr ""
@@ -8074,7 +10382,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypal.php:694
 #: classes/gateways/class.pmprogateway_paypal.php:703
 #: classes/gateways/class.pmprogateway_paypal.php:708
-#: classes/gateways/class.pmprogateway_paypal.php:716
 #: classes/gateways/class.pmprogateway_paypalexpress.php:301
 #: classes/gateways/class.pmprogateway_paypalexpress.php:303
 #: classes/gateways/class.pmprogateway_paypalexpress.php:305
@@ -8091,7 +10398,6 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:785
 #: classes/gateways/class.pmprogateway_paypalexpress.php:786
 #: classes/gateways/class.pmprogateway_paypalexpress.php:790
-#: classes/gateways/class.pmprogateway_paypalexpress.php:795
 #: classes/gateways/class.pmprogateway_paypalstandard.php:216
 #: classes/gateways/class.pmprogateway_paypalstandard.php:220
 #: classes/gateways/class.pmprogateway_paypalstandard.php:230
@@ -8100,26 +10406,29 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalstandard.php:466
 #: classes/gateways/class.pmprogateway_paypalstandard.php:575
 #: classes/gateways/class.pmprogateway_paypalstandard.php:587
-#: classes/gateways/class.pmprogateway_paypalstandard.php:588
-msgid ""
-"Please contact the site owner or cancel your subscription from within PayPal "
-"to make sure you are not charged going forward."
+msgid "Please contact the site owner or cancel your subscription from within PayPal to make sure you are not charged going forward."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypalexpress.php:84
 #: paid-memberships-pro.php:160
 #: classes/gateways/class.pmprogateway_paypalexpress.php:63
 #: classes/gateways/class.pmprogateway_paypalexpress.php:73
-#: classes/gateways/class.pmprogateway_paypalexpress.php:84
-#: paid-memberships-pro.php:118 paid-memberships-pro.php:119
-#: paid-memberships-pro.php:126 paid-memberships-pro.php:127
-#: paid-memberships-pro.php:128 paid-memberships-pro.php:129
-#: paid-memberships-pro.php:130 paid-memberships-pro.php:131
-#: paid-memberships-pro.php:132 paid-memberships-pro.php:133
-#: paid-memberships-pro.php:138 paid-memberships-pro.php:143
-#: paid-memberships-pro.php:148 paid-memberships-pro.php:150
-#: paid-memberships-pro.php:151 paid-memberships-pro.php:159
-#: paid-memberships-pro.php:160
+#: paid-memberships-pro.php:118
+#: paid-memberships-pro.php:119
+#: paid-memberships-pro.php:126
+#: paid-memberships-pro.php:127
+#: paid-memberships-pro.php:128
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:138
+#: paid-memberships-pro.php:143
+#: paid-memberships-pro.php:148
+#: paid-memberships-pro.php:150
+#: paid-memberships-pro.php:151
+#: paid-memberships-pro.php:159
 msgid "PayPal Express"
 msgstr ""
 
@@ -8133,51 +10442,57 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:327
 #: classes/gateways/class.pmprogateway_paypalexpress.php:330
 #: classes/gateways/class.pmprogateway_paypalexpress.php:339
-#: classes/gateways/class.pmprogateway_paypalexpress.php:340
 #: classes/gateways/class.pmprogateway_paypalexpress.php:357
 #: classes/gateways/class.pmprogateway_paypalexpress.php:362
 #: classes/gateways/class.pmprogateway_paypalexpress.php:363
 #: classes/gateways/class.pmprogateway_paypalexpress.php:382
 #: classes/gateways/class.pmprogateway_paypalexpress.php:394
-#: classes/gateways/class.pmprogateway_paypalexpress.php:395
-#: preheaders/checkout.php:690 preheaders/checkout.php:697
-#: preheaders/checkout.php:702 preheaders/checkout.php:735
-#: preheaders/checkout.php:750 preheaders/checkout.php:753
-#: preheaders/checkout.php:754 preheaders/checkout.php:757
-#: preheaders/checkout.php:762 preheaders/checkout.php:803
-#: preheaders/checkout.php:822 preheaders/checkout.php:823
+#: preheaders/checkout.php:690
+#: preheaders/checkout.php:697
+#: preheaders/checkout.php:702
+#: preheaders/checkout.php:735
+#: preheaders/checkout.php:750
+#: preheaders/checkout.php:753
+#: preheaders/checkout.php:754
+#: preheaders/checkout.php:757
+#: preheaders/checkout.php:762
+#: preheaders/checkout.php:803
+#: preheaders/checkout.php:822
+#: preheaders/checkout.php:823
 msgid "The PayPal Token was lost."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypalstandard.php:71
 #: paid-memberships-pro.php:163
 #: classes/gateways/class.pmprogateway_paypalstandard.php:60
-#: classes/gateways/class.pmprogateway_paypalstandard.php:71
-#: paid-memberships-pro.php:121 paid-memberships-pro.php:122
-#: paid-memberships-pro.php:129 paid-memberships-pro.php:130
-#: paid-memberships-pro.php:131 paid-memberships-pro.php:132
-#: paid-memberships-pro.php:133 paid-memberships-pro.php:134
-#: paid-memberships-pro.php:135 paid-memberships-pro.php:136
-#: paid-memberships-pro.php:141 paid-memberships-pro.php:146
-#: paid-memberships-pro.php:151 paid-memberships-pro.php:153
-#: paid-memberships-pro.php:154 paid-memberships-pro.php:162
-#: paid-memberships-pro.php:163
+#: paid-memberships-pro.php:121
+#: paid-memberships-pro.php:122
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:136
+#: paid-memberships-pro.php:141
+#: paid-memberships-pro.php:146
+#: paid-memberships-pro.php:151
+#: paid-memberships-pro.php:153
+#: paid-memberships-pro.php:154
+#: paid-memberships-pro.php:162
 msgid "PayPal Standard"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypalstandard.php:189
 #: classes/gateways/class.pmprogateway_paypalstandard.php:157
 #: classes/gateways/class.pmprogateway_paypalstandard.php:177
-#: classes/gateways/class.pmprogateway_paypalstandard.php:189
-msgid ""
-"Here is your IPN URL for reference. You SHOULD NOT set this in your PayPal "
-"settings."
+msgid "Here is your IPN URL for reference. You SHOULD NOT set this in your PayPal settings."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypalstandard.php:572
 #: classes/gateways/class.pmprogateway_paypalstandard.php:559
 #: classes/gateways/class.pmprogateway_paypalstandard.php:571
-#: classes/gateways/class.pmprogateway_paypalstandard.php:572
 msgid "User requested cancellation"
 msgstr ""
 
@@ -8199,15 +10514,22 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:231
 #: classes/gateways/class.pmprogateway_stripe.php:237
 #: classes/gateways/class.pmprogateway_stripe.php:240
-#: paid-memberships-pro.php:117 paid-memberships-pro.php:118
-#: paid-memberships-pro.php:125 paid-memberships-pro.php:126
-#: paid-memberships-pro.php:127 paid-memberships-pro.php:128
-#: paid-memberships-pro.php:129 paid-memberships-pro.php:130
-#: paid-memberships-pro.php:131 paid-memberships-pro.php:132
-#: paid-memberships-pro.php:137 paid-memberships-pro.php:142
-#: paid-memberships-pro.php:147 paid-memberships-pro.php:149
-#: paid-memberships-pro.php:150 paid-memberships-pro.php:158
-#: paid-memberships-pro.php:159
+#: paid-memberships-pro.php:117
+#: paid-memberships-pro.php:118
+#: paid-memberships-pro.php:125
+#: paid-memberships-pro.php:126
+#: paid-memberships-pro.php:127
+#: paid-memberships-pro.php:128
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:137
+#: paid-memberships-pro.php:142
+#: paid-memberships-pro.php:147
+#: paid-memberships-pro.php:149
+#: paid-memberships-pro.php:150
+#: paid-memberships-pro.php:158
 msgid "Stripe"
 msgstr ""
 
@@ -8244,7 +10566,8 @@ msgid "Stripe Settings"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:332
-#: adminpages/paymentsettings.php:285 adminpages/paymentsettings.php:289
+#: adminpages/paymentsettings.php:285
+#: adminpages/paymentsettings.php:289
 #: adminpages/paymentsettings.php:294
 #: classes/gateways/class.pmprogateway_stripe.php:161
 #: classes/gateways/class.pmprogateway_stripe.php:162
@@ -8280,7 +10603,8 @@ msgid "Your Publishable Key appears incorrect."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:348
-#: adminpages/paymentsettings.php:277 adminpages/paymentsettings.php:281
+#: adminpages/paymentsettings.php:277
+#: adminpages/paymentsettings.php:281
 #: adminpages/paymentsettings.php:286
 #: classes/gateways/class.pmprogateway_stripe.php:153
 #: classes/gateways/class.pmprogateway_stripe.php:154
@@ -8359,9 +10683,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:524
 #: classes/gateways/class.pmprogateway_stripe.php:541
 #: classes/gateways/class.pmprogateway_stripe.php:575
-msgid ""
-"A webhook in Stripe is required to process recurring payments, manage failed "
-"payments, and synchronize cancellations."
+msgid "A webhook in Stripe is required to process recurring payments, manage failed payments, and synchronize cancellations."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:389
@@ -8369,7 +10691,8 @@ msgid "Webhook URL"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:395
-#: adminpages/paymentsettings.php:425 adminpages/paymentsettings.php:430
+#: adminpages/paymentsettings.php:425
+#: adminpages/paymentsettings.php:430
 #: adminpages/paymentsettings.php:432
 #: classes/gateways/class.pmprogateway_stripe.php:169
 #: classes/gateways/class.pmprogateway_stripe.php:170
@@ -8395,7 +10718,8 @@ msgid "Show Billing Address Fields"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:405
-#: adminpages/paymentsettings.php:437 adminpages/paymentsettings.php:439
+#: adminpages/paymentsettings.php:437
+#: adminpages/paymentsettings.php:439
 #: classes/gateways/class.pmprogateway_stripe.php:176
 #: classes/gateways/class.pmprogateway_stripe.php:177
 #: classes/gateways/class.pmprogateway_stripe.php:187
@@ -8416,10 +10740,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:325
 #: classes/gateways/class.pmprogateway_stripe.php:396
 #: classes/gateways/class.pmprogateway_stripe.php:397
-msgid ""
-"Stripe doesn't require billing address fields. Choose 'No' to hide them on "
-"the checkout page.<br /><strong>If No, make sure you disable address "
-"verification in the Stripe dashboard settings.</strong>"
+msgid "Stripe doesn't require billing address fields. Choose 'No' to hide them on the checkout page.<br /><strong>If No, make sure you disable address verification in the Stripe dashboard settings.</strong>"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:410
@@ -8430,54 +10751,31 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:428
 #: classes/gateways/class.pmprogateway_stripe.php:419
 #, php-format
-msgid ""
-"Allow users to pay using Apple Pay, Google Pay, or Microsoft Pay depending "
-"on their browser. When enabled, your domain will automatically be registered "
-"with Apple and a domain association file will be hosted on your site. <a "
-"target=\"_blank\" href=\"%s\" title=\"More Information about the domain "
-"association file for Apple Pay\">More Information &raquo;</a>"
+msgid "Allow users to pay using Apple Pay, Google Pay, or Microsoft Pay depending on their browser. When enabled, your domain will automatically be registered with Apple and a domain association file will be hosted on your site. <a target=\"_blank\" href=\"%s\" title=\"More Information about the domain association file for Apple Pay\">More Information &raquo;</a>"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:441
 #: classes/gateways/class.pmprogateway_stripe.php:432
 #, php-format
-msgid ""
-"This webpage is being served over HTTP, but the Stripe Payment Request "
-"Button will only work on pages being served over HTTPS. To resolve this, you "
-"must <a target=\"_blank\" href=\"%s\" title=\"Configuring WordPress to "
-"Always Use HTTPS/SSL\">set up WordPress to always use HTTPS</a>."
+msgid "This webpage is being served over HTTP, but the Stripe Payment Request Button will only work on pages being served over HTTPS. To resolve this, you must <a target=\"_blank\" href=\"%s\" title=\"Configuring WordPress to Always Use HTTPS/SSL\">set up WordPress to always use HTTPS</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:443
 #: classes/gateways/class.pmprogateway_stripe.php:434
 #, php-format
-msgid ""
-"It looks like you are using an older Stripe publishable key. In order to use "
-"the Payment Request Button feature, you will need to update your API key, "
-"which will be prefixed with \"pk_live_\" or \"pk_test_\". <a target=\"_blank"
-"\" href=\"%s\" title=\"Stripe Dashboard API Key Settings\">Log in to your "
-"Stripe Dashboard to roll your publishable key</a>."
+msgid "It looks like you are using an older Stripe publishable key. In order to use the Payment Request Button feature, you will need to update your API key, which will be prefixed with \"pk_live_\" or \"pk_test_\". <a target=\"_blank\" href=\"%s\" title=\"Stripe Dashboard API Key Settings\">Log in to your Stripe Dashboard to roll your publishable key</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:445
 #: classes/gateways/class.pmprogateway_stripe.php:436
 #, php-format
-msgid ""
-"It looks like you are using an older Stripe secret key. In order to use the "
-"Payment Request Button feature, you will need to update your API key, which "
-"will be prefixed with \"sk_live_\" or \"sk_test_\". <a target=\"_blank\" "
-"href=\"%s\" title=\"Stripe Dashboard API Key Settings\">Log in to your "
-"Stripe Dashboard to roll your secret key</a>."
+msgid "It looks like you are using an older Stripe secret key. In order to use the Payment Request Button feature, you will need to update your API key, which will be prefixed with \"sk_live_\" or \"sk_test_\". <a target=\"_blank\" href=\"%s\" title=\"Stripe Dashboard API Key Settings\">Log in to your Stripe Dashboard to roll your secret key</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:447
 #: classes/gateways/class.pmprogateway_stripe.php:438
 #, php-format
-msgid ""
-"Your domain could not be registered with Apple to enable Apple Pay. Please "
-"try <a target=\"_blank\" href=\"%s\" title=\"Apple Pay Settings Page in "
-"Stripe\">registering your domain manually from the Apple Pay settings page "
-"in Stripe</a>."
+msgid "Your domain could not be registered with Apple to enable Apple Pay. Please try <a target=\"_blank\" href=\"%s\" title=\"Apple Pay Settings Page in Stripe\">registering your domain manually from the Apple Pay settings page in Stripe</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:472
@@ -8487,10 +10785,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:412
 #: classes/gateways/class.pmprogateway_stripe.php:463
 #, php-format
-msgid ""
-"Optional: Offer PayPal Express as an option at checkout using the <a target="
-"\"_blank\" href=\"%s\" title=\"Paid Memberships Pro - Add PayPal Express "
-"Option at Checkout Add On\">Add PayPal Express Add On</a>."
+msgid "Optional: Offer PayPal Express as an option at checkout using the <a target=\"_blank\" href=\"%s\" title=\"Paid Memberships Pro - Add PayPal Express Option at Checkout Add On\">Add PayPal Express Add On</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:492
@@ -8554,9 +10849,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:1086
 #: classes/gateways/class.pmprogateway_stripe.php:1160
 #, php-format
-msgid ""
-"%1$sNote:%2$s Subscription %3$s%4$s%5$s could not be found at Stripe. It may "
-"have been deleted."
+msgid "%1$sNote:%2$s Subscription %3$s%4$s%5$s could not be found at Stripe. It may have been deleted."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:1176
@@ -8614,9 +10907,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:1025
 #: classes/gateways/class.pmprogateway_stripe.php:1095
 #: classes/gateways/class.pmprogateway_stripe.php:1169
-msgid ""
-"Subscription updates, allow you to change the member's subscription values "
-"at predefined times. Be sure to click Update Profile after making changes."
+msgid "Subscription updates, allow you to change the member's subscription values at predefined times. Be sure to click Update Profile after making changes."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:1182
@@ -8645,12 +10936,11 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:1027
 #: classes/gateways/class.pmprogateway_stripe.php:1097
 #: classes/gateways/class.pmprogateway_stripe.php:1171
-msgid ""
-"Subscription updates, allow you to change the member's subscription values "
-"at predefined times. Be sure to click Update User after making changes."
+msgid "Subscription updates, allow you to change the member's subscription values at predefined times. Be sure to click Update User after making changes."
 msgstr ""
 
-#: classes/gateways/class.pmprogateway_stripe.php:1188 pages/billing.php:413
+#: classes/gateways/class.pmprogateway_stripe.php:1188
+#: pages/billing.php:413
 #: classes/gateways/class.pmprogateway_stripe.php:578
 #: classes/gateways/class.pmprogateway_stripe.php:579
 #: classes/gateways/class.pmprogateway_stripe.php:589
@@ -8675,13 +10965,25 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:745
 #: classes/gateways/class.pmprogateway_stripe.php:1033
 #: classes/gateways/class.pmprogateway_stripe.php:1103
-#: classes/gateways/class.pmprogateway_stripe.php:1177 pages/billing.php:294
-#: pages/billing.php:298 pages/billing.php:329 pages/billing.php:338
-#: pages/billing.php:341 pages/billing.php:343 pages/billing.php:347
-#: pages/billing.php:362 pages/billing.php:363 pages/billing.php:364
-#: pages/billing.php:370 pages/billing.php:371 pages/billing.php:379
-#: pages/billing.php:389 pages/billing.php:391 pages/billing.php:396
-#: pages/billing.php:400 pages/billing.php:405 pages/billing.php:413
+#: classes/gateways/class.pmprogateway_stripe.php:1177
+#: pages/billing.php:294
+#: pages/billing.php:298
+#: pages/billing.php:329
+#: pages/billing.php:338
+#: pages/billing.php:341
+#: pages/billing.php:343
+#: pages/billing.php:347
+#: pages/billing.php:362
+#: pages/billing.php:363
+#: pages/billing.php:364
+#: pages/billing.php:370
+#: pages/billing.php:371
+#: pages/billing.php:379
+#: pages/billing.php:389
+#: pages/billing.php:391
+#: pages/billing.php:396
+#: pages/billing.php:400
+#: pages/billing.php:405
 msgid "Update"
 msgstr ""
 
@@ -9091,9 +11393,7 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:2924
 #: classes/gateways/class.pmprogateway_stripe.php:3003
 #: classes/gateways/class.pmprogateway_stripe.php:3086
-msgid ""
-"Customer authentication is required to complete this transaction. Please "
-"complete the verification steps issued by your payment provider."
+msgid "Customer authentication is required to complete this transaction. Please complete the verification steps issued by your payment provider."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:3114
@@ -9106,284 +11406,317 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_stripe.php:2941
 #: classes/gateways/class.pmprogateway_stripe.php:3020
 #: classes/gateways/class.pmprogateway_stripe.php:3103
-msgid ""
-"Customer authentication is required to finish setting up your subscription. "
-"Please complete the verification steps issued by your payment provider."
+msgid "Customer authentication is required to finish setting up your subscription. Please complete the verification steps issued by your payment provider."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:59
 #: paid-memberships-pro.php:166
 #: classes/gateways/class.pmprogateway_twocheckout.php:53
-#: classes/gateways/class.pmprogateway_twocheckout.php:59
 #: classes/gateways/class.pmprogateway_twocheckout.php:60
-#: paid-memberships-pro.php:124 paid-memberships-pro.php:125
-#: paid-memberships-pro.php:132 paid-memberships-pro.php:133
-#: paid-memberships-pro.php:134 paid-memberships-pro.php:135
-#: paid-memberships-pro.php:136 paid-memberships-pro.php:137
-#: paid-memberships-pro.php:138 paid-memberships-pro.php:139
-#: paid-memberships-pro.php:144 paid-memberships-pro.php:149
-#: paid-memberships-pro.php:154 paid-memberships-pro.php:156
-#: paid-memberships-pro.php:157 paid-memberships-pro.php:165
-#: paid-memberships-pro.php:166
+#: paid-memberships-pro.php:124
+#: paid-memberships-pro.php:125
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:136
+#: paid-memberships-pro.php:137
+#: paid-memberships-pro.php:138
+#: paid-memberships-pro.php:139
+#: paid-memberships-pro.php:144
+#: paid-memberships-pro.php:149
+#: paid-memberships-pro.php:154
+#: paid-memberships-pro.php:156
+#: paid-memberships-pro.php:157
+#: paid-memberships-pro.php:165
 msgid "2Checkout"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:115
 #: classes/gateways/class.pmprogateway_twocheckout.php:108
 #: classes/gateways/class.pmprogateway_twocheckout.php:114
-#: classes/gateways/class.pmprogateway_twocheckout.php:115
 #: classes/gateways/class.pmprogateway_twocheckout.php:116
 msgid "2Checkout Settings"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:124
 #: classes/gateways/class.pmprogateway_twocheckout.php:123
-#: classes/gateways/class.pmprogateway_twocheckout.php:124
 #: classes/gateways/class.pmprogateway_twocheckout.php:125
-msgid ""
-"Go to Account &raquo; User Management in 2Checkout and create a user with "
-"API Access and API Updating."
+msgid "Go to Account &raquo; User Management in 2Checkout and create a user with API Access and API Updating."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:133
 #: classes/gateways/class.pmprogateway_twocheckout.php:132
-#: classes/gateways/class.pmprogateway_twocheckout.php:133
 #: classes/gateways/class.pmprogateway_twocheckout.php:134
 msgid "Password for the API user created."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:142
 #: classes/gateways/class.pmprogateway_twocheckout.php:141
-#: classes/gateways/class.pmprogateway_twocheckout.php:142
 #: classes/gateways/class.pmprogateway_twocheckout.php:152
 msgid "Click on the profile icon in 2Checkout to find your Account Number."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:147
-#: adminpages/paymentsettings.php:355 adminpages/paymentsettings.php:360
+#: adminpages/paymentsettings.php:355
+#: adminpages/paymentsettings.php:360
 #: classes/gateways/class.pmprogateway_twocheckout.php:137
 #: classes/gateways/class.pmprogateway_twocheckout.php:146
-#: classes/gateways/class.pmprogateway_twocheckout.php:147
 #: classes/gateways/class.pmprogateway_twocheckout.php:157
 msgid "Secret Word"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:151
 #: classes/gateways/class.pmprogateway_twocheckout.php:150
-#: classes/gateways/class.pmprogateway_twocheckout.php:151
 #: classes/gateways/class.pmprogateway_twocheckout.php:161
-msgid ""
-"Go to Account &raquo; Site Management. Look under Checkout Options to find "
-"the Secret Word."
+msgid "Go to Account &raquo; Site Management. Look under Checkout Options to find the Secret Word."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:156
-#: adminpages/paymentsettings.php:487 adminpages/paymentsettings.php:493
+#: adminpages/paymentsettings.php:487
+#: adminpages/paymentsettings.php:493
 #: adminpages/paymentsettings.php:495
 #: classes/gateways/class.pmprogateway_twocheckout.php:145
 #: classes/gateways/class.pmprogateway_twocheckout.php:155
-#: classes/gateways/class.pmprogateway_twocheckout.php:156
 #: classes/gateways/class.pmprogateway_twocheckout.php:166
 msgid "TwoCheckout INS URL"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:159
 #: classes/gateways/class.pmprogateway_twocheckout.php:158
-#: classes/gateways/class.pmprogateway_twocheckout.php:159
 #: classes/gateways/class.pmprogateway_twocheckout.php:169
-msgid ""
-"To fully integrate with 2Checkout, be sure to use the following for your INS "
-"URL and Approved URL"
+msgid "To fully integrate with 2Checkout, be sure to use the following for your INS URL and Approved URL"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:205
 #: classes/gateways/class.pmprogateway_twocheckout.php:192
 #: classes/gateways/class.pmprogateway_twocheckout.php:203
 #: classes/gateways/class.pmprogateway_twocheckout.php:204
-#: classes/gateways/class.pmprogateway_twocheckout.php:205
 #: classes/gateways/class.pmprogateway_twocheckout.php:214
 msgid "Check Out with 2Checkout"
 msgstr ""
 
-#: includes/addons.php:241 includes/addons.php:222 includes/addons.php:225
-#: includes/addons.php:239 includes/addons.php:241
-msgid ""
-"Important: This plugin requires a valid PMPro Plus license key to update."
+#: includes/addons.php:241
+#: includes/addons.php:222
+#: includes/addons.php:225
+#: includes/addons.php:239
+msgid "Important: This plugin requires a valid PMPro Plus license key to update."
 msgstr ""
 
-#: includes/addons.php:294 includes/addons.php:274 includes/addons.php:278
-#: includes/addons.php:292 includes/addons.php:294
-msgid ""
-"You must have a <a href=\"https://www.paidmembershipspro.com/pricing/?"
-"utm_source=wp-admin&utm_pluginlink=bulkupdate\">valid PMPro Plus License "
-"Key</a> to update PMPro Plus add ons. The following plugins will not be "
-"updated:"
+#: includes/addons.php:294
+#: includes/addons.php:274
+#: includes/addons.php:278
+#: includes/addons.php:292
+msgid "You must have a <a href=\"https://www.paidmembershipspro.com/pricing/?utm_source=wp-admin&utm_pluginlink=bulkupdate\">valid PMPro Plus License Key</a> to update PMPro Plus add ons. The following plugins will not be updated:"
 msgstr ""
 
-#: includes/addons.php:312 includes/addons.php:292 includes/addons.php:296
-#: includes/addons.php:310 includes/addons.php:312
+#: includes/addons.php:312
+#: includes/addons.php:292
+#: includes/addons.php:296
+#: includes/addons.php:310
 msgid "Update Plugin"
 msgstr ""
 
-#: includes/addons.php:314 includes/addons.php:294 includes/addons.php:298
-#: includes/addons.php:312 includes/addons.php:314
-msgid ""
-"You must have a <a href=\"https://www.paidmembershipspro.com/pricing/?"
-"utm_source=wp-admin&utm_pluginlink=addon_update\">valid PMPro Plus License "
-"Key</a> to update PMPro Plus add ons."
+#: includes/addons.php:314
+#: includes/addons.php:294
+#: includes/addons.php:298
+#: includes/addons.php:312
+msgid "You must have a <a href=\"https://www.paidmembershipspro.com/pricing/?utm_source=wp-admin&utm_pluginlink=addon_update\">valid PMPro Plus License Key</a> to update PMPro Plus add ons."
 msgstr ""
 
-#: includes/addons.php:317 includes/addons.php:297 includes/addons.php:301
-#: includes/addons.php:315 includes/addons.php:317
+#: includes/addons.php:317
+#: includes/addons.php:297
+#: includes/addons.php:301
+#: includes/addons.php:315
 msgid "Return to the PMPro Add Ons page"
 msgstr ""
 
-#: includes/addons.php:336 includes/addons.php:316 includes/addons.php:320
-#: includes/addons.php:334 includes/addons.php:336
-msgid ""
-"You must enter a valid PMPro Plus License Key under Settings > PMPro License "
-"to update this add on."
+#: includes/addons.php:336
+#: includes/addons.php:316
+#: includes/addons.php:320
+#: includes/addons.php:334
+msgid "You must enter a valid PMPro Plus License Key under Settings > PMPro License to update this add on."
 msgstr ""
 
-#: includes/adminpages.php:47 includes/adminpages.php:9
-#: includes/adminpages.php:39 includes/adminpages.php:47
-#: includes/adminpages.php:48 includes/adminpages.php:93
+#: includes/adminpages.php:47
+#: includes/adminpages.php:9
+#: includes/adminpages.php:39
+#: includes/adminpages.php:48
+#: includes/adminpages.php:93
 #: includes/adminpages.php:100
 msgid "Memberships"
 msgstr ""
 
-#: includes/adminpages.php:64 includes/adminpages.php:222
-#: includes/adminpages.php:64 includes/adminpages.php:220
+#: includes/adminpages.php:64
 #: includes/adminpages.php:222
+#: includes/adminpages.php:220
 msgid "<span style=\"color: "
 msgstr ""
 
-#: includes/adminpages.php:69 includes/adminpages.php:11
-#: includes/adminpages.php:49 includes/adminpages.php:50
-#: includes/adminpages.php:54 includes/adminpages.php:60
-#: includes/adminpages.php:61 includes/adminpages.php:69
-#: includes/adminpages.php:114 includes/adminpages.php:121
-#: includes/adminpages.php:125 includes/adminpages.php:130
+#: includes/adminpages.php:69
+#: includes/adminpages.php:11
+#: includes/adminpages.php:49
+#: includes/adminpages.php:50
+#: includes/adminpages.php:54
+#: includes/adminpages.php:60
+#: includes/adminpages.php:61
+#: includes/adminpages.php:114
+#: includes/adminpages.php:121
+#: includes/adminpages.php:125
+#: includes/adminpages.php:130
 msgid "Payment Settings"
 msgstr ""
 
-#: includes/adminpages.php:77 includes/adminpages.php:61
-#: includes/adminpages.php:66 includes/adminpages.php:67
-#: includes/adminpages.php:75 includes/adminpages.php:77
+#: includes/adminpages.php:77
+#: includes/adminpages.php:61
+#: includes/adminpages.php:66
+#: includes/adminpages.php:67
+#: includes/adminpages.php:75
 msgid "Updates Required"
 msgstr ""
 
-#: includes/adminpages.php:132 includes/adminpages.php:100
-#: includes/adminpages.php:104 includes/adminpages.php:109
-#: includes/adminpages.php:121 includes/adminpages.php:122
-#: includes/adminpages.php:130 includes/adminpages.php:132
+#: includes/adminpages.php:132
+#: includes/adminpages.php:100
+#: includes/adminpages.php:104
+#: includes/adminpages.php:109
+#: includes/adminpages.php:121
+#: includes/adminpages.php:122
+#: includes/adminpages.php:130
 msgid "<span class=\"ab-icon\"></span>Memberships"
 msgstr ""
 
-#: includes/adminpages.php:323 includes/adminpages.php:253
-#: includes/adminpages.php:289 includes/adminpages.php:302
-#: includes/adminpages.php:306 includes/adminpages.php:321
 #: includes/adminpages.php:323
+#: includes/adminpages.php:253
+#: includes/adminpages.php:289
+#: includes/adminpages.php:302
+#: includes/adminpages.php:306
+#: includes/adminpages.php:321
+#: blocks/account-page/block.js:24
+#: blocks/account-page/block.js:59
 msgid "Membership Account Page"
 msgstr ""
 
-#: includes/adminpages.php:327 includes/adminpages.php:257
-#: includes/adminpages.php:293 includes/adminpages.php:306
-#: includes/adminpages.php:310 includes/adminpages.php:325
 #: includes/adminpages.php:327
+#: includes/adminpages.php:257
+#: includes/adminpages.php:293
+#: includes/adminpages.php:306
+#: includes/adminpages.php:310
+#: includes/adminpages.php:325
 msgid "Membership Billing Information Page"
 msgstr ""
 
-#: includes/adminpages.php:331 includes/adminpages.php:261
-#: includes/adminpages.php:297 includes/adminpages.php:310
-#: includes/adminpages.php:314 includes/adminpages.php:329
 #: includes/adminpages.php:331
+#: includes/adminpages.php:261
+#: includes/adminpages.php:297
+#: includes/adminpages.php:310
+#: includes/adminpages.php:314
+#: includes/adminpages.php:329
+#: blocks/cancel-page/block.js:22
+#: blocks/cancel-page/block.js:39
 msgid "Membership Cancel Page"
 msgstr ""
 
-#: includes/adminpages.php:335 includes/adminpages.php:265
-#: includes/adminpages.php:301 includes/adminpages.php:314
-#: includes/adminpages.php:318 includes/adminpages.php:333
 #: includes/adminpages.php:335
+#: includes/adminpages.php:265
+#: includes/adminpages.php:301
+#: includes/adminpages.php:314
+#: includes/adminpages.php:318
+#: includes/adminpages.php:333
 msgid "Membership Checkout Page"
 msgstr ""
 
-#: includes/adminpages.php:339 includes/adminpages.php:269
-#: includes/adminpages.php:305 includes/adminpages.php:318
-#: includes/adminpages.php:322 includes/adminpages.php:337
 #: includes/adminpages.php:339
+#: includes/adminpages.php:269
+#: includes/adminpages.php:305
+#: includes/adminpages.php:318
+#: includes/adminpages.php:322
+#: includes/adminpages.php:337
+#: blocks/confirmation-page/block.js:22
+#: blocks/confirmation-page/block.js:39
 msgid "Membership Confirmation Page"
 msgstr ""
 
-#: includes/adminpages.php:343 includes/adminpages.php:273
-#: includes/adminpages.php:309 includes/adminpages.php:322
-#: includes/adminpages.php:326 includes/adminpages.php:341
 #: includes/adminpages.php:343
+#: includes/adminpages.php:273
+#: includes/adminpages.php:309
+#: includes/adminpages.php:322
+#: includes/adminpages.php:326
+#: includes/adminpages.php:341
+#: blocks/invoice-page/block.js:22
 msgid "Membership Invoice Page"
 msgstr ""
 
-#: includes/adminpages.php:347 includes/adminpages.php:347
+#: includes/adminpages.php:347
 msgid "Membership Levels Page"
 msgstr ""
 
-#: includes/adminpages.php:369 includes/adminpages.php:365
 #: includes/adminpages.php:369
+#: includes/adminpages.php:365
 msgid "Members Per Page"
 msgstr ""
 
-#: includes/adminpages.php:407 includes/adminpages.php:261
-#: includes/adminpages.php:265 includes/adminpages.php:274
-#: includes/adminpages.php:316 includes/adminpages.php:349
-#: includes/adminpages.php:362 includes/adminpages.php:366
-#: includes/adminpages.php:381 includes/adminpages.php:403
 #: includes/adminpages.php:407
+#: includes/adminpages.php:261
+#: includes/adminpages.php:265
+#: includes/adminpages.php:274
+#: includes/adminpages.php:316
+#: includes/adminpages.php:349
+#: includes/adminpages.php:362
+#: includes/adminpages.php:366
+#: includes/adminpages.php:381
+#: includes/adminpages.php:403
 msgid "Docs"
 msgstr ""
 
-#: includes/adminpages.php:407 includes/adminpages.php:261
-#: includes/adminpages.php:265 includes/adminpages.php:274
-#: includes/adminpages.php:316 includes/adminpages.php:349
-#: includes/adminpages.php:362 includes/adminpages.php:366
-#: includes/adminpages.php:381 includes/adminpages.php:403
 #: includes/adminpages.php:407
+#: includes/adminpages.php:261
+#: includes/adminpages.php:265
+#: includes/adminpages.php:274
+#: includes/adminpages.php:316
+#: includes/adminpages.php:349
+#: includes/adminpages.php:362
+#: includes/adminpages.php:366
+#: includes/adminpages.php:381
+#: includes/adminpages.php:403
 msgid "View PMPro Documentation"
 msgstr ""
 
-#: includes/adminpages.php:408 includes/adminpages.php:262
-#: includes/adminpages.php:266 includes/adminpages.php:275
-#: includes/adminpages.php:317 includes/adminpages.php:350
-#: includes/adminpages.php:363 includes/adminpages.php:367
-#: includes/adminpages.php:382 includes/adminpages.php:404
 #: includes/adminpages.php:408
+#: includes/adminpages.php:262
+#: includes/adminpages.php:266
+#: includes/adminpages.php:275
+#: includes/adminpages.php:317
+#: includes/adminpages.php:350
+#: includes/adminpages.php:363
+#: includes/adminpages.php:367
+#: includes/adminpages.php:382
+#: includes/adminpages.php:404
 msgid "Support"
 msgstr ""
 
-#: includes/adminpages.php:408 includes/adminpages.php:262
-#: includes/adminpages.php:266 includes/adminpages.php:275
-#: includes/adminpages.php:317 includes/adminpages.php:350
-#: includes/adminpages.php:363 includes/adminpages.php:367
-#: includes/adminpages.php:382 includes/adminpages.php:404
 #: includes/adminpages.php:408
+#: includes/adminpages.php:262
+#: includes/adminpages.php:266
+#: includes/adminpages.php:275
+#: includes/adminpages.php:317
+#: includes/adminpages.php:350
+#: includes/adminpages.php:363
+#: includes/adminpages.php:367
+#: includes/adminpages.php:382
+#: includes/adminpages.php:404
 msgid "Visit Customer Support Forum"
 msgstr ""
 
-#: includes/cleanup.php:43 includes/cleanup.php:43
-msgid ""
-"<p><strong>Warning:</strong> One or more users for deletion have an active "
-"membership level. Deleting a user will also cancel their membership and "
-"recurring subscription.</p>"
+#: includes/cleanup.php:43
+msgid "<p><strong>Warning:</strong> One or more users for deletion have an active membership level. Deleting a user will also cancel their membership and recurring subscription.</p>"
 msgstr ""
 
-#: includes/cleanup.php:45 includes/cleanup.php:45
-msgid ""
-"<p><strong>Warning:</strong> This user has an active membership level. "
-"Deleting a user will also cancel their membership and recurring subscription."
-"</p>"
+#: includes/cleanup.php:45
+msgid "<p><strong>Warning:</strong> This user has an active membership level. Deleting a user will also cancel their membership and recurring subscription.</p>"
 msgstr ""
 
 #: includes/compatibility/beaver-builder.php:29
 #: includes/compatibility/beaver-builder.php:126
-#: includes/compatibility/elementor.php:36
 #: includes/compatibility/elementor.php:36
 msgid "Non-members"
 msgstr ""
@@ -9414,1318 +11747,1460 @@ msgstr ""
 msgid "Select a level for module access"
 msgstr ""
 
-#: includes/compatibility/divi.php:34 includes/compatibility/divi.php:34
+#: includes/compatibility/divi.php:34
 msgid "Restrict Row by Level"
 msgstr ""
 
-#: includes/compatibility/divi.php:35 includes/compatibility/divi.php:51
-#: includes/compatibility/divi.php:35 includes/compatibility/divi.php:51
+#: includes/compatibility/divi.php:35
+#: includes/compatibility/divi.php:51
 msgid "Enter comma-separated level IDs."
 msgstr ""
 
-#: includes/compatibility/divi.php:50 includes/compatibility/divi.php:50
+#: includes/compatibility/divi.php:50
 msgid "Restrict Section by Level"
 msgstr ""
 
 #: includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:29
 #: includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:27
-#: includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:29
 msgid "Require Membership Level"
 msgstr ""
 
 #: includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:41
 #: includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:39
-#: includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:41
 msgid "Require membership level to see this content."
 msgstr ""
 
-#: includes/countries.php:7 includes/countries.php:7
+#: includes/countries.php:7
 msgid "Andorra"
 msgstr ""
 
-#: includes/countries.php:8 includes/countries.php:8
+#: includes/countries.php:8
 msgid "United Arab Emirates"
 msgstr ""
 
-#: includes/countries.php:9 includes/countries.php:9
+#: includes/countries.php:9
 msgid "Afghanistan"
 msgstr ""
 
-#: includes/countries.php:10 includes/countries.php:10
+#: includes/countries.php:10
 msgid "Antigua and Barbuda"
 msgstr ""
 
-#: includes/countries.php:11 includes/countries.php:11
+#: includes/countries.php:11
 msgid "Anguilla"
 msgstr ""
 
-#: includes/countries.php:12 includes/countries.php:12
+#: includes/countries.php:12
 msgid "Albania"
 msgstr ""
 
-#: includes/countries.php:13 includes/countries.php:13
+#: includes/countries.php:13
 msgid "Armenia"
 msgstr ""
 
-#: includes/countries.php:14 includes/countries.php:14
+#: includes/countries.php:14
 msgid "Netherlands Antilles"
 msgstr ""
 
-#: includes/countries.php:15 includes/countries.php:15
+#: includes/countries.php:15
 msgid "Angola"
 msgstr ""
 
-#: includes/countries.php:16 includes/countries.php:16
+#: includes/countries.php:16
 msgid "Antarctica"
 msgstr ""
 
-#: includes/countries.php:17 includes/countries.php:17
+#: includes/countries.php:17
 msgid "Argentina"
 msgstr ""
 
-#: includes/countries.php:18 includes/countries.php:18
+#: includes/countries.php:18
 msgid "American Samoa"
 msgstr ""
 
-#: includes/countries.php:19 includes/countries.php:19
+#: includes/countries.php:19
 msgid "Austria"
 msgstr ""
 
-#: includes/countries.php:20 includes/countries.php:20
+#: includes/countries.php:20
 msgid "Australia"
 msgstr ""
 
-#: includes/countries.php:21 includes/countries.php:21
+#: includes/countries.php:21
 msgid "Aruba"
 msgstr ""
 
-#: includes/countries.php:22 includes/countries.php:22
+#: includes/countries.php:22
 msgid "Aland Islands"
 msgstr ""
 
-#: includes/countries.php:23 includes/countries.php:23
+#: includes/countries.php:23
 msgid "Azerbaijan"
 msgstr ""
 
-#: includes/countries.php:24 includes/countries.php:24
+#: includes/countries.php:24
 msgid "Bosnia and Herzegovina"
 msgstr ""
 
-#: includes/countries.php:25 includes/countries.php:25
+#: includes/countries.php:25
 msgid "Barbados"
 msgstr ""
 
-#: includes/countries.php:26 includes/countries.php:26
+#: includes/countries.php:26
 msgid "Bangladesh"
 msgstr ""
 
-#: includes/countries.php:27 includes/countries.php:27
+#: includes/countries.php:27
 msgid "Belgium"
 msgstr ""
 
-#: includes/countries.php:28 includes/countries.php:28
+#: includes/countries.php:28
 msgid "Burkina Faso"
 msgstr ""
 
-#: includes/countries.php:29 includes/countries.php:29
+#: includes/countries.php:29
 msgid "Bulgaria"
 msgstr ""
 
-#: includes/countries.php:30 includes/countries.php:30
+#: includes/countries.php:30
 msgid "Bahrain"
 msgstr ""
 
-#: includes/countries.php:31 includes/countries.php:31
+#: includes/countries.php:31
 msgid "Burundi"
 msgstr ""
 
-#: includes/countries.php:32 includes/countries.php:32
+#: includes/countries.php:32
 msgid "Benin"
 msgstr ""
 
-#: includes/countries.php:33 includes/countries.php:33
+#: includes/countries.php:33
 msgid "Saint Barthelemy"
 msgstr ""
 
-#: includes/countries.php:34 includes/countries.php:34
+#: includes/countries.php:34
 msgid "Bermuda"
 msgstr ""
 
-#: includes/countries.php:35 includes/countries.php:35
+#: includes/countries.php:35
 msgid "Brunei"
 msgstr ""
 
-#: includes/countries.php:36 includes/countries.php:36
+#: includes/countries.php:36
 msgid "Bolivia"
 msgstr ""
 
-#: includes/countries.php:37 includes/countries.php:37
+#: includes/countries.php:37
 msgid "Brazil"
 msgstr ""
 
-#: includes/countries.php:38 includes/countries.php:38
+#: includes/countries.php:38
 msgid "Bahamas"
 msgstr ""
 
-#: includes/countries.php:39 includes/countries.php:39
+#: includes/countries.php:39
 msgid "Bhutan"
 msgstr ""
 
-#: includes/countries.php:40 includes/countries.php:40
+#: includes/countries.php:40
 msgid "Bouvet Island"
 msgstr ""
 
-#: includes/countries.php:41 includes/countries.php:41
+#: includes/countries.php:41
 msgid "Botswana"
 msgstr ""
 
-#: includes/countries.php:42 includes/countries.php:42
+#: includes/countries.php:42
 msgid "Belarus"
 msgstr ""
 
-#: includes/countries.php:43 includes/countries.php:43
+#: includes/countries.php:43
 msgid "Belize"
 msgstr ""
 
-#: includes/countries.php:44 includes/countries.php:44
+#: includes/countries.php:44
 msgid "Canada"
 msgstr ""
 
-#: includes/countries.php:45 includes/countries.php:45
+#: includes/countries.php:45
 msgid "Cocos (Keeling) Islands"
 msgstr ""
 
-#: includes/countries.php:46 includes/countries.php:46
+#: includes/countries.php:46
 msgid "Congo (Kinshasa)"
 msgstr ""
 
-#: includes/countries.php:47 includes/countries.php:47
+#: includes/countries.php:47
 msgid "Central African Republic"
 msgstr ""
 
-#: includes/countries.php:48 includes/countries.php:48
+#: includes/countries.php:48
 msgid "Congo (Brazzaville)"
 msgstr ""
 
-#: includes/countries.php:49 includes/countries.php:49
+#: includes/countries.php:49
 msgid "Switzerland"
 msgstr ""
 
-#: includes/countries.php:50 includes/countries.php:50
+#: includes/countries.php:50
 msgid "Ivory Coast"
 msgstr ""
 
-#: includes/countries.php:51 includes/countries.php:51
+#: includes/countries.php:51
 msgid "Cook Islands"
 msgstr ""
 
-#: includes/countries.php:52 includes/countries.php:52
+#: includes/countries.php:52
 msgid "Chile"
 msgstr ""
 
-#: includes/countries.php:53 includes/countries.php:53
+#: includes/countries.php:53
 msgid "Cameroon"
 msgstr ""
 
-#: includes/countries.php:54 includes/countries.php:54
+#: includes/countries.php:54
 msgid "China"
 msgstr ""
 
-#: includes/countries.php:55 includes/countries.php:55
+#: includes/countries.php:55
 msgid "Colombia"
 msgstr ""
 
-#: includes/countries.php:56 includes/countries.php:56
+#: includes/countries.php:56
 msgid "Costa Rica"
 msgstr ""
 
-#: includes/countries.php:57 includes/countries.php:57
+#: includes/countries.php:57
 msgid "Cuba"
 msgstr ""
 
-#: includes/countries.php:58 includes/countries.php:58
+#: includes/countries.php:58
 msgid "Cape Verde"
 msgstr ""
 
-#: includes/countries.php:59 includes/countries.php:59
+#: includes/countries.php:59
 msgid "Christmas Island"
 msgstr ""
 
-#: includes/countries.php:60 includes/countries.php:60
+#: includes/countries.php:60
 msgid "Cyprus"
 msgstr ""
 
-#: includes/countries.php:61 includes/countries.php:61
+#: includes/countries.php:61
 msgid "Czech Republic"
 msgstr ""
 
-#: includes/countries.php:62 includes/countries.php:62
+#: includes/countries.php:62
 msgid "Germany"
 msgstr ""
 
-#: includes/countries.php:63 includes/countries.php:63
+#: includes/countries.php:63
 msgid "Djibouti"
 msgstr ""
 
-#: includes/countries.php:64 includes/countries.php:64
+#: includes/countries.php:64
 msgid "Denmark"
 msgstr ""
 
-#: includes/countries.php:65 includes/countries.php:65
+#: includes/countries.php:65
 msgid "Dominica"
 msgstr ""
 
-#: includes/countries.php:66 includes/countries.php:66
+#: includes/countries.php:66
 msgid "Dominican Republic"
 msgstr ""
 
-#: includes/countries.php:67 includes/countries.php:67
+#: includes/countries.php:67
 msgid "Algeria"
 msgstr ""
 
-#: includes/countries.php:68 includes/countries.php:68
+#: includes/countries.php:68
 msgid "Ecuador"
 msgstr ""
 
-#: includes/countries.php:69 includes/countries.php:69
+#: includes/countries.php:69
 msgid "Estonia"
 msgstr ""
 
-#: includes/countries.php:70 includes/countries.php:70
+#: includes/countries.php:70
 msgid "Egypt"
 msgstr ""
 
-#: includes/countries.php:71 includes/countries.php:71
+#: includes/countries.php:71
 msgid "Western Sahara"
 msgstr ""
 
-#: includes/countries.php:72 includes/countries.php:72
+#: includes/countries.php:72
 msgid "Eritrea"
 msgstr ""
 
-#: includes/countries.php:73 includes/countries.php:73
+#: includes/countries.php:73
 msgid "Spain"
 msgstr ""
 
-#: includes/countries.php:74 includes/countries.php:74
+#: includes/countries.php:74
 msgid "Ethiopia"
 msgstr ""
 
-#: includes/countries.php:75 includes/countries.php:75
+#: includes/countries.php:75
 msgid "Finland"
 msgstr ""
 
-#: includes/countries.php:76 includes/countries.php:76
+#: includes/countries.php:76
 msgid "Fiji"
 msgstr ""
 
-#: includes/countries.php:77 includes/countries.php:77
+#: includes/countries.php:77
 msgid "Falkland Islands"
 msgstr ""
 
-#: includes/countries.php:78 includes/countries.php:78
+#: includes/countries.php:78
 msgid "Micronesia"
 msgstr ""
 
-#: includes/countries.php:79 includes/countries.php:79
+#: includes/countries.php:79
 msgid "Faroe Islands"
 msgstr ""
 
-#: includes/countries.php:80 includes/countries.php:80
+#: includes/countries.php:80
 msgid "France"
 msgstr ""
 
-#: includes/countries.php:81 includes/countries.php:81
+#: includes/countries.php:81
 msgid "Gabon"
 msgstr ""
 
-#: includes/countries.php:82 includes/countries.php:82
+#: includes/countries.php:82
 msgid "United Kingdom"
 msgstr ""
 
-#: includes/countries.php:83 includes/countries.php:83
+#: includes/countries.php:83
 msgid "Grenada"
 msgstr ""
 
-#: includes/countries.php:84 includes/countries.php:84
+#: includes/countries.php:84
 msgid "Georgia"
 msgstr ""
 
-#: includes/countries.php:85 includes/countries.php:85
+#: includes/countries.php:85
 msgid "French Guiana"
 msgstr ""
 
-#: includes/countries.php:86 includes/countries.php:86
+#: includes/countries.php:86
 msgid "Guernsey"
 msgstr ""
 
-#: includes/countries.php:87 includes/countries.php:87
+#: includes/countries.php:87
 msgid "Ghana"
 msgstr ""
 
-#: includes/countries.php:88 includes/countries.php:88
+#: includes/countries.php:88
 msgid "Gibraltar"
 msgstr ""
 
-#: includes/countries.php:89 includes/countries.php:89
+#: includes/countries.php:89
 msgid "Greenland"
 msgstr ""
 
-#: includes/countries.php:90 includes/countries.php:90
+#: includes/countries.php:90
 msgid "Gambia"
 msgstr ""
 
-#: includes/countries.php:91 includes/countries.php:91
+#: includes/countries.php:91
 msgid "Guinea"
 msgstr ""
 
-#: includes/countries.php:92 includes/countries.php:92
+#: includes/countries.php:92
 msgid "Guadeloupe"
 msgstr ""
 
-#: includes/countries.php:93 includes/countries.php:93
+#: includes/countries.php:93
 msgid "Equatorial Guinea"
 msgstr ""
 
-#: includes/countries.php:94 includes/countries.php:94
+#: includes/countries.php:94
 msgid "Greece"
 msgstr ""
 
-#: includes/countries.php:95 includes/countries.php:95
+#: includes/countries.php:95
 msgid "South Georgia and the South Sandwich Islands"
 msgstr ""
 
-#: includes/countries.php:96 includes/countries.php:96
+#: includes/countries.php:96
 msgid "Guatemala"
 msgstr ""
 
-#: includes/countries.php:97 includes/countries.php:97
+#: includes/countries.php:97
 msgid "Guam"
 msgstr ""
 
-#: includes/countries.php:98 includes/countries.php:98
+#: includes/countries.php:98
 msgid "Guinea-Bissau"
 msgstr ""
 
-#: includes/countries.php:99 includes/countries.php:99
+#: includes/countries.php:99
 msgid "Guyana"
 msgstr ""
 
-#: includes/countries.php:100 includes/countries.php:100
+#: includes/countries.php:100
 msgid "Hong Kong S.A.R., China"
 msgstr ""
 
-#: includes/countries.php:101 includes/countries.php:101
+#: includes/countries.php:101
 msgid "Heard Island and McDonald Islands"
 msgstr ""
 
-#: includes/countries.php:102 includes/countries.php:102
+#: includes/countries.php:102
 msgid "Honduras"
 msgstr ""
 
-#: includes/countries.php:103 includes/countries.php:103
+#: includes/countries.php:103
 msgid "Croatia"
 msgstr ""
 
-#: includes/countries.php:104 includes/countries.php:104
+#: includes/countries.php:104
 msgid "Haiti"
 msgstr ""
 
-#: includes/countries.php:105 includes/countries.php:105
+#: includes/countries.php:105
 msgid "Hungary"
 msgstr ""
 
-#: includes/countries.php:106 includes/countries.php:106
+#: includes/countries.php:106
 msgid "Indonesia"
 msgstr ""
 
-#: includes/countries.php:107 includes/countries.php:107
+#: includes/countries.php:107
 msgid "Ireland"
 msgstr ""
 
-#: includes/countries.php:108 includes/countries.php:108
+#: includes/countries.php:108
 msgid "Israel"
 msgstr ""
 
-#: includes/countries.php:109 includes/countries.php:109
+#: includes/countries.php:109
 msgid "Isle of Man"
 msgstr ""
 
-#: includes/countries.php:110 includes/countries.php:110
+#: includes/countries.php:110
 msgid "India"
 msgstr ""
 
-#: includes/countries.php:111 includes/countries.php:111
+#: includes/countries.php:111
 msgid "British Indian Ocean Territory"
 msgstr ""
 
-#: includes/countries.php:112 includes/countries.php:112
+#: includes/countries.php:112
 msgid "Iraq"
 msgstr ""
 
-#: includes/countries.php:113 includes/countries.php:113
+#: includes/countries.php:113
 msgid "Iran"
 msgstr ""
 
-#: includes/countries.php:114 includes/countries.php:114
+#: includes/countries.php:114
 msgid "Iceland"
 msgstr ""
 
-#: includes/countries.php:115 includes/countries.php:115
+#: includes/countries.php:115
 msgid "Italy"
 msgstr ""
 
-#: includes/countries.php:116 includes/countries.php:116
+#: includes/countries.php:116
 msgid "Jersey"
 msgstr ""
 
-#: includes/countries.php:117 includes/countries.php:117
+#: includes/countries.php:117
 msgid "Jamaica"
 msgstr ""
 
-#: includes/countries.php:118 includes/countries.php:118
+#: includes/countries.php:118
 msgid "Jordan"
 msgstr ""
 
-#: includes/countries.php:119 includes/countries.php:119
+#: includes/countries.php:119
 msgid "Japan"
 msgstr ""
 
-#: includes/countries.php:120 includes/countries.php:120
+#: includes/countries.php:120
 msgid "Kenya"
 msgstr ""
 
-#: includes/countries.php:121 includes/countries.php:121
+#: includes/countries.php:121
 msgid "Kyrgyzstan"
 msgstr ""
 
-#: includes/countries.php:122 includes/countries.php:122
+#: includes/countries.php:122
 msgid "Cambodia"
 msgstr ""
 
-#: includes/countries.php:123 includes/countries.php:123
+#: includes/countries.php:123
 msgid "Kiribati"
 msgstr ""
 
-#: includes/countries.php:124 includes/countries.php:124
+#: includes/countries.php:124
 msgid "Comoros"
 msgstr ""
 
-#: includes/countries.php:125 includes/countries.php:125
+#: includes/countries.php:125
 msgid "Saint Kitts and Nevis"
 msgstr ""
 
-#: includes/countries.php:126 includes/countries.php:126
+#: includes/countries.php:126
 msgid "North Korea"
 msgstr ""
 
-#: includes/countries.php:127 includes/countries.php:127
+#: includes/countries.php:127
 msgid "South Korea"
 msgstr ""
 
-#: includes/countries.php:128 includes/countries.php:128
+#: includes/countries.php:128
 msgid "Kuwait"
 msgstr ""
 
-#: includes/countries.php:129 includes/countries.php:129
+#: includes/countries.php:129
 msgid "Cayman Islands"
 msgstr ""
 
-#: includes/countries.php:130 includes/countries.php:130
+#: includes/countries.php:130
 msgid "Kazakhstan"
 msgstr ""
 
-#: includes/countries.php:131 includes/countries.php:131
+#: includes/countries.php:131
 msgid "Laos"
 msgstr ""
 
-#: includes/countries.php:132 includes/countries.php:132
+#: includes/countries.php:132
 msgid "Lebanon"
 msgstr ""
 
-#: includes/countries.php:133 includes/countries.php:133
+#: includes/countries.php:133
 msgid "Saint Lucia"
 msgstr ""
 
-#: includes/countries.php:134 includes/countries.php:134
+#: includes/countries.php:134
 msgid "Liechtenstein"
 msgstr ""
 
-#: includes/countries.php:135 includes/countries.php:135
+#: includes/countries.php:135
 msgid "Sri Lanka"
 msgstr ""
 
-#: includes/countries.php:136 includes/countries.php:136
+#: includes/countries.php:136
 msgid "Liberia"
 msgstr ""
 
-#: includes/countries.php:137 includes/countries.php:137
+#: includes/countries.php:137
 msgid "Lesotho"
 msgstr ""
 
-#: includes/countries.php:138 includes/countries.php:138
+#: includes/countries.php:138
 msgid "Lithuania"
 msgstr ""
 
-#: includes/countries.php:139 includes/countries.php:139
+#: includes/countries.php:139
 msgid "Luxembourg"
 msgstr ""
 
-#: includes/countries.php:140 includes/countries.php:140
+#: includes/countries.php:140
 msgid "Latvia"
 msgstr ""
 
-#: includes/countries.php:141 includes/countries.php:141
+#: includes/countries.php:141
 msgid "Libya"
 msgstr ""
 
-#: includes/countries.php:142 includes/countries.php:142
+#: includes/countries.php:142
 msgid "Morocco"
 msgstr ""
 
-#: includes/countries.php:143 includes/countries.php:143
+#: includes/countries.php:143
 msgid "Monaco"
 msgstr ""
 
-#: includes/countries.php:144 includes/countries.php:144
+#: includes/countries.php:144
 msgid "Moldova"
 msgstr ""
 
-#: includes/countries.php:145 includes/countries.php:145
+#: includes/countries.php:145
 msgid "Montenegro"
 msgstr ""
 
-#: includes/countries.php:146 includes/countries.php:146
+#: includes/countries.php:146
 msgid "Saint Martin (French part)"
 msgstr ""
 
-#: includes/countries.php:147 includes/countries.php:147
+#: includes/countries.php:147
 msgid "Madagascar"
 msgstr ""
 
-#: includes/countries.php:148 includes/countries.php:148
+#: includes/countries.php:148
 msgid "Marshall Islands"
 msgstr ""
 
-#: includes/countries.php:149 includes/countries.php:149
+#: includes/countries.php:149
 msgid "Macedonia"
 msgstr ""
 
-#: includes/countries.php:150 includes/countries.php:150
+#: includes/countries.php:150
 msgid "Mali"
 msgstr ""
 
-#: includes/countries.php:151 includes/countries.php:151
+#: includes/countries.php:151
 msgid "Myanmar"
 msgstr ""
 
-#: includes/countries.php:152 includes/countries.php:152
+#: includes/countries.php:152
 msgid "Mongolia"
 msgstr ""
 
-#: includes/countries.php:153 includes/countries.php:153
+#: includes/countries.php:153
 msgid "Macao S.A.R., China"
 msgstr ""
 
-#: includes/countries.php:154 includes/countries.php:154
+#: includes/countries.php:154
 msgid "Northern Mariana Islands"
 msgstr ""
 
-#: includes/countries.php:155 includes/countries.php:155
+#: includes/countries.php:155
 msgid "Martinique"
 msgstr ""
 
-#: includes/countries.php:156 includes/countries.php:156
+#: includes/countries.php:156
 msgid "Mauritania"
 msgstr ""
 
-#: includes/countries.php:157 includes/countries.php:157
+#: includes/countries.php:157
 msgid "Montserrat"
 msgstr ""
 
-#: includes/countries.php:158 includes/countries.php:158
+#: includes/countries.php:158
 msgid "Malta"
 msgstr ""
 
-#: includes/countries.php:159 includes/countries.php:159
+#: includes/countries.php:159
 msgid "Mauritius"
 msgstr ""
 
-#: includes/countries.php:160 includes/countries.php:160
+#: includes/countries.php:160
 msgid "Maldives"
 msgstr ""
 
-#: includes/countries.php:161 includes/countries.php:161
+#: includes/countries.php:161
 msgid "Malawi"
 msgstr ""
 
-#: includes/countries.php:162 includes/countries.php:162
+#: includes/countries.php:162
 msgid "Mexico"
 msgstr ""
 
-#: includes/countries.php:163 includes/countries.php:163
+#: includes/countries.php:163
 msgid "Malaysia"
 msgstr ""
 
-#: includes/countries.php:164 includes/countries.php:164
+#: includes/countries.php:164
 msgid "Mozambique"
 msgstr ""
 
-#: includes/countries.php:165 includes/countries.php:165
+#: includes/countries.php:165
 msgid "Namibia"
 msgstr ""
 
-#: includes/countries.php:166 includes/countries.php:166
+#: includes/countries.php:166
 msgid "New Caledonia"
 msgstr ""
 
-#: includes/countries.php:167 includes/countries.php:167
+#: includes/countries.php:167
 msgid "Niger"
 msgstr ""
 
-#: includes/countries.php:168 includes/countries.php:168
+#: includes/countries.php:168
 msgid "Norfolk Island"
 msgstr ""
 
-#: includes/countries.php:169 includes/countries.php:169
+#: includes/countries.php:169
 msgid "Nigeria"
 msgstr ""
 
-#: includes/countries.php:170 includes/countries.php:170
+#: includes/countries.php:170
 msgid "Nicaragua"
 msgstr ""
 
-#: includes/countries.php:171 includes/countries.php:171
+#: includes/countries.php:171
 msgid "Netherlands"
 msgstr ""
 
-#: includes/countries.php:172 includes/countries.php:172
+#: includes/countries.php:172
 msgid "Norway"
 msgstr ""
 
-#: includes/countries.php:173 includes/countries.php:173
+#: includes/countries.php:173
 msgid "Nepal"
 msgstr ""
 
-#: includes/countries.php:174 includes/countries.php:174
+#: includes/countries.php:174
 msgid "Nauru"
 msgstr ""
 
-#: includes/countries.php:175 includes/countries.php:175
+#: includes/countries.php:175
 msgid "Niue"
 msgstr ""
 
-#: includes/countries.php:176 includes/countries.php:176
+#: includes/countries.php:176
 msgid "New Zealand"
 msgstr ""
 
-#: includes/countries.php:177 includes/countries.php:177
+#: includes/countries.php:177
 msgid "Oman"
 msgstr ""
 
-#: includes/countries.php:178 includes/countries.php:178
+#: includes/countries.php:178
 msgid "Panama"
 msgstr ""
 
-#: includes/countries.php:179 includes/countries.php:179
+#: includes/countries.php:179
 msgid "Peru"
 msgstr ""
 
-#: includes/countries.php:180 includes/countries.php:180
+#: includes/countries.php:180
 msgid "French Polynesia"
 msgstr ""
 
-#: includes/countries.php:181 includes/countries.php:181
+#: includes/countries.php:181
 msgid "Papua New Guinea"
 msgstr ""
 
-#: includes/countries.php:182 includes/countries.php:182
+#: includes/countries.php:182
 msgid "Philippines"
 msgstr ""
 
-#: includes/countries.php:183 includes/countries.php:183
+#: includes/countries.php:183
 msgid "Pakistan"
 msgstr ""
 
-#: includes/countries.php:184 includes/countries.php:184
+#: includes/countries.php:184
 msgid "Poland"
 msgstr ""
 
-#: includes/countries.php:185 includes/countries.php:185
+#: includes/countries.php:185
 msgid "Saint Pierre and Miquelon"
 msgstr ""
 
-#: includes/countries.php:186 includes/countries.php:186
+#: includes/countries.php:186
 msgid "Pitcairn"
 msgstr ""
 
-#: includes/countries.php:187 includes/countries.php:187
+#: includes/countries.php:187
 msgid "Puerto Rico"
 msgstr ""
 
-#: includes/countries.php:188 includes/countries.php:188
+#: includes/countries.php:188
 msgid "Palestinian Territory"
 msgstr ""
 
-#: includes/countries.php:189 includes/countries.php:189
+#: includes/countries.php:189
 msgid "Portugal"
 msgstr ""
 
-#: includes/countries.php:190 includes/countries.php:190
+#: includes/countries.php:190
 msgid "Palau"
 msgstr ""
 
-#: includes/countries.php:191 includes/countries.php:191
+#: includes/countries.php:191
 msgid "Paraguay"
 msgstr ""
 
-#: includes/countries.php:192 includes/countries.php:192
+#: includes/countries.php:192
 msgid "Qatar"
 msgstr ""
 
-#: includes/countries.php:193 includes/countries.php:193
+#: includes/countries.php:193
 msgid "Reunion"
 msgstr ""
 
-#: includes/countries.php:194 includes/countries.php:194
+#: includes/countries.php:194
 msgid "Romania"
 msgstr ""
 
-#: includes/countries.php:195 includes/countries.php:195
+#: includes/countries.php:195
 msgid "Serbia"
 msgstr ""
 
-#: includes/countries.php:196 includes/countries.php:196
+#: includes/countries.php:196
 msgid "Russia"
 msgstr ""
 
-#: includes/countries.php:197 includes/countries.php:197
+#: includes/countries.php:197
 msgid "Rwanda"
 msgstr ""
 
-#: includes/countries.php:198 includes/countries.php:198
+#: includes/countries.php:198
 msgid "Saudi Arabia"
 msgstr ""
 
-#: includes/countries.php:199 includes/countries.php:199
+#: includes/countries.php:199
 msgid "Solomon Islands"
 msgstr ""
 
-#: includes/countries.php:200 includes/countries.php:200
+#: includes/countries.php:200
 msgid "Seychelles"
 msgstr ""
 
-#: includes/countries.php:201 includes/countries.php:201
+#: includes/countries.php:201
 msgid "Sudan"
 msgstr ""
 
-#: includes/countries.php:202 includes/countries.php:202
+#: includes/countries.php:202
 msgid "Sweden"
 msgstr ""
 
-#: includes/countries.php:203 includes/countries.php:203
+#: includes/countries.php:203
 msgid "Singapore"
 msgstr ""
 
-#: includes/countries.php:204 includes/countries.php:204
+#: includes/countries.php:204
 msgid "Saint Helena"
 msgstr ""
 
-#: includes/countries.php:205 includes/countries.php:205
+#: includes/countries.php:205
 msgid "Slovenia"
 msgstr ""
 
-#: includes/countries.php:206 includes/countries.php:206
+#: includes/countries.php:206
 msgid "Svalbard and Jan Mayen"
 msgstr ""
 
-#: includes/countries.php:207 includes/countries.php:207
+#: includes/countries.php:207
 msgid "Slovakia"
 msgstr ""
 
-#: includes/countries.php:208 includes/countries.php:208
+#: includes/countries.php:208
 msgid "Sierra Leone"
 msgstr ""
 
-#: includes/countries.php:209 includes/countries.php:209
+#: includes/countries.php:209
 msgid "San Marino"
 msgstr ""
 
-#: includes/countries.php:210 includes/countries.php:210
+#: includes/countries.php:210
 msgid "Senegal"
 msgstr ""
 
-#: includes/countries.php:211 includes/countries.php:211
+#: includes/countries.php:211
 msgid "Somalia"
 msgstr ""
 
-#: includes/countries.php:212 includes/countries.php:212
+#: includes/countries.php:212
 msgid "Suriname"
 msgstr ""
 
-#: includes/countries.php:213 includes/countries.php:213
+#: includes/countries.php:213
 msgid "Sao Tome and Principe"
 msgstr ""
 
-#: includes/countries.php:214 includes/countries.php:214
+#: includes/countries.php:214
 msgid "El Salvador"
 msgstr ""
 
-#: includes/countries.php:215 includes/countries.php:215
+#: includes/countries.php:215
 msgid "Syria"
 msgstr ""
 
-#: includes/countries.php:216 includes/countries.php:216
+#: includes/countries.php:216
 msgid "Swaziland"
 msgstr ""
 
-#: includes/countries.php:217 includes/countries.php:217
+#: includes/countries.php:217
 msgid "Turks and Caicos Islands"
 msgstr ""
 
-#: includes/countries.php:218 includes/countries.php:218
+#: includes/countries.php:218
 msgid "Chad"
 msgstr ""
 
-#: includes/countries.php:219 includes/countries.php:219
+#: includes/countries.php:219
 msgid "French Southern Territories"
 msgstr ""
 
-#: includes/countries.php:220 includes/countries.php:220
+#: includes/countries.php:220
 msgid "Togo"
 msgstr ""
 
-#: includes/countries.php:221 includes/countries.php:221
+#: includes/countries.php:221
 msgid "Thailand"
 msgstr ""
 
-#: includes/countries.php:222 includes/countries.php:222
+#: includes/countries.php:222
 msgid "Tajikistan"
 msgstr ""
 
-#: includes/countries.php:223 includes/countries.php:223
+#: includes/countries.php:223
 msgid "Tokelau"
 msgstr ""
 
-#: includes/countries.php:224 includes/countries.php:224
+#: includes/countries.php:224
 msgid "Timor-Leste"
 msgstr ""
 
-#: includes/countries.php:225 includes/countries.php:225
+#: includes/countries.php:225
 msgid "Turkmenistan"
 msgstr ""
 
-#: includes/countries.php:226 includes/countries.php:226
+#: includes/countries.php:226
 msgid "Tunisia"
 msgstr ""
 
-#: includes/countries.php:227 includes/countries.php:227
+#: includes/countries.php:227
 msgid "Tonga"
 msgstr ""
 
-#: includes/countries.php:228 includes/countries.php:228
+#: includes/countries.php:228
 msgid "Turkey"
 msgstr ""
 
-#: includes/countries.php:229 includes/countries.php:229
+#: includes/countries.php:229
 msgid "Trinidad and Tobago"
 msgstr ""
 
-#: includes/countries.php:230 includes/countries.php:230
+#: includes/countries.php:230
 msgid "Tuvalu"
 msgstr ""
 
-#: includes/countries.php:231 includes/countries.php:231
+#: includes/countries.php:231
 msgid "Taiwan"
 msgstr ""
 
-#: includes/countries.php:232 includes/countries.php:232
+#: includes/countries.php:232
 msgid "Tanzania"
 msgstr ""
 
-#: includes/countries.php:233 includes/countries.php:233
+#: includes/countries.php:233
 msgid "Ukraine"
 msgstr ""
 
-#: includes/countries.php:234 includes/countries.php:234
+#: includes/countries.php:234
 msgid "Uganda"
 msgstr ""
 
-#: includes/countries.php:235 includes/countries.php:235
+#: includes/countries.php:235
 msgid "United States Minor Outlying Islands"
 msgstr ""
 
-#: includes/countries.php:236 includes/countries.php:236
+#: includes/countries.php:236
 msgid "United States"
 msgstr ""
 
-#: includes/countries.php:237 includes/countries.php:237
+#: includes/countries.php:237
 msgid "Uruguay"
 msgstr ""
 
-#: includes/countries.php:238 includes/countries.php:238
+#: includes/countries.php:238
 msgid "Uzbekistan"
 msgstr ""
 
-#: includes/countries.php:239 includes/countries.php:239
+#: includes/countries.php:239
 msgid "Vatican"
 msgstr ""
 
-#: includes/countries.php:240 includes/countries.php:240
+#: includes/countries.php:240
 msgid "Saint Vincent and the Grenadines"
 msgstr ""
 
-#: includes/countries.php:241 includes/countries.php:254
-#: includes/countries.php:241 includes/countries.php:254
+#: includes/countries.php:241
+#: includes/countries.php:254
 msgid "Venezuela"
 msgstr ""
 
-#: includes/countries.php:242 includes/countries.php:242
+#: includes/countries.php:242
 msgid "British Virgin Islands"
 msgstr ""
 
-#: includes/countries.php:243 includes/countries.php:243
+#: includes/countries.php:243
 msgid "U.S. Virgin Islands"
 msgstr ""
 
-#: includes/countries.php:244 includes/countries.php:244
+#: includes/countries.php:244
 msgid "Vietnam"
 msgstr ""
 
-#: includes/countries.php:245 includes/countries.php:245
+#: includes/countries.php:245
 msgid "Vanuatu"
 msgstr ""
 
-#: includes/countries.php:246 includes/countries.php:246
+#: includes/countries.php:246
 msgid "Wallis and Futuna"
 msgstr ""
 
-#: includes/countries.php:247 includes/countries.php:247
+#: includes/countries.php:247
 msgid "Samoa"
 msgstr ""
 
-#: includes/countries.php:248 includes/countries.php:248
+#: includes/countries.php:248
 msgid "Yemen"
 msgstr ""
 
-#: includes/countries.php:249 includes/countries.php:249
+#: includes/countries.php:249
 msgid "Mayotte"
 msgstr ""
 
-#: includes/countries.php:250 includes/countries.php:250
+#: includes/countries.php:250
 msgid "South Africa"
 msgstr ""
 
-#: includes/countries.php:251 includes/countries.php:251
+#: includes/countries.php:251
 msgid "Zambia"
 msgstr ""
 
-#: includes/countries.php:252 includes/countries.php:252
+#: includes/countries.php:252
 msgid "Zimbabwe"
 msgstr ""
 
-#: includes/countries.php:253 includes/countries.php:253
+#: includes/countries.php:253
 msgid "US Armed Forces"
 msgstr ""
 
-#: includes/currencies.php:7 includes/currencies.php:121
-#: includes/currencies.php:148 includes/currencies.php:7
-#: includes/currencies.php:17 includes/currencies.php:37
-#: includes/currencies.php:44 includes/currencies.php:64
-#: includes/currencies.php:68 includes/currencies.php:75
-#: includes/currencies.php:85 includes/currencies.php:87
-#: includes/currencies.php:94 includes/currencies.php:97
-#: includes/currencies.php:99 includes/currencies.php:100
-#: includes/currencies.php:105 includes/currencies.php:107
-#: includes/currencies.php:113 includes/currencies.php:124
-#: includes/currencies.php:127 includes/currencies.php:132
+#: includes/currencies.php:7
+#: includes/currencies.php:121
+#: includes/currencies.php:148
+#: includes/currencies.php:17
+#: includes/currencies.php:37
+#: includes/currencies.php:44
+#: includes/currencies.php:64
+#: includes/currencies.php:68
+#: includes/currencies.php:75
+#: includes/currencies.php:85
+#: includes/currencies.php:87
+#: includes/currencies.php:94
+#: includes/currencies.php:97
+#: includes/currencies.php:99
+#: includes/currencies.php:100
+#: includes/currencies.php:105
+#: includes/currencies.php:107
+#: includes/currencies.php:113
+#: includes/currencies.php:124
+#: includes/currencies.php:127
+#: includes/currencies.php:132
 #: includes/currencies.php:140
 msgid "US Dollars (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:9 includes/currencies.php:124
-#: includes/currencies.php:8 includes/currencies.php:9
-#: includes/currencies.php:19 includes/currencies.php:40
-#: includes/currencies.php:47 includes/currencies.php:67
-#: includes/currencies.php:71 includes/currencies.php:78
-#: includes/currencies.php:88 includes/currencies.php:90
-#: includes/currencies.php:97 includes/currencies.php:100
-#: includes/currencies.php:102 includes/currencies.php:103
-#: includes/currencies.php:108 includes/currencies.php:110
+#: includes/currencies.php:9
+#: includes/currencies.php:124
+#: includes/currencies.php:8
+#: includes/currencies.php:19
+#: includes/currencies.php:40
+#: includes/currencies.php:47
+#: includes/currencies.php:67
+#: includes/currencies.php:71
+#: includes/currencies.php:78
+#: includes/currencies.php:88
+#: includes/currencies.php:90
+#: includes/currencies.php:97
+#: includes/currencies.php:100
+#: includes/currencies.php:102
+#: includes/currencies.php:103
+#: includes/currencies.php:108
+#: includes/currencies.php:110
 #: includes/currencies.php:116
 msgid "Euros (&euro;)"
 msgstr ""
 
-#: includes/currencies.php:14 includes/currencies.php:123
-#: includes/currencies.php:9 includes/currencies.php:14
-#: includes/currencies.php:24 includes/currencies.php:39
-#: includes/currencies.php:46 includes/currencies.php:66
-#: includes/currencies.php:70 includes/currencies.php:77
-#: includes/currencies.php:87 includes/currencies.php:89
-#: includes/currencies.php:96 includes/currencies.php:99
-#: includes/currencies.php:101 includes/currencies.php:102
-#: includes/currencies.php:107 includes/currencies.php:109
+#: includes/currencies.php:14
+#: includes/currencies.php:123
+#: includes/currencies.php:9
+#: includes/currencies.php:24
+#: includes/currencies.php:39
+#: includes/currencies.php:46
+#: includes/currencies.php:66
+#: includes/currencies.php:70
+#: includes/currencies.php:77
+#: includes/currencies.php:87
+#: includes/currencies.php:89
+#: includes/currencies.php:96
+#: includes/currencies.php:99
+#: includes/currencies.php:101
+#: includes/currencies.php:102
+#: includes/currencies.php:107
+#: includes/currencies.php:109
 #: includes/currencies.php:115
 msgid "Pounds Sterling (&pound;)"
 msgstr ""
 
-#: includes/currencies.php:18 includes/currencies.php:18
+#: includes/currencies.php:18
 #: includes/currencies.php:28
 msgid "Argentine Peso (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:19 includes/currencies.php:10
-#: includes/currencies.php:18 includes/currencies.php:19
-#: includes/currencies.php:28 includes/currencies.php:29
+#: includes/currencies.php:19
+#: includes/currencies.php:10
+#: includes/currencies.php:18
+#: includes/currencies.php:28
+#: includes/currencies.php:29
 msgid "Australian Dollars (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:21 includes/currencies.php:20
-#: includes/currencies.php:21 includes/currencies.php:30
+#: includes/currencies.php:21
+#: includes/currencies.php:20
+#: includes/currencies.php:30
 #: includes/currencies.php:31
 msgid "Brazilian Real (R&#36;)"
 msgstr ""
 
-#: includes/currencies.php:25 includes/currencies.php:122
-#: includes/currencies.php:12 includes/currencies.php:24
-#: includes/currencies.php:25 includes/currencies.php:34
-#: includes/currencies.php:35 includes/currencies.php:38
-#: includes/currencies.php:45 includes/currencies.php:65
-#: includes/currencies.php:69 includes/currencies.php:76
-#: includes/currencies.php:86 includes/currencies.php:88
-#: includes/currencies.php:95 includes/currencies.php:98
-#: includes/currencies.php:100 includes/currencies.php:101
-#: includes/currencies.php:106 includes/currencies.php:108
+#: includes/currencies.php:25
+#: includes/currencies.php:122
+#: includes/currencies.php:12
+#: includes/currencies.php:24
+#: includes/currencies.php:34
+#: includes/currencies.php:35
+#: includes/currencies.php:38
+#: includes/currencies.php:45
+#: includes/currencies.php:65
+#: includes/currencies.php:69
+#: includes/currencies.php:76
+#: includes/currencies.php:86
+#: includes/currencies.php:88
+#: includes/currencies.php:95
+#: includes/currencies.php:98
+#: includes/currencies.php:100
+#: includes/currencies.php:101
+#: includes/currencies.php:106
+#: includes/currencies.php:108
 #: includes/currencies.php:114
 msgid "Canadian Dollars (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:26 includes/currencies.php:13
-#: includes/currencies.php:25 includes/currencies.php:26
-#: includes/currencies.php:35 includes/currencies.php:36
+#: includes/currencies.php:26
+#: includes/currencies.php:13
+#: includes/currencies.php:25
+#: includes/currencies.php:35
+#: includes/currencies.php:36
 msgid "Chinese Yuan"
 msgstr ""
 
-#: includes/currencies.php:28 includes/currencies.php:13
-#: includes/currencies.php:14 includes/currencies.php:26
-#: includes/currencies.php:27 includes/currencies.php:28
-#: includes/currencies.php:37 includes/currencies.php:38
+#: includes/currencies.php:28
+#: includes/currencies.php:13
+#: includes/currencies.php:14
+#: includes/currencies.php:26
+#: includes/currencies.php:27
+#: includes/currencies.php:37
+#: includes/currencies.php:38
 msgid "Czech Koruna"
 msgstr ""
 
-#: includes/currencies.php:36 includes/currencies.php:14
-#: includes/currencies.php:15 includes/currencies.php:27
-#: includes/currencies.php:34 includes/currencies.php:36
-#: includes/currencies.php:44 includes/currencies.php:45
+#: includes/currencies.php:36
+#: includes/currencies.php:14
+#: includes/currencies.php:15
+#: includes/currencies.php:27
+#: includes/currencies.php:34
+#: includes/currencies.php:44
+#: includes/currencies.php:45
 #: includes/currencies.php:46
 msgid "Danish Krone"
 msgstr ""
 
-#: includes/currencies.php:44 includes/currencies.php:44
+#: includes/currencies.php:44
 msgid "Ghanaian Cedi (&#8373;)"
 msgstr ""
 
-#: includes/currencies.php:48 includes/currencies.php:15
-#: includes/currencies.php:16 includes/currencies.php:28
-#: includes/currencies.php:35 includes/currencies.php:43
-#: includes/currencies.php:45 includes/currencies.php:46
-#: includes/currencies.php:48 includes/currencies.php:53
+#: includes/currencies.php:48
+#: includes/currencies.php:15
+#: includes/currencies.php:16
+#: includes/currencies.php:28
+#: includes/currencies.php:35
+#: includes/currencies.php:43
+#: includes/currencies.php:45
+#: includes/currencies.php:46
+#: includes/currencies.php:53
 msgid "Hong Kong Dollar (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:49 includes/currencies.php:16
-#: includes/currencies.php:17 includes/currencies.php:29
-#: includes/currencies.php:36 includes/currencies.php:44
-#: includes/currencies.php:46 includes/currencies.php:47
-#: includes/currencies.php:49 includes/currencies.php:54
+#: includes/currencies.php:49
+#: includes/currencies.php:16
+#: includes/currencies.php:17
+#: includes/currencies.php:29
+#: includes/currencies.php:36
+#: includes/currencies.php:44
+#: includes/currencies.php:46
+#: includes/currencies.php:47
+#: includes/currencies.php:54
 msgid "Hungarian Forint"
 msgstr ""
 
-#: includes/currencies.php:50 includes/currencies.php:18
-#: includes/currencies.php:30 includes/currencies.php:37
-#: includes/currencies.php:45 includes/currencies.php:47
-#: includes/currencies.php:48 includes/currencies.php:50
+#: includes/currencies.php:50
+#: includes/currencies.php:18
+#: includes/currencies.php:30
+#: includes/currencies.php:37
+#: includes/currencies.php:45
+#: includes/currencies.php:47
+#: includes/currencies.php:48
 #: includes/currencies.php:55
 msgid "Indian Rupee"
 msgstr ""
 
-#: includes/currencies.php:51 includes/currencies.php:19
-#: includes/currencies.php:31 includes/currencies.php:38
-#: includes/currencies.php:46 includes/currencies.php:48
-#: includes/currencies.php:49 includes/currencies.php:51
+#: includes/currencies.php:51
+#: includes/currencies.php:19
+#: includes/currencies.php:31
+#: includes/currencies.php:38
+#: includes/currencies.php:46
+#: includes/currencies.php:48
+#: includes/currencies.php:49
 #: includes/currencies.php:56
 msgid "Indonesia Rupiah"
 msgstr ""
 
-#: includes/currencies.php:52 includes/currencies.php:17
-#: includes/currencies.php:20 includes/currencies.php:32
-#: includes/currencies.php:39 includes/currencies.php:47
-#: includes/currencies.php:49 includes/currencies.php:50
-#: includes/currencies.php:52 includes/currencies.php:57
+#: includes/currencies.php:52
+#: includes/currencies.php:17
+#: includes/currencies.php:20
+#: includes/currencies.php:32
+#: includes/currencies.php:39
+#: includes/currencies.php:47
+#: includes/currencies.php:49
+#: includes/currencies.php:50
+#: includes/currencies.php:57
 msgid "Israeli Shekel"
 msgstr ""
 
-#: includes/currencies.php:54 includes/currencies.php:18
-#: includes/currencies.php:21 includes/currencies.php:34
-#: includes/currencies.php:41 includes/currencies.php:49
-#: includes/currencies.php:51 includes/currencies.php:52
-#: includes/currencies.php:54 includes/currencies.php:59
+#: includes/currencies.php:54
+#: includes/currencies.php:18
+#: includes/currencies.php:21
+#: includes/currencies.php:34
+#: includes/currencies.php:41
+#: includes/currencies.php:49
+#: includes/currencies.php:51
+#: includes/currencies.php:52
+#: includes/currencies.php:59
 msgid "Japanese Yen (&yen;)"
 msgstr ""
 
-#: includes/currencies.php:59 includes/currencies.php:54
-#: includes/currencies.php:59 includes/currencies.php:64
+#: includes/currencies.php:59
+#: includes/currencies.php:54
+#: includes/currencies.php:64
 msgid "Kenyan Shilling"
 msgstr ""
 
-#: includes/currencies.php:60 includes/currencies.php:19
-#: includes/currencies.php:22 includes/currencies.php:38
-#: includes/currencies.php:45 includes/currencies.php:55
-#: includes/currencies.php:56 includes/currencies.php:57
-#: includes/currencies.php:60 includes/currencies.php:65
+#: includes/currencies.php:60
+#: includes/currencies.php:19
+#: includes/currencies.php:22
+#: includes/currencies.php:38
+#: includes/currencies.php:45
+#: includes/currencies.php:55
+#: includes/currencies.php:56
+#: includes/currencies.php:57
+#: includes/currencies.php:65
 msgid "Malaysian Ringgits"
 msgstr ""
 
-#: includes/currencies.php:61 includes/currencies.php:20
-#: includes/currencies.php:23 includes/currencies.php:39
-#: includes/currencies.php:46 includes/currencies.php:56
-#: includes/currencies.php:57 includes/currencies.php:58
-#: includes/currencies.php:61 includes/currencies.php:66
+#: includes/currencies.php:61
+#: includes/currencies.php:20
+#: includes/currencies.php:23
+#: includes/currencies.php:39
+#: includes/currencies.php:46
+#: includes/currencies.php:56
+#: includes/currencies.php:57
+#: includes/currencies.php:58
+#: includes/currencies.php:66
 msgid "Mexican Peso (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:62 includes/currencies.php:57
-#: includes/currencies.php:58 includes/currencies.php:59
-#: includes/currencies.php:62 includes/currencies.php:67
+#: includes/currencies.php:62
+#: includes/currencies.php:57
+#: includes/currencies.php:58
+#: includes/currencies.php:59
+#: includes/currencies.php:67
 msgid "Nigerian Naira (&#8358;)"
 msgstr ""
 
-#: includes/currencies.php:63 includes/currencies.php:21
-#: includes/currencies.php:24 includes/currencies.php:40
-#: includes/currencies.php:47 includes/currencies.php:57
-#: includes/currencies.php:58 includes/currencies.php:59
-#: includes/currencies.php:60 includes/currencies.php:63
+#: includes/currencies.php:63
+#: includes/currencies.php:21
+#: includes/currencies.php:24
+#: includes/currencies.php:40
+#: includes/currencies.php:47
+#: includes/currencies.php:57
+#: includes/currencies.php:58
+#: includes/currencies.php:59
+#: includes/currencies.php:60
 #: includes/currencies.php:68
 msgid "New Zealand Dollar (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:64 includes/currencies.php:22
-#: includes/currencies.php:25 includes/currencies.php:41
-#: includes/currencies.php:48 includes/currencies.php:58
-#: includes/currencies.php:59 includes/currencies.php:60
-#: includes/currencies.php:61 includes/currencies.php:64
+#: includes/currencies.php:64
+#: includes/currencies.php:22
+#: includes/currencies.php:25
+#: includes/currencies.php:41
+#: includes/currencies.php:48
+#: includes/currencies.php:58
+#: includes/currencies.php:59
+#: includes/currencies.php:60
+#: includes/currencies.php:61
 #: includes/currencies.php:69
 msgid "Norwegian Krone"
 msgstr ""
 
-#: includes/currencies.php:65 includes/currencies.php:23
-#: includes/currencies.php:26 includes/currencies.php:42
-#: includes/currencies.php:49 includes/currencies.php:59
-#: includes/currencies.php:60 includes/currencies.php:61
-#: includes/currencies.php:62 includes/currencies.php:65
+#: includes/currencies.php:65
+#: includes/currencies.php:23
+#: includes/currencies.php:26
+#: includes/currencies.php:42
+#: includes/currencies.php:49
+#: includes/currencies.php:59
+#: includes/currencies.php:60
+#: includes/currencies.php:61
+#: includes/currencies.php:62
 #: includes/currencies.php:70
 msgid "Philippine Pesos"
 msgstr ""
 
-#: includes/currencies.php:66 includes/currencies.php:24
-#: includes/currencies.php:27 includes/currencies.php:43
-#: includes/currencies.php:50 includes/currencies.php:60
-#: includes/currencies.php:61 includes/currencies.php:62
-#: includes/currencies.php:63 includes/currencies.php:66
+#: includes/currencies.php:66
+#: includes/currencies.php:24
+#: includes/currencies.php:27
+#: includes/currencies.php:43
+#: includes/currencies.php:50
+#: includes/currencies.php:60
+#: includes/currencies.php:61
+#: includes/currencies.php:62
+#: includes/currencies.php:63
 #: includes/currencies.php:71
 msgid "Polish Zloty"
 msgstr ""
 
-#: includes/currencies.php:68 includes/currencies.php:68
+#: includes/currencies.php:68
 msgid "Romanian Leu"
 msgstr ""
 
-#: includes/currencies.php:76 includes/currencies.php:63
-#: includes/currencies.php:65 includes/currencies.php:68
-#: includes/currencies.php:73 includes/currencies.php:76
+#: includes/currencies.php:76
+#: includes/currencies.php:63
+#: includes/currencies.php:65
+#: includes/currencies.php:68
+#: includes/currencies.php:73
 msgid "Russian Ruble (&#8381;)"
 msgstr ""
 
-#: includes/currencies.php:84 includes/currencies.php:25
-#: includes/currencies.php:28 includes/currencies.php:45
-#: includes/currencies.php:52 includes/currencies.php:62
-#: includes/currencies.php:64 includes/currencies.php:65
-#: includes/currencies.php:68 includes/currencies.php:70
-#: includes/currencies.php:71 includes/currencies.php:76
-#: includes/currencies.php:78 includes/currencies.php:84
+#: includes/currencies.php:84
+#: includes/currencies.php:25
+#: includes/currencies.php:28
+#: includes/currencies.php:45
+#: includes/currencies.php:52
+#: includes/currencies.php:62
+#: includes/currencies.php:64
+#: includes/currencies.php:65
+#: includes/currencies.php:68
+#: includes/currencies.php:70
+#: includes/currencies.php:71
+#: includes/currencies.php:76
+#: includes/currencies.php:78
 msgid "Singapore Dollar (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:89 includes/currencies.php:50
-#: includes/currencies.php:57 includes/currencies.php:67
-#: includes/currencies.php:69 includes/currencies.php:70
-#: includes/currencies.php:73 includes/currencies.php:75
-#: includes/currencies.php:76 includes/currencies.php:81
-#: includes/currencies.php:83 includes/currencies.php:89
+#: includes/currencies.php:89
+#: includes/currencies.php:50
+#: includes/currencies.php:57
+#: includes/currencies.php:67
+#: includes/currencies.php:69
+#: includes/currencies.php:70
+#: includes/currencies.php:73
+#: includes/currencies.php:75
+#: includes/currencies.php:76
+#: includes/currencies.php:81
+#: includes/currencies.php:83
 msgid "South African Rand (R)"
 msgstr ""
 
-#: includes/currencies.php:94 includes/currencies.php:30
-#: includes/currencies.php:50 includes/currencies.php:54
-#: includes/currencies.php:61 includes/currencies.php:71
-#: includes/currencies.php:73 includes/currencies.php:75
-#: includes/currencies.php:78 includes/currencies.php:80
-#: includes/currencies.php:81 includes/currencies.php:86
-#: includes/currencies.php:88 includes/currencies.php:94
+#: includes/currencies.php:94
+#: includes/currencies.php:30
+#: includes/currencies.php:50
+#: includes/currencies.php:54
+#: includes/currencies.php:61
+#: includes/currencies.php:71
+#: includes/currencies.php:73
+#: includes/currencies.php:75
+#: includes/currencies.php:78
+#: includes/currencies.php:80
+#: includes/currencies.php:81
+#: includes/currencies.php:86
+#: includes/currencies.php:88
 msgid "South Korean Won"
 msgstr ""
 
-#: includes/currencies.php:97 includes/currencies.php:26
-#: includes/currencies.php:31 includes/currencies.php:51
-#: includes/currencies.php:55 includes/currencies.php:62
-#: includes/currencies.php:72 includes/currencies.php:74
-#: includes/currencies.php:78 includes/currencies.php:81
-#: includes/currencies.php:83 includes/currencies.php:84
-#: includes/currencies.php:89 includes/currencies.php:91
 #: includes/currencies.php:97
+#: includes/currencies.php:26
+#: includes/currencies.php:31
+#: includes/currencies.php:51
+#: includes/currencies.php:55
+#: includes/currencies.php:62
+#: includes/currencies.php:72
+#: includes/currencies.php:74
+#: includes/currencies.php:78
+#: includes/currencies.php:81
+#: includes/currencies.php:83
+#: includes/currencies.php:84
+#: includes/currencies.php:89
+#: includes/currencies.php:91
 msgid "Swedish Krona"
 msgstr ""
 
-#: includes/currencies.php:98 includes/currencies.php:27
-#: includes/currencies.php:32 includes/currencies.php:52
-#: includes/currencies.php:56 includes/currencies.php:63
-#: includes/currencies.php:73 includes/currencies.php:75
-#: includes/currencies.php:79 includes/currencies.php:82
-#: includes/currencies.php:84 includes/currencies.php:85
-#: includes/currencies.php:90 includes/currencies.php:92
 #: includes/currencies.php:98
+#: includes/currencies.php:27
+#: includes/currencies.php:32
+#: includes/currencies.php:52
+#: includes/currencies.php:56
+#: includes/currencies.php:63
+#: includes/currencies.php:73
+#: includes/currencies.php:75
+#: includes/currencies.php:79
+#: includes/currencies.php:82
+#: includes/currencies.php:84
+#: includes/currencies.php:85
+#: includes/currencies.php:90
+#: includes/currencies.php:92
 msgid "Swiss Franc"
 msgstr ""
 
-#: includes/currencies.php:99 includes/currencies.php:28
-#: includes/currencies.php:33 includes/currencies.php:53
-#: includes/currencies.php:57 includes/currencies.php:64
-#: includes/currencies.php:74 includes/currencies.php:76
-#: includes/currencies.php:80 includes/currencies.php:83
-#: includes/currencies.php:85 includes/currencies.php:86
-#: includes/currencies.php:91 includes/currencies.php:93
 #: includes/currencies.php:99
+#: includes/currencies.php:28
+#: includes/currencies.php:33
+#: includes/currencies.php:53
+#: includes/currencies.php:57
+#: includes/currencies.php:64
+#: includes/currencies.php:74
+#: includes/currencies.php:76
+#: includes/currencies.php:80
+#: includes/currencies.php:83
+#: includes/currencies.php:85
+#: includes/currencies.php:86
+#: includes/currencies.php:91
+#: includes/currencies.php:93
 msgid "Taiwan New Dollars"
 msgstr ""
 
-#: includes/currencies.php:100 includes/currencies.php:29
-#: includes/currencies.php:34 includes/currencies.php:54
-#: includes/currencies.php:58 includes/currencies.php:65
-#: includes/currencies.php:75 includes/currencies.php:77
-#: includes/currencies.php:81 includes/currencies.php:84
-#: includes/currencies.php:86 includes/currencies.php:87
-#: includes/currencies.php:92 includes/currencies.php:94
 #: includes/currencies.php:100
+#: includes/currencies.php:29
+#: includes/currencies.php:34
+#: includes/currencies.php:54
+#: includes/currencies.php:58
+#: includes/currencies.php:65
+#: includes/currencies.php:75
+#: includes/currencies.php:77
+#: includes/currencies.php:81
+#: includes/currencies.php:84
+#: includes/currencies.php:86
+#: includes/currencies.php:87
+#: includes/currencies.php:92
+#: includes/currencies.php:94
 msgid "Thai Baht"
 msgstr ""
 
-#: includes/currencies.php:101 includes/currencies.php:35
-#: includes/currencies.php:55 includes/currencies.php:59
-#: includes/currencies.php:66 includes/currencies.php:76
-#: includes/currencies.php:78 includes/currencies.php:82
-#: includes/currencies.php:85 includes/currencies.php:87
-#: includes/currencies.php:88 includes/currencies.php:93
-#: includes/currencies.php:95 includes/currencies.php:101
+#: includes/currencies.php:101
+#: includes/currencies.php:35
+#: includes/currencies.php:55
+#: includes/currencies.php:59
+#: includes/currencies.php:66
+#: includes/currencies.php:76
+#: includes/currencies.php:78
+#: includes/currencies.php:82
+#: includes/currencies.php:85
+#: includes/currencies.php:87
+#: includes/currencies.php:88
+#: includes/currencies.php:93
+#: includes/currencies.php:95
 msgid "Turkish Lira"
 msgstr ""
 
@@ -10733,626 +13208,980 @@ msgstr ""
 msgid "Ukrainian Hryvnia (&#8372;)"
 msgstr ""
 
-#: includes/currencies.php:111 includes/currencies.php:36
-#: includes/currencies.php:56 includes/currencies.php:60
-#: includes/currencies.php:67 includes/currencies.php:77
-#: includes/currencies.php:79 includes/currencies.php:84
-#: includes/currencies.php:87 includes/currencies.php:89
-#: includes/currencies.php:90 includes/currencies.php:95
-#: includes/currencies.php:97 includes/currencies.php:103
+#: includes/currencies.php:111
+#: includes/currencies.php:36
+#: includes/currencies.php:56
+#: includes/currencies.php:60
+#: includes/currencies.php:67
+#: includes/currencies.php:77
+#: includes/currencies.php:79
+#: includes/currencies.php:84
+#: includes/currencies.php:87
+#: includes/currencies.php:89
+#: includes/currencies.php:90
+#: includes/currencies.php:95
+#: includes/currencies.php:97
+#: includes/currencies.php:103
 msgid "Vietnamese Dong"
 msgstr ""
 
+#. translators: 1: the old hook name, 2: the new or replacement hook name
 #: includes/deprecated.php:21
 #, php-format
-msgid ""
-"The %1$s hook has been deprecated in Paid Memberships Pro. Please use the "
-"%2$s hook instead."
+msgid "The %1$s hook has been deprecated in Paid Memberships Pro. Please use the %2$s hook instead."
 msgstr ""
 
-#: includes/filters.php:224 includes/filters.php:217 includes/filters.php:224
-msgid ""
-"There was a potential issue while setting the 'Profile Start Date' for a "
-"user's subscription at checkout. PayPal does not allow one to set a Profile "
-"Start Date further than 1 year out. Typically, this is not an issue, but "
-"sometimes a combination of custom code or add ons for PMPro (e.g. the "
-"Prorating or Auto-renewal Checkbox add ons) will try to set a Profile Start "
-"Date out past 1 year in order to respect an existing user's original "
-"expiration date before they checked out. The user's information is below. "
-"PMPro has allowed the checkout and simply restricted the Profile Start Date "
-"to 1 year out with a possible additional free Trial of up to 1 year. You "
-"should double check this information to determine if maybe the user has "
-"overpaid or otherwise needs to be addressed. If you get many of these "
-"emails, you should consider adjusting your custom code to avoid these "
-"situations."
+#: includes/filters.php:224
+#: includes/filters.php:217
+msgid "There was a potential issue while setting the 'Profile Start Date' for a user's subscription at checkout. PayPal does not allow one to set a Profile Start Date further than 1 year out. Typically, this is not an issue, but sometimes a combination of custom code or add ons for PMPro (e.g. the Prorating or Auto-renewal Checkbox add ons) will try to set a Profile Start Date out past 1 year in order to respect an existing user's original expiration date before they checked out. The user's information is below. PMPro has allowed the checkout and simply restricted the Profile Start Date to 1 year out with a possible additional free Trial of up to 1 year. You should double check this information to determine if maybe the user has overpaid or otherwise needs to be addressed. If you get many of these emails, you should consider adjusting your custom code to avoid these situations."
 msgstr ""
 
-#: includes/filters.php:225 includes/filters.php:225
+#: includes/filters.php:225
 #, php-format
-msgid ""
-"User: %1$s<br />Email: %2$s<br />Membership Level: %3$s<br />Order #: "
-"%4$s<br />Original Profile Start Date: %5$s<br />Adjusted Profile Start "
-"Date: %6$s<br />Trial Period: %7$s<br />Trial Frequency: %8$s<br />"
+msgid "User: %1$s<br />Email: %2$s<br />Membership Level: %3$s<br />Order #: %4$s<br />Original Profile Start Date: %5$s<br />Adjusted Profile Start Date: %6$s<br />Trial Period: %7$s<br />Trial Frequency: %8$s<br />"
 msgstr ""
 
-#: includes/filters.php:227 includes/filters.php:220 includes/filters.php:227
+#: includes/filters.php:227
+#: includes/filters.php:220
 #, php-format
 msgid "Profile Start Date Issue Detected and Fixed at %s"
 msgstr ""
 
-#: includes/functions.php:380 includes/functions.php:496
-#: includes/functions.php:160 includes/functions.php:196
-#: includes/functions.php:200 includes/functions.php:202
-#: includes/functions.php:203 includes/functions.php:204
-#: includes/functions.php:207 includes/functions.php:243
-#: includes/functions.php:309 includes/functions.php:315
-#: includes/functions.php:320 includes/functions.php:321
-#: includes/functions.php:329 includes/functions.php:340
-#: includes/functions.php:379 includes/functions.php:380
-#: includes/functions.php:384 includes/functions.php:433
-#: includes/functions.php:452 includes/functions.php:455
-#: includes/functions.php:464 includes/functions.php:491
+#: includes/functions.php:380
 #: includes/functions.php:496
+#: includes/functions.php:160
+#: includes/functions.php:196
+#: includes/functions.php:200
+#: includes/functions.php:202
+#: includes/functions.php:203
+#: includes/functions.php:204
+#: includes/functions.php:207
+#: includes/functions.php:243
+#: includes/functions.php:309
+#: includes/functions.php:315
+#: includes/functions.php:320
+#: includes/functions.php:321
+#: includes/functions.php:329
+#: includes/functions.php:340
+#: includes/functions.php:379
+#: includes/functions.php:384
+#: includes/functions.php:433
+#: includes/functions.php:452
+#: includes/functions.php:455
+#: includes/functions.php:464
+#: includes/functions.php:491
 #, php-format
 msgid "The price for membership is <strong>%s</strong> now"
 msgstr ""
 
-#: includes/functions.php:383 includes/functions.php:383 pages/levels.php:33
-#: pages/levels.php:43 pages/levels.php:55
+#: includes/functions.php:383
+#: pages/levels.php:33
+#: pages/levels.php:43
+#: pages/levels.php:55
 msgid "Free"
 msgstr ""
 
-#: includes/functions.php:385 includes/functions.php:498
-#: includes/functions.php:202 includes/functions.php:204
-#: includes/functions.php:205 includes/functions.php:206
-#: includes/functions.php:209 includes/functions.php:245
-#: includes/functions.php:311 includes/functions.php:317
-#: includes/functions.php:322 includes/functions.php:323
-#: includes/functions.php:331 includes/functions.php:342
-#: includes/functions.php:381 includes/functions.php:385
-#: includes/functions.php:386 includes/functions.php:435
-#: includes/functions.php:454 includes/functions.php:457
-#: includes/functions.php:466 includes/functions.php:493
+#: includes/functions.php:385
 #: includes/functions.php:498
+#: includes/functions.php:202
+#: includes/functions.php:204
+#: includes/functions.php:205
+#: includes/functions.php:206
+#: includes/functions.php:209
+#: includes/functions.php:245
+#: includes/functions.php:311
+#: includes/functions.php:317
+#: includes/functions.php:322
+#: includes/functions.php:323
+#: includes/functions.php:331
+#: includes/functions.php:342
+#: includes/functions.php:381
+#: includes/functions.php:386
+#: includes/functions.php:435
+#: includes/functions.php:454
+#: includes/functions.php:457
+#: includes/functions.php:466
+#: includes/functions.php:493
 #, php-format
 msgid "<strong>%s</strong> now"
 msgstr ""
 
-#: includes/functions.php:393 includes/functions.php:330
-#: includes/functions.php:349 includes/functions.php:388
 #: includes/functions.php:393
+#: includes/functions.php:330
+#: includes/functions.php:349
+#: includes/functions.php:388
 #, php-format
 msgid " and then <strong>%1$s per %2$s for %3$d more %4$s</strong>."
 msgstr ""
 
-#: includes/functions.php:395 includes/functions.php:332
-#: includes/functions.php:351 includes/functions.php:390
 #: includes/functions.php:395
+#: includes/functions.php:332
+#: includes/functions.php:351
+#: includes/functions.php:390
 #, php-format
 msgid " and then <strong>%1$s every %2$d %3$s for %4$d more payments</strong>."
 msgstr ""
 
-#: includes/functions.php:398 includes/functions.php:335
-#: includes/functions.php:354 includes/functions.php:393
 #: includes/functions.php:398
+#: includes/functions.php:335
+#: includes/functions.php:354
+#: includes/functions.php:393
 #, php-format
 msgid " and then <strong>%1$s after %2$d %3$s</strong>."
 msgstr ""
 
-#: includes/functions.php:403 includes/functions.php:340
-#: includes/functions.php:359 includes/functions.php:398
 #: includes/functions.php:403
+#: includes/functions.php:340
+#: includes/functions.php:359
+#: includes/functions.php:398
 #, php-format
 msgid "The price for membership is <strong>%1$s per %2$s</strong>."
 msgstr ""
 
-#: includes/functions.php:405 includes/functions.php:342
-#: includes/functions.php:361 includes/functions.php:400
 #: includes/functions.php:405
+#: includes/functions.php:342
+#: includes/functions.php:361
+#: includes/functions.php:400
 #, php-format
 msgid "<strong>%1$s per %2$s</strong>."
 msgstr ""
 
-#: includes/functions.php:409 includes/functions.php:346
-#: includes/functions.php:365 includes/functions.php:404
 #: includes/functions.php:409
+#: includes/functions.php:346
+#: includes/functions.php:365
+#: includes/functions.php:404
 #, php-format
 msgid "The price for membership is <strong>%1$s every %2$d %3$s</strong>."
 msgstr ""
 
-#: includes/functions.php:411 includes/functions.php:348
-#: includes/functions.php:367 includes/functions.php:406
 #: includes/functions.php:411
+#: includes/functions.php:348
+#: includes/functions.php:367
+#: includes/functions.php:406
 #, php-format
 msgid "<strong>%1$s every %2$d %3$s</strong>."
 msgstr ""
 
-#: includes/functions.php:416 includes/functions.php:353
-#: includes/functions.php:372 includes/functions.php:411
 #: includes/functions.php:416
+#: includes/functions.php:353
+#: includes/functions.php:372
+#: includes/functions.php:411
 #, php-format
 msgid " and then <strong>%1$s per %2$s</strong>."
 msgstr ""
 
-#: includes/functions.php:418 includes/functions.php:355
-#: includes/functions.php:374 includes/functions.php:413
 #: includes/functions.php:418
+#: includes/functions.php:355
+#: includes/functions.php:374
+#: includes/functions.php:413
 #, php-format
 msgid " and then <strong>%1$s every %2$d %3$s</strong>."
 msgstr ""
 
-#: includes/functions.php:433 includes/functions.php:202
-#: includes/functions.php:238 includes/functions.php:249
-#: includes/functions.php:260 includes/functions.php:261
-#: includes/functions.php:262 includes/functions.php:264
-#: includes/functions.php:267 includes/functions.php:271
-#: includes/functions.php:307 includes/functions.php:370
-#: includes/functions.php:373 includes/functions.php:379
-#: includes/functions.php:384 includes/functions.php:389
-#: includes/functions.php:393 includes/functions.php:428
-#: includes/functions.php:433 pages/levels.php:82
+#: includes/functions.php:433
+#: includes/functions.php:202
+#: includes/functions.php:238
+#: includes/functions.php:249
+#: includes/functions.php:260
+#: includes/functions.php:261
+#: includes/functions.php:262
+#: includes/functions.php:264
+#: includes/functions.php:267
+#: includes/functions.php:271
+#: includes/functions.php:307
+#: includes/functions.php:370
+#: includes/functions.php:373
+#: includes/functions.php:379
+#: includes/functions.php:384
+#: includes/functions.php:389
+#: includes/functions.php:393
+#: includes/functions.php:428
+#: pages/levels.php:82
 msgid "After your initial payment, your first payment is Free."
 msgstr ""
 
-#: includes/functions.php:435 includes/functions.php:206
-#: includes/functions.php:242 includes/functions.php:253
-#: includes/functions.php:264 includes/functions.php:265
-#: includes/functions.php:266 includes/functions.php:268
-#: includes/functions.php:271 includes/functions.php:275
-#: includes/functions.php:311 includes/functions.php:372
-#: includes/functions.php:377 includes/functions.php:383
-#: includes/functions.php:388 includes/functions.php:391
-#: includes/functions.php:397 includes/functions.php:430
-#: includes/functions.php:435 pages/levels.php:86
+#: includes/functions.php:435
+#: includes/functions.php:206
+#: includes/functions.php:242
+#: includes/functions.php:253
+#: includes/functions.php:264
+#: includes/functions.php:265
+#: includes/functions.php:266
+#: includes/functions.php:268
+#: includes/functions.php:271
+#: includes/functions.php:275
+#: includes/functions.php:311
+#: includes/functions.php:372
+#: includes/functions.php:377
+#: includes/functions.php:383
+#: includes/functions.php:388
+#: includes/functions.php:391
+#: includes/functions.php:397
+#: includes/functions.php:430
+#: pages/levels.php:86
 #, php-format
 msgid "After your initial payment, your first %d payments are Free."
 msgstr ""
 
-#: includes/functions.php:439 includes/functions.php:213
-#: includes/functions.php:249 includes/functions.php:260
-#: includes/functions.php:271 includes/functions.php:272
-#: includes/functions.php:273 includes/functions.php:275
-#: includes/functions.php:278 includes/functions.php:282
-#: includes/functions.php:318 includes/functions.php:376
-#: includes/functions.php:384 includes/functions.php:390
-#: includes/functions.php:395 includes/functions.php:404
-#: includes/functions.php:434 includes/functions.php:439 pages/levels.php:93
+#: includes/functions.php:439
+#: includes/functions.php:213
+#: includes/functions.php:249
+#: includes/functions.php:260
+#: includes/functions.php:271
+#: includes/functions.php:272
+#: includes/functions.php:273
+#: includes/functions.php:275
+#: includes/functions.php:278
+#: includes/functions.php:282
+#: includes/functions.php:318
+#: includes/functions.php:376
+#: includes/functions.php:384
+#: includes/functions.php:390
+#: includes/functions.php:395
+#: includes/functions.php:404
+#: includes/functions.php:434
+#: pages/levels.php:93
 #, php-format
 msgid "After your initial payment, your first payment will cost %s."
 msgstr ""
 
-#: includes/functions.php:441 includes/functions.php:378
-#: includes/functions.php:397 includes/functions.php:436
 #: includes/functions.php:441
+#: includes/functions.php:378
+#: includes/functions.php:397
+#: includes/functions.php:436
 #, php-format
 msgid "After your initial payment, your first %1$d payments will cost %2$s."
 msgstr ""
 
-#: includes/functions.php:451 includes/functions.php:552
-#: includes/functions.php:388 includes/functions.php:407
-#: includes/functions.php:446 includes/functions.php:451
-#: includes/functions.php:489 includes/functions.php:508
-#: includes/functions.php:547 includes/functions.php:552
+#: includes/functions.php:451
+#: includes/functions.php:552
+#: includes/functions.php:388
+#: includes/functions.php:407
+#: includes/functions.php:446
+#: includes/functions.php:489
+#: includes/functions.php:508
+#: includes/functions.php:547
 #, php-format
 msgid "Customers in %1$s will be charged %2$s%% tax."
 msgstr ""
 
-#: includes/functions.php:509 includes/functions.php:446
-#: includes/functions.php:465 includes/functions.php:504
 #: includes/functions.php:509
+#: includes/functions.php:446
+#: includes/functions.php:465
+#: includes/functions.php:504
 #, php-format
 msgid "<strong>%1$s per %2$s for %3$d more %4$s</strong>"
 msgstr ""
 
-#: includes/functions.php:511 includes/functions.php:448
-#: includes/functions.php:467 includes/functions.php:506
 #: includes/functions.php:511
+#: includes/functions.php:448
+#: includes/functions.php:467
+#: includes/functions.php:506
 #, php-format
 msgid "<strong>%1$s every %2$d %3$s for %4$d more payments</strong>"
 msgstr ""
 
-#: includes/functions.php:514 includes/functions.php:451
-#: includes/functions.php:470 includes/functions.php:509
 #: includes/functions.php:514
+#: includes/functions.php:451
+#: includes/functions.php:470
+#: includes/functions.php:509
 #, php-format
 msgid "<strong>%1$s after %2$d %3$s</strong>"
 msgstr ""
 
-#: includes/functions.php:517 includes/functions.php:454
-#: includes/functions.php:473 includes/functions.php:512
 #: includes/functions.php:517
+#: includes/functions.php:454
+#: includes/functions.php:473
+#: includes/functions.php:512
 #, php-format
 msgid "<strong>%1$s every %2$s</strong>"
 msgstr ""
 
-#: includes/functions.php:519 includes/functions.php:456
-#: includes/functions.php:475 includes/functions.php:514
 #: includes/functions.php:519
+#: includes/functions.php:456
+#: includes/functions.php:475
+#: includes/functions.php:514
 #, php-format
 msgid "<strong>%1$s every %2$d %3$s</strong>"
 msgstr ""
 
-#: includes/functions.php:541 includes/functions.php:478
-#: includes/functions.php:497 includes/functions.php:511
-#: includes/functions.php:520 includes/functions.php:536
 #: includes/functions.php:541
+#: includes/functions.php:478
+#: includes/functions.php:497
+#: includes/functions.php:511
+#: includes/functions.php:520
+#: includes/functions.php:536
 msgid "Trial pricing has been applied to the first payment."
 msgstr ""
 
-#: includes/functions.php:543 includes/functions.php:480
-#: includes/functions.php:499 includes/functions.php:513
-#: includes/functions.php:522 includes/functions.php:538
 #: includes/functions.php:543
+#: includes/functions.php:480
+#: includes/functions.php:499
+#: includes/functions.php:513
+#: includes/functions.php:522
+#: includes/functions.php:538
 #, php-format
 msgid "Trial pricing has been applied to the first %d payments."
 msgstr ""
 
-#: includes/functions.php:568 includes/functions.php:505
-#: includes/functions.php:524 includes/functions.php:563
 #: includes/functions.php:568
+#: includes/functions.php:505
+#: includes/functions.php:524
+#: includes/functions.php:563
 #, php-format
 msgid "Membership expires after %1$d %2$s."
 msgstr ""
 
-#: includes/functions.php:587 includes/functions.php:524
-#: includes/functions.php:543 includes/functions.php:582
 #: includes/functions.php:587
+#: includes/functions.php:524
+#: includes/functions.php:543
+#: includes/functions.php:582
 #, php-format
 msgid "%1$s membership expires after %2$d %3$s"
 msgstr ""
 
-#: includes/functions.php:964 includes/functions.php:491
-#: includes/functions.php:514 includes/functions.php:525
-#: includes/functions.php:536 includes/functions.php:537
-#: includes/functions.php:538 includes/functions.php:545
-#: includes/functions.php:569 includes/functions.php:570
-#: includes/functions.php:576 includes/functions.php:592
-#: includes/functions.php:615 includes/functions.php:694
-#: includes/functions.php:760 includes/functions.php:766
-#: includes/functions.php:874 includes/functions.php:877
-#: includes/functions.php:882 includes/functions.php:901
-#: includes/functions.php:940 includes/functions.php:945
-#: includes/functions.php:947 includes/functions.php:956
 #: includes/functions.php:964
+#: includes/functions.php:491
+#: includes/functions.php:514
+#: includes/functions.php:525
+#: includes/functions.php:536
+#: includes/functions.php:537
+#: includes/functions.php:538
+#: includes/functions.php:545
+#: includes/functions.php:569
+#: includes/functions.php:570
+#: includes/functions.php:576
+#: includes/functions.php:592
+#: includes/functions.php:615
+#: includes/functions.php:694
+#: includes/functions.php:760
+#: includes/functions.php:766
+#: includes/functions.php:874
+#: includes/functions.php:877
+#: includes/functions.php:882
+#: includes/functions.php:901
+#: includes/functions.php:940
+#: includes/functions.php:945
+#: includes/functions.php:947
+#: includes/functions.php:956
 msgid "User ID not found."
 msgstr ""
 
-#: includes/functions.php:976 includes/functions.php:886
-#: includes/functions.php:889 includes/functions.php:894
-#: includes/functions.php:913 includes/functions.php:952
-#: includes/functions.php:957 includes/functions.php:976
+#: includes/functions.php:976
+#: includes/functions.php:886
+#: includes/functions.php:889
+#: includes/functions.php:894
+#: includes/functions.php:913
+#: includes/functions.php:952
+#: includes/functions.php:957
 msgid "No membership_id specified in pmpro_changeMembershipLevel."
 msgstr ""
 
-#: includes/functions.php:982 includes/functions.php:990
-#: includes/functions.php:508 includes/functions.php:531
-#: includes/functions.php:542 includes/functions.php:553
-#: includes/functions.php:554 includes/functions.php:555
-#: includes/functions.php:562 includes/functions.php:586
-#: includes/functions.php:587 includes/functions.php:589
-#: includes/functions.php:596 includes/functions.php:612
-#: includes/functions.php:635 includes/functions.php:714
-#: includes/functions.php:780 includes/functions.php:786
-#: includes/functions.php:892 includes/functions.php:895
-#: includes/functions.php:900 includes/functions.php:903
-#: includes/functions.php:908 includes/functions.php:919
-#: includes/functions.php:927 includes/functions.php:958
-#: includes/functions.php:963 includes/functions.php:965
-#: includes/functions.php:966 includes/functions.php:967
-#: includes/functions.php:971 includes/functions.php:976
-#: includes/functions.php:982 includes/functions.php:990
+#: includes/functions.php:982
+#: includes/functions.php:990
+#: includes/functions.php:508
+#: includes/functions.php:531
+#: includes/functions.php:542
+#: includes/functions.php:553
+#: includes/functions.php:554
+#: includes/functions.php:555
+#: includes/functions.php:562
+#: includes/functions.php:586
+#: includes/functions.php:587
+#: includes/functions.php:589
+#: includes/functions.php:596
+#: includes/functions.php:612
+#: includes/functions.php:635
+#: includes/functions.php:714
+#: includes/functions.php:780
+#: includes/functions.php:786
+#: includes/functions.php:892
+#: includes/functions.php:895
+#: includes/functions.php:900
+#: includes/functions.php:903
+#: includes/functions.php:908
+#: includes/functions.php:919
+#: includes/functions.php:927
+#: includes/functions.php:958
+#: includes/functions.php:963
+#: includes/functions.php:965
+#: includes/functions.php:966
+#: includes/functions.php:967
+#: includes/functions.php:971
+#: includes/functions.php:976
 msgid "Invalid level."
 msgstr ""
 
-#: includes/functions.php:1001 includes/functions.php:520
-#: includes/functions.php:542 includes/functions.php:553
-#: includes/functions.php:564 includes/functions.php:565
-#: includes/functions.php:566 includes/functions.php:573
-#: includes/functions.php:597 includes/functions.php:598
-#: includes/functions.php:600 includes/functions.php:607
-#: includes/functions.php:623 includes/functions.php:646
-#: includes/functions.php:725 includes/functions.php:791
-#: includes/functions.php:797 includes/functions.php:911
-#: includes/functions.php:914 includes/functions.php:919
-#: includes/functions.php:938 includes/functions.php:976
-#: includes/functions.php:977 includes/functions.php:978
-#: includes/functions.php:982 includes/functions.php:987
 #: includes/functions.php:1001
+#: includes/functions.php:520
+#: includes/functions.php:542
+#: includes/functions.php:553
+#: includes/functions.php:564
+#: includes/functions.php:565
+#: includes/functions.php:566
+#: includes/functions.php:573
+#: includes/functions.php:597
+#: includes/functions.php:598
+#: includes/functions.php:600
+#: includes/functions.php:607
+#: includes/functions.php:623
+#: includes/functions.php:646
+#: includes/functions.php:725
+#: includes/functions.php:791
+#: includes/functions.php:797
+#: includes/functions.php:911
+#: includes/functions.php:914
+#: includes/functions.php:919
+#: includes/functions.php:938
+#: includes/functions.php:976
+#: includes/functions.php:977
+#: includes/functions.php:978
+#: includes/functions.php:982
+#: includes/functions.php:987
 msgid "not changing?"
 msgstr ""
 
-#: includes/functions.php:1057 includes/functions.php:537
-#: includes/functions.php:559 includes/functions.php:570
-#: includes/functions.php:581 includes/functions.php:582
-#: includes/functions.php:583 includes/functions.php:590
-#: includes/functions.php:592 includes/functions.php:605
-#: includes/functions.php:614 includes/functions.php:615
-#: includes/functions.php:617 includes/functions.php:624
-#: includes/functions.php:626 includes/functions.php:628
-#: includes/functions.php:631 includes/functions.php:632
-#: includes/functions.php:633 includes/functions.php:637
-#: includes/functions.php:640 includes/functions.php:649
-#: includes/functions.php:656 includes/functions.php:657
-#: includes/functions.php:663 includes/functions.php:673
-#: includes/functions.php:674 includes/functions.php:676
-#: includes/functions.php:683 includes/functions.php:697
-#: includes/functions.php:698 includes/functions.php:699
-#: includes/functions.php:700 includes/functions.php:707
-#: includes/functions.php:722 includes/functions.php:723
-#: includes/functions.php:742 includes/functions.php:746
-#: includes/functions.php:808 includes/functions.php:814
-#: includes/functions.php:815 includes/functions.php:839
-#: includes/functions.php:881 includes/functions.php:887
-#: includes/functions.php:905 includes/functions.php:911
-#: includes/functions.php:967 includes/functions.php:970
-#: includes/functions.php:975 includes/functions.php:994
-#: includes/functions.php:1017 includes/functions.php:1033
-#: includes/functions.php:1037 includes/functions.php:1038
-#: includes/functions.php:1046 includes/functions.php:1057
+#: includes/functions.php:1057
+#: includes/functions.php:537
+#: includes/functions.php:559
+#: includes/functions.php:570
+#: includes/functions.php:581
+#: includes/functions.php:582
+#: includes/functions.php:583
+#: includes/functions.php:590
+#: includes/functions.php:592
+#: includes/functions.php:605
+#: includes/functions.php:614
+#: includes/functions.php:615
+#: includes/functions.php:617
+#: includes/functions.php:624
+#: includes/functions.php:626
+#: includes/functions.php:628
+#: includes/functions.php:631
+#: includes/functions.php:632
+#: includes/functions.php:633
+#: includes/functions.php:637
+#: includes/functions.php:640
+#: includes/functions.php:649
+#: includes/functions.php:656
+#: includes/functions.php:657
+#: includes/functions.php:663
+#: includes/functions.php:673
+#: includes/functions.php:674
+#: includes/functions.php:676
+#: includes/functions.php:683
+#: includes/functions.php:697
+#: includes/functions.php:698
+#: includes/functions.php:699
+#: includes/functions.php:700
+#: includes/functions.php:707
+#: includes/functions.php:722
+#: includes/functions.php:723
+#: includes/functions.php:742
+#: includes/functions.php:746
+#: includes/functions.php:808
+#: includes/functions.php:814
+#: includes/functions.php:815
+#: includes/functions.php:839
+#: includes/functions.php:881
+#: includes/functions.php:887
+#: includes/functions.php:905
+#: includes/functions.php:911
+#: includes/functions.php:967
+#: includes/functions.php:970
+#: includes/functions.php:975
+#: includes/functions.php:994
+#: includes/functions.php:1017
+#: includes/functions.php:1033
+#: includes/functions.php:1037
+#: includes/functions.php:1038
+#: includes/functions.php:1046
 msgid "Error interacting with database"
 msgstr ""
 
-#: includes/functions.php:1163 includes/functions.php:907
-#: includes/functions.php:1064 includes/functions.php:1067
-#: includes/functions.php:1077 includes/functions.php:1096
-#: includes/functions.php:1123 includes/functions.php:1127
-#: includes/functions.php:1129 includes/functions.php:1135
-#: includes/functions.php:1138 includes/functions.php:1139
-#: includes/functions.php:1140 includes/functions.php:1163
+#: includes/functions.php:1163
+#: includes/functions.php:907
+#: includes/functions.php:1064
+#: includes/functions.php:1067
+#: includes/functions.php:1077
+#: includes/functions.php:1096
+#: includes/functions.php:1123
+#: includes/functions.php:1127
+#: includes/functions.php:1129
+#: includes/functions.php:1135
+#: includes/functions.php:1138
+#: includes/functions.php:1139
+#: includes/functions.php:1140
 #, php-format
 msgid "Error interacting with database: %s"
 msgstr ""
 
-#: includes/functions.php:1242 includes/functions.php:1280
-#: includes/functions.php:629 includes/functions.php:651
-#: includes/functions.php:667 includes/functions.php:668
-#: includes/functions.php:678 includes/functions.php:681
-#: includes/functions.php:690 includes/functions.php:697
-#: includes/functions.php:698 includes/functions.php:706
-#: includes/functions.php:714 includes/functions.php:717
-#: includes/functions.php:720 includes/functions.php:736
-#: includes/functions.php:737 includes/functions.php:738
-#: includes/functions.php:739 includes/functions.php:741
-#: includes/functions.php:748 includes/functions.php:753
-#: includes/functions.php:764 includes/functions.php:777
-#: includes/functions.php:778 includes/functions.php:780
-#: includes/functions.php:787 includes/functions.php:803
-#: includes/functions.php:826 includes/functions.php:881
-#: includes/functions.php:920 includes/functions.php:947
-#: includes/functions.php:948 includes/functions.php:953
-#: includes/functions.php:986 includes/functions.php:987
-#: includes/functions.php:992 includes/functions.php:1138
-#: includes/functions.php:1141 includes/functions.php:1155
-#: includes/functions.php:1174 includes/functions.php:1176
-#: includes/functions.php:1179 includes/functions.php:1193
-#: includes/functions.php:1198 includes/functions.php:1202
-#: includes/functions.php:1204 includes/functions.php:1212
-#: includes/functions.php:1213 includes/functions.php:1217
-#: includes/functions.php:1218 includes/functions.php:1237
-#: includes/functions.php:1241 includes/functions.php:1243
-#: includes/functions.php:1251 includes/functions.php:1252
-#: includes/functions.php:1255 includes/functions.php:1256
+#: includes/functions.php:1242
+#: includes/functions.php:1280
+#: includes/functions.php:629
+#: includes/functions.php:651
+#: includes/functions.php:667
+#: includes/functions.php:668
+#: includes/functions.php:678
+#: includes/functions.php:681
+#: includes/functions.php:690
+#: includes/functions.php:697
+#: includes/functions.php:698
+#: includes/functions.php:706
+#: includes/functions.php:714
+#: includes/functions.php:717
+#: includes/functions.php:720
+#: includes/functions.php:736
+#: includes/functions.php:737
+#: includes/functions.php:738
+#: includes/functions.php:739
+#: includes/functions.php:741
+#: includes/functions.php:748
+#: includes/functions.php:753
+#: includes/functions.php:764
+#: includes/functions.php:777
+#: includes/functions.php:778
+#: includes/functions.php:780
+#: includes/functions.php:787
+#: includes/functions.php:803
+#: includes/functions.php:826
+#: includes/functions.php:881
+#: includes/functions.php:920
+#: includes/functions.php:947
+#: includes/functions.php:948
+#: includes/functions.php:953
+#: includes/functions.php:986
+#: includes/functions.php:987
+#: includes/functions.php:992
+#: includes/functions.php:1138
+#: includes/functions.php:1141
+#: includes/functions.php:1155
+#: includes/functions.php:1174
+#: includes/functions.php:1176
+#: includes/functions.php:1179
+#: includes/functions.php:1193
+#: includes/functions.php:1198
+#: includes/functions.php:1202
+#: includes/functions.php:1204
+#: includes/functions.php:1212
+#: includes/functions.php:1213
+#: includes/functions.php:1217
+#: includes/functions.php:1218
+#: includes/functions.php:1237
+#: includes/functions.php:1241
+#: includes/functions.php:1243
+#: includes/functions.php:1251
+#: includes/functions.php:1252
+#: includes/functions.php:1255
+#: includes/functions.php:1256
 #: includes/functions.php:1279
 msgid "Membership level not found."
 msgstr ""
 
-#: includes/functions.php:1658 includes/functions.php:1100
-#: includes/functions.php:1101 includes/functions.php:1118
-#: includes/functions.php:1142 includes/functions.php:1143
-#: includes/functions.php:1150 includes/functions.php:1157
-#: includes/functions.php:1173 includes/functions.php:1196
-#: includes/functions.php:1290 includes/functions.php:1356
-#: includes/functions.php:1357 includes/functions.php:1362
-#: includes/functions.php:1530 includes/functions.php:1533
-#: includes/functions.php:1547 includes/functions.php:1586
-#: includes/functions.php:1605 includes/functions.php:1609
-#: includes/functions.php:1611 includes/functions.php:1620
-#: includes/functions.php:1625 includes/functions.php:1629
-#: includes/functions.php:1630 includes/functions.php:1657
+#: includes/functions.php:1658
+#: includes/functions.php:1100
+#: includes/functions.php:1101
+#: includes/functions.php:1118
+#: includes/functions.php:1142
+#: includes/functions.php:1143
+#: includes/functions.php:1150
+#: includes/functions.php:1157
+#: includes/functions.php:1173
+#: includes/functions.php:1196
+#: includes/functions.php:1290
+#: includes/functions.php:1356
+#: includes/functions.php:1357
+#: includes/functions.php:1362
+#: includes/functions.php:1530
+#: includes/functions.php:1533
+#: includes/functions.php:1547
+#: includes/functions.php:1586
+#: includes/functions.php:1605
+#: includes/functions.php:1609
+#: includes/functions.php:1611
+#: includes/functions.php:1620
+#: includes/functions.php:1625
+#: includes/functions.php:1629
+#: includes/functions.php:1630
+#: includes/functions.php:1657
 msgid "No code was given to check."
 msgstr ""
 
-#: includes/functions.php:1667 includes/functions.php:1050
-#: includes/functions.php:1072 includes/functions.php:1088
-#: includes/functions.php:1099 includes/functions.php:1102
-#: includes/functions.php:1109 includes/functions.php:1110
-#: includes/functions.php:1112 includes/functions.php:1113
-#: includes/functions.php:1127 includes/functions.php:1151
-#: includes/functions.php:1152 includes/functions.php:1159
-#: includes/functions.php:1166 includes/functions.php:1182
-#: includes/functions.php:1205 includes/functions.php:1299
-#: includes/functions.php:1365 includes/functions.php:1366
-#: includes/functions.php:1371 includes/functions.php:1539
-#: includes/functions.php:1542 includes/functions.php:1556
-#: includes/functions.php:1595 includes/functions.php:1614
-#: includes/functions.php:1618 includes/functions.php:1620
-#: includes/functions.php:1629 includes/functions.php:1634
-#: includes/functions.php:1638 includes/functions.php:1639
+#: includes/functions.php:1667
+#: includes/functions.php:1050
+#: includes/functions.php:1072
+#: includes/functions.php:1088
+#: includes/functions.php:1099
+#: includes/functions.php:1102
+#: includes/functions.php:1109
+#: includes/functions.php:1110
+#: includes/functions.php:1112
+#: includes/functions.php:1113
+#: includes/functions.php:1127
+#: includes/functions.php:1151
+#: includes/functions.php:1152
+#: includes/functions.php:1159
+#: includes/functions.php:1166
+#: includes/functions.php:1182
+#: includes/functions.php:1205
+#: includes/functions.php:1299
+#: includes/functions.php:1365
+#: includes/functions.php:1366
+#: includes/functions.php:1371
+#: includes/functions.php:1539
+#: includes/functions.php:1542
+#: includes/functions.php:1556
+#: includes/functions.php:1595
+#: includes/functions.php:1614
+#: includes/functions.php:1618
+#: includes/functions.php:1620
+#: includes/functions.php:1629
+#: includes/functions.php:1634
+#: includes/functions.php:1638
+#: includes/functions.php:1639
 #: includes/functions.php:1666
 msgid "The discount code could not be found."
 msgstr ""
 
-#: includes/functions.php:1682 includes/functions.php:1066
-#: includes/functions.php:1088 includes/functions.php:1104
-#: includes/functions.php:1115 includes/functions.php:1118
-#: includes/functions.php:1124 includes/functions.php:1125
-#: includes/functions.php:1128 includes/functions.php:1129
-#: includes/functions.php:1142 includes/functions.php:1166
-#: includes/functions.php:1167 includes/functions.php:1174
-#: includes/functions.php:1181 includes/functions.php:1197
-#: includes/functions.php:1220 includes/functions.php:1314
-#: includes/functions.php:1380 includes/functions.php:1381
-#: includes/functions.php:1386 includes/functions.php:1554
-#: includes/functions.php:1557 includes/functions.php:1571
-#: includes/functions.php:1610 includes/functions.php:1629
-#: includes/functions.php:1633 includes/functions.php:1635
-#: includes/functions.php:1644 includes/functions.php:1649
-#: includes/functions.php:1653 includes/functions.php:1654
+#: includes/functions.php:1682
+#: includes/functions.php:1066
+#: includes/functions.php:1088
+#: includes/functions.php:1104
+#: includes/functions.php:1115
+#: includes/functions.php:1118
+#: includes/functions.php:1124
+#: includes/functions.php:1125
+#: includes/functions.php:1128
+#: includes/functions.php:1129
+#: includes/functions.php:1142
+#: includes/functions.php:1166
+#: includes/functions.php:1167
+#: includes/functions.php:1174
+#: includes/functions.php:1181
+#: includes/functions.php:1197
+#: includes/functions.php:1220
+#: includes/functions.php:1314
+#: includes/functions.php:1380
+#: includes/functions.php:1381
+#: includes/functions.php:1386
+#: includes/functions.php:1554
+#: includes/functions.php:1557
+#: includes/functions.php:1571
+#: includes/functions.php:1610
+#: includes/functions.php:1629
+#: includes/functions.php:1633
+#: includes/functions.php:1635
+#: includes/functions.php:1644
+#: includes/functions.php:1649
+#: includes/functions.php:1653
+#: includes/functions.php:1654
 #: includes/functions.php:1681
 #, php-format
 msgid "This discount code goes into effect on %s."
 msgstr ""
 
-#: includes/functions.php:1689 includes/functions.php:1075
-#: includes/functions.php:1097 includes/functions.php:1113
-#: includes/functions.php:1124 includes/functions.php:1127
-#: includes/functions.php:1131 includes/functions.php:1132
-#: includes/functions.php:1137 includes/functions.php:1138
-#: includes/functions.php:1149 includes/functions.php:1173
-#: includes/functions.php:1174 includes/functions.php:1181
-#: includes/functions.php:1188 includes/functions.php:1204
-#: includes/functions.php:1227 includes/functions.php:1321
-#: includes/functions.php:1387 includes/functions.php:1388
-#: includes/functions.php:1393 includes/functions.php:1561
-#: includes/functions.php:1564 includes/functions.php:1578
-#: includes/functions.php:1617 includes/functions.php:1636
-#: includes/functions.php:1640 includes/functions.php:1642
-#: includes/functions.php:1651 includes/functions.php:1656
-#: includes/functions.php:1660 includes/functions.php:1661
+#: includes/functions.php:1689
+#: includes/functions.php:1075
+#: includes/functions.php:1097
+#: includes/functions.php:1113
+#: includes/functions.php:1124
+#: includes/functions.php:1127
+#: includes/functions.php:1131
+#: includes/functions.php:1132
+#: includes/functions.php:1137
+#: includes/functions.php:1138
+#: includes/functions.php:1149
+#: includes/functions.php:1173
+#: includes/functions.php:1174
+#: includes/functions.php:1181
+#: includes/functions.php:1188
+#: includes/functions.php:1204
+#: includes/functions.php:1227
+#: includes/functions.php:1321
+#: includes/functions.php:1387
+#: includes/functions.php:1388
+#: includes/functions.php:1393
+#: includes/functions.php:1561
+#: includes/functions.php:1564
+#: includes/functions.php:1578
+#: includes/functions.php:1617
+#: includes/functions.php:1636
+#: includes/functions.php:1640
+#: includes/functions.php:1642
+#: includes/functions.php:1651
+#: includes/functions.php:1656
+#: includes/functions.php:1660
+#: includes/functions.php:1661
 #: includes/functions.php:1688
 #, php-format
 msgid "This discount code expired on %s."
 msgstr ""
 
-#: includes/functions.php:1698 includes/functions.php:1087
-#: includes/functions.php:1109 includes/functions.php:1125
-#: includes/functions.php:1136 includes/functions.php:1139
-#: includes/functions.php:1141 includes/functions.php:1142
-#: includes/functions.php:1149 includes/functions.php:1150
-#: includes/functions.php:1159 includes/functions.php:1183
-#: includes/functions.php:1184 includes/functions.php:1191
-#: includes/functions.php:1198 includes/functions.php:1214
-#: includes/functions.php:1237 includes/functions.php:1331
-#: includes/functions.php:1397 includes/functions.php:1398
-#: includes/functions.php:1403 includes/functions.php:1570
-#: includes/functions.php:1573 includes/functions.php:1587
-#: includes/functions.php:1626 includes/functions.php:1646
-#: includes/functions.php:1650 includes/functions.php:1652
-#: includes/functions.php:1661 includes/functions.php:1665
-#: includes/functions.php:1669 includes/functions.php:1670
+#: includes/functions.php:1698
+#: includes/functions.php:1087
+#: includes/functions.php:1109
+#: includes/functions.php:1125
+#: includes/functions.php:1136
+#: includes/functions.php:1139
+#: includes/functions.php:1141
+#: includes/functions.php:1142
+#: includes/functions.php:1149
+#: includes/functions.php:1150
+#: includes/functions.php:1159
+#: includes/functions.php:1183
+#: includes/functions.php:1184
+#: includes/functions.php:1191
+#: includes/functions.php:1198
+#: includes/functions.php:1214
+#: includes/functions.php:1237
+#: includes/functions.php:1331
+#: includes/functions.php:1397
+#: includes/functions.php:1398
+#: includes/functions.php:1403
+#: includes/functions.php:1570
+#: includes/functions.php:1573
+#: includes/functions.php:1587
+#: includes/functions.php:1626
+#: includes/functions.php:1646
+#: includes/functions.php:1650
+#: includes/functions.php:1652
+#: includes/functions.php:1661
+#: includes/functions.php:1665
+#: includes/functions.php:1669
+#: includes/functions.php:1670
 #: includes/functions.php:1697
 msgid "This discount code is no longer valid."
 msgstr ""
 
-#: includes/functions.php:1717 includes/functions.php:1102
-#: includes/functions.php:1124 includes/functions.php:1140
-#: includes/functions.php:1151 includes/functions.php:1154
-#: includes/functions.php:1155 includes/functions.php:1164
-#: includes/functions.php:1165 includes/functions.php:1172
-#: includes/functions.php:1196 includes/functions.php:1197
-#: includes/functions.php:1204 includes/functions.php:1211
-#: includes/functions.php:1227 includes/functions.php:1250
-#: includes/functions.php:1344 includes/functions.php:1410
-#: includes/functions.php:1411 includes/functions.php:1416
-#: includes/functions.php:1589 includes/functions.php:1592
-#: includes/functions.php:1606 includes/functions.php:1645
-#: includes/functions.php:1666 includes/functions.php:1670
-#: includes/functions.php:1672 includes/functions.php:1681
-#: includes/functions.php:1684 includes/functions.php:1688
-#: includes/functions.php:1689 includes/functions.php:1716
+#: includes/functions.php:1717
+#: includes/functions.php:1102
+#: includes/functions.php:1124
+#: includes/functions.php:1140
+#: includes/functions.php:1151
+#: includes/functions.php:1154
+#: includes/functions.php:1155
+#: includes/functions.php:1164
+#: includes/functions.php:1165
+#: includes/functions.php:1172
+#: includes/functions.php:1196
+#: includes/functions.php:1197
+#: includes/functions.php:1204
+#: includes/functions.php:1211
+#: includes/functions.php:1227
+#: includes/functions.php:1250
+#: includes/functions.php:1344
+#: includes/functions.php:1410
+#: includes/functions.php:1411
+#: includes/functions.php:1416
+#: includes/functions.php:1589
+#: includes/functions.php:1592
+#: includes/functions.php:1606
+#: includes/functions.php:1645
+#: includes/functions.php:1666
+#: includes/functions.php:1670
+#: includes/functions.php:1672
+#: includes/functions.php:1681
+#: includes/functions.php:1684
+#: includes/functions.php:1688
+#: includes/functions.php:1689
+#: includes/functions.php:1716
 msgid "This discount code does not apply to this membership level."
 msgstr ""
 
-#: includes/functions.php:1755 includes/functions.php:1110
-#: includes/functions.php:1132 includes/functions.php:1148
-#: includes/functions.php:1159 includes/functions.php:1162
-#: includes/functions.php:1172 includes/functions.php:1180
-#: includes/functions.php:1181 includes/functions.php:1182
-#: includes/functions.php:1198 includes/functions.php:1222
-#: includes/functions.php:1223 includes/functions.php:1230
-#: includes/functions.php:1237 includes/functions.php:1253
-#: includes/functions.php:1276 includes/functions.php:1370
-#: includes/functions.php:1436 includes/functions.php:1442
-#: includes/functions.php:1448 includes/functions.php:1627
-#: includes/functions.php:1630 includes/functions.php:1644
-#: includes/functions.php:1683 includes/functions.php:1703
-#: includes/functions.php:1707 includes/functions.php:1709
-#: includes/functions.php:1718 includes/functions.php:1722
-#: includes/functions.php:1726 includes/functions.php:1727
+#: includes/functions.php:1755
+#: includes/functions.php:1110
+#: includes/functions.php:1132
+#: includes/functions.php:1148
+#: includes/functions.php:1159
+#: includes/functions.php:1162
+#: includes/functions.php:1172
+#: includes/functions.php:1180
+#: includes/functions.php:1181
+#: includes/functions.php:1182
+#: includes/functions.php:1198
+#: includes/functions.php:1222
+#: includes/functions.php:1223
+#: includes/functions.php:1230
+#: includes/functions.php:1237
+#: includes/functions.php:1253
+#: includes/functions.php:1276
+#: includes/functions.php:1370
+#: includes/functions.php:1436
+#: includes/functions.php:1442
+#: includes/functions.php:1448
+#: includes/functions.php:1627
+#: includes/functions.php:1630
+#: includes/functions.php:1644
+#: includes/functions.php:1683
+#: includes/functions.php:1703
+#: includes/functions.php:1707
+#: includes/functions.php:1709
+#: includes/functions.php:1718
+#: includes/functions.php:1722
+#: includes/functions.php:1726
+#: includes/functions.php:1727
 #: includes/functions.php:1754
 msgid "This discount code is okay."
 msgstr ""
 
-#: includes/functions.php:1783 includes/functions.php:1134
-#: includes/functions.php:1156 includes/functions.php:1172
-#: includes/functions.php:1183 includes/functions.php:1186
-#: includes/functions.php:1196 includes/functions.php:1205
-#: includes/functions.php:1206 includes/functions.php:1223
-#: includes/functions.php:1247 includes/functions.php:1248
-#: includes/functions.php:1255 includes/functions.php:1262
-#: includes/functions.php:1278 includes/functions.php:1301
-#: includes/functions.php:1395 includes/functions.php:1397
-#: includes/functions.php:1463 includes/functions.php:1469
-#: includes/functions.php:1475 includes/functions.php:1655
-#: includes/functions.php:1658 includes/functions.php:1672
-#: includes/functions.php:1711 includes/functions.php:1730
-#: includes/functions.php:1734 includes/functions.php:1736
-#: includes/functions.php:1745 includes/functions.php:1750
-#: includes/functions.php:1754 includes/functions.php:1755
+#: includes/functions.php:1783
+#: includes/functions.php:1134
+#: includes/functions.php:1156
+#: includes/functions.php:1172
+#: includes/functions.php:1183
+#: includes/functions.php:1186
+#: includes/functions.php:1196
+#: includes/functions.php:1205
+#: includes/functions.php:1206
+#: includes/functions.php:1223
+#: includes/functions.php:1247
+#: includes/functions.php:1248
+#: includes/functions.php:1255
+#: includes/functions.php:1262
+#: includes/functions.php:1278
+#: includes/functions.php:1301
+#: includes/functions.php:1395
+#: includes/functions.php:1397
+#: includes/functions.php:1463
+#: includes/functions.php:1469
+#: includes/functions.php:1475
+#: includes/functions.php:1655
+#: includes/functions.php:1658
+#: includes/functions.php:1672
+#: includes/functions.php:1711
+#: includes/functions.php:1730
+#: includes/functions.php:1734
+#: includes/functions.php:1736
+#: includes/functions.php:1745
+#: includes/functions.php:1750
+#: includes/functions.php:1754
+#: includes/functions.php:1755
 #: includes/functions.php:1782
 msgid "and"
 msgstr ""
 
-#: includes/functions.php:2303 includes/functions.php:1319
-#: includes/functions.php:1341 includes/functions.php:1361
-#: includes/functions.php:1372 includes/functions.php:1375
-#: includes/functions.php:1385 includes/functions.php:1394
-#: includes/functions.php:1395 includes/functions.php:1412
-#: includes/functions.php:1436 includes/functions.php:1437
-#: includes/functions.php:1450 includes/functions.php:1457
-#: includes/functions.php:1473 includes/functions.php:1496
-#: includes/functions.php:1501 includes/functions.php:1620
-#: includes/functions.php:1624 includes/functions.php:1691
-#: includes/functions.php:1697 includes/functions.php:1703
-#: includes/functions.php:1977 includes/functions.php:1997
-#: includes/functions.php:2015 includes/functions.php:2019
-#: includes/functions.php:2022 includes/functions.php:2024
-#: includes/functions.php:2030 includes/functions.php:2033
-#: includes/functions.php:2034 includes/functions.php:2061
-#: includes/functions.php:2100 includes/functions.php:2102
-#: includes/functions.php:2155 includes/functions.php:2199
-#: includes/functions.php:2210 includes/functions.php:2302
+#: includes/functions.php:2303
+#: includes/functions.php:1319
+#: includes/functions.php:1341
+#: includes/functions.php:1361
+#: includes/functions.php:1372
+#: includes/functions.php:1375
+#: includes/functions.php:1385
+#: includes/functions.php:1394
+#: includes/functions.php:1395
+#: includes/functions.php:1412
+#: includes/functions.php:1436
+#: includes/functions.php:1437
+#: includes/functions.php:1450
+#: includes/functions.php:1457
+#: includes/functions.php:1473
+#: includes/functions.php:1496
+#: includes/functions.php:1501
+#: includes/functions.php:1620
+#: includes/functions.php:1624
+#: includes/functions.php:1691
+#: includes/functions.php:1697
+#: includes/functions.php:1703
+#: includes/functions.php:1977
+#: includes/functions.php:1997
+#: includes/functions.php:2015
+#: includes/functions.php:2019
+#: includes/functions.php:2022
+#: includes/functions.php:2024
+#: includes/functions.php:2030
+#: includes/functions.php:2033
+#: includes/functions.php:2034
+#: includes/functions.php:2061
+#: includes/functions.php:2100
+#: includes/functions.php:2102
+#: includes/functions.php:2155
+#: includes/functions.php:2199
+#: includes/functions.php:2210
+#: includes/functions.php:2302
 msgid "Sign Up for !!name!! Now"
 msgstr ""
 
-#: includes/functions.php:2327 includes/functions.php:2021
-#: includes/functions.php:2054 includes/functions.php:2085
-#: includes/functions.php:2124 includes/functions.php:2126
-#: includes/functions.php:2179 includes/functions.php:2223
-#: includes/functions.php:2234 includes/functions.php:2326
+#: includes/functions.php:2327
+#: includes/functions.php:2021
+#: includes/functions.php:2054
+#: includes/functions.php:2085
+#: includes/functions.php:2124
+#: includes/functions.php:2126
+#: includes/functions.php:2179
+#: includes/functions.php:2223
+#: includes/functions.php:2234
+#: includes/functions.php:2326
 msgid "Sign Up Now"
 msgstr ""
 
-#: includes/init.php:176 includes/profile.php:22 pages/checkout.php:50
-#: pages/confirmation.php:53 pages/confirmation.php:127 pages/invoice.php:26
-#: adminpages/orders.php:601 adminpages/orders.php:904
-#: adminpages/orders.php:914 adminpages/orders.php:941
-#: adminpages/orders.php:970 adminpages/orders.php:1107
-#: adminpages/orders.php:1138 adminpages/orders.php:1144
-#: adminpages/orders.php:1235 adminpages/orders.php:1311
-#: adminpages/orders.php:1356 includes/init.php:171 includes/init.php:176
-#: includes/init.php:214 includes/init.php:217 includes/init.php:218
-#: includes/init.php:220 includes/init.php:222 includes/init.php:230
-#: includes/init.php:238 includes/init.php:242 includes/init.php:243
-#: includes/init.php:244 includes/init.php:258 includes/init.php:262
-#: includes/profile.php:22 includes/profile.php:25 includes/profile.php:27
-#: includes/profile.php:30 includes/profile.php:31 includes/profile.php:36
-#: pages/checkout.php:33 pages/checkout.php:34 pages/checkout.php:35
-#: pages/checkout.php:39 pages/checkout.php:42 pages/checkout.php:45
-#: pages/checkout.php:47 pages/confirmation.php:46 pages/confirmation.php:47
-#: pages/confirmation.php:52 pages/confirmation.php:53
-#: pages/confirmation.php:62 pages/confirmation.php:64
-#: pages/confirmation.php:70 pages/confirmation.php:91
-#: pages/confirmation.php:103 pages/confirmation.php:105
-#: pages/confirmation.php:113 pages/confirmation.php:116
-#: pages/confirmation.php:123 pages/confirmation.php:124
-#: pages/confirmation.php:126 pages/confirmation.php:127 pages/invoice.php:26
-#: pages/invoice.php:27 pages/invoice.php:28 pages/invoice.php:49
-#: pages/invoice.php:51 pages/invoice.php:70
+#: includes/init.php:176
+#: includes/profile.php:22
+#: pages/checkout.php:50
+#: pages/confirmation.php:53
+#: pages/confirmation.php:127
+#: pages/invoice.php:26
+#: adminpages/orders.php:601
+#: adminpages/orders.php:904
+#: adminpages/orders.php:914
+#: adminpages/orders.php:941
+#: adminpages/orders.php:970
+#: adminpages/orders.php:1107
+#: adminpages/orders.php:1138
+#: adminpages/orders.php:1144
+#: adminpages/orders.php:1235
+#: adminpages/orders.php:1311
+#: adminpages/orders.php:1356
+#: includes/init.php:171
+#: includes/init.php:214
+#: includes/init.php:217
+#: includes/init.php:218
+#: includes/init.php:220
+#: includes/init.php:222
+#: includes/init.php:230
+#: includes/init.php:238
+#: includes/init.php:242
+#: includes/init.php:243
+#: includes/init.php:244
+#: includes/init.php:258
+#: includes/init.php:262
+#: includes/profile.php:25
+#: includes/profile.php:27
+#: includes/profile.php:30
+#: includes/profile.php:31
+#: includes/profile.php:36
+#: pages/checkout.php:33
+#: pages/checkout.php:34
+#: pages/checkout.php:35
+#: pages/checkout.php:39
+#: pages/checkout.php:42
+#: pages/checkout.php:45
+#: pages/checkout.php:47
+#: pages/confirmation.php:46
+#: pages/confirmation.php:47
+#: pages/confirmation.php:52
+#: pages/confirmation.php:62
+#: pages/confirmation.php:64
+#: pages/confirmation.php:70
+#: pages/confirmation.php:91
+#: pages/confirmation.php:103
+#: pages/confirmation.php:105
+#: pages/confirmation.php:113
+#: pages/confirmation.php:116
+#: pages/confirmation.php:123
+#: pages/confirmation.php:124
+#: pages/confirmation.php:126
+#: pages/invoice.php:27
+#: pages/invoice.php:28
+#: pages/invoice.php:49
+#: pages/invoice.php:51
+#: pages/invoice.php:70
+#: blocks/checkout-button/block.js:73
+#: blocks/checkout-page/block.js:55
+#: blocks/checkout-page/inspector.js:31
 msgid "Membership Level"
 msgstr ""
 
-#: includes/lib/SendWP/sendwp.php:90 includes/lib/SendWP/sendwp.php:90
+#: includes/lib/SendWP/sendwp.php:90
 msgid "Something went wrong. SendWP was not installed correctly."
 msgstr ""
 
@@ -11368,174 +14197,239 @@ msgstr ""
 msgid "SendWP is already connected."
 msgstr ""
 
-#: includes/localization.php:33 includes/localization.php:23
-#: includes/localization.php:26 includes/localization.php:33
+#: includes/localization.php:33
+#: includes/localization.php:23
+#: includes/localization.php:26
 msgid "Day"
 msgstr ""
 
-#: includes/localization.php:35 includes/localization.php:25
-#: includes/localization.php:28 includes/localization.php:35
+#: includes/localization.php:35
+#: includes/localization.php:25
+#: includes/localization.php:28
 msgid "Week"
 msgstr ""
 
-#: includes/localization.php:37 includes/localization.php:27
-#: includes/localization.php:30 includes/localization.php:37
+#: includes/localization.php:37
+#: includes/localization.php:27
+#: includes/localization.php:30
 msgid "Month"
 msgstr ""
 
-#: includes/localization.php:39 includes/localization.php:29
-#: includes/localization.php:32 includes/localization.php:39
+#: includes/localization.php:39
+#: includes/localization.php:29
+#: includes/localization.php:32
 msgid "Year"
 msgstr ""
 
-#: includes/localization.php:44 includes/localization.php:37
 #: includes/localization.php:44
+#: includes/localization.php:37
 msgid "Days"
 msgstr ""
 
-#: includes/localization.php:46 includes/localization.php:39
 #: includes/localization.php:46
+#: includes/localization.php:39
 msgid "Weeks"
 msgstr ""
 
-#: includes/localization.php:48 includes/localization.php:41
 #: includes/localization.php:48
+#: includes/localization.php:41
 msgid "Months"
 msgstr ""
 
-#: includes/localization.php:50 includes/localization.php:43
 #: includes/localization.php:50
+#: includes/localization.php:43
 msgid "Years"
 msgstr ""
 
-#: includes/login.php:264 includes/login.php:288 includes/login.php:211
-#: includes/login.php:235 includes/login.php:251 includes/login.php:257
-#: includes/login.php:275 includes/login.php:281
+#: includes/login.php:264
+#: includes/login.php:288
+#: includes/login.php:211
+#: includes/login.php:235
+#: includes/login.php:251
+#: includes/login.php:257
+#: includes/login.php:275
+#: includes/login.php:281
 msgid "Welcome"
 msgstr ""
 
-#: includes/login.php:266 includes/login.php:290 includes/login.php:213
-#: includes/login.php:237 includes/login.php:253 includes/login.php:259
-#: includes/login.php:277 includes/login.php:283
+#: includes/login.php:266
+#: includes/login.php:290
+#: includes/login.php:213
+#: includes/login.php:237
+#: includes/login.php:253
+#: includes/login.php:259
+#: includes/login.php:277
+#: includes/login.php:283
 msgid "Lost Password"
 msgstr ""
 
-#: includes/login.php:268 includes/login.php:292 includes/login.php:689
-#: includes/login.php:215 includes/login.php:239 includes/login.php:255
-#: includes/login.php:261 includes/login.php:279 includes/login.php:285
+#: includes/login.php:268
+#: includes/login.php:292
+#: includes/login.php:689
+#: includes/login.php:215
+#: includes/login.php:239
+#: includes/login.php:255
+#: includes/login.php:261
+#: includes/login.php:279
+#: includes/login.php:285
 msgid "Reset Password"
 msgstr ""
 
-#: includes/login.php:316 includes/login.php:868 includes/login.php:263
-#: includes/login.php:303 includes/login.php:309 includes/login.php:751
-#: includes/login.php:820 includes/login.php:830
+#: includes/login.php:316
+#: includes/login.php:868
+#: includes/login.php:263
+#: includes/login.php:303
+#: includes/login.php:309
+#: includes/login.php:751
+#: includes/login.php:820
+#: includes/login.php:830
 msgid "There was a problem with your username or password."
 msgstr ""
 
-#: includes/login.php:320 includes/login.php:267 includes/login.php:307
+#: includes/login.php:320
+#: includes/login.php:267
+#: includes/login.php:307
 #: includes/login.php:313
 msgid "Unknown username. Check again or try your email address."
 msgstr ""
 
-#: includes/login.php:324 includes/login.php:271 includes/login.php:311
+#: includes/login.php:324
+#: includes/login.php:271
+#: includes/login.php:311
 #: includes/login.php:317
 msgid "Empty username. Please enter your username and try again."
 msgstr ""
 
-#: includes/login.php:328 includes/login.php:275 includes/login.php:315
+#: includes/login.php:328
+#: includes/login.php:275
+#: includes/login.php:315
 #: includes/login.php:321
 msgid "Empty password. Please enter your password and try again."
 msgstr ""
 
-#: includes/login.php:332 includes/login.php:279 includes/login.php:319
+#: includes/login.php:332
+#: includes/login.php:279
+#: includes/login.php:319
 #: includes/login.php:325
 msgid "The password you entered for the user is incorrect. Please try again."
 msgstr ""
 
-#: includes/login.php:336 includes/login.php:283 includes/login.php:323
+#: includes/login.php:336
+#: includes/login.php:283
+#: includes/login.php:323
 #: includes/login.php:329
 msgid "Check your email for the confirmation link."
 msgstr ""
 
-#: includes/login.php:345 includes/login.php:292 includes/login.php:332
+#: includes/login.php:345
+#: includes/login.php:292
+#: includes/login.php:332
 #: includes/login.php:338
 msgid "You are now logged out."
 msgstr ""
 
-#: includes/login.php:349 includes/login.php:296 includes/login.php:336
+#: includes/login.php:349
+#: includes/login.php:296
+#: includes/login.php:336
 #: includes/login.php:342
 msgid "There was a problem logging you out."
 msgstr ""
 
-#: includes/login.php:360 includes/login.php:307 includes/login.php:347
+#: includes/login.php:360
+#: includes/login.php:307
+#: includes/login.php:347
 #: includes/login.php:353
 msgid "Check your email for a link to reset your password."
 msgstr ""
 
-#: includes/login.php:363 includes/login.php:310 includes/login.php:350
+#: includes/login.php:363
+#: includes/login.php:310
+#: includes/login.php:350
 #: includes/login.php:356
 msgid "There was an unexpected error regarding your email. Please try again"
 msgstr ""
 
-#: includes/login.php:373 includes/login.php:320 includes/login.php:360
+#: includes/login.php:373
+#: includes/login.php:320
+#: includes/login.php:360
 #: includes/login.php:366
 msgid "Your reset password key is invalid."
 msgstr ""
 
-#: includes/login.php:377 includes/login.php:324 includes/login.php:364
+#: includes/login.php:377
+#: includes/login.php:324
+#: includes/login.php:364
 #: includes/login.php:370
-msgid ""
-"Your reset password key is expired, please request a new key from the "
-"password reset page."
+msgid "Your reset password key is expired, please request a new key from the password reset page."
 msgstr ""
 
-#: includes/login.php:389 includes/login.php:336 includes/login.php:376
+#: includes/login.php:389
+#: includes/login.php:336
+#: includes/login.php:376
 #: includes/login.php:382
 msgid "Your password has successfully been updated."
 msgstr ""
 
-#: includes/login.php:393 includes/login.php:340 includes/login.php:380
+#: includes/login.php:393
+#: includes/login.php:340
+#: includes/login.php:380
 #: includes/login.php:386
 msgid "There was a problem updating your password"
 msgstr ""
 
-#: includes/login.php:407 includes/login.php:349 includes/login.php:394
+#: includes/login.php:407
+#: includes/login.php:349
+#: includes/login.php:394
 #: includes/login.php:400
 msgid "There is no account with that username or email address."
 msgstr ""
 
-#: includes/login.php:411 includes/login.php:353 includes/login.php:398
+#: includes/login.php:411
+#: includes/login.php:353
+#: includes/login.php:398
 #: includes/login.php:404
 msgid "Please enter a valid username."
 msgstr ""
 
-#: includes/login.php:415 includes/login.php:357 includes/login.php:402
+#: includes/login.php:415
+#: includes/login.php:357
+#: includes/login.php:402
 #: includes/login.php:408
 msgid "You've entered an invalid email address."
 msgstr ""
 
-#: includes/login.php:419 includes/profile.php:603 includes/login.php:361
-#: includes/login.php:406 includes/login.php:412 includes/profile.php:586
-#: includes/profile.php:595 includes/profile.php:604 includes/profile.php:624
+#: includes/login.php:419
+#: includes/profile.php:603
+#: includes/login.php:361
+#: includes/login.php:406
+#: includes/login.php:412
+#: includes/profile.php:586
+#: includes/profile.php:595
+#: includes/profile.php:604
+#: includes/profile.php:624
 msgid "New passwords do not match."
 msgstr ""
 
-#: includes/login.php:423 includes/profile.php:599 includes/login.php:365
-#: includes/login.php:410 includes/login.php:416 includes/profile.php:582
-#: includes/profile.php:591 includes/profile.php:600 includes/profile.php:620
+#: includes/login.php:423
+#: includes/profile.php:599
+#: includes/login.php:365
+#: includes/login.php:410
+#: includes/login.php:416
+#: includes/profile.php:582
+#: includes/profile.php:591
+#: includes/profile.php:600
+#: includes/profile.php:620
 msgid "Please complete all fields."
 msgstr ""
 
-#: includes/login.php:427 includes/login.php:414 includes/login.php:420
-msgid ""
-"The email could not be sent. This site may not be correctly configured to "
-"send emails."
+#: includes/login.php:427
+#: includes/login.php:414
+#: includes/login.php:420
+msgid "The email could not be sent. This site may not be correctly configured to send emails."
 msgstr ""
 
 #: includes/login.php:498
-msgid ""
-"Please enter your username or email address. You will receive a link to "
-"create a new password via email."
+msgid "Please enter your username or email address. You will receive a link to create a new password via email."
 msgstr ""
 
 #: includes/login.php:523
@@ -11550,30 +14444,45 @@ msgstr ""
 msgid "Get New Password"
 msgstr ""
 
-#: includes/login.php:642 includes/login.php:651
-msgid ""
-"Your password reset link appears to be invalid. Please request a new link "
-"below."
+#: includes/login.php:642
+#: includes/login.php:651
+msgid "Your password reset link appears to be invalid. Please request a new link below."
 msgstr ""
 
-#: includes/login.php:644 includes/login.php:653
+#: includes/login.php:644
+#: includes/login.php:653
 msgid "Your password reset link has expired. Please request a new link below."
 msgstr ""
 
-#: includes/login.php:678 includes/profile.php:651 includes/profile.php:634
-#: includes/profile.php:643 includes/profile.php:652 includes/profile.php:672
+#: includes/login.php:678
+#: includes/profile.php:651
+#: includes/profile.php:634
+#: includes/profile.php:643
+#: includes/profile.php:652
+#: includes/profile.php:672
 msgid "New Password"
 msgstr ""
 
-#: includes/login.php:680 includes/profile.php:654 includes/scripts.php:86
-#: includes/login.php:587 includes/login.php:636 includes/login.php:642
-#: includes/profile.php:637 includes/profile.php:646 includes/profile.php:655
-#: includes/profile.php:675 includes/scripts.php:72 includes/scripts.php:86
+#: includes/login.php:680
+#: includes/profile.php:654
+#: includes/scripts.php:86
+#: includes/login.php:587
+#: includes/login.php:636
+#: includes/login.php:642
+#: includes/profile.php:637
+#: includes/profile.php:646
+#: includes/profile.php:655
+#: includes/profile.php:675
+#: includes/scripts.php:72
 msgid "Strength Indicator"
 msgstr ""
 
-#: includes/login.php:684 includes/profile.php:658 includes/profile.php:641
-#: includes/profile.php:650 includes/profile.php:659 includes/profile.php:679
+#: includes/login.php:684
+#: includes/profile.php:658
+#: includes/profile.php:641
+#: includes/profile.php:650
+#: includes/profile.php:659
+#: includes/profile.php:679
 msgid "Confirm New Password"
 msgstr ""
 
@@ -11593,23 +14502,30 @@ msgstr ""
 msgid "Invalid Request"
 msgstr ""
 
+#. translators: a generated link to the user's account or profile page
 #: includes/login.php:940
 #, php-format
 msgid "Welcome, %s"
 msgstr ""
 
-#: includes/login.php:974 includes/menus.php:76 includes/menus.php:79
-#: includes/menus.php:169 shortcodes/pmpro_account.php:185
-#: includes/menus.php:76 includes/menus.php:79 includes/menus.php:169
+#: includes/login.php:974
+#: includes/menus.php:76
+#: includes/menus.php:79
+#: includes/menus.php:169
+#: shortcodes/pmpro_account.php:185
 msgid "Log Out"
 msgstr ""
 
-#: includes/login.php:1007 includes/login.php:886 includes/login.php:959
+#: includes/login.php:1007
+#: includes/login.php:886
+#: includes/login.php:959
 #: includes/login.php:969
 msgid "Missing request ID."
 msgstr ""
 
-#: includes/login.php:1011 includes/login.php:890 includes/login.php:963
+#: includes/login.php:1011
+#: includes/login.php:890
+#: includes/login.php:963
 #: includes/login.php:973
 msgid "Missing confirm key."
 msgstr ""
@@ -11618,263 +14534,265 @@ msgstr ""
 msgid "Add to Menu"
 msgstr ""
 
-#: includes/menus.php:105 includes/menus.php:105
+#: includes/menus.php:105
 msgid "Paid Memberships Pro Page"
 msgstr ""
 
-#: includes/menus.php:162 includes/menus.php:171 includes/menus.php:162
+#: includes/menus.php:162
 #: includes/menus.php:171
 msgid "Page"
 msgstr ""
 
-#: includes/menus.php:231 includes/menus.php:231
+#: includes/menus.php:231
 msgid "Log In Widget - PMPro"
 msgstr ""
 
-#: includes/metaboxes.php:37 includes/metaboxes.php:37
-#: includes/metaboxes.php:38 includes/metaboxes.php:39
+#: includes/metaboxes.php:37
+#: includes/metaboxes.php:38
+#: includes/metaboxes.php:39
 #: includes/metaboxes.php:40
-msgid ""
-"This post is already protected for this level because it is within a "
-"category that requires membership."
+msgid "This post is already protected for this level because it is within a category that requires membership."
 msgstr ""
 
-#: includes/metaboxes.php:106 includes/metaboxes.php:107
-#: includes/metaboxes.php:99 includes/metaboxes.php:100
-#: includes/metaboxes.php:104 includes/metaboxes.php:105
-#: includes/metaboxes.php:106 includes/metaboxes.php:107
+#: includes/metaboxes.php:106
+#: includes/metaboxes.php:107
+#: includes/metaboxes.php:99
+#: includes/metaboxes.php:100
+#: includes/metaboxes.php:104
+#: includes/metaboxes.php:105
+#: blocks/membership/block.js:70
+#: blocks/membership/block.js:88
 msgid "Require Membership"
 msgstr ""
 
-#: includes/metaboxes.php:135 includes/metaboxes.php:130
-#: includes/metaboxes.php:134 includes/metaboxes.php:135
+#: includes/metaboxes.php:135
+#: includes/metaboxes.php:130
+#: includes/metaboxes.php:134
 #: includes/metaboxes.php:136
-msgid ""
-"Only members of these levels will be able to view posts in this category."
+msgid "Only members of these levels will be able to view posts in this category."
 msgstr ""
 
 #: includes/notifications.php:25
 msgid "Dismiss this notice."
 msgstr ""
 
-#: includes/pointers.php:31 includes/pointers.php:28 includes/pointers.php:31
+#: includes/pointers.php:31
+#: includes/pointers.php:28
 msgid "PMPro v2.0 Update"
 msgstr ""
 
-#: includes/pointers.php:32 includes/pointers.php:29 includes/pointers.php:32
+#: includes/pointers.php:32
+#: includes/pointers.php:29
 #, php-format
-msgid ""
-"The Memberships menu has moved. Check out the new dashboard. The Membership "
-"Levels and Discount Codes pages can now be found under <a href=\"%s"
-"\">Settings</a>."
+msgid "The Memberships menu has moved. Check out the new dashboard. The Membership Levels and Discount Codes pages can now be found under <a href=\"%s\">Settings</a>."
 msgstr ""
 
-#: includes/pointers.php:47 includes/pointers.php:44 includes/pointers.php:45
 #: includes/pointers.php:47
+#: includes/pointers.php:44
+#: includes/pointers.php:45
 msgid "Close"
 msgstr ""
 
-#: includes/privacy.php:19 includes/privacy.php:19
+#: includes/privacy.php:19
 msgid "Data Collected to Manage Your Membership"
 msgstr ""
 
-#: includes/privacy.php:20 includes/privacy.php:20
-msgid ""
-"At checkout, we will collect your name, email address, username, and "
-"password. This information is used to setup your account for our site. If "
-"you are redirected to an offsite payment gateway to complete your payment, "
-"we may store this information in a temporary session variable to setup your "
-"account when you return to our site."
+#: includes/privacy.php:20
+msgid "At checkout, we will collect your name, email address, username, and password. This information is used to setup your account for our site. If you are redirected to an offsite payment gateway to complete your payment, we may store this information in a temporary session variable to setup your account when you return to our site."
 msgstr ""
 
-#: includes/privacy.php:21 includes/privacy.php:21
-msgid ""
-"At checkout, we may also collect your billing address and phone number. This "
-"information is used to confirm your credit card. The billing address and "
-"phone number are saved by our site to prepopulate the checkout form for "
-"future purchases and so we can get in touch with you if needed to discuss "
-"your order."
+#: includes/privacy.php:21
+msgid "At checkout, we may also collect your billing address and phone number. This information is used to confirm your credit card. The billing address and phone number are saved by our site to prepopulate the checkout form for future purchases and so we can get in touch with you if needed to discuss your order."
 msgstr ""
 
-#: includes/privacy.php:22 includes/privacy.php:22
-msgid ""
-"At checkout, we may also collect your credit card number, expiration date, "
-"and security code. This information is passed to our payment gateway to "
-"process your purchase. The last 4 digits of your credit card number and the "
-"expiration date are saved by our site to use for reference and to send you "
-"an email if your credit card will expire before the next recurring payment."
+#: includes/privacy.php:22
+msgid "At checkout, we may also collect your credit card number, expiration date, and security code. This information is passed to our payment gateway to process your purchase. The last 4 digits of your credit card number and the expiration date are saved by our site to use for reference and to send you an email if your credit card will expire before the next recurring payment."
 msgstr ""
 
-#: includes/privacy.php:23 includes/privacy.php:23
-msgid ""
-"When logged in, we use cookies to track some of your activity on our site "
-"including logins, visits, and page views."
+#: includes/privacy.php:23
+msgid "When logged in, we use cookies to track some of your activity on our site including logins, visits, and page views."
 msgstr ""
 
-#: includes/privacy.php:35 includes/privacy.php:109 includes/privacy.php:35
+#: includes/privacy.php:35
 #: includes/privacy.php:109
 msgid "Paid Memberships Pro Data"
 msgstr ""
 
-#: includes/privacy.php:81 includes/privacy.php:81
+#: includes/privacy.php:81
 msgid "1 PMPro order was retained for business records."
 msgstr ""
 
-#: includes/privacy.php:83 includes/privacy.php:83
+#: includes/privacy.php:83
 #, php-format
 msgid "%d PMPro orders were retained for business records."
 msgstr ""
 
-#: includes/privacy.php:88 includes/privacy.php:88
-msgid ""
-"Please note that data erasure will not cancel a user's membership level or "
-"any active subscriptions. Please edit or delete the user through the "
-"WordPress dashboard."
+#: includes/privacy.php:88
+msgid "Please note that data erasure will not cancel a user's membership level or any active subscriptions. Please edit or delete the user through the WordPress dashboard."
 msgstr ""
 
-#: includes/privacy.php:160 includes/privacy.php:160
+#: includes/privacy.php:160
 msgid "Paid Memberships Pro User Data"
 msgstr ""
 
-#: includes/privacy.php:182 includes/privacy.php:182
+#: includes/privacy.php:182
 msgid "Level ID"
 msgstr ""
 
-#: includes/privacy.php:190 includes/privacy.php:190
+#: includes/privacy.php:190
 msgid "Date Modified"
 msgstr ""
 
-#: includes/privacy.php:194 includes/privacy.php:194
+#: includes/privacy.php:194
 msgid "End Date"
 msgstr ""
 
-#: includes/privacy.php:198 includes/privacy.php:198
+#: includes/privacy.php:198
 msgid "Level Cost"
 msgstr ""
 
-#: includes/privacy.php:209 includes/privacy.php:209
+#: includes/privacy.php:209
 msgid "Paid Memberships Pro Membership History"
 msgstr ""
 
-#: includes/privacy.php:229 includes/privacy.php:229
+#: includes/privacy.php:229
 msgid "Order ID"
 msgstr ""
 
-#: includes/privacy.php:233 includes/privacy.php:233
+#: includes/privacy.php:233
 msgid "Order Code"
 msgstr ""
 
-#: includes/privacy.php:237 includes/privacy.php:237
+#: includes/privacy.php:237
 msgid "Order Date"
 msgstr ""
 
-#: includes/privacy.php:333 includes/privacy.php:333
+#: includes/privacy.php:333
 msgid "Paid Memberships Pro Order History"
 msgstr ""
 
-#: includes/privacy.php:354 includes/privacy.php:354
+#: includes/privacy.php:354
 msgid "Billing First Name"
 msgstr ""
 
-#: includes/privacy.php:355 includes/privacy.php:355
+#: includes/privacy.php:355
 msgid "Billing Last Name"
 msgstr ""
 
-#: includes/privacy.php:356 includes/privacy.php:356
+#: includes/privacy.php:356
 msgid "Billing Address 1"
 msgstr ""
 
-#: includes/privacy.php:357 includes/privacy.php:357
+#: includes/privacy.php:357
 msgid "Billing Address 2"
 msgstr ""
 
-#: includes/privacy.php:359 includes/privacy.php:359
+#: includes/privacy.php:359
 msgid "Billing State/Province"
 msgstr ""
 
-#: includes/privacy.php:361 includes/privacy.php:361
+#: includes/privacy.php:361
 msgid "Billing Phone Number"
 msgstr ""
 
-#: includes/privacy.php:363 includes/privacy.php:363
+#: includes/privacy.php:363
 msgid "Credit Card Type"
 msgstr ""
 
-#: includes/privacy.php:364 includes/privacy.php:364
+#: includes/privacy.php:364
 msgid "Credit Card Account Number"
 msgstr ""
 
-#: includes/privacy.php:365 includes/privacy.php:365
+#: includes/privacy.php:365
 msgid "Credit Card Expiration Month"
 msgstr ""
 
-#: includes/privacy.php:366 includes/privacy.php:366
+#: includes/privacy.php:366
 msgid "Credit Card Expiration Year"
 msgstr ""
 
-#: includes/privacy.php:367 includes/privacy.php:367
+#: includes/privacy.php:367
 msgid "Login Data"
 msgstr ""
 
-#: includes/privacy.php:368 includes/privacy.php:368
+#: includes/privacy.php:368
 msgid "Visits Data"
 msgstr ""
 
-#: includes/privacy.php:369 includes/privacy.php:369
+#: includes/privacy.php:369
 msgid "Views Data"
 msgstr ""
 
-#: includes/privacy.php:512 includes/privacy.php:507 includes/privacy.php:512
+#: includes/privacy.php:512
+#: includes/privacy.php:507
 #, php-format
 msgid "%s agreed to %s (ID #%d, last modified %s) on %s."
 msgstr ""
 
-#: includes/privacy.php:520 includes/privacy.php:515 includes/privacy.php:520
+#: includes/privacy.php:520
+#: includes/privacy.php:515
 msgid "That post has since been updated."
 msgstr ""
 
-#: includes/profile.php:31 includes/profile.php:31 includes/profile.php:34
-#: includes/profile.php:36 includes/profile.php:39 includes/profile.php:40
+#: includes/profile.php:31
+#: includes/profile.php:34
+#: includes/profile.php:36
+#: includes/profile.php:39
+#: includes/profile.php:40
 #: includes/profile.php:45
 msgid "Current Level"
 msgstr ""
 
-#: includes/profile.php:58 pages/invoice.php:31
-#: shortcodes/pmpro_account.php:231 includes/profile.php:58
-#: includes/profile.php:67 includes/profile.php:72 pages/invoice.php:31
-#: shortcodes/pmpro_account.php:148 shortcodes/pmpro_account.php:224
+#: includes/profile.php:58
+#: pages/invoice.php:31
 #: shortcodes/pmpro_account.php:231
+#: includes/profile.php:67
+#: includes/profile.php:72
+#: shortcodes/pmpro_account.php:148
+#: shortcodes/pmpro_account.php:224
 msgid "Paid"
 msgstr ""
 
-#: includes/profile.php:60 includes/profile.php:190 includes/profile.php:237
-#: includes/profile.php:54 includes/profile.php:60 includes/profile.php:65
-#: includes/profile.php:68 includes/profile.php:69 includes/profile.php:74
-#: includes/profile.php:190 includes/profile.php:195 includes/profile.php:221
-#: includes/profile.php:226 includes/profile.php:237 includes/profile.php:242
-#: includes/profile.php:268 includes/profile.php:273
+#: includes/profile.php:60
+#: includes/profile.php:190
+#: includes/profile.php:237
+#: includes/profile.php:54
+#: includes/profile.php:65
+#: includes/profile.php:68
+#: includes/profile.php:69
+#: includes/profile.php:74
+#: includes/profile.php:195
+#: includes/profile.php:221
+#: includes/profile.php:226
+#: includes/profile.php:242
+#: includes/profile.php:268
+#: includes/profile.php:273
 msgid "Not paying."
 msgstr ""
 
-#: includes/profile.php:68 includes/profile.php:64 includes/profile.php:68
-#: includes/profile.php:73 includes/profile.php:76 includes/profile.php:77
+#: includes/profile.php:68
+#: includes/profile.php:64
+#: includes/profile.php:73
+#: includes/profile.php:76
+#: includes/profile.php:77
 #: includes/profile.php:82
-msgid ""
-"This will not change the subscription at the gateway unless the 'Cancel' "
-"checkbox is selected below."
+msgid "This will not change the subscription at the gateway unless the 'Cancel' checkbox is selected below."
 msgstr ""
 
-#: includes/profile.php:120 includes/profile.php:120 includes/profile.php:151
+#: includes/profile.php:120
+#: includes/profile.php:151
 #: includes/profile.php:156
 msgid "Send the user an email about this change."
 msgstr ""
 
-#: includes/profile.php:126 includes/profile.php:126 includes/profile.php:157
+#: includes/profile.php:126
+#: includes/profile.php:157
 #: includes/profile.php:162
 msgid "Cancel this user's subscription at the gateway."
 msgstr ""
 
-#: includes/profile.php:140 includes/profile.php:140 includes/profile.php:171
+#: includes/profile.php:140
+#: includes/profile.php:171
 #: includes/profile.php:176
 msgid "TOS Consent History"
 msgstr ""
@@ -11883,108 +14801,199 @@ msgstr ""
 msgid "Log in to edit your profile."
 msgstr ""
 
-#: includes/profile.php:439 includes/profile.php:440 includes/profile.php:473
+#: includes/profile.php:439
+#: includes/profile.php:440
+#: includes/profile.php:473
 msgid "Please enter a display name."
 msgstr ""
 
-#: includes/profile.php:449 includes/profile.php:450 includes/profile.php:483
+#: includes/profile.php:449
+#: includes/profile.php:450
+#: includes/profile.php:483
 msgid "Please enter an email address."
 msgstr ""
 
-#: includes/profile.php:451 includes/profile.php:452 includes/profile.php:485
+#: includes/profile.php:451
+#: includes/profile.php:452
+#: includes/profile.php:485
 msgid "The email address isn&#8217;t correct."
 msgstr ""
 
-#: includes/profile.php:455 includes/profile.php:456 includes/profile.php:489
+#: includes/profile.php:455
+#: includes/profile.php:456
+#: includes/profile.php:489
 msgid "This email is already registered, please choose another one."
 msgstr ""
 
-#: includes/profile.php:482 includes/profile.php:474 includes/profile.php:483
+#: includes/profile.php:482
+#: includes/profile.php:474
+#: includes/profile.php:483
 #: includes/profile.php:507
 msgid "Your profile has been updated."
 msgstr ""
 
-#: includes/profile.php:507 pages/billing.php:152 pages/checkout.php:233
-#: includes/profile.php:490 includes/profile.php:499 includes/profile.php:508
-#: includes/profile.php:523 pages/billing.php:65 pages/billing.php:69
-#: pages/billing.php:78 pages/billing.php:81 pages/billing.php:83
-#: pages/billing.php:84 pages/billing.php:87 pages/billing.php:104
-#: pages/billing.php:107 pages/billing.php:108 pages/billing.php:110
-#: pages/billing.php:112 pages/billing.php:113 pages/billing.php:121
-#: pages/billing.php:130 pages/billing.php:152 pages/checkout.php:230
-#: pages/checkout.php:279 pages/checkout.php:287 pages/checkout.php:305
-#: pages/checkout.php:307 pages/checkout.php:309 pages/checkout.php:318
-#: pages/checkout.php:321 pages/checkout.php:324 pages/checkout.php:326
-#: pages/checkout.php:328 pages/checkout.php:333 pages/checkout.php:336
+#: includes/profile.php:507
+#: pages/billing.php:152
+#: pages/checkout.php:233
+#: includes/profile.php:490
+#: includes/profile.php:499
+#: includes/profile.php:508
+#: includes/profile.php:523
+#: pages/billing.php:65
+#: pages/billing.php:69
+#: pages/billing.php:78
+#: pages/billing.php:81
+#: pages/billing.php:83
+#: pages/billing.php:84
+#: pages/billing.php:87
+#: pages/billing.php:104
+#: pages/billing.php:107
+#: pages/billing.php:108
+#: pages/billing.php:110
+#: pages/billing.php:112
+#: pages/billing.php:113
+#: pages/billing.php:121
+#: pages/billing.php:130
+#: pages/checkout.php:230
+#: pages/checkout.php:279
+#: pages/checkout.php:287
+#: pages/checkout.php:305
+#: pages/checkout.php:307
+#: pages/checkout.php:309
+#: pages/checkout.php:318
+#: pages/checkout.php:321
+#: pages/checkout.php:324
+#: pages/checkout.php:326
+#: pages/checkout.php:328
+#: pages/checkout.php:333
+#: pages/checkout.php:336
 msgid "First Name"
 msgstr ""
 
-#: includes/profile.php:508 pages/billing.php:156 pages/checkout.php:237
-#: includes/profile.php:491 includes/profile.php:500 includes/profile.php:509
-#: includes/profile.php:528 pages/billing.php:69 pages/billing.php:73
-#: pages/billing.php:82 pages/billing.php:85 pages/billing.php:87
-#: pages/billing.php:88 pages/billing.php:91 pages/billing.php:108
-#: pages/billing.php:111 pages/billing.php:112 pages/billing.php:114
-#: pages/billing.php:116 pages/billing.php:117 pages/billing.php:125
-#: pages/billing.php:134 pages/billing.php:156 pages/checkout.php:234
-#: pages/checkout.php:283 pages/checkout.php:291 pages/checkout.php:309
-#: pages/checkout.php:311 pages/checkout.php:313 pages/checkout.php:322
-#: pages/checkout.php:325 pages/checkout.php:328 pages/checkout.php:330
-#: pages/checkout.php:332 pages/checkout.php:337 pages/checkout.php:340
+#: includes/profile.php:508
+#: pages/billing.php:156
+#: pages/checkout.php:237
+#: includes/profile.php:491
+#: includes/profile.php:500
+#: includes/profile.php:509
+#: includes/profile.php:528
+#: pages/billing.php:69
+#: pages/billing.php:73
+#: pages/billing.php:82
+#: pages/billing.php:85
+#: pages/billing.php:87
+#: pages/billing.php:88
+#: pages/billing.php:91
+#: pages/billing.php:108
+#: pages/billing.php:111
+#: pages/billing.php:112
+#: pages/billing.php:114
+#: pages/billing.php:116
+#: pages/billing.php:117
+#: pages/billing.php:125
+#: pages/billing.php:134
+#: pages/checkout.php:234
+#: pages/checkout.php:283
+#: pages/checkout.php:291
+#: pages/checkout.php:309
+#: pages/checkout.php:311
+#: pages/checkout.php:313
+#: pages/checkout.php:322
+#: pages/checkout.php:325
+#: pages/checkout.php:328
+#: pages/checkout.php:330
+#: pages/checkout.php:332
+#: pages/checkout.php:337
+#: pages/checkout.php:340
 msgid "Last Name"
 msgstr ""
 
-#: includes/profile.php:509 includes/profile.php:492 includes/profile.php:501
-#: includes/profile.php:510 includes/profile.php:533
+#: includes/profile.php:509
+#: includes/profile.php:492
+#: includes/profile.php:501
+#: includes/profile.php:510
+#: includes/profile.php:533
 msgid "Display name publicly as"
 msgstr ""
 
 #: includes/profile.php:522
-msgid ""
-"Site administrators must use the WordPress dashboard to update their email "
-"address."
+msgid "Site administrators must use the WordPress dashboard to update their email address."
 msgstr ""
 
-#: includes/profile.php:545 includes/profile.php:528 includes/profile.php:537
-#: includes/profile.php:546 includes/profile.php:566
+#: includes/profile.php:545
+#: includes/profile.php:528
+#: includes/profile.php:537
+#: includes/profile.php:546
+#: includes/profile.php:566
 msgid "Update Profile"
 msgstr ""
 
-#: includes/profile.php:601 includes/profile.php:584 includes/profile.php:593
-#: includes/profile.php:602 includes/profile.php:622
+#: includes/profile.php:601
+#: includes/profile.php:584
+#: includes/profile.php:593
+#: includes/profile.php:602
+#: includes/profile.php:622
 msgid "Please enter your current password."
 msgstr ""
 
-#: includes/profile.php:605 includes/profile.php:588 includes/profile.php:597
-#: includes/profile.php:606 includes/profile.php:626
+#: includes/profile.php:605
+#: includes/profile.php:588
+#: includes/profile.php:597
+#: includes/profile.php:606
+#: includes/profile.php:626
 msgid "Your current password is incorrect."
 msgstr ""
 
-#: includes/profile.php:616 includes/profile.php:599 includes/profile.php:608
-#: includes/profile.php:617 includes/profile.php:637
+#: includes/profile.php:616
+#: includes/profile.php:599
+#: includes/profile.php:608
+#: includes/profile.php:617
+#: includes/profile.php:637
 msgid "Your password has been updated."
 msgstr ""
 
-#: includes/profile.php:632 includes/profile.php:669
-#: shortcodes/pmpro_account.php:182 includes/profile.php:615
-#: includes/profile.php:624 includes/profile.php:633 includes/profile.php:653
-#: pages/account.php:56 pages/account.php:60 pages/account.php:81
-#: shortcodes/pmpro_account.php:111 shortcodes/pmpro_account.php:113
-#: shortcodes/pmpro_account.php:114 shortcodes/pmpro_account.php:116
+#: includes/profile.php:632
+#: includes/profile.php:669
+#: shortcodes/pmpro_account.php:182
+#: includes/profile.php:615
+#: includes/profile.php:624
+#: includes/profile.php:633
+#: includes/profile.php:653
+#: pages/account.php:56
+#: pages/account.php:60
+#: pages/account.php:81
+#: shortcodes/pmpro_account.php:111
+#: shortcodes/pmpro_account.php:113
+#: shortcodes/pmpro_account.php:114
+#: shortcodes/pmpro_account.php:116
 msgid "Change Password"
 msgstr ""
 
-#: includes/profile.php:646 includes/profile.php:629 includes/profile.php:638
-#: includes/profile.php:647 includes/profile.php:667
+#: includes/profile.php:646
+#: includes/profile.php:629
+#: includes/profile.php:638
+#: includes/profile.php:647
+#: includes/profile.php:667
 msgid "Current Password"
 msgstr ""
 
-#: includes/profile.php:648 includes/profile.php:653 includes/profile.php:660
-#: includes/profile.php:535 includes/profile.php:546 includes/profile.php:631
-#: includes/profile.php:636 includes/profile.php:640 includes/profile.php:643
-#: includes/profile.php:645 includes/profile.php:649 includes/profile.php:652
-#: includes/profile.php:654 includes/profile.php:661 includes/profile.php:669
-#: includes/profile.php:674 includes/profile.php:681
+#: includes/profile.php:648
+#: includes/profile.php:653
+#: includes/profile.php:660
+#: includes/profile.php:535
+#: includes/profile.php:546
+#: includes/profile.php:631
+#: includes/profile.php:636
+#: includes/profile.php:640
+#: includes/profile.php:643
+#: includes/profile.php:645
+#: includes/profile.php:649
+#: includes/profile.php:652
+#: includes/profile.php:654
+#: includes/profile.php:661
+#: includes/profile.php:669
+#: includes/profile.php:674
+#: includes/profile.php:681
 msgid "Required Field"
 msgstr ""
 
@@ -11992,53 +15001,51 @@ msgstr ""
 msgid "Please check the ReCAPTCHA box to confirm you are not a bot."
 msgstr ""
 
-#: includes/updates.php:109 includes/updates.php:97 includes/updates.php:109
+#: includes/updates.php:109
+#: includes/updates.php:97
 #: includes/updates.php:110
 msgid "Paid Memberships Pro Data Update Required"
 msgstr ""
 
-#: includes/updates.php:110 includes/updates.php:110 includes/updates.php:111
+#: includes/updates.php:110
+#: includes/updates.php:111
 #, php-format
-msgid ""
-"(1) <a target=\"_blank\" href=\"%s\">Backup your WordPress database</a></"
-"strong> and then (2) <a href=\"%s\">click here to start the update</a>."
+msgid "(1) <a target=\"_blank\" href=\"%s\">Backup your WordPress database</a></strong> and then (2) <a href=\"%s\">click here to start the update</a>."
 msgstr ""
 
-#: includes/updates.php:130 includes/updates.php:123 includes/updates.php:130
-#: includes/updates.php:132 includes/updates.php:136
+#: includes/updates.php:130
+#: includes/updates.php:123
+#: includes/updates.php:132
+#: includes/updates.php:136
 msgid "All Paid Memberships Pro updates have finished."
 msgstr ""
 
-#: includes/updates/upgrade_1.php:10 includes/updates/upgrade_1.php:10
+#: includes/updates/upgrade_1.php:10
 #, php-format
-msgid ""
-"This content is for !!levels!! members only.<br /><a href=\"%s\">Login</a> "
-"<a href=\"%s\">Join Now</a>"
+msgid "This content is for !!levels!! members only.<br /><a href=\"%s\">Login</a> <a href=\"%s\">Join Now</a>"
 msgstr ""
 
-#: includes/updates/upgrade_1_9_4.php:26 includes/updates/upgrade_1_9_4.php:26
-msgid ""
-"We have detected that you are using a custom checkout page template for Paid "
-"Memberships Pro. This was recently changed and may need to be updated in "
-"order to display correctly."
+#: includes/updates/upgrade_1_9_4.php:26
+msgid "We have detected that you are using a custom checkout page template for Paid Memberships Pro. This was recently changed and may need to be updated in order to display correctly."
 msgstr ""
 
-#: includes/updates/upgrade_1_9_4.php:27 includes/license.php:203
-#: includes/license.php:206 includes/license.php:274 includes/license.php:279
-#: includes/license.php:289 includes/license.php:292 includes/license.php:294
-#: includes/license.php:302 includes/updates/upgrade_1_9_4.php:27
+#: includes/updates/upgrade_1_9_4.php:27
+#: includes/license.php:203
+#: includes/license.php:206
+#: includes/license.php:274
+#: includes/license.php:279
+#: includes/license.php:289
+#: includes/license.php:292
+#: includes/license.php:294
+#: includes/license.php:302
 msgid "Dismiss"
 msgstr ""
 
-#: includes/updates/upgrade_1_9_4.php:27 includes/updates/upgrade_1_9_4.php:27
-msgid ""
-"If you notice UI issues after upgrading, <a href=\"https://www."
-"paidmembershipspro.com/add-ons/table-layout-plugin-pages/\">see this free "
-"add on to temporarily roll back to the table-based layout while you resolve "
-"the issues</a>."
+#: includes/updates/upgrade_1_9_4.php:27
+msgid "If you notice UI issues after upgrading, <a href=\"https://www.paidmembershipspro.com/add-ons/table-layout-plugin-pages/\">see this free add on to temporarily roll back to the table-based layout while you resolve the issues</a>."
 msgstr ""
 
-#: includes/widgets.php:17 includes/widgets.php:17
+#: includes/widgets.php:17
 msgid "Display a login form and optional \"Logged In\" member content."
 msgstr ""
 
@@ -12058,1152 +15065,1970 @@ msgstr ""
 msgid "Display the \"Log In Widget\" menu."
 msgstr ""
 
-#: includes/widgets.php:124 includes/widgets.php:124
+#: includes/widgets.php:124
 #, php-format
-msgid ""
-"Customize this menu per level using the <a href=\"%s\" title=\"Paid "
-"Memberships Pro - Nav Menus Add On\" target=\"_blank\">Nav Menus Add On</a>. "
-"Assign the menu under Appearance > Menus."
+msgid "Customize this menu per level using the <a href=\"%s\" title=\"Paid Memberships Pro - Nav Menus Add On\" target=\"_blank\">Nav Menus Add On</a>. Assign the menu under Appearance > Menus."
 msgstr ""
 
-#: pages/billing.php:34 pages/billing.php:14 pages/billing.php:23
-#: pages/billing.php:25 pages/billing.php:26 pages/billing.php:27
-#: pages/billing.php:28 pages/billing.php:31 pages/billing.php:32
-#: pages/billing.php:33 pages/billing.php:34 pages/billing.php:389
+#: pages/billing.php:34
+#: pages/billing.php:14
+#: pages/billing.php:23
+#: pages/billing.php:25
+#: pages/billing.php:26
+#: pages/billing.php:27
+#: pages/billing.php:28
+#: pages/billing.php:31
+#: pages/billing.php:32
+#: pages/billing.php:33
+#: pages/billing.php:389
 #, php-format
 msgid "Logged in as <strong>%s</strong>."
 msgstr ""
 
-#: pages/billing.php:34 pages/billing.php:14 pages/billing.php:23
-#: pages/billing.php:25 pages/billing.php:26 pages/billing.php:27
-#: pages/billing.php:28 pages/billing.php:31 pages/billing.php:32
-#: pages/billing.php:33 pages/billing.php:34 pages/billing.php:389
+#: pages/billing.php:34
+#: pages/billing.php:14
+#: pages/billing.php:23
+#: pages/billing.php:25
+#: pages/billing.php:26
+#: pages/billing.php:27
+#: pages/billing.php:28
+#: pages/billing.php:31
+#: pages/billing.php:32
+#: pages/billing.php:33
+#: pages/billing.php:389
 msgid "logout"
 msgstr ""
 
-#: pages/billing.php:60 pages/account.php:14 pages/billing.php:18
-#: pages/billing.php:27 pages/billing.php:29 pages/billing.php:30
-#: pages/billing.php:32 pages/billing.php:43 pages/billing.php:46
-#: pages/billing.php:47 pages/billing.php:51 pages/billing.php:52
-#: pages/billing.php:59 pages/billing.php:60
+#: pages/billing.php:60
+#: pages/account.php:14
+#: pages/billing.php:18
+#: pages/billing.php:27
+#: pages/billing.php:29
+#: pages/billing.php:30
+#: pages/billing.php:32
+#: pages/billing.php:43
+#: pages/billing.php:46
+#: pages/billing.php:47
+#: pages/billing.php:51
+#: pages/billing.php:52
+#: pages/billing.php:59
 msgid "Membership Fee"
 msgstr ""
 
-#: pages/billing.php:64 pages/account.php:18 pages/billing.php:22
-#: pages/billing.php:31 pages/billing.php:33 pages/billing.php:34
-#: pages/billing.php:36 pages/billing.php:47 pages/billing.php:50
-#: pages/billing.php:51 pages/billing.php:55 pages/billing.php:56
-#: pages/billing.php:63 pages/billing.php:64 pages/levels.php:70
+#: pages/billing.php:64
+#: pages/account.php:18
+#: pages/billing.php:22
+#: pages/billing.php:31
+#: pages/billing.php:33
+#: pages/billing.php:34
+#: pages/billing.php:36
+#: pages/billing.php:47
+#: pages/billing.php:50
+#: pages/billing.php:51
+#: pages/billing.php:55
+#: pages/billing.php:56
+#: pages/billing.php:63
+#: pages/levels.php:70
 #, php-format
 msgid "%s every %d %s."
 msgstr ""
 
-#: pages/billing.php:66 pages/account.php:20 pages/billing.php:24
-#: pages/billing.php:33 pages/billing.php:35 pages/billing.php:36
-#: pages/billing.php:38 pages/billing.php:49 pages/billing.php:52
-#: pages/billing.php:53 pages/billing.php:57 pages/billing.php:58
-#: pages/billing.php:65 pages/billing.php:66 pages/levels.php:66
+#: pages/billing.php:66
+#: pages/account.php:20
+#: pages/billing.php:24
+#: pages/billing.php:33
+#: pages/billing.php:35
+#: pages/billing.php:36
+#: pages/billing.php:38
+#: pages/billing.php:49
+#: pages/billing.php:52
+#: pages/billing.php:53
+#: pages/billing.php:57
+#: pages/billing.php:58
+#: pages/billing.php:65
+#: pages/levels.php:66
 #, php-format
 msgid "%s per %s."
 msgstr ""
 
-#: pages/billing.php:77 pages/account.php:25 pages/account.php:29
-#: pages/billing.php:29 pages/billing.php:33 pages/billing.php:42
-#: pages/billing.php:44 pages/billing.php:45 pages/billing.php:47
-#: pages/billing.php:59 pages/billing.php:62 pages/billing.php:63
-#: pages/billing.php:67 pages/billing.php:68 pages/billing.php:76
 #: pages/billing.php:77
+#: pages/account.php:25
+#: pages/account.php:29
+#: pages/billing.php:29
+#: pages/billing.php:33
+#: pages/billing.php:42
+#: pages/billing.php:44
+#: pages/billing.php:45
+#: pages/billing.php:47
+#: pages/billing.php:59
+#: pages/billing.php:62
+#: pages/billing.php:63
+#: pages/billing.php:67
+#: pages/billing.php:68
+#: pages/billing.php:76
 msgid "Duration"
 msgstr ""
 
-#: pages/billing.php:84 pages/confirmation.php:79 pages/invoice.php:69
-#: pages/account.php:105 pages/account.php:109 pages/billing.php:84
-#: pages/confirmation.php:61 pages/confirmation.php:63
-#: pages/confirmation.php:69 pages/confirmation.php:78
-#: pages/confirmation.php:79 pages/confirmation.php:82 pages/invoice.php:48
-#: pages/invoice.php:50 pages/invoice.php:60 pages/invoice.php:61
-#: pages/invoice.php:62 pages/invoice.php:69
+#: pages/billing.php:84
+#: pages/confirmation.php:79
+#: pages/invoice.php:69
+#: pages/account.php:105
+#: pages/account.php:109
+#: pages/confirmation.php:61
+#: pages/confirmation.php:63
+#: pages/confirmation.php:69
+#: pages/confirmation.php:78
+#: pages/confirmation.php:82
+#: pages/invoice.php:48
+#: pages/invoice.php:50
+#: pages/invoice.php:60
+#: pages/invoice.php:61
+#: pages/invoice.php:62
 msgid "Payment Method"
 msgstr ""
 
-#: pages/billing.php:86 pages/confirmation.php:81 pages/invoice.php:71
-#: pages/billing.php:86 pages/confirmation.php:79 pages/confirmation.php:80
-#: pages/confirmation.php:81 pages/confirmation.php:82
-#: pages/confirmation.php:83 pages/confirmation.php:88 pages/invoice.php:61
-#: pages/invoice.php:62 pages/invoice.php:63 pages/invoice.php:67
-#: pages/invoice.php:69 pages/invoice.php:71
+#: pages/billing.php:86
+#: pages/confirmation.php:81
+#: pages/invoice.php:71
+#: pages/confirmation.php:79
+#: pages/confirmation.php:80
+#: pages/confirmation.php:82
+#: pages/confirmation.php:83
+#: pages/confirmation.php:88
+#: pages/invoice.php:61
+#: pages/invoice.php:62
+#: pages/invoice.php:63
+#: pages/invoice.php:67
+#: pages/invoice.php:69
 msgid "ending in"
 msgstr ""
 
-#: pages/billing.php:113 pages/billing.php:119 pages/confirmation.php:134
-#: pages/invoice.php:144 pages/billing.php:97 pages/billing.php:103
-#: pages/billing.php:113 pages/billing.php:119 pages/confirmation.php:111
-#: pages/confirmation.php:113 pages/confirmation.php:121
-#: pages/confirmation.php:124 pages/confirmation.php:131
-#: pages/confirmation.php:132 pages/confirmation.php:133
-#: pages/confirmation.php:134 pages/invoice.php:121 pages/invoice.php:133
-#: pages/invoice.php:134 pages/invoice.php:135 pages/invoice.php:136
-#: pages/invoice.php:139 pages/invoice.php:141 pages/invoice.php:143
+#: pages/billing.php:113
+#: pages/billing.php:119
+#: pages/confirmation.php:134
 #: pages/invoice.php:144
+#: pages/billing.php:97
+#: pages/billing.php:103
+#: pages/confirmation.php:111
+#: pages/confirmation.php:113
+#: pages/confirmation.php:121
+#: pages/confirmation.php:124
+#: pages/confirmation.php:131
+#: pages/confirmation.php:132
+#: pages/confirmation.php:133
+#: pages/invoice.php:121
+#: pages/invoice.php:133
+#: pages/invoice.php:134
+#: pages/invoice.php:135
+#: pages/invoice.php:136
+#: pages/invoice.php:139
+#: pages/invoice.php:141
+#: pages/invoice.php:143
 msgid "View Your Membership Account &rarr;"
 msgstr ""
 
-#: pages/billing.php:116 pages/billing.php:39 pages/billing.php:43
-#: pages/billing.php:52 pages/billing.php:54 pages/billing.php:55
-#: pages/billing.php:57 pages/billing.php:77 pages/billing.php:80
-#: pages/billing.php:81 pages/billing.php:85 pages/billing.php:86
-#: pages/billing.php:94 pages/billing.php:100 pages/billing.php:116
-msgid ""
-"Your payment subscription is managed by PayPal. Please <a href=\"http://www."
-"paypal.com\">login to PayPal here</a> to update your billing information."
+#: pages/billing.php:116
+#: pages/billing.php:39
+#: pages/billing.php:43
+#: pages/billing.php:52
+#: pages/billing.php:54
+#: pages/billing.php:55
+#: pages/billing.php:57
+#: pages/billing.php:77
+#: pages/billing.php:80
+#: pages/billing.php:81
+#: pages/billing.php:85
+#: pages/billing.php:86
+#: pages/billing.php:94
+#: pages/billing.php:100
+msgid "Your payment subscription is managed by PayPal. Please <a href=\"http://www.paypal.com\">login to PayPal here</a> to update your billing information."
 msgstr ""
 
-#: pages/billing.php:124 pages/billing.php:124
+#: pages/billing.php:124
 msgid "Your billing information cannot be updated at this time."
 msgstr ""
 
-#: pages/billing.php:148 pages/checkout.php:229 pages/confirmation.php:66
-#: pages/invoice.php:56 adminpages/memberslist.php:117
-#: adminpages/memberslist.php:150 adminpages/memberslist.php:160
-#: adminpages/memberslist.php:170 adminpages/memberslist.php:174
-#: pages/account.php:90 pages/account.php:94 pages/billing.php:58
-#: pages/billing.php:62 pages/billing.php:71 pages/billing.php:74
-#: pages/billing.php:76 pages/billing.php:77 pages/billing.php:80
-#: pages/billing.php:100 pages/billing.php:103 pages/billing.php:104
-#: pages/billing.php:108 pages/billing.php:109 pages/billing.php:117
-#: pages/billing.php:126 pages/billing.php:148 pages/checkout.php:226
-#: pages/checkout.php:275 pages/checkout.php:283 pages/checkout.php:298
-#: pages/checkout.php:300 pages/checkout.php:302 pages/checkout.php:311
-#: pages/checkout.php:314 pages/checkout.php:317 pages/checkout.php:319
-#: pages/checkout.php:321 pages/checkout.php:326 pages/checkout.php:329
-#: pages/confirmation.php:59 pages/confirmation.php:61
-#: pages/confirmation.php:65 pages/confirmation.php:66
-#: pages/confirmation.php:67 pages/confirmation.php:69 pages/invoice.php:46
-#: pages/invoice.php:47 pages/invoice.php:48 pages/invoice.php:49
+#: pages/billing.php:148
+#: pages/checkout.php:229
+#: pages/confirmation.php:66
 #: pages/invoice.php:56
+#: adminpages/memberslist.php:117
+#: adminpages/memberslist.php:150
+#: adminpages/memberslist.php:160
+#: adminpages/memberslist.php:170
+#: adminpages/memberslist.php:174
+#: pages/account.php:90
+#: pages/account.php:94
+#: pages/billing.php:58
+#: pages/billing.php:62
+#: pages/billing.php:71
+#: pages/billing.php:74
+#: pages/billing.php:76
+#: pages/billing.php:77
+#: pages/billing.php:80
+#: pages/billing.php:100
+#: pages/billing.php:103
+#: pages/billing.php:104
+#: pages/billing.php:108
+#: pages/billing.php:109
+#: pages/billing.php:117
+#: pages/billing.php:126
+#: pages/checkout.php:226
+#: pages/checkout.php:275
+#: pages/checkout.php:283
+#: pages/checkout.php:298
+#: pages/checkout.php:300
+#: pages/checkout.php:302
+#: pages/checkout.php:311
+#: pages/checkout.php:314
+#: pages/checkout.php:317
+#: pages/checkout.php:319
+#: pages/checkout.php:321
+#: pages/checkout.php:326
+#: pages/checkout.php:329
+#: pages/confirmation.php:59
+#: pages/confirmation.php:61
+#: pages/confirmation.php:65
+#: pages/confirmation.php:67
+#: pages/confirmation.php:69
+#: pages/invoice.php:46
+#: pages/invoice.php:47
+#: pages/invoice.php:48
+#: pages/invoice.php:49
 msgid "Billing Address"
 msgstr ""
 
-#: pages/billing.php:162 pages/checkout.php:241 pages/billing.php:73
-#: pages/billing.php:77 pages/billing.php:86 pages/billing.php:89
-#: pages/billing.php:91 pages/billing.php:92 pages/billing.php:95
-#: pages/billing.php:112 pages/billing.php:115 pages/billing.php:116
-#: pages/billing.php:118 pages/billing.php:120 pages/billing.php:121
-#: pages/billing.php:129 pages/billing.php:138 pages/billing.php:162
-#: pages/checkout.php:238 pages/checkout.php:287 pages/checkout.php:295
-#: pages/checkout.php:313 pages/checkout.php:315 pages/checkout.php:317
-#: pages/checkout.php:326 pages/checkout.php:329 pages/checkout.php:332
-#: pages/checkout.php:334 pages/checkout.php:336 pages/checkout.php:341
+#: pages/billing.php:162
+#: pages/checkout.php:241
+#: pages/billing.php:73
+#: pages/billing.php:77
+#: pages/billing.php:86
+#: pages/billing.php:89
+#: pages/billing.php:91
+#: pages/billing.php:92
+#: pages/billing.php:95
+#: pages/billing.php:112
+#: pages/billing.php:115
+#: pages/billing.php:116
+#: pages/billing.php:118
+#: pages/billing.php:120
+#: pages/billing.php:121
+#: pages/billing.php:129
+#: pages/billing.php:138
+#: pages/checkout.php:238
+#: pages/checkout.php:287
+#: pages/checkout.php:295
+#: pages/checkout.php:313
+#: pages/checkout.php:315
+#: pages/checkout.php:317
+#: pages/checkout.php:326
+#: pages/checkout.php:329
+#: pages/checkout.php:332
+#: pages/checkout.php:334
+#: pages/checkout.php:336
+#: pages/checkout.php:341
 #: pages/checkout.php:344
 msgid "Address 1"
 msgstr ""
 
-#: pages/billing.php:166 pages/checkout.php:245 pages/billing.php:77
-#: pages/billing.php:81 pages/billing.php:90 pages/billing.php:93
-#: pages/billing.php:95 pages/billing.php:96 pages/billing.php:99
-#: pages/billing.php:116 pages/billing.php:119 pages/billing.php:120
-#: pages/billing.php:122 pages/billing.php:124 pages/billing.php:125
-#: pages/billing.php:133 pages/billing.php:142 pages/billing.php:166
-#: pages/checkout.php:242 pages/checkout.php:291 pages/checkout.php:299
-#: pages/checkout.php:317 pages/checkout.php:319 pages/checkout.php:321
-#: pages/checkout.php:330 pages/checkout.php:333 pages/checkout.php:336
-#: pages/checkout.php:338 pages/checkout.php:340 pages/checkout.php:345
+#: pages/billing.php:166
+#: pages/checkout.php:245
+#: pages/billing.php:77
+#: pages/billing.php:81
+#: pages/billing.php:90
+#: pages/billing.php:93
+#: pages/billing.php:95
+#: pages/billing.php:96
+#: pages/billing.php:99
+#: pages/billing.php:116
+#: pages/billing.php:119
+#: pages/billing.php:120
+#: pages/billing.php:122
+#: pages/billing.php:124
+#: pages/billing.php:125
+#: pages/billing.php:133
+#: pages/billing.php:142
+#: pages/checkout.php:242
+#: pages/checkout.php:291
+#: pages/checkout.php:299
+#: pages/checkout.php:317
+#: pages/checkout.php:319
+#: pages/checkout.php:321
+#: pages/checkout.php:330
+#: pages/checkout.php:333
+#: pages/checkout.php:336
+#: pages/checkout.php:338
+#: pages/checkout.php:340
+#: pages/checkout.php:345
 #: pages/checkout.php:348
 msgid "Address 2"
 msgstr ""
 
-#: pages/billing.php:176 pages/checkout.php:252 pages/billing.php:87
-#: pages/billing.php:91 pages/billing.php:100 pages/billing.php:103
-#: pages/billing.php:105 pages/billing.php:106 pages/billing.php:109
-#: pages/billing.php:126 pages/billing.php:129 pages/billing.php:130
-#: pages/billing.php:132 pages/billing.php:134 pages/billing.php:135
-#: pages/billing.php:143 pages/billing.php:152 pages/billing.php:176
-#: pages/checkout.php:249 pages/checkout.php:298 pages/checkout.php:306
-#: pages/checkout.php:327 pages/checkout.php:329 pages/checkout.php:331
-#: pages/checkout.php:340 pages/checkout.php:343 pages/checkout.php:346
-#: pages/checkout.php:348 pages/checkout.php:350 pages/checkout.php:355
+#: pages/billing.php:176
+#: pages/checkout.php:252
+#: pages/billing.php:87
+#: pages/billing.php:91
+#: pages/billing.php:100
+#: pages/billing.php:103
+#: pages/billing.php:105
+#: pages/billing.php:106
+#: pages/billing.php:109
+#: pages/billing.php:126
+#: pages/billing.php:129
+#: pages/billing.php:130
+#: pages/billing.php:132
+#: pages/billing.php:134
+#: pages/billing.php:135
+#: pages/billing.php:143
+#: pages/billing.php:152
+#: pages/checkout.php:249
+#: pages/checkout.php:298
+#: pages/checkout.php:306
+#: pages/checkout.php:327
+#: pages/checkout.php:329
+#: pages/checkout.php:331
+#: pages/checkout.php:340
+#: pages/checkout.php:343
+#: pages/checkout.php:346
+#: pages/checkout.php:348
+#: pages/checkout.php:350
+#: pages/checkout.php:355
 #: pages/checkout.php:358
 msgid "City"
 msgstr ""
 
-#: pages/billing.php:180 pages/checkout.php:256 pages/billing.php:91
-#: pages/billing.php:95 pages/billing.php:104 pages/billing.php:107
-#: pages/billing.php:109 pages/billing.php:110 pages/billing.php:113
-#: pages/billing.php:130 pages/billing.php:133 pages/billing.php:134
-#: pages/billing.php:136 pages/billing.php:138 pages/billing.php:139
-#: pages/billing.php:147 pages/billing.php:156 pages/billing.php:180
-#: pages/checkout.php:253 pages/checkout.php:302 pages/checkout.php:310
-#: pages/checkout.php:331 pages/checkout.php:333 pages/checkout.php:335
-#: pages/checkout.php:344 pages/checkout.php:347 pages/checkout.php:350
-#: pages/checkout.php:352 pages/checkout.php:354 pages/checkout.php:359
+#: pages/billing.php:180
+#: pages/checkout.php:256
+#: pages/billing.php:91
+#: pages/billing.php:95
+#: pages/billing.php:104
+#: pages/billing.php:107
+#: pages/billing.php:109
+#: pages/billing.php:110
+#: pages/billing.php:113
+#: pages/billing.php:130
+#: pages/billing.php:133
+#: pages/billing.php:134
+#: pages/billing.php:136
+#: pages/billing.php:138
+#: pages/billing.php:139
+#: pages/billing.php:147
+#: pages/billing.php:156
+#: pages/checkout.php:253
+#: pages/checkout.php:302
+#: pages/checkout.php:310
+#: pages/checkout.php:331
+#: pages/checkout.php:333
+#: pages/checkout.php:335
+#: pages/checkout.php:344
+#: pages/checkout.php:347
+#: pages/checkout.php:350
+#: pages/checkout.php:352
+#: pages/checkout.php:354
+#: pages/checkout.php:359
 #: pages/checkout.php:362
 msgid "State"
 msgstr ""
 
-#: pages/billing.php:184 pages/checkout.php:260 pages/billing.php:95
-#: pages/billing.php:99 pages/billing.php:108 pages/billing.php:111
-#: pages/billing.php:113 pages/billing.php:114 pages/billing.php:117
-#: pages/billing.php:134 pages/billing.php:137 pages/billing.php:138
-#: pages/billing.php:140 pages/billing.php:142 pages/billing.php:143
-#: pages/billing.php:151 pages/billing.php:160 pages/billing.php:184
-#: pages/checkout.php:257 pages/checkout.php:306 pages/checkout.php:314
-#: pages/checkout.php:335 pages/checkout.php:337 pages/checkout.php:339
-#: pages/checkout.php:348 pages/checkout.php:351 pages/checkout.php:354
-#: pages/checkout.php:356 pages/checkout.php:358 pages/checkout.php:363
+#: pages/billing.php:184
+#: pages/checkout.php:260
+#: pages/billing.php:95
+#: pages/billing.php:99
+#: pages/billing.php:108
+#: pages/billing.php:111
+#: pages/billing.php:113
+#: pages/billing.php:114
+#: pages/billing.php:117
+#: pages/billing.php:134
+#: pages/billing.php:137
+#: pages/billing.php:138
+#: pages/billing.php:140
+#: pages/billing.php:142
+#: pages/billing.php:143
+#: pages/billing.php:151
+#: pages/billing.php:160
+#: pages/checkout.php:257
+#: pages/checkout.php:306
+#: pages/checkout.php:314
+#: pages/checkout.php:335
+#: pages/checkout.php:337
+#: pages/checkout.php:339
+#: pages/checkout.php:348
+#: pages/checkout.php:351
+#: pages/checkout.php:354
+#: pages/checkout.php:356
+#: pages/checkout.php:358
+#: pages/checkout.php:363
 #: pages/checkout.php:366
 msgid "Postal Code"
 msgstr ""
 
-#: pages/billing.php:193 pages/checkout.php:265 pages/billing.php:104
-#: pages/billing.php:108 pages/billing.php:117 pages/billing.php:120
-#: pages/billing.php:122 pages/billing.php:123 pages/billing.php:126
-#: pages/billing.php:143 pages/billing.php:146 pages/billing.php:147
-#: pages/billing.php:149 pages/billing.php:151 pages/billing.php:152
-#: pages/billing.php:160 pages/billing.php:169 pages/billing.php:193
-#: pages/checkout.php:262 pages/checkout.php:311 pages/checkout.php:319
-#: pages/checkout.php:344 pages/checkout.php:346 pages/checkout.php:348
-#: pages/checkout.php:357 pages/checkout.php:360 pages/checkout.php:363
-#: pages/checkout.php:365 pages/checkout.php:367 pages/checkout.php:372
+#: pages/billing.php:193
+#: pages/checkout.php:265
+#: pages/billing.php:104
+#: pages/billing.php:108
+#: pages/billing.php:117
+#: pages/billing.php:120
+#: pages/billing.php:122
+#: pages/billing.php:123
+#: pages/billing.php:126
+#: pages/billing.php:143
+#: pages/billing.php:146
+#: pages/billing.php:147
+#: pages/billing.php:149
+#: pages/billing.php:151
+#: pages/billing.php:152
+#: pages/billing.php:160
+#: pages/billing.php:169
+#: pages/checkout.php:262
+#: pages/checkout.php:311
+#: pages/checkout.php:319
+#: pages/checkout.php:344
+#: pages/checkout.php:346
+#: pages/checkout.php:348
+#: pages/checkout.php:357
+#: pages/checkout.php:360
+#: pages/checkout.php:363
+#: pages/checkout.php:365
+#: pages/checkout.php:367
+#: pages/checkout.php:372
 #: pages/checkout.php:375
 msgid "City, State Zip"
 msgstr ""
 
-#: pages/billing.php:246 pages/checkout.php:302 pages/billing.php:157
-#: pages/billing.php:161 pages/billing.php:170 pages/billing.php:173
-#: pages/billing.php:175 pages/billing.php:176 pages/billing.php:179
-#: pages/billing.php:196 pages/billing.php:199 pages/billing.php:200
-#: pages/billing.php:202 pages/billing.php:204 pages/billing.php:205
-#: pages/billing.php:213 pages/billing.php:222 pages/billing.php:246
-#: pages/checkout.php:299 pages/checkout.php:348 pages/checkout.php:356
-#: pages/checkout.php:397 pages/checkout.php:399 pages/checkout.php:401
-#: pages/checkout.php:410 pages/checkout.php:413 pages/checkout.php:416
-#: pages/checkout.php:418 pages/checkout.php:420 pages/checkout.php:425
+#: pages/billing.php:246
+#: pages/checkout.php:302
+#: pages/billing.php:157
+#: pages/billing.php:161
+#: pages/billing.php:170
+#: pages/billing.php:173
+#: pages/billing.php:175
+#: pages/billing.php:176
+#: pages/billing.php:179
+#: pages/billing.php:196
+#: pages/billing.php:199
+#: pages/billing.php:200
+#: pages/billing.php:202
+#: pages/billing.php:204
+#: pages/billing.php:205
+#: pages/billing.php:213
+#: pages/billing.php:222
+#: pages/checkout.php:299
+#: pages/checkout.php:348
+#: pages/checkout.php:356
+#: pages/checkout.php:397
+#: pages/checkout.php:399
+#: pages/checkout.php:401
+#: pages/checkout.php:410
+#: pages/checkout.php:413
+#: pages/checkout.php:416
+#: pages/checkout.php:418
+#: pages/checkout.php:420
+#: pages/checkout.php:425
 #: pages/checkout.php:428
 msgid "Country"
 msgstr ""
 
-#: pages/billing.php:271 pages/checkout.php:318 pages/billing.php:182
-#: pages/billing.php:186 pages/billing.php:195 pages/billing.php:198
-#: pages/billing.php:200 pages/billing.php:201 pages/billing.php:204
-#: pages/billing.php:221 pages/billing.php:224 pages/billing.php:225
-#: pages/billing.php:227 pages/billing.php:229 pages/billing.php:230
-#: pages/billing.php:238 pages/billing.php:247 pages/billing.php:271
-#: pages/checkout.php:315 pages/checkout.php:364 pages/checkout.php:372
-#: pages/checkout.php:422 pages/checkout.php:424 pages/checkout.php:426
-#: pages/checkout.php:435 pages/checkout.php:438 pages/checkout.php:441
-#: pages/checkout.php:443 pages/checkout.php:445 pages/checkout.php:450
+#: pages/billing.php:271
+#: pages/checkout.php:318
+#: pages/billing.php:182
+#: pages/billing.php:186
+#: pages/billing.php:195
+#: pages/billing.php:198
+#: pages/billing.php:200
+#: pages/billing.php:201
+#: pages/billing.php:204
+#: pages/billing.php:221
+#: pages/billing.php:224
+#: pages/billing.php:225
+#: pages/billing.php:227
+#: pages/billing.php:229
+#: pages/billing.php:230
+#: pages/billing.php:238
+#: pages/billing.php:247
+#: pages/checkout.php:315
+#: pages/checkout.php:364
+#: pages/checkout.php:372
+#: pages/checkout.php:422
+#: pages/checkout.php:424
+#: pages/checkout.php:426
+#: pages/checkout.php:435
+#: pages/checkout.php:438
+#: pages/checkout.php:441
+#: pages/checkout.php:443
+#: pages/checkout.php:445
+#: pages/checkout.php:450
 #: pages/checkout.php:453
 msgid "Phone"
 msgstr ""
 
-#: pages/billing.php:282 pages/checkout.php:151 pages/checkout.php:333
-#: pages/billing.php:193 pages/billing.php:197 pages/billing.php:206
-#: pages/billing.php:209 pages/billing.php:211 pages/billing.php:212
-#: pages/billing.php:215 pages/billing.php:232 pages/billing.php:235
-#: pages/billing.php:236 pages/billing.php:238 pages/billing.php:240
-#: pages/billing.php:241 pages/billing.php:249 pages/billing.php:258
-#: pages/billing.php:282 pages/checkout.php:148 pages/checkout.php:197
-#: pages/checkout.php:204 pages/checkout.php:205 pages/checkout.php:207
-#: pages/checkout.php:209 pages/checkout.php:216 pages/checkout.php:218
-#: pages/checkout.php:220 pages/checkout.php:227 pages/checkout.php:230
-#: pages/checkout.php:330 pages/checkout.php:379 pages/checkout.php:387
-#: pages/checkout.php:436 pages/checkout.php:438 pages/checkout.php:440
-#: pages/checkout.php:449 pages/checkout.php:453 pages/checkout.php:455
-#: pages/checkout.php:457 pages/checkout.php:460 pages/checkout.php:464
+#: pages/billing.php:282
+#: pages/checkout.php:151
+#: pages/checkout.php:333
+#: pages/billing.php:193
+#: pages/billing.php:197
+#: pages/billing.php:206
+#: pages/billing.php:209
+#: pages/billing.php:211
+#: pages/billing.php:212
+#: pages/billing.php:215
+#: pages/billing.php:232
+#: pages/billing.php:235
+#: pages/billing.php:236
+#: pages/billing.php:238
+#: pages/billing.php:240
+#: pages/billing.php:241
+#: pages/billing.php:249
+#: pages/billing.php:258
+#: pages/checkout.php:148
+#: pages/checkout.php:197
+#: pages/checkout.php:204
+#: pages/checkout.php:205
+#: pages/checkout.php:207
+#: pages/checkout.php:209
+#: pages/checkout.php:216
+#: pages/checkout.php:218
+#: pages/checkout.php:220
+#: pages/checkout.php:227
+#: pages/checkout.php:230
+#: pages/checkout.php:330
+#: pages/checkout.php:379
+#: pages/checkout.php:387
+#: pages/checkout.php:436
+#: pages/checkout.php:438
+#: pages/checkout.php:440
+#: pages/checkout.php:449
+#: pages/checkout.php:453
+#: pages/checkout.php:455
+#: pages/checkout.php:457
+#: pages/checkout.php:460
+#: pages/checkout.php:464
 #: pages/checkout.php:467
 msgid "Email Address"
 msgstr ""
 
-#: pages/billing.php:286 pages/checkout.php:340 pages/billing.php:197
-#: pages/billing.php:201 pages/billing.php:210 pages/billing.php:213
-#: pages/billing.php:215 pages/billing.php:216 pages/billing.php:219
-#: pages/billing.php:236 pages/billing.php:239 pages/billing.php:240
-#: pages/billing.php:242 pages/billing.php:244 pages/billing.php:245
-#: pages/billing.php:253 pages/billing.php:262 pages/billing.php:286
-#: pages/checkout.php:337 pages/checkout.php:386 pages/checkout.php:394
-#: pages/checkout.php:445 pages/checkout.php:447 pages/checkout.php:449
-#: pages/checkout.php:458 pages/checkout.php:462 pages/checkout.php:464
-#: pages/checkout.php:466 pages/checkout.php:469 pages/checkout.php:473
+#: pages/billing.php:286
+#: pages/checkout.php:340
+#: pages/billing.php:197
+#: pages/billing.php:201
+#: pages/billing.php:210
+#: pages/billing.php:213
+#: pages/billing.php:215
+#: pages/billing.php:216
+#: pages/billing.php:219
+#: pages/billing.php:236
+#: pages/billing.php:239
+#: pages/billing.php:240
+#: pages/billing.php:242
+#: pages/billing.php:244
+#: pages/billing.php:245
+#: pages/billing.php:253
+#: pages/billing.php:262
+#: pages/checkout.php:337
+#: pages/checkout.php:386
+#: pages/checkout.php:394
+#: pages/checkout.php:445
+#: pages/checkout.php:447
+#: pages/checkout.php:449
+#: pages/checkout.php:458
+#: pages/checkout.php:462
+#: pages/checkout.php:464
+#: pages/checkout.php:466
+#: pages/checkout.php:469
+#: pages/checkout.php:473
 #: pages/checkout.php:476
 msgid "Confirm Email"
 msgstr ""
 
-#: pages/billing.php:309 pages/billing.php:217 pages/billing.php:221
-#: pages/billing.php:230 pages/billing.php:231 pages/billing.php:234
-#: pages/billing.php:238 pages/billing.php:244 pages/billing.php:247
-#: pages/billing.php:259 pages/billing.php:262 pages/billing.php:263
-#: pages/billing.php:267 pages/billing.php:268 pages/billing.php:270
-#: pages/billing.php:276 pages/billing.php:285 pages/billing.php:309
+#: pages/billing.php:309
+#: pages/billing.php:217
+#: pages/billing.php:221
+#: pages/billing.php:230
+#: pages/billing.php:231
+#: pages/billing.php:234
+#: pages/billing.php:238
+#: pages/billing.php:244
+#: pages/billing.php:247
+#: pages/billing.php:259
+#: pages/billing.php:262
+#: pages/billing.php:263
+#: pages/billing.php:267
+#: pages/billing.php:268
+#: pages/billing.php:270
+#: pages/billing.php:276
+#: pages/billing.php:285
 msgid "Credit Card Information"
 msgstr ""
 
-#: pages/billing.php:310 pages/billing.php:217 pages/billing.php:221
-#: pages/billing.php:230 pages/billing.php:232 pages/billing.php:235
-#: pages/billing.php:239 pages/billing.php:245 pages/billing.php:248
-#: pages/billing.php:260 pages/billing.php:263 pages/billing.php:264
-#: pages/billing.php:268 pages/billing.php:269 pages/billing.php:271
-#: pages/billing.php:277 pages/billing.php:286 pages/billing.php:310
+#: pages/billing.php:310
+#: pages/billing.php:217
+#: pages/billing.php:221
+#: pages/billing.php:230
+#: pages/billing.php:232
+#: pages/billing.php:235
+#: pages/billing.php:239
+#: pages/billing.php:245
+#: pages/billing.php:248
+#: pages/billing.php:260
+#: pages/billing.php:263
+#: pages/billing.php:264
+#: pages/billing.php:268
+#: pages/billing.php:269
+#: pages/billing.php:271
+#: pages/billing.php:277
+#: pages/billing.php:286
 #, php-format
 msgid "We accept %s"
 msgstr ""
 
-#: pages/billing.php:446 shortcodes/pmpro_account.php:68 pages/billing.php:410
-#: pages/billing.php:412 pages/billing.php:418 pages/billing.php:422
-#: pages/billing.php:446 shortcodes/pmpro_account.php:68
+#: pages/billing.php:446
+#: shortcodes/pmpro_account.php:68
+#: pages/billing.php:410
+#: pages/billing.php:412
+#: pages/billing.php:418
+#: pages/billing.php:422
 #, php-format
 msgid "Your membership is not active. <a href='%s'>Renew now.</a>"
 msgstr ""
 
-#: pages/billing.php:449 shortcodes/pmpro_account.php:71 pages/billing.php:407
-#: pages/billing.php:409 pages/billing.php:415 pages/billing.php:425
-#: pages/billing.php:449 shortcodes/pmpro_account.php:71
+#: pages/billing.php:449
+#: shortcodes/pmpro_account.php:71
+#: pages/billing.php:407
+#: pages/billing.php:409
+#: pages/billing.php:415
+#: pages/billing.php:425
 #, php-format
 msgid "You do not have an active membership. <a href='%s'>Register here.</a>"
 msgstr ""
 
-#: pages/billing.php:452 shortcodes/pmpro_account.php:74 pages/billing.php:404
-#: pages/billing.php:406 pages/billing.php:412 pages/billing.php:428
-#: pages/billing.php:452 shortcodes/pmpro_account.php:74
+#: pages/billing.php:452
+#: shortcodes/pmpro_account.php:74
+#: pages/billing.php:404
+#: pages/billing.php:406
+#: pages/billing.php:412
+#: pages/billing.php:428
 #, php-format
-msgid ""
-"You do not have an active membership. <a href='%s'>Choose a membership level."
-"</a>"
+msgid "You do not have an active membership. <a href='%s'>Choose a membership level.</a>"
 msgstr ""
 
-#: pages/billing.php:455 pages/billing.php:309 pages/billing.php:313
-#: pages/billing.php:344 pages/billing.php:353 pages/billing.php:356
-#: pages/billing.php:360 pages/billing.php:364 pages/billing.php:378
-#: pages/billing.php:380 pages/billing.php:381 pages/billing.php:385
-#: pages/billing.php:387 pages/billing.php:408 pages/billing.php:413
-#: pages/billing.php:415 pages/billing.php:417 pages/billing.php:421
-#: pages/billing.php:422 pages/billing.php:431 pages/billing.php:455
-msgid ""
-"This subscription is not recurring. So you don't need to update your billing "
-"information."
+#: pages/billing.php:455
+#: pages/billing.php:309
+#: pages/billing.php:313
+#: pages/billing.php:344
+#: pages/billing.php:353
+#: pages/billing.php:356
+#: pages/billing.php:360
+#: pages/billing.php:364
+#: pages/billing.php:378
+#: pages/billing.php:380
+#: pages/billing.php:381
+#: pages/billing.php:385
+#: pages/billing.php:387
+#: pages/billing.php:408
+#: pages/billing.php:413
+#: pages/billing.php:415
+#: pages/billing.php:417
+#: pages/billing.php:421
+#: pages/billing.php:422
+#: pages/billing.php:431
+msgid "This subscription is not recurring. So you don't need to update your billing information."
 msgstr ""
 
-#: pages/cancel.php:34 pages/cancel.php:14 pages/cancel.php:26
-#: pages/cancel.php:33 pages/cancel.php:34
+#: pages/cancel.php:34
+#: pages/cancel.php:14
+#: pages/cancel.php:26
+#: pages/cancel.php:33
 msgid "Are you sure you want to cancel your membership?"
 msgstr ""
 
-#: pages/cancel.php:41 pages/cancel.php:32 pages/cancel.php:40
 #: pages/cancel.php:41
+#: pages/cancel.php:32
+#: pages/cancel.php:40
 #, php-format
 msgid "Are you sure you want to cancel your %s membership?"
-msgstr ""
+msgid_plural "Are you sure you want to cancel your %s memberships?"
+msgstr[0] ""
+msgstr[1] ""
 
-#: pages/cancel.php:46 pages/cancel.php:45 pages/cancel.php:46
+#: pages/cancel.php:46
+#: pages/cancel.php:45
 msgid "Yes, cancel this membership"
 msgstr ""
 
-#: pages/cancel.php:47 pages/cancel.php:46 pages/cancel.php:47
+#: pages/cancel.php:47
+#: pages/cancel.php:46
 msgid "No, keep this membership"
 msgstr ""
 
-#: pages/cancel.php:56 shortcodes/pmpro_account.php:38 pages/account.php:14
-#: pages/cancel.php:48 pages/cancel.php:56 pages/cancel.php:57
-#: shortcodes/pmpro_account.php:38 shortcodes/pmpro_account.php:39
+#: pages/cancel.php:56
+#: shortcodes/pmpro_account.php:38
+#: pages/account.php:14
+#: pages/cancel.php:48
+#: pages/cancel.php:57
+#: shortcodes/pmpro_account.php:39
 #: shortcodes/pmpro_account.php:40
 msgid "My Memberships"
 msgstr ""
 
-#: pages/cancel.php:95 pages/cancel.php:77 pages/cancel.php:92
-#: pages/cancel.php:93 pages/cancel.php:95
+#: pages/cancel.php:95
+#: pages/cancel.php:77
+#: pages/cancel.php:92
+#: pages/cancel.php:93
 msgid "Cancel All Memberships"
 msgstr ""
 
-#: pages/cancel.php:104 pages/cancel.php:22 pages/cancel.php:86
-#: pages/cancel.php:101 pages/cancel.php:102 pages/cancel.php:104
+#: pages/cancel.php:104
+#: pages/cancel.php:22
+#: pages/cancel.php:86
+#: pages/cancel.php:101
+#: pages/cancel.php:102
 msgid "Click here to go to the home page."
 msgstr ""
 
-#: pages/checkout.php:41 pages/checkout.php:26 pages/checkout.php:27
-#: pages/checkout.php:28 pages/checkout.php:30 pages/checkout.php:35
+#: pages/checkout.php:41
+#: pages/checkout.php:26
+#: pages/checkout.php:27
+#: pages/checkout.php:28
+#: pages/checkout.php:30
+#: pages/checkout.php:35
 #: pages/checkout.php:38
-msgid ""
-"Almost done. Review the membership information and pricing below then "
-"<strong>click the \"Complete Payment\" button</strong> to finish your order."
+msgid "Almost done. Review the membership information and pricing below then <strong>click the \"Complete Payment\" button</strong> to finish your order."
 msgstr ""
 
-#: pages/checkout.php:51 pages/checkout.php:33 pages/checkout.php:34
-#: pages/checkout.php:35 pages/checkout.php:40 pages/checkout.php:42
-#: pages/checkout.php:43 pages/checkout.php:46 pages/checkout.php:48
+#: pages/checkout.php:51
+#: pages/checkout.php:33
+#: pages/checkout.php:34
+#: pages/checkout.php:35
+#: pages/checkout.php:40
+#: pages/checkout.php:42
+#: pages/checkout.php:43
+#: pages/checkout.php:46
+#: pages/checkout.php:48
 msgid "change"
 msgstr ""
 
-#: pages/checkout.php:55 pages/checkout.php:39 pages/checkout.php:41
-#: pages/checkout.php:42 pages/checkout.php:43 pages/checkout.php:44
-#: pages/checkout.php:50 pages/checkout.php:51 pages/checkout.php:52
+#: pages/checkout.php:55
+#: pages/checkout.php:39
+#: pages/checkout.php:41
+#: pages/checkout.php:42
+#: pages/checkout.php:43
+#: pages/checkout.php:44
+#: pages/checkout.php:50
+#: pages/checkout.php:51
+#: pages/checkout.php:52
 #: pages/checkout.php:54
 #, php-format
 msgid "You have selected the <strong>%s</strong> membership level."
 msgstr ""
 
-#: pages/checkout.php:72 pages/checkout.php:69
+#: pages/checkout.php:72
+#: pages/checkout.php:69
 msgid "<p class=\""
 msgstr ""
 
-#: pages/checkout.php:82 pages/checkout.php:66 pages/checkout.php:71
+#: pages/checkout.php:82
+#: pages/checkout.php:66
+#: pages/checkout.php:71
 #: pages/checkout.php:79
 msgid "Click here to change your discount code."
 msgstr ""
 
-#: pages/checkout.php:84 pages/checkout.php:64 pages/checkout.php:65
-#: pages/checkout.php:66 pages/checkout.php:68 pages/checkout.php:73
-#: pages/checkout.php:74 pages/checkout.php:81 pages/checkout.php:84
+#: pages/checkout.php:84
+#: pages/checkout.php:64
+#: pages/checkout.php:65
+#: pages/checkout.php:66
+#: pages/checkout.php:68
+#: pages/checkout.php:73
+#: pages/checkout.php:74
+#: pages/checkout.php:81
 msgid "Click here to enter your discount code"
 msgstr ""
 
-#: pages/checkout.php:84 pages/checkout.php:64 pages/checkout.php:65
-#: pages/checkout.php:66 pages/checkout.php:68 pages/checkout.php:73
-#: pages/checkout.php:74 pages/checkout.php:81 pages/checkout.php:84
+#: pages/checkout.php:84
+#: pages/checkout.php:64
+#: pages/checkout.php:65
+#: pages/checkout.php:66
+#: pages/checkout.php:68
+#: pages/checkout.php:73
+#: pages/checkout.php:74
+#: pages/checkout.php:81
 msgid "Do you have a discount code?"
 msgstr ""
 
-#: pages/checkout.php:116 pages/checkout.php:113 pages/checkout.php:160
-#: pages/checkout.php:162 pages/checkout.php:163 pages/checkout.php:165
-#: pages/checkout.php:170 pages/checkout.php:172 pages/checkout.php:173
-#: pages/checkout.php:175 pages/checkout.php:182 pages/checkout.php:185
+#: pages/checkout.php:116
+#: pages/checkout.php:113
+#: pages/checkout.php:160
+#: pages/checkout.php:162
+#: pages/checkout.php:163
+#: pages/checkout.php:165
+#: pages/checkout.php:170
+#: pages/checkout.php:172
+#: pages/checkout.php:173
+#: pages/checkout.php:175
+#: pages/checkout.php:182
+#: pages/checkout.php:185
 msgid "Account Information"
 msgstr ""
 
-#: pages/checkout.php:117 pages/checkout.php:114 pages/checkout.php:160
-#: pages/checkout.php:163 pages/checkout.php:165 pages/checkout.php:171
-#: pages/checkout.php:172 pages/checkout.php:174 pages/checkout.php:176
-#: pages/checkout.php:183 pages/checkout.php:186
+#: pages/checkout.php:117
+#: pages/checkout.php:114
+#: pages/checkout.php:160
+#: pages/checkout.php:163
+#: pages/checkout.php:165
+#: pages/checkout.php:171
+#: pages/checkout.php:172
+#: pages/checkout.php:174
+#: pages/checkout.php:176
+#: pages/checkout.php:183
+#: pages/checkout.php:186
 msgid "Already have an account?"
 msgstr ""
 
-#: pages/checkout.php:117 pages/checkout.php:114 pages/checkout.php:160
-#: pages/checkout.php:163 pages/checkout.php:165 pages/checkout.php:171
-#: pages/checkout.php:172 pages/checkout.php:174 pages/checkout.php:176
-#: pages/checkout.php:183 pages/checkout.php:186
+#: pages/checkout.php:117
+#: pages/checkout.php:114
+#: pages/checkout.php:160
+#: pages/checkout.php:163
+#: pages/checkout.php:165
+#: pages/checkout.php:171
+#: pages/checkout.php:172
+#: pages/checkout.php:174
+#: pages/checkout.php:176
+#: pages/checkout.php:183
+#: pages/checkout.php:186
 msgid "Log in here"
 msgstr ""
 
-#: pages/checkout.php:138 pages/checkout.php:135 pages/checkout.php:184
-#: pages/checkout.php:186 pages/checkout.php:189 pages/checkout.php:191
-#: pages/checkout.php:192 pages/checkout.php:198 pages/checkout.php:200
-#: pages/checkout.php:202 pages/checkout.php:209 pages/checkout.php:212
+#: pages/checkout.php:138
+#: pages/checkout.php:135
+#: pages/checkout.php:184
+#: pages/checkout.php:186
+#: pages/checkout.php:189
+#: pages/checkout.php:191
+#: pages/checkout.php:192
+#: pages/checkout.php:198
+#: pages/checkout.php:200
+#: pages/checkout.php:202
+#: pages/checkout.php:209
+#: pages/checkout.php:212
 msgid "Confirm Password"
 msgstr ""
 
-#: pages/checkout.php:159 pages/checkout.php:156 pages/checkout.php:205
-#: pages/checkout.php:213 pages/checkout.php:216 pages/checkout.php:218
-#: pages/checkout.php:225 pages/checkout.php:227 pages/checkout.php:229
-#: pages/checkout.php:236 pages/checkout.php:239
+#: pages/checkout.php:159
+#: pages/checkout.php:156
+#: pages/checkout.php:205
+#: pages/checkout.php:213
+#: pages/checkout.php:216
+#: pages/checkout.php:218
+#: pages/checkout.php:225
+#: pages/checkout.php:227
+#: pages/checkout.php:229
+#: pages/checkout.php:236
+#: pages/checkout.php:239
 msgid "Confirm Email Address"
 msgstr ""
 
-#: pages/checkout.php:172 pages/checkout.php:169 pages/checkout.php:218
-#: pages/checkout.php:226 pages/checkout.php:232 pages/checkout.php:235
-#: pages/checkout.php:237 pages/checkout.php:244 pages/checkout.php:246
-#: pages/checkout.php:248 pages/checkout.php:255 pages/checkout.php:258
+#: pages/checkout.php:172
+#: pages/checkout.php:169
+#: pages/checkout.php:218
+#: pages/checkout.php:226
+#: pages/checkout.php:232
+#: pages/checkout.php:235
+#: pages/checkout.php:237
+#: pages/checkout.php:244
+#: pages/checkout.php:246
+#: pages/checkout.php:248
+#: pages/checkout.php:255
+#: pages/checkout.php:258
 msgid "Full Name"
 msgstr ""
 
-#: pages/checkout.php:173 pages/checkout.php:170 pages/checkout.php:219
-#: pages/checkout.php:227 pages/checkout.php:233 pages/checkout.php:236
-#: pages/checkout.php:238 pages/checkout.php:245 pages/checkout.php:247
-#: pages/checkout.php:249 pages/checkout.php:256 pages/checkout.php:259
+#: pages/checkout.php:173
+#: pages/checkout.php:170
+#: pages/checkout.php:219
+#: pages/checkout.php:227
+#: pages/checkout.php:233
+#: pages/checkout.php:236
+#: pages/checkout.php:238
+#: pages/checkout.php:245
+#: pages/checkout.php:247
+#: pages/checkout.php:249
+#: pages/checkout.php:256
+#: pages/checkout.php:259
 msgid "LEAVE THIS BLANK"
 msgstr ""
 
-#: pages/checkout.php:192 pages/checkout.php:189 pages/checkout.php:238
-#: pages/checkout.php:246 pages/checkout.php:257 pages/checkout.php:260
-#: pages/checkout.php:262 pages/checkout.php:269 pages/checkout.php:271
-#: pages/checkout.php:273 pages/checkout.php:280 pages/checkout.php:283
+#: pages/checkout.php:192
+#: pages/checkout.php:189
+#: pages/checkout.php:238
+#: pages/checkout.php:246
+#: pages/checkout.php:257
+#: pages/checkout.php:260
+#: pages/checkout.php:262
+#: pages/checkout.php:269
+#: pages/checkout.php:271
+#: pages/checkout.php:273
+#: pages/checkout.php:280
+#: pages/checkout.php:283
 #, php-format
-msgid ""
-"You are logged in as <strong>%s</strong>. If you would like to use a "
-"different account for this membership, <a href=\"%s\">log out now</a>."
+msgid "You are logged in as <strong>%s</strong>. If you would like to use a different account for this membership, <a href=\"%s\">log out now</a>."
 msgstr ""
 
-#: pages/checkout.php:208 pages/checkout.php:205 pages/checkout.php:254
-#: pages/checkout.php:262 pages/checkout.php:276 pages/checkout.php:278
-#: pages/checkout.php:285 pages/checkout.php:287 pages/checkout.php:289
-#: pages/checkout.php:292 pages/checkout.php:296 pages/checkout.php:299
+#: pages/checkout.php:208
+#: pages/checkout.php:205
+#: pages/checkout.php:254
+#: pages/checkout.php:262
+#: pages/checkout.php:276
+#: pages/checkout.php:278
+#: pages/checkout.php:285
+#: pages/checkout.php:287
+#: pages/checkout.php:289
+#: pages/checkout.php:292
+#: pages/checkout.php:296
+#: pages/checkout.php:299
 msgid "Choose your Payment Method"
 msgstr ""
 
-#: pages/checkout.php:213 pages/checkout.php:210 pages/checkout.php:259
-#: pages/checkout.php:267 pages/checkout.php:284 pages/checkout.php:286
-#: pages/checkout.php:293 pages/checkout.php:296 pages/checkout.php:298
-#: pages/checkout.php:300 pages/checkout.php:305 pages/checkout.php:307
+#: pages/checkout.php:213
+#: pages/checkout.php:210
+#: pages/checkout.php:259
+#: pages/checkout.php:267
+#: pages/checkout.php:284
+#: pages/checkout.php:286
+#: pages/checkout.php:293
+#: pages/checkout.php:296
+#: pages/checkout.php:298
+#: pages/checkout.php:300
+#: pages/checkout.php:305
+#: pages/checkout.php:307
 #: pages/checkout.php:308
 msgid "Check Out with a Credit Card Here"
 msgstr ""
 
-#: pages/checkout.php:423 classes/gateways/class.pmprogateway_stripe.php:623
+#: pages/checkout.php:423
+#: classes/gateways/class.pmprogateway_stripe.php:623
 #: classes/gateways/class.pmprogateway_stripe.php:638
 #: classes/gateways/class.pmprogateway_stripe.php:646
 #: classes/gateways/class.pmprogateway_stripe.php:653
 #: classes/gateways/class.pmprogateway_stripe.php:654
-#: classes/gateways/class.pmprogateway_stripe.php:655 pages/checkout.php:420
-#: pages/checkout.php:492 pages/checkout.php:500
+#: classes/gateways/class.pmprogateway_stripe.php:655
+#: pages/checkout.php:420
+#: pages/checkout.php:492
+#: pages/checkout.php:500
 msgid "Security Code (CVC)"
 msgstr ""
 
-#: pages/checkout.php:475 pages/checkout.php:277 pages/checkout.php:284
-#: pages/checkout.php:459 pages/checkout.php:472 pages/checkout.php:567
-#: pages/checkout.php:575 pages/checkout.php:657 pages/checkout.php:672
-#: pages/checkout.php:673 pages/checkout.php:681 pages/checkout.php:686
-#: pages/checkout.php:690 pages/checkout.php:692 pages/checkout.php:693
-#: pages/checkout.php:696 pages/checkout.php:697
+#: pages/checkout.php:475
+#: pages/checkout.php:277
+#: pages/checkout.php:284
+#: pages/checkout.php:459
+#: pages/checkout.php:472
+#: pages/checkout.php:567
+#: pages/checkout.php:575
+#: pages/checkout.php:657
+#: pages/checkout.php:672
+#: pages/checkout.php:673
+#: pages/checkout.php:681
+#: pages/checkout.php:686
+#: pages/checkout.php:690
+#: pages/checkout.php:692
+#: pages/checkout.php:693
+#: pages/checkout.php:696
+#: pages/checkout.php:697
 #, php-format
 msgid "I agree to the %s"
 msgstr ""
 
-#: pages/checkout.php:500 pages/checkout.php:484 pages/checkout.php:497
-#: pages/checkout.php:586 pages/checkout.php:594 pages/checkout.php:667
-#: pages/checkout.php:674 pages/checkout.php:677 pages/checkout.php:692
-#: pages/checkout.php:693 pages/checkout.php:701 pages/checkout.php:706
-#: pages/checkout.php:710 pages/checkout.php:712 pages/checkout.php:713
-#: pages/checkout.php:716 pages/checkout.php:717
+#: pages/checkout.php:500
+#: pages/checkout.php:484
+#: pages/checkout.php:497
+#: pages/checkout.php:586
+#: pages/checkout.php:594
+#: pages/checkout.php:667
+#: pages/checkout.php:674
+#: pages/checkout.php:677
+#: pages/checkout.php:692
+#: pages/checkout.php:693
+#: pages/checkout.php:701
+#: pages/checkout.php:706
+#: pages/checkout.php:710
+#: pages/checkout.php:712
+#: pages/checkout.php:713
+#: pages/checkout.php:716
+#: pages/checkout.php:717
 msgid "Complete Payment"
 msgstr ""
 
-#: pages/checkout.php:522 pages/checkout.php:506 pages/checkout.php:519
-#: pages/checkout.php:608 pages/checkout.php:616 pages/checkout.php:687
-#: pages/checkout.php:694 pages/checkout.php:697 pages/checkout.php:713
-#: pages/checkout.php:714 pages/checkout.php:723 pages/checkout.php:728
-#: pages/checkout.php:732 pages/checkout.php:734 pages/checkout.php:735
-#: pages/checkout.php:738 pages/checkout.php:739
+#: pages/checkout.php:522
+#: pages/checkout.php:506
+#: pages/checkout.php:519
+#: pages/checkout.php:608
+#: pages/checkout.php:616
+#: pages/checkout.php:687
+#: pages/checkout.php:694
+#: pages/checkout.php:697
+#: pages/checkout.php:713
+#: pages/checkout.php:714
+#: pages/checkout.php:723
+#: pages/checkout.php:728
+#: pages/checkout.php:732
+#: pages/checkout.php:734
+#: pages/checkout.php:735
+#: pages/checkout.php:738
+#: pages/checkout.php:739
 msgid "Processing..."
 msgstr ""
 
-#: pages/confirmation.php:13 pages/confirmation.php:12
 #: pages/confirmation.php:13
-msgid ""
-"Your payment has been submitted. Your membership will be activated shortly."
+#: pages/confirmation.php:12
+msgid "Your payment has been submitted. Your membership will be activated shortly."
 msgstr ""
 
-#: pages/confirmation.php:15 pages/confirmation.php:14
 #: pages/confirmation.php:15
+#: pages/confirmation.php:14
 #, php-format
 msgid "Thank you for your membership to %s. Your %s membership is now active."
 msgstr ""
 
-#: pages/confirmation.php:29 pages/confirmation.php:28
 #: pages/confirmation.php:29
+#: pages/confirmation.php:28
 #, php-format
-msgid ""
-"Below are details about your membership account and a receipt for your "
-"initial membership invoice. A welcome email with a copy of your initial "
-"membership invoice has been sent to %s."
+msgid "Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s."
 msgstr ""
 
-#: pages/confirmation.php:47 pages/invoice.php:21 pages/confirmation.php:41
-#: pages/confirmation.php:46 pages/confirmation.php:47 pages/invoice.php:21
+#: pages/confirmation.php:47
+#: pages/invoice.php:21
+#: pages/confirmation.php:41
+#: pages/confirmation.php:46
 #: pages/invoice.php:22
 #, php-format
 msgid "Invoice #%s on %s"
 msgstr ""
 
-#: pages/confirmation.php:52 pages/confirmation.php:126 pages/invoice.php:25
-#: pages/confirmation.php:45 pages/confirmation.php:46
-#: pages/confirmation.php:51 pages/confirmation.php:52
-#: pages/confirmation.php:102 pages/confirmation.php:104
-#: pages/confirmation.php:112 pages/confirmation.php:115
-#: pages/confirmation.php:122 pages/confirmation.php:123
-#: pages/confirmation.php:125 pages/confirmation.php:126 pages/invoice.php:25
-#: pages/invoice.php:26 pages/invoice.php:27
+#: pages/confirmation.php:52
+#: pages/confirmation.php:126
+#: pages/invoice.php:25
+#: pages/confirmation.php:45
+#: pages/confirmation.php:46
+#: pages/confirmation.php:51
+#: pages/confirmation.php:102
+#: pages/confirmation.php:104
+#: pages/confirmation.php:112
+#: pages/confirmation.php:115
+#: pages/confirmation.php:122
+#: pages/confirmation.php:123
+#: pages/confirmation.php:125
+#: pages/invoice.php:26
+#: pages/invoice.php:27
 msgid "Account"
 msgstr ""
 
-#: pages/confirmation.php:55 pages/account.php:29 pages/account.php:33
-#: pages/confirmation.php:48 pages/confirmation.php:49
-#: pages/confirmation.php:54 pages/confirmation.php:55 pages/invoice.php:29
-#: pages/invoice.php:30 pages/invoice.php:31
+#: pages/confirmation.php:55
+#: pages/account.php:29
+#: pages/account.php:33
+#: pages/confirmation.php:48
+#: pages/confirmation.php:49
+#: pages/confirmation.php:54
+#: pages/invoice.php:29
+#: pages/invoice.php:30
+#: pages/invoice.php:31
 msgid "Membership Expires"
 msgstr ""
 
-#: pages/confirmation.php:91 pages/invoice.php:81 pages/invoice.php:114
-#: pages/confirmation.php:61 pages/confirmation.php:63
-#: pages/confirmation.php:65 pages/confirmation.php:71
-#: pages/confirmation.php:87 pages/confirmation.php:88
-#: pages/confirmation.php:90 pages/confirmation.php:91 pages/invoice.php:50
-#: pages/invoice.php:52 pages/invoice.php:69 pages/invoice.php:70
-#: pages/invoice.php:71 pages/invoice.php:72 pages/invoice.php:80
-#: pages/invoice.php:81 pages/invoice.php:90 pages/invoice.php:102
-#: pages/invoice.php:103 pages/invoice.php:104 pages/invoice.php:105
-#: pages/invoice.php:107 pages/invoice.php:109 pages/invoice.php:110
-#: pages/invoice.php:113 pages/invoice.php:114
+#: pages/confirmation.php:91
+#: pages/invoice.php:81
+#: pages/invoice.php:114
+#: pages/confirmation.php:61
+#: pages/confirmation.php:63
+#: pages/confirmation.php:65
+#: pages/confirmation.php:71
+#: pages/confirmation.php:87
+#: pages/confirmation.php:88
+#: pages/confirmation.php:90
+#: pages/invoice.php:50
+#: pages/invoice.php:52
+#: pages/invoice.php:69
+#: pages/invoice.php:70
+#: pages/invoice.php:71
+#: pages/invoice.php:72
+#: pages/invoice.php:80
+#: pages/invoice.php:90
+#: pages/invoice.php:102
+#: pages/invoice.php:103
+#: pages/invoice.php:104
+#: pages/invoice.php:105
+#: pages/invoice.php:107
+#: pages/invoice.php:109
+#: pages/invoice.php:110
+#: pages/invoice.php:113
 msgid "Total Billed"
 msgstr ""
 
-#: pages/confirmation.php:97 pages/invoice.php:87 pages/confirmation.php:93
-#: pages/confirmation.php:94 pages/confirmation.php:96
-#: pages/confirmation.php:97 pages/invoice.php:75 pages/invoice.php:76
-#: pages/invoice.php:77 pages/invoice.php:78 pages/invoice.php:80
-#: pages/invoice.php:82 pages/invoice.php:86 pages/invoice.php:87
+#: pages/confirmation.php:97
+#: pages/invoice.php:87
+#: pages/confirmation.php:93
+#: pages/confirmation.php:94
+#: pages/confirmation.php:96
+#: pages/invoice.php:75
+#: pages/invoice.php:76
+#: pages/invoice.php:77
+#: pages/invoice.php:78
+#: pages/invoice.php:80
+#: pages/invoice.php:82
+#: pages/invoice.php:86
 msgid "Coupon"
 msgstr ""
 
-#: pages/confirmation.php:114 pages/confirmation.php:97
-#: pages/confirmation.php:100 pages/confirmation.php:103
-#: pages/confirmation.php:110 pages/confirmation.php:111
-#: pages/confirmation.php:113 pages/confirmation.php:114
+#: pages/confirmation.php:114
+#: pages/confirmation.php:97
+#: pages/confirmation.php:100
+#: pages/confirmation.php:103
+#: pages/confirmation.php:110
+#: pages/confirmation.php:111
+#: pages/confirmation.php:113
 #, php-format
-msgid ""
-"Below are details about your membership account. A welcome email has been "
-"sent to %s."
+msgid "Below are details about your membership account. A welcome email has been sent to %s."
 msgstr ""
 
-#: pages/confirmation.php:127 shortcodes/pmpro_account.php:234
-#: pages/confirmation.php:103 pages/confirmation.php:105
-#: pages/confirmation.php:113 pages/confirmation.php:116
-#: pages/confirmation.php:123 pages/confirmation.php:124
-#: pages/confirmation.php:126 pages/confirmation.php:127
-#: shortcodes/pmpro_account.php:151 shortcodes/pmpro_account.php:227
+#: pages/confirmation.php:127
 #: shortcodes/pmpro_account.php:234
+#: pages/confirmation.php:103
+#: pages/confirmation.php:105
+#: pages/confirmation.php:113
+#: pages/confirmation.php:116
+#: pages/confirmation.php:123
+#: pages/confirmation.php:124
+#: pages/confirmation.php:126
+#: shortcodes/pmpro_account.php:151
+#: shortcodes/pmpro_account.php:227
 msgid "Pending"
 msgstr ""
 
-#: pages/confirmation.php:136 pages/confirmation.php:113
-#: pages/confirmation.php:115 pages/confirmation.php:123
-#: pages/confirmation.php:126 pages/confirmation.php:133
-#: pages/confirmation.php:134 pages/confirmation.php:135
 #: pages/confirmation.php:136
-msgid ""
-"If your account is not activated within a few minutes, please contact the "
-"site owner."
+#: pages/confirmation.php:113
+#: pages/confirmation.php:115
+#: pages/confirmation.php:123
+#: pages/confirmation.php:126
+#: pages/confirmation.php:133
+#: pages/confirmation.php:134
+#: pages/confirmation.php:135
+msgid "If your account is not activated within a few minutes, please contact the site owner."
 msgstr ""
 
-#: pages/invoice.php:112 pages/invoice.php:88 pages/invoice.php:100
-#: pages/invoice.php:101 pages/invoice.php:102 pages/invoice.php:103
-#: pages/invoice.php:106 pages/invoice.php:108 pages/invoice.php:111
 #: pages/invoice.php:112
+#: pages/invoice.php:88
+#: pages/invoice.php:100
+#: pages/invoice.php:101
+#: pages/invoice.php:102
+#: pages/invoice.php:103
+#: pages/invoice.php:106
+#: pages/invoice.php:108
+#: pages/invoice.php:111
 msgid "Invoice #"
 msgstr ""
 
-#: pages/invoice.php:138 pages/invoice.php:114 pages/invoice.php:126
-#: pages/invoice.php:127 pages/invoice.php:128 pages/invoice.php:129
-#: pages/invoice.php:132 pages/invoice.php:134 pages/invoice.php:137
 #: pages/invoice.php:138
+#: pages/invoice.php:114
+#: pages/invoice.php:126
+#: pages/invoice.php:127
+#: pages/invoice.php:128
+#: pages/invoice.php:129
+#: pages/invoice.php:132
+#: pages/invoice.php:134
+#: pages/invoice.php:137
 msgid "No invoices found."
 msgstr ""
 
-#: pages/invoice.php:146 pages/invoice.php:125 pages/invoice.php:137
-#: pages/invoice.php:138 pages/invoice.php:139 pages/invoice.php:140
-#: pages/invoice.php:143 pages/invoice.php:145 pages/invoice.php:146
+#: pages/invoice.php:146
+#: pages/invoice.php:125
+#: pages/invoice.php:137
+#: pages/invoice.php:138
+#: pages/invoice.php:139
+#: pages/invoice.php:140
+#: pages/invoice.php:143
+#: pages/invoice.php:145
 msgid "&larr; View All Invoices"
 msgstr ""
 
-#: pages/levels.php:66 pages/levels.php:47 pages/levels.php:49
-#: pages/levels.php:66 pages/levels.php:68 pages/levels.php:69
-#: pages/levels.php:71 pages/levels.php:113 pages/levels.php:115
+#: pages/levels.php:66
+#: pages/levels.php:47
+#: pages/levels.php:49
+#: pages/levels.php:68
+#: pages/levels.php:69
+#: pages/levels.php:71
+#: pages/levels.php:113
+#: pages/levels.php:115
 msgid "Select"
 msgstr ""
 
-#: pages/levels.php:72 shortcodes/pmpro_account.php:94 pages/account.php:33
-#: pages/levels.php:57 pages/levels.php:75 pages/levels.php:78
-#: pages/levels.php:123 shortcodes/pmpro_account.php:59
-#: shortcodes/pmpro_account.php:60 shortcodes/pmpro_account.php:61
+#: pages/levels.php:72
+#: shortcodes/pmpro_account.php:94
+#: pages/account.php:33
+#: pages/levels.php:57
+#: pages/levels.php:75
+#: pages/levels.php:78
+#: pages/levels.php:123
+#: shortcodes/pmpro_account.php:59
+#: shortcodes/pmpro_account.php:60
+#: shortcodes/pmpro_account.php:61
 msgid "Renew"
 msgstr ""
 
-#: pages/levels.php:76 pages/levels.php:63 pages/levels.php:79
-#: pages/levels.php:82 pages/levels.php:117 pages/levels.php:129
+#: pages/levels.php:76
+#: pages/levels.php:63
+#: pages/levels.php:79
+#: pages/levels.php:82
+#: pages/levels.php:117
+#: pages/levels.php:129
 msgid "Your&nbsp;Level"
 msgstr ""
 
-#: pages/levels.php:90 pages/levels.php:79 pages/levels.php:94
-#: pages/levels.php:97 pages/levels.php:98 pages/levels.php:129
+#: pages/levels.php:90
+#: pages/levels.php:79
+#: pages/levels.php:94
+#: pages/levels.php:97
+#: pages/levels.php:98
+#: pages/levels.php:129
 #: pages/levels.php:145
 msgid "&larr; Return to Your Account"
 msgstr ""
 
-#: pages/levels.php:92 pages/levels.php:81 pages/levels.php:96
-#: pages/levels.php:99 pages/levels.php:100 pages/levels.php:131
+#: pages/levels.php:92
+#: pages/levels.php:81
+#: pages/levels.php:96
+#: pages/levels.php:99
+#: pages/levels.php:100
+#: pages/levels.php:131
 #: pages/levels.php:147
 msgid "&larr; Return to Home"
 msgstr ""
 
-#: paid-memberships-pro.php:157 adminpages/orders.php:398
-#: adminpages/orders.php:448 paid-memberships-pro.php:115
-#: paid-memberships-pro.php:116 paid-memberships-pro.php:123
-#: paid-memberships-pro.php:124 paid-memberships-pro.php:125
-#: paid-memberships-pro.php:126 paid-memberships-pro.php:127
-#: paid-memberships-pro.php:128 paid-memberships-pro.php:129
-#: paid-memberships-pro.php:130 paid-memberships-pro.php:135
-#: paid-memberships-pro.php:140 paid-memberships-pro.php:145
-#: paid-memberships-pro.php:147 paid-memberships-pro.php:148
-#: paid-memberships-pro.php:156 paid-memberships-pro.php:157
+#: paid-memberships-pro.php:157
+#: adminpages/orders.php:398
+#: adminpages/orders.php:448
+#: paid-memberships-pro.php:115
+#: paid-memberships-pro.php:116
+#: paid-memberships-pro.php:123
+#: paid-memberships-pro.php:124
+#: paid-memberships-pro.php:125
+#: paid-memberships-pro.php:126
+#: paid-memberships-pro.php:127
+#: paid-memberships-pro.php:128
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:140
+#: paid-memberships-pro.php:145
+#: paid-memberships-pro.php:147
+#: paid-memberships-pro.php:148
+#: paid-memberships-pro.php:156
 msgid "Testing Only"
 msgstr ""
 
-#: paid-memberships-pro.php:162 paid-memberships-pro.php:120
-#: paid-memberships-pro.php:121 paid-memberships-pro.php:128
-#: paid-memberships-pro.php:129 paid-memberships-pro.php:130
-#: paid-memberships-pro.php:131 paid-memberships-pro.php:132
-#: paid-memberships-pro.php:133 paid-memberships-pro.php:134
-#: paid-memberships-pro.php:135 paid-memberships-pro.php:140
-#: paid-memberships-pro.php:145 paid-memberships-pro.php:150
-#: paid-memberships-pro.php:152 paid-memberships-pro.php:153
-#: paid-memberships-pro.php:161 paid-memberships-pro.php:162
+#: paid-memberships-pro.php:162
+#: paid-memberships-pro.php:120
+#: paid-memberships-pro.php:121
+#: paid-memberships-pro.php:128
+#: paid-memberships-pro.php:129
+#: paid-memberships-pro.php:130
+#: paid-memberships-pro.php:131
+#: paid-memberships-pro.php:132
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:140
+#: paid-memberships-pro.php:145
+#: paid-memberships-pro.php:150
+#: paid-memberships-pro.php:152
+#: paid-memberships-pro.php:153
+#: paid-memberships-pro.php:161
 msgid "PayPal Payflow Pro/PayPal Pro"
 msgstr ""
 
-#: paid-memberships-pro.php:167 paid-memberships-pro.php:125
-#: paid-memberships-pro.php:126 paid-memberships-pro.php:133
-#: paid-memberships-pro.php:134 paid-memberships-pro.php:135
-#: paid-memberships-pro.php:136 paid-memberships-pro.php:137
-#: paid-memberships-pro.php:138 paid-memberships-pro.php:139
-#: paid-memberships-pro.php:140 paid-memberships-pro.php:145
-#: paid-memberships-pro.php:150 paid-memberships-pro.php:155
-#: paid-memberships-pro.php:157 paid-memberships-pro.php:158
-#: paid-memberships-pro.php:166 paid-memberships-pro.php:167
+#: paid-memberships-pro.php:167
+#: paid-memberships-pro.php:125
+#: paid-memberships-pro.php:126
+#: paid-memberships-pro.php:133
+#: paid-memberships-pro.php:134
+#: paid-memberships-pro.php:135
+#: paid-memberships-pro.php:136
+#: paid-memberships-pro.php:137
+#: paid-memberships-pro.php:138
+#: paid-memberships-pro.php:139
+#: paid-memberships-pro.php:140
+#: paid-memberships-pro.php:145
+#: paid-memberships-pro.php:150
+#: paid-memberships-pro.php:155
+#: paid-memberships-pro.php:157
+#: paid-memberships-pro.php:158
+#: paid-memberships-pro.php:166
 msgid "Cybersource"
 msgstr ""
 
-#: paid-memberships-pro.php:171 paid-memberships-pro.php:161
-#: paid-memberships-pro.php:162 paid-memberships-pro.php:170
 #: paid-memberships-pro.php:171
+#: paid-memberships-pro.php:161
+#: paid-memberships-pro.php:162
+#: paid-memberships-pro.php:170
 msgid "Default"
 msgstr ""
 
-#: paid-memberships-pro.php:193 paid-memberships-pro.php:156
-#: paid-memberships-pro.php:157 paid-memberships-pro.php:158
-#: paid-memberships-pro.php:159 paid-memberships-pro.php:160
-#: paid-memberships-pro.php:161 paid-memberships-pro.php:166
-#: paid-memberships-pro.php:171 paid-memberships-pro.php:176
-#: paid-memberships-pro.php:182 paid-memberships-pro.php:183
-#: paid-memberships-pro.php:192 paid-memberships-pro.php:193
+#: paid-memberships-pro.php:193
+#: paid-memberships-pro.php:156
+#: paid-memberships-pro.php:157
+#: paid-memberships-pro.php:158
+#: paid-memberships-pro.php:159
+#: paid-memberships-pro.php:160
+#: paid-memberships-pro.php:161
+#: paid-memberships-pro.php:166
+#: paid-memberships-pro.php:171
+#: paid-memberships-pro.php:176
+#: paid-memberships-pro.php:182
+#: paid-memberships-pro.php:183
+#: paid-memberships-pro.php:192
 msgid "Once a month"
 msgstr ""
 
-#: preheaders/account.php:31 preheaders/levels.php:22 preheaders/account.php:7
-#: preheaders/account.php:9 preheaders/account.php:10 preheaders/account.php:31
-#: preheaders/levels.php:19 preheaders/levels.php:21 preheaders/levels.php:22
+#: preheaders/account.php:31
+#: preheaders/levels.php:22
+#: preheaders/account.php:7
+#: preheaders/account.php:9
+#: preheaders/account.php:10
+#: preheaders/levels.php:19
+#: preheaders/levels.php:21
 msgid "Your membership status has been updated - Thank you!"
 msgstr ""
 
-#: preheaders/account.php:33 preheaders/levels.php:24 preheaders/account.php:11
-#: preheaders/account.php:12 preheaders/account.php:33 preheaders/levels.php:23
+#: preheaders/account.php:33
 #: preheaders/levels.php:24
-msgid ""
-"Sorry, your request could not be completed - please try again in a few "
-"moments."
+#: preheaders/account.php:11
+#: preheaders/account.php:12
+#: preheaders/levels.php:23
+msgid "Sorry, your request could not be completed - please try again in a few moments."
 msgstr ""
 
-#: preheaders/billing.php:162 preheaders/checkout.php:336
-#: preheaders/billing.php:145 preheaders/billing.php:147
-#: preheaders/billing.php:151 preheaders/billing.php:153
-#: preheaders/billing.php:158 preheaders/billing.php:162
-#: preheaders/billing.php:258 preheaders/billing.php:265
-#: preheaders/billing.php:266 preheaders/billing.php:270
-#: preheaders/billing.php:273 preheaders/billing.php:279
-#: preheaders/checkout.php:322 preheaders/checkout.php:332
-#: preheaders/checkout.php:336 preheaders/checkout.php:364
-#: preheaders/checkout.php:458 preheaders/checkout.php:464
-#: preheaders/checkout.php:465 preheaders/checkout.php:470
-#: preheaders/checkout.php:481 preheaders/checkout.php:482
+#: preheaders/billing.php:162
+#: preheaders/checkout.php:336
+#: preheaders/billing.php:145
+#: preheaders/billing.php:147
+#: preheaders/billing.php:151
+#: preheaders/billing.php:153
+#: preheaders/billing.php:158
+#: preheaders/billing.php:258
+#: preheaders/billing.php:265
+#: preheaders/billing.php:266
+#: preheaders/billing.php:270
+#: preheaders/billing.php:273
+#: preheaders/billing.php:279
+#: preheaders/checkout.php:322
+#: preheaders/checkout.php:332
+#: preheaders/checkout.php:364
+#: preheaders/checkout.php:458
+#: preheaders/checkout.php:464
+#: preheaders/checkout.php:465
+#: preheaders/checkout.php:470
+#: preheaders/checkout.php:481
+#: preheaders/checkout.php:482
 msgid "Please complete all required fields."
 msgstr ""
 
-#: preheaders/billing.php:165 preheaders/checkout.php:344
-#: preheaders/billing.php:148 preheaders/billing.php:150
-#: preheaders/billing.php:154 preheaders/billing.php:156
-#: preheaders/billing.php:161 preheaders/billing.php:165
-#: preheaders/billing.php:263 preheaders/billing.php:268
-#: preheaders/billing.php:269 preheaders/billing.php:273
-#: preheaders/billing.php:276 preheaders/billing.php:284
-#: preheaders/checkout.php:330 preheaders/checkout.php:340
-#: preheaders/checkout.php:344 preheaders/checkout.php:372
-#: preheaders/checkout.php:466 preheaders/checkout.php:473
-#: preheaders/checkout.php:474 preheaders/checkout.php:478
-#: preheaders/checkout.php:491 preheaders/checkout.php:492
+#: preheaders/billing.php:165
+#: preheaders/checkout.php:344
+#: preheaders/billing.php:148
+#: preheaders/billing.php:150
+#: preheaders/billing.php:154
+#: preheaders/billing.php:156
+#: preheaders/billing.php:161
+#: preheaders/billing.php:263
+#: preheaders/billing.php:268
+#: preheaders/billing.php:269
+#: preheaders/billing.php:273
+#: preheaders/billing.php:276
+#: preheaders/billing.php:284
+#: preheaders/checkout.php:330
+#: preheaders/checkout.php:340
+#: preheaders/checkout.php:372
+#: preheaders/checkout.php:466
+#: preheaders/checkout.php:473
+#: preheaders/checkout.php:474
+#: preheaders/checkout.php:478
+#: preheaders/checkout.php:491
+#: preheaders/checkout.php:492
 msgid "Your email addresses do not match. Please try again."
 msgstr ""
 
-#: preheaders/billing.php:168 preheaders/checkout.php:349
-#: preheaders/billing.php:151 preheaders/billing.php:153
-#: preheaders/billing.php:157 preheaders/billing.php:159
-#: preheaders/billing.php:164 preheaders/billing.php:168
-#: preheaders/billing.php:268 preheaders/billing.php:271
-#: preheaders/billing.php:272 preheaders/billing.php:276
-#: preheaders/billing.php:279 preheaders/billing.php:289
-#: preheaders/checkout.php:335 preheaders/checkout.php:345
-#: preheaders/checkout.php:349 preheaders/checkout.php:377
-#: preheaders/checkout.php:471 preheaders/checkout.php:478
-#: preheaders/checkout.php:480 preheaders/checkout.php:483
-#: preheaders/checkout.php:497 preheaders/checkout.php:498
+#: preheaders/billing.php:168
+#: preheaders/checkout.php:349
+#: preheaders/billing.php:151
+#: preheaders/billing.php:153
+#: preheaders/billing.php:157
+#: preheaders/billing.php:159
+#: preheaders/billing.php:164
+#: preheaders/billing.php:268
+#: preheaders/billing.php:271
+#: preheaders/billing.php:272
+#: preheaders/billing.php:276
+#: preheaders/billing.php:279
+#: preheaders/billing.php:289
+#: preheaders/checkout.php:335
+#: preheaders/checkout.php:345
+#: preheaders/checkout.php:377
+#: preheaders/checkout.php:471
+#: preheaders/checkout.php:478
+#: preheaders/checkout.php:480
+#: preheaders/checkout.php:483
+#: preheaders/checkout.php:497
+#: preheaders/checkout.php:498
 msgid "The email address entered is in an invalid format. Please try again."
 msgstr ""
 
-#: preheaders/billing.php:172 preheaders/billing.php:155
-#: preheaders/billing.php:157 preheaders/billing.php:161
-#: preheaders/billing.php:163 preheaders/billing.php:168
-#: preheaders/billing.php:172 preheaders/billing.php:274
-#: preheaders/billing.php:275 preheaders/billing.php:276
-#: preheaders/billing.php:280 preheaders/billing.php:283
+#: preheaders/billing.php:172
+#: preheaders/billing.php:155
+#: preheaders/billing.php:157
+#: preheaders/billing.php:161
+#: preheaders/billing.php:163
+#: preheaders/billing.php:168
+#: preheaders/billing.php:274
+#: preheaders/billing.php:275
+#: preheaders/billing.php:276
+#: preheaders/billing.php:280
+#: preheaders/billing.php:283
 #: preheaders/billing.php:295
 msgid "All good!"
 msgstr ""
 
-#: preheaders/billing.php:239 preheaders/billing.php:222
-#: preheaders/billing.php:224 preheaders/billing.php:228
-#: preheaders/billing.php:230 preheaders/billing.php:235
-#: preheaders/billing.php:239 preheaders/billing.php:340
-#: preheaders/billing.php:345 preheaders/billing.php:346
-#: preheaders/billing.php:350 preheaders/billing.php:353
+#: preheaders/billing.php:239
+#: preheaders/billing.php:222
+#: preheaders/billing.php:224
+#: preheaders/billing.php:228
+#: preheaders/billing.php:230
+#: preheaders/billing.php:235
+#: preheaders/billing.php:340
+#: preheaders/billing.php:345
+#: preheaders/billing.php:346
+#: preheaders/billing.php:350
+#: preheaders/billing.php:353
 #: preheaders/billing.php:370
 #, php-format
 msgid "Information updated. <a href=\"%s\">&laquo; back to my account</a>"
 msgstr ""
 
-#: preheaders/billing.php:245 preheaders/billing.php:228
-#: preheaders/billing.php:230 preheaders/billing.php:234
-#: preheaders/billing.php:236 preheaders/billing.php:241
-#: preheaders/billing.php:245 preheaders/billing.php:347
-#: preheaders/billing.php:351 preheaders/billing.php:352
-#: preheaders/billing.php:356 preheaders/billing.php:359
-#: preheaders/billing.php:378 preheaders/billing.php:380
+#: preheaders/billing.php:245
+#: preheaders/billing.php:228
+#: preheaders/billing.php:230
+#: preheaders/billing.php:234
+#: preheaders/billing.php:236
+#: preheaders/billing.php:241
+#: preheaders/billing.php:347
+#: preheaders/billing.php:351
+#: preheaders/billing.php:352
+#: preheaders/billing.php:356
+#: preheaders/billing.php:359
+#: preheaders/billing.php:378
+#: preheaders/billing.php:380
 msgid "Error updating billing information."
 msgstr ""
 
-#: preheaders/cancel.php:76 preheaders/cancel.php:24 preheaders/cancel.php:25
-#: preheaders/cancel.php:28 preheaders/cancel.php:59 preheaders/cancel.php:60
 #: preheaders/cancel.php:76
+#: preheaders/cancel.php:24
+#: preheaders/cancel.php:25
+#: preheaders/cancel.php:28
+#: preheaders/cancel.php:59
+#: preheaders/cancel.php:60
 msgid "Your membership has been cancelled."
 msgstr ""
 
-#: preheaders/checkout.php:37 preheaders/checkout.php:358
-#: preheaders/checkout.php:28 preheaders/checkout.php:30
-#: preheaders/checkout.php:31 preheaders/checkout.php:32
-#: preheaders/checkout.php:34 preheaders/checkout.php:37
-#: preheaders/checkout.php:344 preheaders/checkout.php:354
-#: preheaders/checkout.php:358 preheaders/checkout.php:386
-#: preheaders/checkout.php:480 preheaders/checkout.php:487
-#: preheaders/checkout.php:491 preheaders/checkout.php:492
-#: preheaders/checkout.php:508 preheaders/checkout.php:509
+#: preheaders/checkout.php:37
+#: preheaders/checkout.php:358
+#: preheaders/checkout.php:28
+#: preheaders/checkout.php:30
+#: preheaders/checkout.php:31
+#: preheaders/checkout.php:32
+#: preheaders/checkout.php:34
+#: preheaders/checkout.php:344
+#: preheaders/checkout.php:354
+#: preheaders/checkout.php:386
+#: preheaders/checkout.php:480
+#: preheaders/checkout.php:487
+#: preheaders/checkout.php:491
+#: preheaders/checkout.php:492
+#: preheaders/checkout.php:508
+#: preheaders/checkout.php:509
 msgid "Invalid gateway."
 msgstr ""
 
-#: preheaders/checkout.php:72 preheaders/checkout.php:54
-#: preheaders/checkout.php:68 preheaders/checkout.php:72
-#: preheaders/checkout.php:88 preheaders/checkout.php:89
-#: preheaders/checkout.php:91 preheaders/checkout.php:95
+#: preheaders/checkout.php:72
+#: preheaders/checkout.php:54
+#: preheaders/checkout.php:68
+#: preheaders/checkout.php:88
+#: preheaders/checkout.php:89
+#: preheaders/checkout.php:91
+#: preheaders/checkout.php:95
 #: preheaders/checkout.php:96
 msgid "Checkout: Payment Information"
 msgstr ""
 
-#: preheaders/checkout.php:77 preheaders/checkout.php:59
-#: preheaders/checkout.php:73 preheaders/checkout.php:77
-#: preheaders/checkout.php:100 preheaders/checkout.php:101
+#: preheaders/checkout.php:77
+#: preheaders/checkout.php:59
+#: preheaders/checkout.php:73
+#: preheaders/checkout.php:100
+#: preheaders/checkout.php:101
 msgid "Set Up Your Account"
 msgstr ""
 
-#: preheaders/checkout.php:301 preheaders/checkout.php:289
-#: preheaders/checkout.php:300 preheaders/checkout.php:301
-#: preheaders/checkout.php:303 preheaders/checkout.php:304
-#: preheaders/checkout.php:331 preheaders/checkout.php:416
+#: preheaders/checkout.php:301
+#: preheaders/checkout.php:289
+#: preheaders/checkout.php:300
+#: preheaders/checkout.php:303
+#: preheaders/checkout.php:304
+#: preheaders/checkout.php:331
+#: preheaders/checkout.php:416
 #: preheaders/checkout.php:421
 msgid "There are JavaScript errors on the page. Please contact the webmaster."
 msgstr ""
 
-#: preheaders/checkout.php:339 preheaders/checkout.php:325
-#: preheaders/checkout.php:335 preheaders/checkout.php:339
-#: preheaders/checkout.php:367 preheaders/checkout.php:461
-#: preheaders/checkout.php:468 preheaders/checkout.php:473
-#: preheaders/checkout.php:485 preheaders/checkout.php:486
+#: preheaders/checkout.php:339
+#: preheaders/checkout.php:325
+#: preheaders/checkout.php:335
+#: preheaders/checkout.php:367
+#: preheaders/checkout.php:461
+#: preheaders/checkout.php:468
+#: preheaders/checkout.php:473
+#: preheaders/checkout.php:485
+#: preheaders/checkout.php:486
 msgid "Your passwords do not match. Please try again."
 msgstr ""
 
-#: preheaders/checkout.php:354 preheaders/checkout.php:340
-#: preheaders/checkout.php:350 preheaders/checkout.php:354
-#: preheaders/checkout.php:382 preheaders/checkout.php:476
-#: preheaders/checkout.php:483 preheaders/checkout.php:486
-#: preheaders/checkout.php:488 preheaders/checkout.php:503
+#: preheaders/checkout.php:354
+#: preheaders/checkout.php:340
+#: preheaders/checkout.php:350
+#: preheaders/checkout.php:382
+#: preheaders/checkout.php:476
+#: preheaders/checkout.php:483
+#: preheaders/checkout.php:486
+#: preheaders/checkout.php:488
+#: preheaders/checkout.php:503
 #: preheaders/checkout.php:504
 #, php-format
 msgid "Please check the box to agree to the %s."
 msgstr ""
 
-#: preheaders/checkout.php:361 preheaders/checkout.php:347
-#: preheaders/checkout.php:357 preheaders/checkout.php:361
-#: preheaders/checkout.php:389 preheaders/checkout.php:483
-#: preheaders/checkout.php:490 preheaders/checkout.php:495
-#: preheaders/checkout.php:512 preheaders/checkout.php:513
+#: preheaders/checkout.php:361
+#: preheaders/checkout.php:347
+#: preheaders/checkout.php:357
+#: preheaders/checkout.php:389
+#: preheaders/checkout.php:483
+#: preheaders/checkout.php:490
+#: preheaders/checkout.php:495
+#: preheaders/checkout.php:512
+#: preheaders/checkout.php:513
 msgid "Are you a spammer?"
 msgstr ""
 
-#: preheaders/checkout.php:382 preheaders/checkout.php:368
-#: preheaders/checkout.php:377 preheaders/checkout.php:381
-#: preheaders/checkout.php:382 preheaders/checkout.php:410
-#: preheaders/checkout.php:503 preheaders/checkout.php:510
-#: preheaders/checkout.php:515 preheaders/checkout.php:518
-#: preheaders/checkout.php:535 preheaders/checkout.php:536
+#: preheaders/checkout.php:382
+#: preheaders/checkout.php:368
+#: preheaders/checkout.php:377
+#: preheaders/checkout.php:381
+#: preheaders/checkout.php:410
+#: preheaders/checkout.php:503
+#: preheaders/checkout.php:510
+#: preheaders/checkout.php:515
+#: preheaders/checkout.php:518
+#: preheaders/checkout.php:535
+#: preheaders/checkout.php:536
 msgid "That username is already taken. Please try another."
 msgstr ""
 
-#: preheaders/checkout.php:387 preheaders/checkout.php:373
 #: preheaders/checkout.php:387
-msgid ""
-"That email address is already in use. Please log in, or use a different "
-"email address."
+#: preheaders/checkout.php:373
+msgid "That email address is already in use. Please log in, or use a different email address."
 msgstr ""
 
-#: preheaders/checkout.php:419 preheaders/checkout.php:397
-#: preheaders/checkout.php:399 preheaders/checkout.php:404
-#: preheaders/checkout.php:416 preheaders/checkout.php:418
-#: preheaders/checkout.php:419 preheaders/checkout.php:420
-#: preheaders/checkout.php:446 preheaders/checkout.php:525
-#: preheaders/checkout.php:532 preheaders/checkout.php:537
-#: preheaders/checkout.php:544 preheaders/checkout.php:561
+#: preheaders/checkout.php:419
+#: preheaders/checkout.php:397
+#: preheaders/checkout.php:399
+#: preheaders/checkout.php:404
+#: preheaders/checkout.php:416
+#: preheaders/checkout.php:418
+#: preheaders/checkout.php:420
+#: preheaders/checkout.php:446
+#: preheaders/checkout.php:525
+#: preheaders/checkout.php:532
+#: preheaders/checkout.php:537
+#: preheaders/checkout.php:544
+#: preheaders/checkout.php:561
 #: preheaders/checkout.php:562
 #, php-format
 msgid "reCAPTCHA failed. (%s) Please try again."
 msgstr ""
 
-#: preheaders/checkout.php:445 preheaders/checkout.php:445
-#: preheaders/checkout.php:482 preheaders/checkout.php:484
-#: preheaders/checkout.php:491 preheaders/checkout.php:495
-#: preheaders/checkout.php:496 preheaders/checkout.php:501
-#: preheaders/checkout.php:505 preheaders/checkout.php:509
-#: preheaders/checkout.php:533 preheaders/checkout.php:647
-#: preheaders/checkout.php:654 preheaders/checkout.php:659
-#: preheaders/checkout.php:683 preheaders/checkout.php:701
+#: preheaders/checkout.php:445
+#: preheaders/checkout.php:482
+#: preheaders/checkout.php:484
+#: preheaders/checkout.php:491
+#: preheaders/checkout.php:495
+#: preheaders/checkout.php:496
+#: preheaders/checkout.php:501
+#: preheaders/checkout.php:505
+#: preheaders/checkout.php:509
+#: preheaders/checkout.php:533
+#: preheaders/checkout.php:647
+#: preheaders/checkout.php:654
+#: preheaders/checkout.php:659
+#: preheaders/checkout.php:683
+#: preheaders/checkout.php:701
 #: preheaders/checkout.php:702
 msgid "Payment accepted."
 msgstr ""
 
-#: preheaders/checkout.php:451 preheaders/checkout.php:451
-#: preheaders/checkout.php:490 preheaders/checkout.php:492
-#: preheaders/checkout.php:497 preheaders/checkout.php:501
-#: preheaders/checkout.php:502 preheaders/checkout.php:509
-#: preheaders/checkout.php:513 preheaders/checkout.php:515
-#: preheaders/checkout.php:539 preheaders/checkout.php:653
-#: preheaders/checkout.php:660 preheaders/checkout.php:665
-#: preheaders/checkout.php:691 preheaders/checkout.php:709
+#: preheaders/checkout.php:451
+#: preheaders/checkout.php:490
+#: preheaders/checkout.php:492
+#: preheaders/checkout.php:497
+#: preheaders/checkout.php:501
+#: preheaders/checkout.php:502
+#: preheaders/checkout.php:509
+#: preheaders/checkout.php:513
+#: preheaders/checkout.php:515
+#: preheaders/checkout.php:539
+#: preheaders/checkout.php:653
+#: preheaders/checkout.php:660
+#: preheaders/checkout.php:665
+#: preheaders/checkout.php:691
+#: preheaders/checkout.php:709
 #: preheaders/checkout.php:710
-msgid ""
-"Unknown error generating account. Please contact us to set up your "
-"membership."
+msgid "Unknown error generating account. Please contact us to set up your membership."
 msgstr ""
 
-#: preheaders/checkout.php:537 preheaders/checkout.php:537
-#: preheaders/checkout.php:550 preheaders/checkout.php:552
-#: preheaders/checkout.php:569 preheaders/checkout.php:571
-#: preheaders/checkout.php:572 preheaders/checkout.php:575
-#: preheaders/checkout.php:576 preheaders/checkout.php:577
-#: preheaders/checkout.php:581 preheaders/checkout.php:596
-#: preheaders/checkout.php:614 preheaders/checkout.php:785
-#: preheaders/checkout.php:792 preheaders/checkout.php:797
-#: preheaders/checkout.php:825 preheaders/checkout.php:844
-#: preheaders/checkout.php:859 preheaders/checkout.php:860
-msgid ""
-"Your payment was accepted, but there was an error setting up your account. "
-"Please contact us."
+#: preheaders/checkout.php:537
+#: preheaders/checkout.php:550
+#: preheaders/checkout.php:552
+#: preheaders/checkout.php:569
+#: preheaders/checkout.php:571
+#: preheaders/checkout.php:572
+#: preheaders/checkout.php:575
+#: preheaders/checkout.php:576
+#: preheaders/checkout.php:577
+#: preheaders/checkout.php:581
+#: preheaders/checkout.php:596
+#: preheaders/checkout.php:614
+#: preheaders/checkout.php:785
+#: preheaders/checkout.php:792
+#: preheaders/checkout.php:797
+#: preheaders/checkout.php:825
+#: preheaders/checkout.php:844
+#: preheaders/checkout.php:859
+#: preheaders/checkout.php:860
+msgid "Your payment was accepted, but there was an error setting up your account. Please contact us."
 msgstr ""
 
-#: preheaders/checkout.php:775 preheaders/checkout.php:691
-#: preheaders/checkout.php:693 preheaders/checkout.php:710
-#: preheaders/checkout.php:712 preheaders/checkout.php:722
-#: preheaders/checkout.php:730 preheaders/checkout.php:754
-#: preheaders/checkout.php:767 preheaders/checkout.php:773
-#: preheaders/checkout.php:802 preheaders/checkout.php:806
-#: preheaders/checkout.php:807 preheaders/checkout.php:826
-#: preheaders/checkout.php:953 preheaders/checkout.php:960
-#: preheaders/checkout.php:970 preheaders/checkout.php:983
-#: preheaders/checkout.php:1030 preheaders/checkout.php:1045
+#: preheaders/checkout.php:775
+#: preheaders/checkout.php:691
+#: preheaders/checkout.php:693
+#: preheaders/checkout.php:710
+#: preheaders/checkout.php:712
+#: preheaders/checkout.php:722
+#: preheaders/checkout.php:730
+#: preheaders/checkout.php:754
+#: preheaders/checkout.php:767
+#: preheaders/checkout.php:773
+#: preheaders/checkout.php:802
+#: preheaders/checkout.php:806
+#: preheaders/checkout.php:807
+#: preheaders/checkout.php:826
+#: preheaders/checkout.php:953
+#: preheaders/checkout.php:960
+#: preheaders/checkout.php:970
+#: preheaders/checkout.php:983
+#: preheaders/checkout.php:1030
+#: preheaders/checkout.php:1045
 #: preheaders/checkout.php:1046
-msgid ""
-"IMPORTANT: Something went wrong during membership creation. Your credit card "
-"authorized, but we cancelled the order immediately. You should not try to "
-"submit this form again. Please contact the site owner to fix this issue."
+msgid "IMPORTANT: Something went wrong during membership creation. Your credit card authorized, but we cancelled the order immediately. You should not try to submit this form again. Please contact the site owner to fix this issue."
 msgstr ""
 
-#: preheaders/checkout.php:778 preheaders/checkout.php:694
-#: preheaders/checkout.php:696 preheaders/checkout.php:713
-#: preheaders/checkout.php:715 preheaders/checkout.php:725
-#: preheaders/checkout.php:733 preheaders/checkout.php:757
-#: preheaders/checkout.php:770 preheaders/checkout.php:776
-#: preheaders/checkout.php:805 preheaders/checkout.php:809
-#: preheaders/checkout.php:810 preheaders/checkout.php:829
-#: preheaders/checkout.php:956 preheaders/checkout.php:963
-#: preheaders/checkout.php:973 preheaders/checkout.php:988
-#: preheaders/checkout.php:1035 preheaders/checkout.php:1050
+#: preheaders/checkout.php:778
+#: preheaders/checkout.php:694
+#: preheaders/checkout.php:696
+#: preheaders/checkout.php:713
+#: preheaders/checkout.php:715
+#: preheaders/checkout.php:725
+#: preheaders/checkout.php:733
+#: preheaders/checkout.php:757
+#: preheaders/checkout.php:770
+#: preheaders/checkout.php:776
+#: preheaders/checkout.php:805
+#: preheaders/checkout.php:809
+#: preheaders/checkout.php:810
+#: preheaders/checkout.php:829
+#: preheaders/checkout.php:956
+#: preheaders/checkout.php:963
+#: preheaders/checkout.php:973
+#: preheaders/checkout.php:988
+#: preheaders/checkout.php:1035
+#: preheaders/checkout.php:1050
 #: preheaders/checkout.php:1051
-msgid ""
-"IMPORTANT: Something went wrong during membership creation. Your credit card "
-"was charged, but we couldn't assign your membership. You should not submit "
-"this form again. Please contact the site owner to fix this issue."
+msgid "IMPORTANT: Something went wrong during membership creation. Your credit card was charged, but we couldn't assign your membership. You should not submit this form again. Please contact the site owner to fix this issue."
 msgstr ""
 
-#: preheaders/checkout.php:789 preheaders/checkout.php:705
-#: preheaders/checkout.php:707 preheaders/checkout.php:724
-#: preheaders/checkout.php:726 preheaders/checkout.php:736
-#: preheaders/checkout.php:744 preheaders/checkout.php:768
-#: preheaders/checkout.php:781 preheaders/checkout.php:787
-#: preheaders/checkout.php:816 preheaders/checkout.php:820
-#: preheaders/checkout.php:821 preheaders/checkout.php:840
-#: preheaders/checkout.php:967 preheaders/checkout.php:974
-#: preheaders/checkout.php:984 preheaders/checkout.php:1001
-#: preheaders/checkout.php:1048 preheaders/checkout.php:1063
+#: preheaders/checkout.php:789
+#: preheaders/checkout.php:705
+#: preheaders/checkout.php:707
+#: preheaders/checkout.php:724
+#: preheaders/checkout.php:726
+#: preheaders/checkout.php:736
+#: preheaders/checkout.php:744
+#: preheaders/checkout.php:768
+#: preheaders/checkout.php:781
+#: preheaders/checkout.php:787
+#: preheaders/checkout.php:816
+#: preheaders/checkout.php:820
+#: preheaders/checkout.php:821
+#: preheaders/checkout.php:840
+#: preheaders/checkout.php:967
+#: preheaders/checkout.php:974
+#: preheaders/checkout.php:984
+#: preheaders/checkout.php:1001
+#: preheaders/checkout.php:1048
+#: preheaders/checkout.php:1063
 #: preheaders/checkout.php:1064
 #, php-format
-msgid ""
-"You must <a href=\"%s\">set up a Payment Gateway</a> before any payments "
-"will be processed."
+msgid "You must <a href=\"%s\">set up a Payment Gateway</a> before any payments will be processed."
 msgstr ""
 
-#: preheaders/checkout.php:791 preheaders/checkout.php:707
-#: preheaders/checkout.php:709 preheaders/checkout.php:726
-#: preheaders/checkout.php:728 preheaders/checkout.php:738
-#: preheaders/checkout.php:746 preheaders/checkout.php:770
-#: preheaders/checkout.php:783 preheaders/checkout.php:789
-#: preheaders/checkout.php:818 preheaders/checkout.php:822
-#: preheaders/checkout.php:823 preheaders/checkout.php:842
-#: preheaders/checkout.php:969 preheaders/checkout.php:976
-#: preheaders/checkout.php:986 preheaders/checkout.php:1003
-#: preheaders/checkout.php:1050 preheaders/checkout.php:1065
+#: preheaders/checkout.php:791
+#: preheaders/checkout.php:707
+#: preheaders/checkout.php:709
+#: preheaders/checkout.php:726
+#: preheaders/checkout.php:728
+#: preheaders/checkout.php:738
+#: preheaders/checkout.php:746
+#: preheaders/checkout.php:770
+#: preheaders/checkout.php:783
+#: preheaders/checkout.php:789
+#: preheaders/checkout.php:818
+#: preheaders/checkout.php:822
+#: preheaders/checkout.php:823
+#: preheaders/checkout.php:842
+#: preheaders/checkout.php:969
+#: preheaders/checkout.php:976
+#: preheaders/checkout.php:986
+#: preheaders/checkout.php:1003
+#: preheaders/checkout.php:1050
+#: preheaders/checkout.php:1065
 #: preheaders/checkout.php:1066
 msgid "A Payment Gateway must be set up before any payments will be processed."
 msgstr ""
 
-#: scheduled/crons.php:42 scheduled/crons.php:31 scheduled/crons.php:34
-#: scheduled/crons.php:38 scheduled/crons.php:39 scheduled/crons.php:41
+#: scheduled/crons.php:42
+#: scheduled/crons.php:31
+#: scheduled/crons.php:34
+#: scheduled/crons.php:38
+#: scheduled/crons.php:39
+#: scheduled/crons.php:41
 #: scheduled/crons.php:61
 #, php-format
 msgid "Membership expired email sent to %s. "
 msgstr ""
 
-#: scheduled/crons.php:113 scheduled/crons.php:27 scheduled/crons.php:74
-#: scheduled/crons.php:80 scheduled/crons.php:84 scheduled/crons.php:88
-#: scheduled/crons.php:99 scheduled/crons.php:100 scheduled/crons.php:105
+#: scheduled/crons.php:113
+#: scheduled/crons.php:27
+#: scheduled/crons.php:74
+#: scheduled/crons.php:80
+#: scheduled/crons.php:84
+#: scheduled/crons.php:88
+#: scheduled/crons.php:99
+#: scheduled/crons.php:100
+#: scheduled/crons.php:105
 #: scheduled/crons.php:109
 #, php-format
 msgid "Membership expiring email sent to %s. "
 msgstr ""
 
-#: scheduled/crons.php:202 scheduled/crons.php:143 scheduled/crons.php:152
-#: scheduled/crons.php:157 scheduled/crons.php:164 scheduled/crons.php:175
-#: scheduled/crons.php:176 scheduled/crons.php:184 scheduled/crons.php:191
+#: scheduled/crons.php:202
+#: scheduled/crons.php:143
+#: scheduled/crons.php:152
+#: scheduled/crons.php:157
+#: scheduled/crons.php:164
+#: scheduled/crons.php:175
+#: scheduled/crons.php:176
+#: scheduled/crons.php:184
+#: scheduled/crons.php:191
 #: scheduled/crons.php:193
 #, php-format
 msgid "Credit card expiring email sent to %s. "
 msgstr ""
 
-#: scheduled/crons.php:262 scheduled/crons.php:104 scheduled/crons.php:196
-#: scheduled/crons.php:208 scheduled/crons.php:210 scheduled/crons.php:220
-#: scheduled/crons.php:231 scheduled/crons.php:232 scheduled/crons.php:240
-#: scheduled/crons.php:249 scheduled/crons.php:251
+#: scheduled/crons.php:262
+#: scheduled/crons.php:104
+#: scheduled/crons.php:196
+#: scheduled/crons.php:208
+#: scheduled/crons.php:210
+#: scheduled/crons.php:220
+#: scheduled/crons.php:231
+#: scheduled/crons.php:232
+#: scheduled/crons.php:240
+#: scheduled/crons.php:249
+#: scheduled/crons.php:251
 #, php-format
 msgid "Trial ending email sent to %s. "
 msgstr ""
 
-#: services/applydiscountcode.php:93 services/applydiscountcode.php:64
-#: services/applydiscountcode.php:67 services/applydiscountcode.php:70
+#: services/applydiscountcode.php:93
+#: services/applydiscountcode.php:64
+#: services/applydiscountcode.php:67
+#: services/applydiscountcode.php:70
 #: services/applydiscountcode.php:86
 #, php-format
 msgid "The %s code has been applied to your order. "
 msgstr ""
 
-#: services/applydiscountcode.php:127 pages/checkout.php:62
-#: pages/checkout.php:63 pages/checkout.php:64 pages/checkout.php:66
-#: pages/checkout.php:71 pages/checkout.php:72 pages/checkout.php:79
-#: pages/checkout.php:82 services/applydiscountcode.php:74
-#: services/applydiscountcode.php:75 services/applydiscountcode.php:78
-#: services/applydiscountcode.php:89 services/applydiscountcode.php:92
+#: services/applydiscountcode.php:127
+#: pages/checkout.php:62
+#: pages/checkout.php:63
+#: pages/checkout.php:64
+#: pages/checkout.php:66
+#: pages/checkout.php:71
+#: pages/checkout.php:72
+#: pages/checkout.php:79
+#: pages/checkout.php:82
+#: services/applydiscountcode.php:74
+#: services/applydiscountcode.php:75
+#: services/applydiscountcode.php:78
+#: services/applydiscountcode.php:89
+#: services/applydiscountcode.php:92
 #: services/applydiscountcode.php:120
 msgid "Click here to change your discount code"
 msgstr ""
 
-#: services/applydiscountcode.php:139 services/applydiscountcode.php:143
-#: services/applydiscountcode.php:82 services/applydiscountcode.php:83
-#: services/applydiscountcode.php:86 services/applydiscountcode.php:97
-#: services/applydiscountcode.php:100 services/applydiscountcode.php:132
+#: services/applydiscountcode.php:139
+#: services/applydiscountcode.php:143
+#: services/applydiscountcode.php:82
+#: services/applydiscountcode.php:83
+#: services/applydiscountcode.php:86
+#: services/applydiscountcode.php:97
+#: services/applydiscountcode.php:100
+#: services/applydiscountcode.php:132
 #: services/applydiscountcode.php:136
 #, php-format
 msgid "The <strong>%s</strong> code has been applied to your order."
 msgstr ""
 
-#: services/authnet-silent-post.php:172 services/authnet-silent-post.php:133
-#: services/authnet-silent-post.php:138 services/authnet-silent-post.php:141
-#: services/authnet-silent-post.php:144 services/authnet-silent-post.php:145
-#: services/authnet-silent-post.php:149 services/authnet-silent-post.php:167
 #: services/authnet-silent-post.php:172
-msgid ""
-"<p>A payment is being held for review within Authorize.net.</p><p>Payment "
-"Information From Authorize.net"
+#: services/authnet-silent-post.php:133
+#: services/authnet-silent-post.php:138
+#: services/authnet-silent-post.php:141
+#: services/authnet-silent-post.php:144
+#: services/authnet-silent-post.php:145
+#: services/authnet-silent-post.php:149
+#: services/authnet-silent-post.php:167
+msgid "<p>A payment is being held for review within Authorize.net.</p><p>Payment Information From Authorize.net"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:43 pages/account.php:19
-#: shortcodes/pmpro_account.php:43 shortcodes/pmpro_account.php:44
+#: shortcodes/pmpro_account.php:43
+#: pages/account.php:19
+#: shortcodes/pmpro_account.php:44
 #: shortcodes/pmpro_account.php:45
 msgid "Billing"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:98 pages/account.php:36
-#: shortcodes/pmpro_account.php:62 shortcodes/pmpro_account.php:64
+#: shortcodes/pmpro_account.php:98
+#: pages/account.php:36
+#: shortcodes/pmpro_account.php:62
+#: shortcodes/pmpro_account.php:64
 #: shortcodes/pmpro_account.php:65
 msgid "Update Billing Info"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:103 pages/account.php:42
-#: shortcodes/pmpro_account.php:68 shortcodes/pmpro_account.php:70
+#: shortcodes/pmpro_account.php:103
+#: pages/account.php:42
+#: shortcodes/pmpro_account.php:68
+#: shortcodes/pmpro_account.php:70
 #: shortcodes/pmpro_account.php:71
 msgid "Change"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:145 pages/account.php:64
-#: shortcodes/pmpro_account.php:90 shortcodes/pmpro_account.php:92
-#: shortcodes/pmpro_account.php:93 shortcodes/pmpro_account.php:95
-#: shortcodes/pmpro_account.php:144 shortcodes/pmpro_account.php:145
+#: shortcodes/pmpro_account.php:145
+#: pages/account.php:64
+#: shortcodes/pmpro_account.php:90
+#: shortcodes/pmpro_account.php:92
+#: shortcodes/pmpro_account.php:93
+#: shortcodes/pmpro_account.php:95
+#: shortcodes/pmpro_account.php:144
 msgid "View all Membership Options"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:154 pages/account.php:46 pages/account.php:50
-#: pages/account.php:71 shortcodes/pmpro_account.php:99
-#: shortcodes/pmpro_account.php:101 shortcodes/pmpro_account.php:102
-#: shortcodes/pmpro_account.php:104 shortcodes/pmpro_account.php:153
 #: shortcodes/pmpro_account.php:154
+#: pages/account.php:46
+#: pages/account.php:50
+#: pages/account.php:71
+#: shortcodes/pmpro_account.php:99
+#: shortcodes/pmpro_account.php:101
+#: shortcodes/pmpro_account.php:102
+#: shortcodes/pmpro_account.php:104
+#: shortcodes/pmpro_account.php:153
 msgid "My Account"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:178 pages/account.php:55 pages/account.php:59
-#: pages/account.php:80 shortcodes/pmpro_account.php:110
-#: shortcodes/pmpro_account.php:112 shortcodes/pmpro_account.php:113
+#: shortcodes/pmpro_account.php:178
+#: pages/account.php:55
+#: pages/account.php:59
+#: pages/account.php:80
+#: shortcodes/pmpro_account.php:110
+#: shortcodes/pmpro_account.php:112
+#: shortcodes/pmpro_account.php:113
 #: shortcodes/pmpro_account.php:115
 msgid "Edit Profile"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:206 pages/account.php:87 pages/account.php:125
-#: pages/account.php:129 shortcodes/pmpro_account.php:118
-#: shortcodes/pmpro_account.php:120 shortcodes/pmpro_account.php:121
-#: shortcodes/pmpro_account.php:123 shortcodes/pmpro_account.php:199
 #: shortcodes/pmpro_account.php:206
+#: pages/account.php:87
+#: pages/account.php:125
+#: pages/account.php:129
+#: shortcodes/pmpro_account.php:118
+#: shortcodes/pmpro_account.php:120
+#: shortcodes/pmpro_account.php:121
+#: shortcodes/pmpro_account.php:123
+#: shortcodes/pmpro_account.php:199
 msgid "Past Invoices"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:212 pages/account.php:93
-#: shortcodes/pmpro_account.php:124 shortcodes/pmpro_account.php:126
-#: shortcodes/pmpro_account.php:127 shortcodes/pmpro_account.php:129
-#: shortcodes/pmpro_account.php:205 shortcodes/pmpro_account.php:212
+#: shortcodes/pmpro_account.php:212
+#: pages/account.php:93
+#: shortcodes/pmpro_account.php:124
+#: shortcodes/pmpro_account.php:126
+#: shortcodes/pmpro_account.php:127
+#: shortcodes/pmpro_account.php:129
+#: shortcodes/pmpro_account.php:205
 msgid "Amount"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:236 shortcodes/pmpro_account.php:153
-#: shortcodes/pmpro_account.php:229 shortcodes/pmpro_account.php:236
+#: shortcodes/pmpro_account.php:236
+#: shortcodes/pmpro_account.php:153
+#: shortcodes/pmpro_account.php:229
 msgid "Refunded"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:251 pages/account.php:121 pages/account.php:140
-#: pages/account.php:144 shortcodes/pmpro_account.php:152
-#: shortcodes/pmpro_account.php:154 shortcodes/pmpro_account.php:155
-#: shortcodes/pmpro_account.php:157 shortcodes/pmpro_account.php:168
-#: shortcodes/pmpro_account.php:244 shortcodes/pmpro_account.php:251
+#: shortcodes/pmpro_account.php:251
+#: pages/account.php:121
+#: pages/account.php:140
+#: pages/account.php:144
+#: shortcodes/pmpro_account.php:152
+#: shortcodes/pmpro_account.php:154
+#: shortcodes/pmpro_account.php:155
+#: shortcodes/pmpro_account.php:157
+#: shortcodes/pmpro_account.php:168
+#: shortcodes/pmpro_account.php:244
 msgid "View All Invoices"
 msgstr ""
 
-#: shortcodes/pmpro_account.php:258 pages/account.php:128 pages/account.php:146
-#: pages/account.php:150 shortcodes/pmpro_account.php:159
-#: shortcodes/pmpro_account.php:161 shortcodes/pmpro_account.php:162
-#: shortcodes/pmpro_account.php:164 shortcodes/pmpro_account.php:175
-#: shortcodes/pmpro_account.php:251 shortcodes/pmpro_account.php:258
+#: shortcodes/pmpro_account.php:258
+#: pages/account.php:128
+#: pages/account.php:146
+#: pages/account.php:150
+#: shortcodes/pmpro_account.php:159
+#: shortcodes/pmpro_account.php:161
+#: shortcodes/pmpro_account.php:162
+#: shortcodes/pmpro_account.php:164
+#: shortcodes/pmpro_account.php:175
+#: shortcodes/pmpro_account.php:251
 msgid "Member Links"
 msgstr ""
 
@@ -13215,38 +17040,48 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: adminpages/admin_header.php:106 adminpages/admin_header.php:127
-#: adminpages/admin_header.php:136 adminpages/admin_header.php:148
+#: adminpages/admin_header.php:106
+#: adminpages/admin_header.php:127
+#: adminpages/admin_header.php:136
+#: adminpages/admin_header.php:148
 msgid "Plugin Support"
 msgstr ""
 
-#: adminpages/admin_header.php:106 adminpages/admin_header.php:127
-#: adminpages/admin_header.php:136 adminpages/admin_header.php:148
+#: adminpages/admin_header.php:106
+#: adminpages/admin_header.php:127
+#: adminpages/admin_header.php:136
+#: adminpages/admin_header.php:148
 msgid "User Forum"
 msgstr ""
 
-#: adminpages/advancedsettings.php:66 adminpages/advancedsettings.php:68
-#: adminpages/advancedsettings.php:71 adminpages/advancedsettings.php:85
-#: adminpages/advancedsettings.php:87 adminpages/advancedsettings.php:89
+#: adminpages/advancedsettings.php:66
+#: adminpages/advancedsettings.php:68
+#: adminpages/advancedsettings.php:71
+#: adminpages/advancedsettings.php:85
+#: adminpages/advancedsettings.php:87
+#: adminpages/advancedsettings.php:89
 #, php-format
-msgid ""
-"This content is for !!levels!! members only. <a href=\"%s\">Register here</"
-"a>."
+msgid "This content is for !!levels!! members only. <a href=\"%s\">Register here</a>."
 msgstr ""
 
-#: adminpages/advancedsettings.php:71 adminpages/advancedsettings.php:73
-#: adminpages/advancedsettings.php:76 adminpages/advancedsettings.php:90
-#: adminpages/advancedsettings.php:92 adminpages/advancedsettings.php:94
+#: adminpages/advancedsettings.php:71
+#: adminpages/advancedsettings.php:73
+#: adminpages/advancedsettings.php:76
+#: adminpages/advancedsettings.php:90
+#: adminpages/advancedsettings.php:92
+#: adminpages/advancedsettings.php:94
 #, php-format
-msgid ""
-"Please <a href=\"%s\">login</a> to view this content. (<a href=\"%s"
-"\">Register here</a>.)"
+msgid "Please <a href=\"%s\">login</a> to view this content. (<a href=\"%s\">Register here</a>.)"
 msgstr ""
 
-#: adminpages/advancedsettings.php:137 adminpages/advancedsettings.php:144
-#: adminpages/advancedsettings.php:157 adminpages/advancedsettings.php:160
-#: adminpages/advancedsettings.php:176 adminpages/advancedsettings.php:178
-#: adminpages/advancedsettings.php:234 adminpages/advancedsettings.php:237
+#: adminpages/advancedsettings.php:137
+#: adminpages/advancedsettings.php:144
+#: adminpages/advancedsettings.php:157
+#: adminpages/advancedsettings.php:160
+#: adminpages/advancedsettings.php:176
+#: adminpages/advancedsettings.php:178
+#: adminpages/advancedsettings.php:234
+#: adminpages/advancedsettings.php:237
 #: adminpages/advancedsettings.php:344
 msgid "Ads from the following plugins will be automatically turned off"
 msgstr ""
@@ -13255,28 +17090,39 @@ msgstr ""
 msgid "reCAPTCHA Settings"
 msgstr ""
 
-#: adminpages/advancedsettings.php:209 adminpages/advancedsettings.php:216
-#: adminpages/advancedsettings.php:229 adminpages/advancedsettings.php:232
+#: adminpages/advancedsettings.php:209
+#: adminpages/advancedsettings.php:216
+#: adminpages/advancedsettings.php:229
+#: adminpages/advancedsettings.php:232
 #: adminpages/advancedsettings.php:248
 msgid "reCAPTCHA Public Key"
 msgstr ""
 
-#: adminpages/advancedsettings.php:212 adminpages/advancedsettings.php:219
-#: adminpages/advancedsettings.php:232 adminpages/advancedsettings.php:235
+#: adminpages/advancedsettings.php:212
+#: adminpages/advancedsettings.php:219
+#: adminpages/advancedsettings.php:232
+#: adminpages/advancedsettings.php:235
 #: adminpages/advancedsettings.php:251
 msgid "reCAPTCHA Private Key"
 msgstr ""
 
-#: adminpages/advancedsettings.php:272 adminpages/advancedsettings.php:285
+#: adminpages/advancedsettings.php:272
+#: adminpages/advancedsettings.php:285
 msgid "selected"
 msgstr ""
 
-#: adminpages/dashboard.php:216 adminpages/dashboard.php:224
-#: adminpages/memberslist.php:118 adminpages/memberslist.php:151
-#: adminpages/memberslist.php:161 adminpages/memberslist.php:171
-#: adminpages/pagesettings.php:51 adminpages/reports/login.php:143
-#: adminpages/reports/login.php:145 adminpages/reports/login.php:161
-#: adminpages/reports/login.php:165 adminpages/reports/login.php:181
+#: adminpages/dashboard.php:216
+#: adminpages/dashboard.php:224
+#: adminpages/memberslist.php:118
+#: adminpages/memberslist.php:151
+#: adminpages/memberslist.php:161
+#: adminpages/memberslist.php:171
+#: adminpages/pagesettings.php:51
+#: adminpages/reports/login.php:143
+#: adminpages/reports/login.php:145
+#: adminpages/reports/login.php:161
+#: adminpages/reports/login.php:165
+#: adminpages/reports/login.php:181
 #: classes/gateways/class.pmprogateway_authorizenet.php:187
 #: classes/gateways/class.pmprogateway_authorizenet.php:303
 #: classes/gateways/class.pmprogateway_authorizenet.php:304
@@ -13293,67 +17139,104 @@ msgid "Check this to set an expiration date for new sign ups."
 msgstr ""
 
 #: adminpages/discountcodes.php:497
-msgid ""
-"How long before the expiration expires. Note that any future payments will "
-"be cancelled when the membership expires."
+msgid "How long before the expiration expires. Note that any future payments will be cancelled when the membership expires."
 msgstr ""
 
-#: adminpages/discountcodes.php:570 adminpages/discountcodes.php:574
-#: adminpages/discountcodes.php:602 adminpages/discountcodes.php:603
-#: adminpages/discountcodes.php:604 adminpages/discountcodes.php:609
-#: adminpages/discountcodes.php:682 adminpages/discountcodes.php:736
+#: adminpages/discountcodes.php:570
+#: adminpages/discountcodes.php:574
+#: adminpages/discountcodes.php:602
+#: adminpages/discountcodes.php:603
+#: adminpages/discountcodes.php:604
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:682
+#: adminpages/discountcodes.php:736
 msgid "Create your first discount code now"
 msgstr ""
 
-#: adminpages/discountcodes.php:570 adminpages/discountcodes.php:574
-#: adminpages/discountcodes.php:602 adminpages/discountcodes.php:603
-#: adminpages/discountcodes.php:604 adminpages/discountcodes.php:609
-#: adminpages/discountcodes.php:682 adminpages/discountcodes.php:736
-msgid ""
-"Discount codes allow you to offer your memberships at discounted prices to "
-"select customers."
+#: adminpages/discountcodes.php:570
+#: adminpages/discountcodes.php:574
+#: adminpages/discountcodes.php:602
+#: adminpages/discountcodes.php:603
+#: adminpages/discountcodes.php:604
+#: adminpages/discountcodes.php:609
+#: adminpages/discountcodes.php:682
+#: adminpages/discountcodes.php:736
+msgid "Discount codes allow you to offer your memberships at discounted prices to select customers."
 msgstr ""
 
-#: adminpages/discountcodes.php:617 adminpages/discountcodes.php:622
-#: adminpages/discountcodes.php:650 adminpages/discountcodes.php:651
-#: adminpages/discountcodes.php:652 adminpages/discountcodes.php:653
-#: adminpages/discountcodes.php:658 adminpages/discountcodes.php:738
-#: adminpages/discountcodes.php:792 adminpages/discountcodes.php:805
-#: adminpages/membershiplevels.php:566 adminpages/membershiplevels.php:572
-#: adminpages/membershiplevels.php:574 adminpages/membershiplevels.php:580
-#: adminpages/membershiplevels.php:601 adminpages/membershiplevels.php:660
-#: adminpages/membershiplevels.php:662 adminpages/membershiplevels.php:664
-#: adminpages/membershiplevels.php:669 adminpages/membershiplevels.php:670
-#: adminpages/membershiplevels.php:674 adminpages/membershiplevels.php:686
-#: adminpages/membershiplevels.php:696 adminpages/membershiplevels.php:746
-#: adminpages/membershiplevels.php:748 adminpages/orders.php:664
-#: adminpages/orders.php:967 adminpages/orders.php:985
-#: adminpages/orders.php:995 adminpages/orders.php:998
-#: adminpages/orders.php:1027 adminpages/orders.php:1056
-#: adminpages/orders.php:1211 adminpages/orders.php:1245
-#: adminpages/orders.php:1251 adminpages/orders.php:1366
+#: adminpages/discountcodes.php:617
+#: adminpages/discountcodes.php:622
+#: adminpages/discountcodes.php:650
+#: adminpages/discountcodes.php:651
+#: adminpages/discountcodes.php:652
+#: adminpages/discountcodes.php:653
+#: adminpages/discountcodes.php:658
+#: adminpages/discountcodes.php:738
+#: adminpages/discountcodes.php:792
+#: adminpages/discountcodes.php:805
+#: adminpages/membershiplevels.php:566
+#: adminpages/membershiplevels.php:572
+#: adminpages/membershiplevels.php:574
+#: adminpages/membershiplevels.php:580
+#: adminpages/membershiplevels.php:601
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:662
+#: adminpages/membershiplevels.php:664
+#: adminpages/membershiplevels.php:669
+#: adminpages/membershiplevels.php:670
+#: adminpages/membershiplevels.php:674
+#: adminpages/membershiplevels.php:686
+#: adminpages/membershiplevels.php:696
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:748
+#: adminpages/orders.php:664
+#: adminpages/orders.php:967
+#: adminpages/orders.php:985
+#: adminpages/orders.php:995
+#: adminpages/orders.php:998
+#: adminpages/orders.php:1027
+#: adminpages/orders.php:1056
+#: adminpages/orders.php:1211
+#: adminpages/orders.php:1245
+#: adminpages/orders.php:1251
+#: adminpages/orders.php:1366
 #: adminpages/orders.php:1495
 msgid "delete"
 msgstr ""
 
-#: adminpages/discountcodes.php:804 adminpages/membershiplevels.php:565
-#: adminpages/membershiplevels.php:571 adminpages/membershiplevels.php:573
-#: adminpages/membershiplevels.php:580 adminpages/membershiplevels.php:600
-#: adminpages/membershiplevels.php:660 adminpages/membershiplevels.php:662
-#: adminpages/membershiplevels.php:664 adminpages/membershiplevels.php:669
-#: adminpages/membershiplevels.php:670 adminpages/membershiplevels.php:674
-#: adminpages/membershiplevels.php:686 adminpages/membershiplevels.php:696
-#: adminpages/membershiplevels.php:746 adminpages/membershiplevels.php:748
-#: adminpages/orders.php:661 adminpages/orders.php:964
-#: adminpages/orders.php:982 adminpages/orders.php:992
-#: adminpages/orders.php:995 adminpages/orders.php:1024
-#: adminpages/orders.php:1053 adminpages/orders.php:1208
-#: adminpages/orders.php:1242 adminpages/orders.php:1248
-#: adminpages/orders.php:1363 adminpages/orders.php:1492
+#: adminpages/discountcodes.php:804
+#: adminpages/membershiplevels.php:565
+#: adminpages/membershiplevels.php:571
+#: adminpages/membershiplevels.php:573
+#: adminpages/membershiplevels.php:580
+#: adminpages/membershiplevels.php:600
+#: adminpages/membershiplevels.php:660
+#: adminpages/membershiplevels.php:662
+#: adminpages/membershiplevels.php:664
+#: adminpages/membershiplevels.php:669
+#: adminpages/membershiplevels.php:670
+#: adminpages/membershiplevels.php:674
+#: adminpages/membershiplevels.php:686
+#: adminpages/membershiplevels.php:696
+#: adminpages/membershiplevels.php:746
+#: adminpages/membershiplevels.php:748
+#: adminpages/orders.php:661
+#: adminpages/orders.php:964
+#: adminpages/orders.php:982
+#: adminpages/orders.php:992
+#: adminpages/orders.php:995
+#: adminpages/orders.php:1024
+#: adminpages/orders.php:1053
+#: adminpages/orders.php:1208
+#: adminpages/orders.php:1242
+#: adminpages/orders.php:1248
+#: adminpages/orders.php:1363
+#: adminpages/orders.php:1492
 msgid "copy"
 msgstr ""
 
-#: adminpages/discountcodes.php:807 adminpages/discountcodes.php:809
+#: adminpages/discountcodes.php:807
+#: adminpages/discountcodes.php:809
 msgid "orders"
 msgstr ""
 
@@ -13365,45 +17248,27 @@ msgstr ""
 msgid "no orders"
 msgstr ""
 
-#: adminpages/emailsettings.php:63 adminpages/emailsettings.php:72
-msgid ""
-"To modify the appearance of system generated emails, add the files "
-"<em>email_header.html</em> and <em>email_footer.html</em> to your theme's "
-"directory. This will modify both the WordPress default messages as well as "
-"messages generated by Paid Memberships Pro. <a title=\"Paid Memberships Pro "
-"- Member Communications\" target=\"_blank\" href=\"http://www."
-"paidmembershipspro.com/documentation/member-communications/\">Click here to "
-"learn more about Paid Memberships Pro emails</a>."
+#: adminpages/emailsettings.php:63
+#: adminpages/emailsettings.php:72
+msgid "To modify the appearance of system generated emails, add the files <em>email_header.html</em> and <em>email_footer.html</em> to your theme's directory. This will modify both the WordPress default messages as well as messages generated by Paid Memberships Pro. <a title=\"Paid Memberships Pro - Member Communications\" target=\"_blank\" href=\"http://www.paidmembershipspro.com/documentation/member-communications/\">Click here to learn more about Paid Memberships Pro emails</a>."
 msgstr ""
 
-#: adminpages/emailsettings.php:82 adminpages/emailsettings.php:86
-msgid ""
-"To modify the appearance of system generated emails, add the files "
-"<em>email_header.html</em> and <em>email_footer.html</em> to your theme's "
-"directory. This will modify both the WordPress default messages as well as "
-"messages generated by Paid Memberships Pro. <a title=\"Paid Memberships Pro "
-"- Member Communications\" target=\"_blank\" href=\"http://www."
-"paidmembershipspro.com/documentation/member-communications/?"
-"utm_source=plugin&utm_medium=banner&utm_campaign=admin_email_settings"
-"\">Click here to learn more about Paid Memberships Pro emails</a>."
+#: adminpages/emailsettings.php:82
+#: adminpages/emailsettings.php:86
+msgid "To modify the appearance of system generated emails, add the files <em>email_header.html</em> and <em>email_footer.html</em> to your theme's directory. This will modify both the WordPress default messages as well as messages generated by Paid Memberships Pro. <a title=\"Paid Memberships Pro - Member Communications\" target=\"_blank\" href=\"http://www.paidmembershipspro.com/documentation/member-communications/?utm_source=plugin&utm_medium=banner&utm_campaign=admin_email_settings\">Click here to learn more about Paid Memberships Pro emails</a>."
 msgstr ""
 
-#: adminpages/emailsettings.php:86 adminpages/emailsettings.php:88
-msgid ""
-"To modify the appearance of system generated emails, add the files "
-"<em>email_header.html</em> and <em>email_footer.html</em> to your theme's "
-"directory. This will modify both the WordPress default messages as well as "
-"messages generated by Paid Memberships Pro. <a title=\"Paid Memberships Pro "
-"- Member Communications\" target=\"_blank\" href=\"http://www."
-"paidmembershipspro.com/documentation/member-communications/?"
-"utm_source=plugin&utm_medium=pmpro-"
-"emailsettings&utm_campaign=documentation&utm_content=member-communications"
-"\">Click here to learn more about Paid Memberships Pro emails</a>."
+#: adminpages/emailsettings.php:86
+#: adminpages/emailsettings.php:88
+msgid "To modify the appearance of system generated emails, add the files <em>email_header.html</em> and <em>email_footer.html</em> to your theme's directory. This will modify both the WordPress default messages as well as messages generated by Paid Memberships Pro. <a title=\"Paid Memberships Pro - Member Communications\" target=\"_blank\" href=\"http://www.paidmembershipspro.com/documentation/member-communications/?utm_source=plugin&utm_medium=pmpro-emailsettings&utm_campaign=documentation&utm_content=member-communications\">Click here to learn more about Paid Memberships Pro emails</a>."
 msgstr ""
 
-#: adminpages/emailsettings.php:92 adminpages/emailsettings.php:110
-#: adminpages/emailsettings.php:121 adminpages/emailsettings.php:131
-#: adminpages/emailsettings.php:135 adminpages/emailsettings.php:136
+#: adminpages/emailsettings.php:92
+#: adminpages/emailsettings.php:110
+#: adminpages/emailsettings.php:121
+#: adminpages/emailsettings.php:131
+#: adminpages/emailsettings.php:135
+#: adminpages/emailsettings.php:136
 #: adminpages/emailsettings.php:137
 msgid "Checkout"
 msgstr ""
@@ -13412,171 +17277,199 @@ msgstr ""
 msgid "If unchecked, all emails from \"WordPress &lt;"
 msgstr ""
 
-#: adminpages/emailsettings.php:101 adminpages/emailsettings.php:119
-#: adminpages/emailsettings.php:130 adminpages/emailsettings.php:140
-#: adminpages/emailsettings.php:144 adminpages/emailsettings.php:145
+#: adminpages/emailsettings.php:101
+#: adminpages/emailsettings.php:119
+#: adminpages/emailsettings.php:130
+#: adminpages/emailsettings.php:140
+#: adminpages/emailsettings.php:144
+#: adminpages/emailsettings.php:145
 #: adminpages/emailsettings.php:146
 msgid "Admin Changes"
 msgstr ""
 
-#: adminpages/emailsettings.php:110 adminpages/emailsettings.php:128
-#: adminpages/emailsettings.php:139 adminpages/emailsettings.php:149
-#: adminpages/emailsettings.php:153 adminpages/emailsettings.php:154
+#: adminpages/emailsettings.php:110
+#: adminpages/emailsettings.php:128
+#: adminpages/emailsettings.php:139
+#: adminpages/emailsettings.php:149
+#: adminpages/emailsettings.php:153
+#: adminpages/emailsettings.php:154
 #: adminpages/emailsettings.php:155
 msgid "Cancellation"
 msgstr ""
 
-#: adminpages/emailsettings.php:119 adminpages/emailsettings.php:137
-#: adminpages/emailsettings.php:148 adminpages/emailsettings.php:158
-#: adminpages/emailsettings.php:162 adminpages/emailsettings.php:163
+#: adminpages/emailsettings.php:119
+#: adminpages/emailsettings.php:137
+#: adminpages/emailsettings.php:148
+#: adminpages/emailsettings.php:158
+#: adminpages/emailsettings.php:162
+#: adminpages/emailsettings.php:163
 #: adminpages/emailsettings.php:164
 msgid "Bill Updates"
 msgstr ""
 
-#: adminpages/emailsettings.php:135 adminpages/emailsettings.php:153
-#: adminpages/emailsettings.php:164 adminpages/emailsettings.php:174
-#: adminpages/emailsettings.php:178 adminpages/emailsettings.php:180
+#: adminpages/emailsettings.php:135
+#: adminpages/emailsettings.php:153
+#: adminpages/emailsettings.php:164
+#: adminpages/emailsettings.php:174
+#: adminpages/emailsettings.php:178
+#: adminpages/emailsettings.php:180
 msgid "New Users"
 msgstr ""
 
-#: adminpages/emailsettings.php:139 adminpages/emailsettings.php:157
-#: adminpages/emailsettings.php:168 adminpages/emailsettings.php:178
+#: adminpages/emailsettings.php:139
+#: adminpages/emailsettings.php:157
+#: adminpages/emailsettings.php:168
+#: adminpages/emailsettings.php:178
 #: adminpages/emailsettings.php:182
-msgid ""
-"Default WP notification email. (Recommended: Leave unchecked. Members will "
-"still get an email confirmation from PMPro after checkout.)"
+msgid "Default WP notification email. (Recommended: Leave unchecked. Members will still get an email confirmation from PMPro after checkout.)"
 msgstr ""
 
 #: adminpages/license.php:47
-msgid ""
-"Enter your support license key.</strong> Your license key can be found in "
-"your membership email receipt or in your <a href=\"https://www."
-"paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account"
-"%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign"
-"%3Dmembership-account%26utm_content%3Dno-key\" target=\"_blank\">Membership "
-"Account</a>."
+msgid "Enter your support license key.</strong> Your license key can be found in your membership email receipt or in your <a href=\"https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dno-key\" target=\"_blank\">Membership Account</a>."
 msgstr ""
 
 #: adminpages/license.php:49
-msgid ""
-"Visit the PMPro <a href=\"https://www.paidmembershipspro.com/membership-"
-"account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin"
-"%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account"
-"%26utm_content%3Dkey-not-valid\" target=\"_blank\">Membership Account</a> "
-"page to confirm that your account is active and to find your license key."
+msgid "Visit the PMPro <a href=\"https://www.paidmembershipspro.com/membership-account/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dkey-not-valid\" target=\"_blank\">Membership Account</a> page to confirm that your account is active and to find your license key."
 msgstr ""
 
 #: adminpages/membershiplevels.php:364
-msgid ""
-"Stripe integration currently only supports billing periods of \"Month\" or "
-"\"Year\"."
+msgid "Stripe integration currently only supports billing periods of \"Month\" or \"Year\"."
 msgstr ""
 
-#: adminpages/membershiplevels.php:366 adminpages/membershiplevels.php:385
-#: adminpages/membershiplevels.php:387 adminpages/membershiplevels.php:388
-#: adminpages/membershiplevels.php:411 adminpages/membershiplevels.php:421
-msgid ""
-"Stripe integration currently only supports billing periods of \"Week\", "
-"\"Month\" or \"Year\"."
+#: adminpages/membershiplevels.php:366
+#: adminpages/membershiplevels.php:385
+#: adminpages/membershiplevels.php:387
+#: adminpages/membershiplevels.php:388
+#: adminpages/membershiplevels.php:411
+#: adminpages/membershiplevels.php:421
+msgid "Stripe integration currently only supports billing periods of \"Week\", \"Month\" or \"Year\"."
 msgstr ""
 
-#: adminpages/membershiplevels.php:368 adminpages/membershiplevels.php:370
-#: adminpages/membershiplevels.php:389 adminpages/membershiplevels.php:391
+#: adminpages/membershiplevels.php:368
+#: adminpages/membershiplevels.php:370
+#: adminpages/membershiplevels.php:389
+#: adminpages/membershiplevels.php:391
 #: adminpages/membershiplevels.php:392
-msgid ""
-"Payflow integration currently only supports billing frequencies of 1 and "
-"billing periods of \"Week\", \"Month\" or \"Year\"."
+msgid "Payflow integration currently only supports billing frequencies of 1 and billing periods of \"Week\", \"Month\" or \"Year\"."
 msgstr ""
 
-#: adminpages/membershiplevels.php:374 adminpages/membershiplevels.php:376
-#: adminpages/membershiplevels.php:395 adminpages/membershiplevels.php:397
-#: adminpages/membershiplevels.php:398 adminpages/membershiplevels.php:419
+#: adminpages/membershiplevels.php:374
+#: adminpages/membershiplevels.php:376
+#: adminpages/membershiplevels.php:395
+#: adminpages/membershiplevels.php:397
+#: adminpages/membershiplevels.php:398
+#: adminpages/membershiplevels.php:419
 #: adminpages/membershiplevels.php:429
-msgid ""
-"You will need to create a \"Plan\" in your Braintree dashboard with the same "
-"settings and the \"Plan ID\" set to"
+msgid "You will need to create a \"Plan\" in your Braintree dashboard with the same settings and the \"Plan ID\" set to"
 msgstr ""
 
 #: adminpages/membershiplevels.php:398
-msgid ""
-"2Checkout integration does not currently support custom trials. You can do "
-"one period trials by setting an initial payment different from the billing "
-"amount."
+msgid "2Checkout integration does not currently support custom trials. You can do one period trials by setting an initial payment different from the billing amount."
 msgstr ""
 
-#: adminpages/membershiplevels.php:508 adminpages/membershiplevels.php:514
-#: adminpages/membershiplevels.php:516 adminpages/membershiplevels.php:543
+#: adminpages/membershiplevels.php:508
+#: adminpages/membershiplevels.php:514
+#: adminpages/membershiplevels.php:516
+#: adminpages/membershiplevels.php:543
 msgid "Billing Cycle"
 msgstr ""
 
-#: adminpages/membershiplevels.php:509 adminpages/membershiplevels.php:515
-#: adminpages/membershiplevels.php:517 adminpages/membershiplevels.php:544
+#: adminpages/membershiplevels.php:509
+#: adminpages/membershiplevels.php:515
+#: adminpages/membershiplevels.php:517
+#: adminpages/membershiplevels.php:544
 msgid "Trial Cycle"
 msgstr ""
 
-#: adminpages/membershiplevels.php:543 adminpages/membershiplevels.php:549
-#: adminpages/membershiplevels.php:551 adminpages/membershiplevels.php:578
+#: adminpages/membershiplevels.php:543
+#: adminpages/membershiplevels.php:549
+#: adminpages/membershiplevels.php:551
+#: adminpages/membershiplevels.php:578
 msgid "every"
 msgstr ""
 
-#: adminpages/memberslist.php:103 adminpages/memberslist.php:136
-#: adminpages/memberslist.php:146 adminpages/memberslist.php:156
+#: adminpages/memberslist.php:103
+#: adminpages/memberslist.php:136
+#: adminpages/memberslist.php:146
+#: adminpages/memberslist.php:156
 #: adminpages/memberslist.php:160
 #, php-format
 msgid "%d members found."
 msgstr ""
 
-#: adminpages/memberslist.php:113 adminpages/memberslist.php:146
-#: adminpages/memberslist.php:156 adminpages/memberslist.php:166
+#: adminpages/memberslist.php:113
+#: adminpages/memberslist.php:146
+#: adminpages/memberslist.php:156
+#: adminpages/memberslist.php:166
 #: adminpages/memberslist.php:170
 msgid "First&nbsp;Name"
 msgstr ""
 
-#: adminpages/memberslist.php:114 adminpages/memberslist.php:147
-#: adminpages/memberslist.php:157 adminpages/memberslist.php:167
+#: adminpages/memberslist.php:114
+#: adminpages/memberslist.php:147
+#: adminpages/memberslist.php:157
+#: adminpages/memberslist.php:167
 #: adminpages/memberslist.php:171
 msgid "Last&nbsp;Name"
 msgstr ""
 
-#: adminpages/memberslist.php:119 adminpages/memberslist.php:152
-#: adminpages/memberslist.php:162 adminpages/memberslist.php:172
+#: adminpages/memberslist.php:119
+#: adminpages/memberslist.php:152
+#: adminpages/memberslist.php:162
+#: adminpages/memberslist.php:172
 #: adminpages/memberslist.php:176
 msgid "Fee"
 msgstr ""
 
-#: adminpages/memberslist.php:157 adminpages/memberslist.php:167
-#: adminpages/memberslist.php:177 adminpages/memberslist.php:181
+#: adminpages/memberslist.php:157
+#: adminpages/memberslist.php:167
+#: adminpages/memberslist.php:177
+#: adminpages/memberslist.php:181
 msgid "Ended"
 msgstr ""
 
-#: adminpages/memberslist.php:179 adminpages/memberslist.php:183
+#: adminpages/memberslist.php:179
+#: adminpages/memberslist.php:183
 msgid "Cancelled"
 msgstr ""
 
-#: adminpages/memberslist.php:181 adminpages/memberslist.php:185
+#: adminpages/memberslist.php:181
+#: adminpages/memberslist.php:185
 msgid "Expired"
 msgstr ""
 
-#: adminpages/orders.php:325 adminpages/orders.php:375
-#: adminpages/orders.php:447 adminpages/orders.php:476
-#: adminpages/orders.php:513 adminpages/orders.php:544
-#: adminpages/orders.php:555 adminpages/orders.php:593
-#: adminpages/orders.php:632 adminpages/orders.php:636
-#: adminpages/orders.php:637 adminpages/orders.php:638
+#: adminpages/orders.php:325
+#: adminpages/orders.php:375
+#: adminpages/orders.php:447
+#: adminpages/orders.php:476
+#: adminpages/orders.php:513
+#: adminpages/orders.php:544
+#: adminpages/orders.php:555
+#: adminpages/orders.php:593
+#: adminpages/orders.php:632
+#: adminpages/orders.php:636
+#: adminpages/orders.php:637
+#: adminpages/orders.php:638
 #: adminpages/orders.php:648
 msgid "Should be subtotal + tax - couponamount."
 msgstr ""
 
-#: adminpages/orders.php:1030 adminpages/orders.php:1059
-#: adminpages/orders.php:1215 adminpages/orders.php:1249
-#: adminpages/orders.php:1255 adminpages/orders.php:1370
+#: adminpages/orders.php:1030
+#: adminpages/orders.php:1059
+#: adminpages/orders.php:1215
+#: adminpages/orders.php:1249
+#: adminpages/orders.php:1255
+#: adminpages/orders.php:1370
 #: adminpages/orders.php:1499
 msgid "print"
 msgstr ""
 
-#: adminpages/orders.php:1033 adminpages/orders.php:1062
-#: adminpages/orders.php:1219 adminpages/orders.php:1253
-#: adminpages/orders.php:1259 adminpages/orders.php:1374
+#: adminpages/orders.php:1033
+#: adminpages/orders.php:1062
+#: adminpages/orders.php:1219
+#: adminpages/orders.php:1253
+#: adminpages/orders.php:1259
+#: adminpages/orders.php:1374
 #: adminpages/orders.php:1503
 msgid "email"
 msgstr ""
@@ -13586,30 +17479,18 @@ msgstr ""
 msgid "Membership %s"
 msgstr ""
 
-#: adminpages/paymentsettings.php:95 adminpages/paymentsettings.php:112
+#: adminpages/paymentsettings.php:95
+#: adminpages/paymentsettings.php:112
 #: adminpages/paymentsettings.php:148
-msgid ""
-"Learn more about <a title=\"Paid Memberships Pro - SSL Settings\" target="
-"\"_blank\" href=\"http://www.paidmembershipspro.com/support/initial-plugin-"
-"setup/ssl/\">SSL</a> or <a title=\"Paid Memberships Pro - Payment Gateway "
-"Settings\" target=\"_blank\" href=\"http://www.paidmembershipspro.com/"
-"support/initial-plugin-setup/payment-gateway/\">Payment Gateway Settings</a>."
+msgid "Learn more about <a title=\"Paid Memberships Pro - SSL Settings\" target=\"_blank\" href=\"http://www.paidmembershipspro.com/support/initial-plugin-setup/ssl/\">SSL</a> or <a title=\"Paid Memberships Pro - Payment Gateway Settings\" target=\"_blank\" href=\"http://www.paidmembershipspro.com/support/initial-plugin-setup/payment-gateway/\">Payment Gateway Settings</a>."
 msgstr ""
 
 #: adminpages/paymentsettings.php:112
-msgid ""
-"Learn more about <a title=\"Paid Memberships Pro - SSL Settings\" target="
-"\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-"
-"plugin-setup/ssl/\">SSL</a> or <a title=\"Paid Memberships Pro - Payment "
-"Gateway Settings\" target=\"_blank\" href=\"https://www.paidmembershipspro."
-"com/documentation/initial-plugin-setup/step-3-payment-gateway-security/"
-"\">Payment Gateway Settings</a>."
+msgid "Learn more about <a title=\"Paid Memberships Pro - SSL Settings\" target=\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-plugin-setup/ssl/\">SSL</a> or <a title=\"Paid Memberships Pro - Payment Gateway Settings\" target=\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-plugin-setup/step-3-payment-gateway-security/\">Payment Gateway Settings</a>."
 msgstr ""
 
 #: adminpages/paymentsettings.php:170
-msgid ""
-"Payflow Pro currently only supports one-time payments. Users will not be "
-"able to checkout for levels with recurring payments."
+msgid "Payflow Pro currently only supports one-time payments. Users will not be able to checkout for levels with recurring payments."
 msgstr ""
 
 #: adminpages/paymentsettings.php:179
@@ -13621,78 +17502,45 @@ msgstr ""
 #: classes/gateways/class.pmprogateway_paypalexpress.php:145
 #: classes/gateways/class.pmprogateway_paypalstandard.php:117
 #: classes/gateways/class.pmprogateway_paypalstandard.php:137
-msgid ""
-"We do not recommend using PayPal Standard. We suggest using PayPal Express, "
-"Website Payments Pro (Legacy), or PayPal Pro (Payflow Pro). <a target="
-"\"_blank\" href=\"http://www.paidmembershipspro.com/2013/09/read-using-"
-"paypal-standard-paid-memberships-pro/\">More information on why can be found "
-"here.</a>"
+msgid "We do not recommend using PayPal Standard. We suggest using PayPal Express, Website Payments Pro (Legacy), or PayPal Pro (Payflow Pro). <a target=\"_blank\" href=\"http://www.paidmembershipspro.com/2013/09/read-using-paypal-standard-paid-memberships-pro/\">More information on why can be found here.</a>"
 msgstr ""
 
-#: adminpages/paymentsettings.php:195 adminpages/paymentsettings.php:450
+#: adminpages/paymentsettings.php:195
+#: adminpages/paymentsettings.php:450
 #: adminpages/paymentsettings.php:452
-msgid ""
-"US only. If values are given, tax will be applied for any members ordering "
-"from the selected state.<br />For non-US or more complex tax rules, use the "
-"<a target=\"_blank\" href=\"http://www.paidmembershipspro.com/2013/10/non-us-"
-"taxes-paid-memberships-pro/\">pmpro_tax filter</a>."
+msgid "US only. If values are given, tax will be applied for any members ordering from the selected state.<br />For non-US or more complex tax rules, use the <a target=\"_blank\" href=\"http://www.paidmembershipspro.com/2013/10/non-us-taxes-paid-memberships-pro/\">pmpro_tax filter</a>."
 msgstr ""
 
 #: adminpages/paymentsettings.php:212
-msgid ""
-"US only. If values are given, tax will be applied for any members ordering "
-"from the selected state.<br />For non-US or more complex tax rules, use the "
-"<a target=\"_blank\" href=\"http://www.paidmembershipspro.com/2013/10/non-us-"
-"taxes-paid-memberships-pro/?"
-"utm_source=plugin&utm_medium=banner&utm_campaign=payment_settings"
-"\">pmpro_tax filter</a>."
+msgid "US only. If values are given, tax will be applied for any members ordering from the selected state.<br />For non-US or more complex tax rules, use the <a target=\"_blank\" href=\"http://www.paidmembershipspro.com/2013/10/non-us-taxes-paid-memberships-pro/?utm_source=plugin&utm_medium=banner&utm_campaign=payment_settings\">pmpro_tax filter</a>."
 msgstr ""
 
-#: adminpages/paymentsettings.php:212 adminpages/paymentsettings.php:229
-msgid ""
-"US only. If values are given, tax will be applied for any members ordering "
-"from the selected state.<br />For non-US or more complex tax rules, use the "
-"<a target=\"_blank\" href=\"https://www.paidmembershipspro.com/non-us-taxes-"
-"paid-memberships-pro/?"
-"utm_source=plugin&utm_medium=banner&utm_campaign=payment_settings"
-"\">pmpro_tax filter</a>."
+#: adminpages/paymentsettings.php:212
+#: adminpages/paymentsettings.php:229
+msgid "US only. If values are given, tax will be applied for any members ordering from the selected state.<br />For non-US or more complex tax rules, use the <a target=\"_blank\" href=\"https://www.paidmembershipspro.com/non-us-taxes-paid-memberships-pro/?utm_source=plugin&utm_medium=banner&utm_campaign=payment_settings\">pmpro_tax filter</a>."
 msgstr ""
 
-#: adminpages/paymentsettings.php:223 adminpages/paymentsettings.php:235
-msgid ""
-"Your <strong><a target=\"_blank\" href=\"http://www.paidmembershipspro.com/"
-"documentation/initial-plugin-setup/ssl/\">SSL Certificate</a></strong> must "
-"be installed by your web host. Your <strong>SSL Seal</strong> will be a "
-"short HTML or JavaScript snippet that can be pasted here."
+#: adminpages/paymentsettings.php:223
+#: adminpages/paymentsettings.php:235
+msgid "Your <strong><a target=\"_blank\" href=\"http://www.paidmembershipspro.com/documentation/initial-plugin-setup/ssl/\">SSL Certificate</a></strong> must be installed by your web host. Your <strong>SSL Seal</strong> will be a short HTML or JavaScript snippet that can be pasted here."
 msgstr ""
 
-#: adminpages/paymentsettings.php:252 adminpages/paymentsettings.php:269
-msgid ""
-"Your <strong><a target=\"_blank\" href=\"http://www.paidmembershipspro.com/"
-"documentation/initial-plugin-setup/ssl/?"
-"utm_source=plugin&utm_medium=banner&utm_campaign=payment_settings\">SSL "
-"Certificate</a></strong> must be installed by your web host. Your "
-"<strong>SSL Seal</strong> will be a short HTML or JavaScript snippet that "
-"can be pasted here."
+#: adminpages/paymentsettings.php:252
+#: adminpages/paymentsettings.php:269
+msgid "Your <strong><a target=\"_blank\" href=\"http://www.paidmembershipspro.com/documentation/initial-plugin-setup/ssl/?utm_source=plugin&utm_medium=banner&utm_campaign=payment_settings\">SSL Certificate</a></strong> must be installed by your web host. Your <strong>SSL Seal</strong> will be a short HTML or JavaScript snippet that can be pasted here."
 msgstr ""
 
 #: adminpages/paymentsettings.php:269
-msgid ""
-"Your <strong><a target=\"_blank\" href=\"https://www.paidmembershipspro.com/"
-"documentation/initial-plugin-setup/ssl/?utm_source=plugin&utm_medium=pmpro-"
-"paymentsettings&utm_campaign=documentation&utm_content=ssl&utm_term=link2\">SSL "
-"Certificate</a></strong> must be installed by your web host. Your "
-"<strong>SSL Seal</strong> will be a short HTML or JavaScript snippet that "
-"can be pasted here."
+msgid "Your <strong><a target=\"_blank\" href=\"https://www.paidmembershipspro.com/documentation/initial-plugin-setup/ssl/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=ssl&utm_term=link2\">SSL Certificate</a></strong> must be installed by your web host. Your <strong>SSL Seal</strong> will be a short HTML or JavaScript snippet that can be pasted here."
 msgstr ""
 
-#: adminpages/paymentsettings.php:405 adminpages/paymentsettings.php:445
-msgid ""
-"If values are given, tax will be applied for any members ordering from the "
-"selected state. For more complex tax rules, use the \"pmpro_tax\" filter."
+#: adminpages/paymentsettings.php:405
+#: adminpages/paymentsettings.php:445
+msgid "If values are given, tax will be applied for any members ordering from the selected state. For more complex tax rules, use the \"pmpro_tax\" filter."
 msgstr ""
 
-#: adminpages/paymentsettings.php:410 adminpages/paymentsettings.php:421
+#: adminpages/paymentsettings.php:410
+#: adminpages/paymentsettings.php:421
 msgid "Use SSL"
 msgstr ""
 
@@ -13701,25 +17549,27 @@ msgid "Required by this Gateway Option"
 msgstr ""
 
 #: adminpages/paymentsettings.php:432
-msgid ""
-"Stripe doesn't require billing address fields. Choose 'No' to hide them on "
-"the checkout page."
+msgid "Stripe doesn't require billing address fields. Choose 'No' to hide them on the checkout page."
 msgstr ""
 
-#: adminpages/paymentsettings.php:438 adminpages/paymentsettings.php:471
-#: adminpages/paymentsettings.php:477 adminpages/paymentsettings.php:479
+#: adminpages/paymentsettings.php:438
+#: adminpages/paymentsettings.php:471
+#: adminpages/paymentsettings.php:477
+#: adminpages/paymentsettings.php:479
 msgid "HTTPS Nuclear Option"
 msgstr ""
 
-#: adminpages/paymentsettings.php:441 adminpages/paymentsettings.php:474
-#: adminpages/paymentsettings.php:480 adminpages/paymentsettings.php:482
-msgid ""
-"Use the \"Nuclear Option\" to use secure (HTTPS) URLs on your secure pages. "
-"Check this if you are using SSL and have warnings on your checkout pages."
+#: adminpages/paymentsettings.php:441
+#: adminpages/paymentsettings.php:474
+#: adminpages/paymentsettings.php:480
+#: adminpages/paymentsettings.php:482
+msgid "Use the \"Nuclear Option\" to use secure (HTTPS) URLs on your secure pages. Check this if you are using SSL and have warnings on your checkout pages."
 msgstr ""
 
-#: adminpages/paymentsettings.php:465 adminpages/paymentsettings.php:506
-#: adminpages/paymentsettings.php:512 adminpages/paymentsettings.php:514
+#: adminpages/paymentsettings.php:465
+#: adminpages/paymentsettings.php:506
+#: adminpages/paymentsettings.php:512
+#: adminpages/paymentsettings.php:514
 #: classes/gateways/class.pmprogateway_stripe.php:184
 #: classes/gateways/class.pmprogateway_stripe.php:185
 #: classes/gateways/class.pmprogateway_stripe.php:195
@@ -13741,41 +17591,51 @@ msgstr ""
 msgid "To fully integrate with Stripe, be sure to set your Web Hook URL to"
 msgstr ""
 
-#: adminpages/paymentsettings.php:490 adminpages/paymentsettings.php:496
+#: adminpages/paymentsettings.php:490
+#: adminpages/paymentsettings.php:496
 #: adminpages/paymentsettings.php:498
 #: classes/gateways/class.pmprogateway_twocheckout.php:148
-msgid ""
-"To fully integrate with 2Checkout, be sure to set your 2Checkout INS URL "
+msgid "To fully integrate with 2Checkout, be sure to set your 2Checkout INS URL "
 msgstr ""
 
-#: adminpages/reports/login.php:26 adminpages/reports/login.php:27
+#: adminpages/reports/login.php:26
+#: adminpages/reports/login.php:27
 msgid "Visits Today"
 msgstr ""
 
-#: adminpages/reports/login.php:31 adminpages/reports/login.php:32
+#: adminpages/reports/login.php:31
+#: adminpages/reports/login.php:32
 msgid "Views Today"
 msgstr ""
 
-#: adminpages/reports/login.php:36 adminpages/reports/login.php:37
+#: adminpages/reports/login.php:36
+#: adminpages/reports/login.php:37
 msgid "Logins Today"
 msgstr ""
 
-#: adminpages/reports/login.php:148 adminpages/reports/login.php:150
-#: adminpages/reports/login.php:166 adminpages/reports/login.php:170
+#: adminpages/reports/login.php:148
+#: adminpages/reports/login.php:150
+#: adminpages/reports/login.php:166
+#: adminpages/reports/login.php:170
 msgid "Total Visits"
 msgstr ""
 
-#: adminpages/reports/login.php:150 adminpages/reports/login.php:152
-#: adminpages/reports/login.php:168 adminpages/reports/login.php:172
+#: adminpages/reports/login.php:150
+#: adminpages/reports/login.php:152
+#: adminpages/reports/login.php:168
+#: adminpages/reports/login.php:172
 msgid "Total Views"
 msgstr ""
 
-#: adminpages/reports/login.php:153 adminpages/reports/login.php:155
-#: adminpages/reports/login.php:171 adminpages/reports/login.php:175
+#: adminpages/reports/login.php:153
+#: adminpages/reports/login.php:155
+#: adminpages/reports/login.php:171
+#: adminpages/reports/login.php:175
 msgid "Total Logins"
 msgstr ""
 
-#: adminpages/reports/memberships.php:38 adminpages/reports/memberships.php:67
+#: adminpages/reports/memberships.php:38
+#: adminpages/reports/memberships.php:67
 msgid "Cancellations"
 msgstr ""
 
@@ -13821,21 +17681,26 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: classes/class.pmproemail.php:342 classes/class.pmproemail.php:345
-#: classes/class.pmproemail.php:363 classes/class.pmproemail.php:366
+#: classes/class.pmproemail.php:342
+#: classes/class.pmproemail.php:345
+#: classes/class.pmproemail.php:363
+#: classes/class.pmproemail.php:366
 #: classes/class.pmproemail.php:375
 #, php-format
 msgid "Your billing information has been udpated at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:386 classes/class.pmproemail.php:390
-#: classes/class.pmproemail.php:416 classes/class.pmproemail.php:419
+#: classes/class.pmproemail.php:386
+#: classes/class.pmproemail.php:390
+#: classes/class.pmproemail.php:416
+#: classes/class.pmproemail.php:419
 #: classes/class.pmproemail.php:428
 #, php-format
 msgid "Billing information has been udpated for %s at %s"
 msgstr ""
 
-#: classes/class.pmproemail.php:685 classes/class.pmproemail.php:734
+#: classes/class.pmproemail.php:685
+#: classes/class.pmproemail.php:734
 #: classes/class.pmproemail.php:799
 msgid "membership has been cancelled"
 msgstr ""
@@ -13876,26 +17741,20 @@ msgstr ""
 
 #: classes/gateways/class.pmprogateway_payflowpro.php:137
 #, php-format
-msgid ""
-"Payflow does not use IPN. To sync recurring subscriptions, please see <a "
-"target=\"_blank\" href=\"%s\">this addon</a>."
+msgid "Payflow does not use IPN. To sync recurring subscriptions, please see <a target=\"_blank\" href=\"%s\">this addon</a>."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_paypal.php:158
 #: classes/gateways/class.pmprogateway_paypal.php:181
 #: classes/gateways/class.pmprogateway_paypal.php:187
 #: classes/gateways/class.pmprogateway_paypal.php:199
-msgid ""
-"This URL is passed to PayPal for all new charges and subscriptions. You "
-"SHOULD NOT set this in your PayPal account settings."
+msgid "This URL is passed to PayPal for all new charges and subscriptions. You SHOULD NOT set this in your PayPal account settings."
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:51
 #: classes/gateways/class.pmprogateway_stripe.php:55
 #, php-format
-msgid ""
-"The %s gateway depends on the %s PHP extension. Please enable it, or ask "
-"your hosting provider to enable it"
+msgid "The %s gateway depends on the %s PHP extension. Please enable it, or ask your hosting provider to enable it"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_stripe.php:285
@@ -13919,15 +17778,11 @@ msgid "API Private Key"
 msgstr ""
 
 #: classes/gateways/class.pmprogateway_twocheckout.php:143
-msgid ""
-"Go to API in 2Checkout and generate a new key pair. Paste the Private Key "
-"here."
+msgid "Go to API in 2Checkout and generate a new key pair. Paste the Private Key here."
 msgstr ""
 
 #: includes/admin.php:47
-msgid ""
-"<strong>Welcome to Paid Memberships Pro</strong> &mdash; We&lsquo;re here to "
-"help you #GetPaid."
+msgid "<strong>Welcome to Paid Memberships Pro</strong> &mdash; We&lsquo;re here to help you #GetPaid."
 msgstr ""
 
 #: includes/admin.php:48
@@ -13938,9 +17793,12 @@ msgstr ""
 msgid "<span style=\"color:#7FFF00\">License</span>"
 msgstr ""
 
-#: includes/adminpages.php:277 includes/adminpages.php:313
-#: includes/adminpages.php:326 includes/adminpages.php:330
-#: includes/adminpages.php:345 includes/adminpages.php:347
+#: includes/adminpages.php:277
+#: includes/adminpages.php:313
+#: includes/adminpages.php:326
+#: includes/adminpages.php:330
+#: includes/adminpages.php:345
+#: includes/adminpages.php:347
 msgid "Membership Levels  Page"
 msgstr ""
 
@@ -13948,372 +17806,486 @@ msgstr ""
 msgid "Brazilian Real (&#36;)"
 msgstr ""
 
-#: includes/currencies.php:29 includes/currencies.php:49
+#: includes/currencies.php:29
+#: includes/currencies.php:49
 msgid "South African Rand"
 msgstr ""
 
 #: includes/filters.php:218
 #, php-format
-msgid ""
-"User: %s<br />Email: %s<br />Membership Level: %s<br />Order #: %s<br /"
-">Original Profile Start Date: %s<br />Adjusted Profile Start Date: %s<br /"
-">Trial Period: %s<br />Trial Frequency: %s<br />"
+msgid "User: %s<br />Email: %s<br />Membership Level: %s<br />Order #: %s<br />Original Profile Start Date: %s<br />Adjusted Profile Start Date: %s<br />Trial Period: %s<br />Trial Frequency: %s<br />"
 msgstr ""
 
-#: includes/functions.php:169 includes/functions.php:205
-#: includes/functions.php:211 includes/functions.php:213
-#: includes/functions.php:214 includes/functions.php:215
-#: includes/functions.php:218 includes/functions.php:254
-#: includes/functions.php:320 includes/functions.php:326
-#: includes/functions.php:331 includes/functions.php:340
+#: includes/functions.php:169
+#: includes/functions.php:205
+#: includes/functions.php:211
+#: includes/functions.php:213
+#: includes/functions.php:214
+#: includes/functions.php:215
+#: includes/functions.php:218
+#: includes/functions.php:254
+#: includes/functions.php:320
+#: includes/functions.php:326
+#: includes/functions.php:331
+#: includes/functions.php:340
 #, php-format
 msgid " and then <strong>%s per %s for %d more %s</strong>."
 msgstr ""
 
-#: includes/functions.php:173 includes/functions.php:209
-#: includes/functions.php:215 includes/functions.php:217
-#: includes/functions.php:218 includes/functions.php:219
+#: includes/functions.php:173
+#: includes/functions.php:209
+#: includes/functions.php:215
+#: includes/functions.php:217
+#: includes/functions.php:218
+#: includes/functions.php:219
 #: includes/functions.php:222
 #, php-format
 msgid " and then <strong>%s every %d %s for %d more %s</strong>."
 msgstr ""
 
-#: includes/functions.php:178 includes/functions.php:214
-#: includes/functions.php:220 includes/functions.php:222
-#: includes/functions.php:223 includes/functions.php:224
-#: includes/functions.php:227 includes/functions.php:263
-#: includes/functions.php:329 includes/functions.php:335
-#: includes/functions.php:340 includes/functions.php:349
+#: includes/functions.php:178
+#: includes/functions.php:214
+#: includes/functions.php:220
+#: includes/functions.php:222
+#: includes/functions.php:223
+#: includes/functions.php:224
+#: includes/functions.php:227
+#: includes/functions.php:263
+#: includes/functions.php:329
+#: includes/functions.php:335
+#: includes/functions.php:340
+#: includes/functions.php:349
 #, php-format
 msgid " and then <strong>%s after %d %s</strong>."
 msgstr ""
 
-#: includes/functions.php:184 includes/functions.php:220
-#: includes/functions.php:228 includes/functions.php:238
-#: includes/functions.php:239 includes/functions.php:240
-#: includes/functions.php:242 includes/functions.php:245
-#: includes/functions.php:249 includes/functions.php:285
-#: includes/functions.php:351 includes/functions.php:357
-#: includes/functions.php:362 includes/functions.php:371
+#: includes/functions.php:184
+#: includes/functions.php:220
+#: includes/functions.php:228
+#: includes/functions.php:238
+#: includes/functions.php:239
+#: includes/functions.php:240
+#: includes/functions.php:242
+#: includes/functions.php:245
+#: includes/functions.php:249
+#: includes/functions.php:285
+#: includes/functions.php:351
+#: includes/functions.php:357
+#: includes/functions.php:362
+#: includes/functions.php:371
 #, php-format
 msgid " and then <strong>%s per %s</strong>."
 msgstr ""
 
-#: includes/functions.php:188 includes/functions.php:224
-#: includes/functions.php:232 includes/functions.php:242
-#: includes/functions.php:243 includes/functions.php:244
-#: includes/functions.php:246 includes/functions.php:249
-#: includes/functions.php:253 includes/functions.php:289
-#: includes/functions.php:355 includes/functions.php:361
-#: includes/functions.php:366 includes/functions.php:375
+#: includes/functions.php:188
+#: includes/functions.php:224
+#: includes/functions.php:232
+#: includes/functions.php:242
+#: includes/functions.php:243
+#: includes/functions.php:244
+#: includes/functions.php:246
+#: includes/functions.php:249
+#: includes/functions.php:253
+#: includes/functions.php:289
+#: includes/functions.php:355
+#: includes/functions.php:361
+#: includes/functions.php:366
+#: includes/functions.php:375
 #, php-format
 msgid " and then <strong>%s every %d %s</strong>."
 msgstr ""
 
-#: includes/functions.php:217 includes/functions.php:253
-#: includes/functions.php:264 includes/functions.php:275
-#: includes/functions.php:276 includes/functions.php:277
-#: includes/functions.php:279 includes/functions.php:282
-#: includes/functions.php:286 includes/functions.php:322
-#: includes/functions.php:388 includes/functions.php:394
-#: includes/functions.php:399 includes/functions.php:408 pages/levels.php:97
+#: includes/functions.php:217
+#: includes/functions.php:253
+#: includes/functions.php:264
+#: includes/functions.php:275
+#: includes/functions.php:276
+#: includes/functions.php:277
+#: includes/functions.php:279
+#: includes/functions.php:282
+#: includes/functions.php:286
+#: includes/functions.php:322
+#: includes/functions.php:388
+#: includes/functions.php:394
+#: includes/functions.php:399
+#: includes/functions.php:408
+#: pages/levels.php:97
 #, php-format
 msgid "After your initial payment, your first %d payments will cost %s."
 msgstr ""
 
-#: includes/functions.php:228 includes/functions.php:264
-#: includes/functions.php:275 includes/functions.php:286
-#: includes/functions.php:287 includes/functions.php:288
-#: includes/functions.php:290 includes/functions.php:293
-#: includes/functions.php:297 includes/functions.php:333
-#: includes/functions.php:399 includes/functions.php:405
-#: includes/functions.php:410 includes/functions.php:419
-#: includes/functions.php:523 includes/functions.php:532
+#: includes/functions.php:228
+#: includes/functions.php:264
+#: includes/functions.php:275
+#: includes/functions.php:286
+#: includes/functions.php:287
+#: includes/functions.php:288
+#: includes/functions.php:290
+#: includes/functions.php:293
+#: includes/functions.php:297
+#: includes/functions.php:333
+#: includes/functions.php:399
+#: includes/functions.php:405
+#: includes/functions.php:410
+#: includes/functions.php:419
+#: includes/functions.php:523
+#: includes/functions.php:532
 #, php-format
 msgid "Customers in %s will be charged %s%% tax."
 msgstr ""
 
-#: includes/functions.php:228 includes/functions.php:229
-#: includes/functions.php:230 includes/functions.php:231
-#: includes/functions.php:235 includes/functions.php:271
-#: includes/functions.php:337 includes/functions.php:343
-#: includes/functions.php:348 includes/functions.php:357
+#: includes/functions.php:228
+#: includes/functions.php:229
+#: includes/functions.php:230
+#: includes/functions.php:231
+#: includes/functions.php:235
+#: includes/functions.php:271
+#: includes/functions.php:337
+#: includes/functions.php:343
+#: includes/functions.php:348
+#: includes/functions.php:357
 #, php-format
 msgid "The price for membership is <strong>%s per %s</strong>."
 msgstr ""
 
-#: includes/functions.php:230 includes/functions.php:233
-#: includes/functions.php:237 includes/functions.php:273
-#: includes/functions.php:339 includes/functions.php:345
-#: includes/functions.php:350 includes/functions.php:359
+#: includes/functions.php:230
+#: includes/functions.php:233
+#: includes/functions.php:237
+#: includes/functions.php:273
+#: includes/functions.php:339
+#: includes/functions.php:345
+#: includes/functions.php:350
+#: includes/functions.php:359
 #, php-format
 msgid "<strong>%s per %s</strong>."
 msgstr ""
 
-#: includes/functions.php:233 includes/functions.php:234
-#: includes/functions.php:235 includes/functions.php:238
-#: includes/functions.php:242 includes/functions.php:278
-#: includes/functions.php:344 includes/functions.php:350
-#: includes/functions.php:355 includes/functions.php:364
+#: includes/functions.php:233
+#: includes/functions.php:234
+#: includes/functions.php:235
+#: includes/functions.php:238
+#: includes/functions.php:242
+#: includes/functions.php:278
+#: includes/functions.php:344
+#: includes/functions.php:350
+#: includes/functions.php:355
+#: includes/functions.php:364
 #, php-format
 msgid "The price for membership is <strong>%s every %d %s</strong>."
 msgstr ""
 
-#: includes/functions.php:237 includes/functions.php:240
-#: includes/functions.php:244 includes/functions.php:280
-#: includes/functions.php:346 includes/functions.php:352
-#: includes/functions.php:357 includes/functions.php:366
+#: includes/functions.php:237
+#: includes/functions.php:240
+#: includes/functions.php:244
+#: includes/functions.php:280
+#: includes/functions.php:346
+#: includes/functions.php:352
+#: includes/functions.php:357
+#: includes/functions.php:366
 #, php-format
 msgid "<strong>%s every %d %s</strong>."
 msgstr ""
 
-#: includes/functions.php:242 includes/functions.php:278
-#: includes/functions.php:289 includes/functions.php:300
-#: includes/functions.php:301 includes/functions.php:302
-#: includes/functions.php:304 includes/functions.php:307
-#: includes/functions.php:311 includes/functions.php:347
-#: includes/functions.php:413 includes/functions.php:419
-#: includes/functions.php:540 includes/functions.php:549
+#: includes/functions.php:242
+#: includes/functions.php:278
+#: includes/functions.php:289
+#: includes/functions.php:300
+#: includes/functions.php:301
+#: includes/functions.php:302
+#: includes/functions.php:304
+#: includes/functions.php:307
+#: includes/functions.php:311
+#: includes/functions.php:347
+#: includes/functions.php:413
+#: includes/functions.php:419
+#: includes/functions.php:540
+#: includes/functions.php:549
 #, php-format
 msgid "Membership expires after %d %s."
 msgstr ""
 
-#: includes/functions.php:258 includes/functions.php:324
-#: includes/functions.php:330 includes/functions.php:335
+#: includes/functions.php:258
+#: includes/functions.php:324
+#: includes/functions.php:330
+#: includes/functions.php:335
 #: includes/functions.php:344
 #, php-format
 msgid " and then <strong>%s every %d %s for %d more payments</strong>."
 msgstr ""
 
-#: includes/functions.php:469 includes/functions.php:478
+#: includes/functions.php:469
+#: includes/functions.php:478
 #, php-format
 msgid "<strong>%s per %s for %d more %s</strong>"
 msgstr ""
 
-#: includes/functions.php:473 includes/functions.php:482
+#: includes/functions.php:473
+#: includes/functions.php:482
 #, php-format
 msgid "<strong>%s every %d %s for %d more payments</strong>"
 msgstr ""
 
-#: includes/functions.php:478 includes/functions.php:487
+#: includes/functions.php:478
+#: includes/functions.php:487
 #, php-format
 msgid "<strong>%s after %d %s</strong>"
 msgstr ""
 
-#: includes/functions.php:484 includes/functions.php:493
+#: includes/functions.php:484
+#: includes/functions.php:493
 #, php-format
 msgid "<strong>%s every %s</strong>"
 msgstr ""
 
-#: includes/functions.php:488 includes/functions.php:497
+#: includes/functions.php:488
+#: includes/functions.php:497
 #, php-format
 msgid "<strong>%s every %d %s</strong>"
 msgstr ""
 
-#: includes/functions.php:556 includes/functions.php:557
+#: includes/functions.php:556
+#: includes/functions.php:557
 #: includes/functions.php:566
 #, php-format
 msgid "%s membership expires after %d %s"
 msgstr ""
 
-#: includes/functions.php:1325 includes/functions.php:1347
-#: includes/functions.php:1367 includes/functions.php:1378
-#: includes/functions.php:1381 includes/functions.php:1391
-#: includes/functions.php:1400 includes/functions.php:1401
-#: includes/functions.php:1418 includes/functions.php:1442
-#: includes/functions.php:1443 includes/functions.php:1456
-#: includes/functions.php:1463 includes/functions.php:1479
-#: includes/functions.php:1502 includes/functions.php:1507
-#: includes/functions.php:1626 includes/functions.php:1630
-#: includes/functions.php:1697 includes/functions.php:1703
-#: includes/functions.php:1709 includes/functions.php:1985
-#: includes/functions.php:2021 includes/functions.php:2025
-#: includes/functions.php:2028 includes/functions.php:2030
-#: includes/functions.php:2039 includes/functions.php:2040
+#: includes/functions.php:1325
+#: includes/functions.php:1347
+#: includes/functions.php:1367
+#: includes/functions.php:1378
+#: includes/functions.php:1381
+#: includes/functions.php:1391
+#: includes/functions.php:1400
+#: includes/functions.php:1401
+#: includes/functions.php:1418
+#: includes/functions.php:1442
+#: includes/functions.php:1443
+#: includes/functions.php:1456
+#: includes/functions.php:1463
+#: includes/functions.php:1479
+#: includes/functions.php:1502
+#: includes/functions.php:1507
+#: includes/functions.php:1626
+#: includes/functions.php:1630
+#: includes/functions.php:1697
+#: includes/functions.php:1703
+#: includes/functions.php:1709
+#: includes/functions.php:1985
+#: includes/functions.php:2021
+#: includes/functions.php:2025
+#: includes/functions.php:2028
+#: includes/functions.php:2030
+#: includes/functions.php:2039
+#: includes/functions.php:2040
 msgid "Please specify a level id."
 msgstr ""
 
-#: includes/functions.php:1991 includes/functions.php:2046
+#: includes/functions.php:1991
+#: includes/functions.php:2046
 #: includes/functions.php:2047
 #, php-format
 msgid "Level #%s not found."
 msgstr ""
 
-#: includes/license.php:86 includes/license.php:88 includes/license.php:89
+#: includes/license.php:86
+#: includes/license.php:88
+#: includes/license.php:89
 msgid "License Key"
 msgstr ""
 
-#: includes/license.php:89 includes/license.php:92
-msgid ""
-"Enter your support license key.</strong> Your license key can be found in "
-"your membership email receipt or in your <a href=\"http://www."
-"paidmembershipspro.com/login/?redirect_to=/membership-account/\" target="
-"\"_blank\">Membership Account</a>."
+#: includes/license.php:89
+#: includes/license.php:92
+msgid "Enter your support license key.</strong> Your license key can be found in your membership email receipt or in your <a href=\"http://www.paidmembershipspro.com/login/?redirect_to=/membership-account/\" target=\"_blank\">Membership Account</a>."
 msgstr ""
 
-#: includes/license.php:91 includes/license.php:94
-msgid ""
-"Visit the PMPro <a href=\"http://www.paidmembershipspro.com/login/?"
-"redirect_to=/membership-account/\" target=\"_blank\">Membership Account</a> "
-"page to confirm that your account is active and to find your license key."
+#: includes/license.php:91
+#: includes/license.php:94
+msgid "Visit the PMPro <a href=\"http://www.paidmembershipspro.com/login/?redirect_to=/membership-account/\" target=\"_blank\">Membership Account</a> page to confirm that your account is active and to find your license key."
 msgstr ""
 
 #: includes/license.php:92
-msgid ""
-"Enter your support license key.</strong> Your license key can be found in "
-"your membership email receipt or in your <a href=\"http://www."
-"paidmembershipspro.com/login/?redirect_to=/membership-account/?"
-"utm_source=plugin&utm_medium=banner&utm_campaign=license_notice\" target="
-"\"_blank\">Membership Account</a>."
+msgid "Enter your support license key.</strong> Your license key can be found in your membership email receipt or in your <a href=\"http://www.paidmembershipspro.com/login/?redirect_to=/membership-account/?utm_source=plugin&utm_medium=banner&utm_campaign=license_notice\" target=\"_blank\">Membership Account</a>."
 msgstr ""
 
-#: includes/license.php:93 includes/license.php:95 includes/license.php:96
+#: includes/license.php:93
+#: includes/license.php:95
+#: includes/license.php:96
 #, php-format
-msgid ""
-"<p><strong>Thank you!</strong> A valid <strong>%s</strong> license key has "
-"been used to activate your support license on this site.</p>"
+msgid "<p><strong>Thank you!</strong> A valid <strong>%s</strong> license key has been used to activate your support license on this site.</p>"
 msgstr ""
 
 #: includes/license.php:94
-msgid ""
-"Visit the PMPro <a href=\"http://www.paidmembershipspro.com/login/?"
-"redirect_to=/membership-account/?"
-"utm_source=plugin&utm_medium=banner&utm_campaign=license_notice\" target="
-"\"_blank\">Membership Account</a> page to confirm that your account is "
-"active and to find your license key."
+msgid "Visit the PMPro <a href=\"http://www.paidmembershipspro.com/login/?redirect_to=/membership-account/?utm_source=plugin&utm_medium=banner&utm_campaign=license_notice\" target=\"_blank\">Membership Account</a> page to confirm that your account is active and to find your license key."
 msgstr ""
 
-#: includes/license.php:102 includes/license.php:104 includes/license.php:105
+#: includes/license.php:102
+#: includes/license.php:104
+#: includes/license.php:105
 msgid "Verify Key"
 msgstr ""
 
-#: includes/license.php:199 includes/license.php:202 includes/license.php:273
-#: includes/license.php:278 includes/license.php:288 includes/license.php:290
-#: includes/license.php:291 includes/license.php:298
+#: includes/license.php:199
+#: includes/license.php:202
+#: includes/license.php:273
+#: includes/license.php:278
+#: includes/license.php:288
+#: includes/license.php:290
+#: includes/license.php:291
+#: includes/license.php:298
 msgid "Invalid PMPro License Key."
 msgstr ""
 
-#: includes/license.php:202 includes/license.php:205 includes/license.php:273
-#: includes/license.php:278 includes/license.php:288 includes/license.php:291
-#: includes/license.php:293 includes/license.php:301
-msgid ""
-"If you're running Paid Memberships Pro on a production website, we recommend "
-"an annual support license."
+#: includes/license.php:202
+#: includes/license.php:205
+#: includes/license.php:273
+#: includes/license.php:278
+#: includes/license.php:288
+#: includes/license.php:291
+#: includes/license.php:293
+#: includes/license.php:301
+msgid "If you're running Paid Memberships Pro on a production website, we recommend an annual support license."
 msgstr ""
 
-#: includes/license.php:203 includes/license.php:206 includes/license.php:274
-#: includes/license.php:279 includes/license.php:289 includes/license.php:292
-#: includes/license.php:294 includes/license.php:302
+#: includes/license.php:203
+#: includes/license.php:206
+#: includes/license.php:274
+#: includes/license.php:279
+#: includes/license.php:289
+#: includes/license.php:292
+#: includes/license.php:294
+#: includes/license.php:302
 msgid "More Info"
 msgstr ""
 
-#: includes/profile.php:82 includes/profile.php:84
+#: includes/profile.php:82
+#: includes/profile.php:84
 msgid "User is not paying."
 msgstr ""
 
-#: includes/updates.php:102 includes/updates.php:115
+#: includes/updates.php:102
+#: includes/updates.php:115
 msgid "Start the Update"
 msgstr ""
 
-#: includes/updates/upgrade_1.php:7 includes/upgradecheck.php:401
-#: includes/upgradecheck.php:410 includes/upgradecheck.php:422
-#: includes/upgradecheck.php:442 includes/upgradecheck.php:542
-#: includes/upgradecheck.php:561 includes/upgradecheck.php:563
+#: includes/updates/upgrade_1.php:7
+#: includes/upgradecheck.php:401
+#: includes/upgradecheck.php:410
+#: includes/upgradecheck.php:422
+#: includes/upgradecheck.php:442
+#: includes/upgradecheck.php:542
+#: includes/upgradecheck.php:561
+#: includes/upgradecheck.php:563
 #, php-format
-msgid ""
-"This content is for !!levels!! members only.<br /><a href=\"%s\">Register</a>"
+msgid "This content is for !!levels!! members only.<br /><a href=\"%s\">Register</a>"
 msgstr ""
 
-#: includes/updates/upgrade_1.php:10 includes/upgradecheck.php:404
-#: includes/upgradecheck.php:413 includes/upgradecheck.php:425
-#: includes/upgradecheck.php:445 includes/upgradecheck.php:545
-#: includes/upgradecheck.php:564 includes/upgradecheck.php:566
+#: includes/updates/upgrade_1.php:10
+#: includes/upgradecheck.php:404
+#: includes/upgradecheck.php:413
+#: includes/upgradecheck.php:425
+#: includes/upgradecheck.php:445
+#: includes/upgradecheck.php:545
+#: includes/upgradecheck.php:564
+#: includes/upgradecheck.php:566
 #, php-format
-msgid ""
-"This content is for !!levels!! members only.<br /><a href=\"%s\">Log In</a> "
-"<a href=\"%s\">Register</a>"
+msgid "This content is for !!levels!! members only.<br /><a href=\"%s\">Log In</a> <a href=\"%s\">Register</a>"
 msgstr ""
 
-#: includes/updates/upgrade_1.php:14 includes/upgradecheck.php:408
-#: includes/upgradecheck.php:417 includes/upgradecheck.php:429
-#: includes/upgradecheck.php:449 includes/upgradecheck.php:549
-#: includes/upgradecheck.php:568 includes/upgradecheck.php:570
-msgid ""
-"This content is for !!levels!! members only. Visit the site and log in/"
-"register to read."
+#: includes/updates/upgrade_1.php:14
+#: includes/upgradecheck.php:408
+#: includes/upgradecheck.php:417
+#: includes/upgradecheck.php:429
+#: includes/upgradecheck.php:449
+#: includes/upgradecheck.php:549
+#: includes/upgradecheck.php:568
+#: includes/upgradecheck.php:570
+msgid "This content is for !!levels!! members only. Visit the site and log in/register to read."
 msgstr ""
 
 #: pages/account.php:10
 msgid "Your membership is <strong>active</strong>."
 msgstr ""
 
-#: pages/account.php:34 pages/account.php:38
+#: pages/account.php:34
+#: pages/account.php:38
 #, php-format
 msgid "Your first payment will cost %s."
 msgstr ""
 
-#: pages/account.php:38 pages/account.php:42
+#: pages/account.php:38
+#: pages/account.php:42
 #, php-format
 msgid "Your first %d payments will cost %s."
 msgstr ""
 
-#: pages/account.php:87 pages/account.php:91
+#: pages/account.php:87
+#: pages/account.php:91
 msgid "Billing Information"
 msgstr ""
 
-#: pages/account.php:114 pages/account.php:118
+#: pages/account.php:114
+#: pages/account.php:118
 msgid "Edit Billing Information"
 msgstr ""
 
-#: pages/account.php:152 pages/account.php:156
+#: pages/account.php:152
+#: pages/account.php:156
 msgid "Update Billing Information"
 msgstr ""
 
-#: pages/account.php:155 pages/account.php:159
+#: pages/account.php:155
+#: pages/account.php:159
 msgid "Change Membership Level"
 msgstr ""
 
-#: pages/account.php:157 pages/account.php:161
+#: pages/account.php:157
+#: pages/account.php:161
 msgid "Cancel Membership"
 msgstr ""
 
-#: pages/cancel.php:17 pages/cancel.php:37
+#: pages/cancel.php:17
+#: pages/cancel.php:37
 msgid "Yes, cancel my account"
 msgstr ""
 
-#: pages/cancel.php:19 pages/cancel.php:38
+#: pages/cancel.php:19
+#: pages/cancel.php:38
 msgid "No, keep my account"
 msgstr ""
 
-#: pages/checkout.php:51 pages/checkout.php:53 pages/checkout.php:56
-#: pages/checkout.php:60 pages/checkout.php:61 pages/checkout.php:68
-#: pages/checkout.php:69 pages/checkout.php:71
+#: pages/checkout.php:51
+#: pages/checkout.php:53
+#: pages/checkout.php:56
+#: pages/checkout.php:60
+#: pages/checkout.php:61
+#: pages/checkout.php:68
+#: pages/checkout.php:69
+#: pages/checkout.php:71
 #, php-format
-msgid ""
-"<p class=\"pmpro_level_discount_applied\">The <strong>%s</strong> code has "
-"been applied to your order.</p>"
+msgid "<p class=\"pmpro_level_discount_applied\">The <strong>%s</strong> code has been applied to your order.</p>"
 msgstr ""
 
-#: pages/checkout.php:51 pages/checkout.php:52
+#: pages/checkout.php:51
+#: pages/checkout.php:52
 #, php-format
 msgid "<p>The <strong>%s</strong> code has been applied to your order.</p>"
 msgstr ""
 
-#: pages/checkout.php:688 pages/checkout.php:691 pages/checkout.php:707
+#: pages/checkout.php:688
+#: pages/checkout.php:691
+#: pages/checkout.php:707
 msgid "Submit and Pay with 2CheckOut"
 msgstr ""
 
 #: pages/confirmation.php:12
-msgid ""
-"Your payment has been submitted to PayPal. Your membership will be activated "
-"shortly."
+msgid "Your payment has been submitted to PayPal. Your membership will be activated shortly."
 msgstr ""
 
-#: pages/confirmation.php:95 pages/confirmation.php:97
+#: pages/confirmation.php:95
+#: pages/confirmation.php:97
 #, php-format
-msgid ""
-"Below are details about your membership account. A welcome email with has "
-"been sent to %s."
+msgid "Below are details about your membership account. A welcome email with has been sent to %s."
 msgstr ""
 
 #: pages/invoice.php:27
@@ -14324,7 +18296,8 @@ msgstr ""
 msgid "success"
 msgstr ""
 
-#: pages/invoice.php:120 pages/invoice.php:122
+#: pages/invoice.php:120
+#: pages/invoice.php:122
 msgid "View Invoice"
 msgstr ""
 
@@ -14351,34 +18324,300 @@ msgstr ""
 msgid "%s after %d %s."
 msgstr ""
 
-#: preheaders/checkout.php:99 preheaders/checkout.php:100
-#: preheaders/checkout.php:102 preheaders/checkout.php:109
+#: preheaders/checkout.php:99
+#: preheaders/checkout.php:100
+#: preheaders/checkout.php:102
+#: preheaders/checkout.php:109
 msgid "Set up Your Account"
 msgstr ""
 
-#: preheaders/checkout.php:373 preheaders/checkout.php:382
-#: preheaders/checkout.php:386 preheaders/checkout.php:415
-#: preheaders/checkout.php:508 preheaders/checkout.php:515
-#: preheaders/checkout.php:520 preheaders/checkout.php:524
-#: preheaders/checkout.php:541 preheaders/checkout.php:542
+#: preheaders/checkout.php:373
+#: preheaders/checkout.php:382
+#: preheaders/checkout.php:386
+#: preheaders/checkout.php:415
+#: preheaders/checkout.php:508
+#: preheaders/checkout.php:515
+#: preheaders/checkout.php:520
+#: preheaders/checkout.php:524
+#: preheaders/checkout.php:541
+#: preheaders/checkout.php:542
 msgid "That email address is already taken. Please try another."
 msgstr ""
 
-#: services/stripe-webhook.php:176 services/stripe-webhook.php:194
-#: services/stripe-webhook.php:270 services/stripe-webhook.php:271
-#: services/stripe-webhook.php:272 services/stripe-webhook.php:283
-#: services/stripe-webhook.php:290 services/stripe-webhook.php:304
+#: services/stripe-webhook.php:176
+#: services/stripe-webhook.php:194
+#: services/stripe-webhook.php:270
+#: services/stripe-webhook.php:271
+#: services/stripe-webhook.php:272
+#: services/stripe-webhook.php:283
+#: services/stripe-webhook.php:290
+#: services/stripe-webhook.php:304
 #: services/stripe-webhook.php:320
 #, php-format
-msgid ""
-"%s has had their payment subscription cancelled by Stripe. Please check that "
-"this user's membership is cancelled on your site if it should be."
+msgid "%s has had their payment subscription cancelled by Stripe. Please check that this user's membership is cancelled on your site if it should be."
 msgstr ""
 
-#: services/stripe-webhook.php:193 services/stripe-webhook.php:203
+#: services/stripe-webhook.php:193
+#: services/stripe-webhook.php:203
 #, php-format
+msgid "While processing an update to the subscription for %s, we failed to cancel their old subscription in Stripe. Please check that this user's original subscription (%s) is cancelled in the Stripe dashboard."
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://www.paidmembershipspro.com"
+msgstr ""
+
+#. Description of the plugin
+msgid "The most complete member management and membership subscriptions plugin for WordPress."
+msgstr ""
+
+#. Author of the plugin
+msgid "Stranger Studios"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://www.strangerstudios.com"
+msgstr ""
+
+#: classes/class.pmproemail.php:1087
 msgid ""
-"While processing an update to the subscription for %s, we failed to cancel "
-"their old subscription in Stripe. Please check that this user's original "
-"subscription (%s) is cancelled in the Stripe dashboard."
+"<p>An administrator at !!sitename!! has changed your membership level.</p>\n"
+"\n"
+"<p>!!membership_change!!.</p>\n"
+"\n"
+"<p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>\n"
+"\n"
+"<p>Log in to your membership account here: !!login_link!!</p>"
+msgstr ""
+
+#: blocks/account-invoices-section/block.js:22
+#: blocks/account-invoices-section/block.js:39
+msgid "Membership Account: Invoices"
+msgstr ""
+
+#: blocks/account-invoices-section/block.js:23
+msgid "Displays the member's invoices."
+msgstr ""
+
+#: blocks/account-invoices-section/block.js:30
+#: blocks/account-links-section/block.js:30
+#: blocks/account-membership-section/block.js:30
+#: blocks/account-page/block.js:32
+#: blocks/account-profile-section/block.js:31
+#: blocks/billing-page/block.js:30
+#: blocks/cancel-page/block.js:30
+#: blocks/checkout-button/block.js:40
+#: blocks/checkout-page/block.js:36
+#: blocks/confirmation-page/block.js:30
+#: blocks/invoice-page/block.js:30
+#: blocks/levels-page/block.js:30
+#: blocks/login/block.js:35
+#: blocks/member-profile-edit/block.js:26
+#: blocks/membership/block.js:40
+msgid "pmpro"
+msgstr ""
+
+#: blocks/account-links-section/block.js:22
+msgid "Membership Account: Links"
+msgstr ""
+
+#: blocks/account-links-section/block.js:23
+msgid "Displays the member's member links. This block is only visible if other Add Ons or custom code have added links."
+msgstr ""
+
+#: blocks/account-links-section/block.js:39
+msgid "Membership Account: Member Links"
+msgstr ""
+
+#: blocks/account-membership-section/block.js:22
+msgid "Membership Account: Memberships"
+msgstr ""
+
+#: blocks/account-membership-section/block.js:23
+msgid "Displays the member's membership information."
+msgstr ""
+
+#: blocks/account-membership-section/block.js:39
+msgid "Membership Account: My Memberships"
+msgstr ""
+
+#: blocks/account-page/block.js:25
+msgid "Displays the sections of the Membership Account page as selected below."
+msgstr ""
+
+#: blocks/account-page/inspector.js:30
+msgid "Show 'My Memberships' Section"
+msgstr ""
+
+#: blocks/account-page/inspector.js:37
+msgid "Show 'Profile' Section"
+msgstr ""
+
+#: blocks/account-page/inspector.js:44
+msgid "Show 'Invoices' Section"
+msgstr ""
+
+#: blocks/account-page/inspector.js:51
+msgid "Show 'Member Links' Section"
+msgstr ""
+
+#: blocks/account-profile-section/block.js:23
+#: blocks/account-profile-section/block.js:40
+msgid "Membership Account: Profile"
+msgstr ""
+
+#: blocks/account-profile-section/block.js:24
+msgid "Displays the member's profile information."
+msgstr ""
+
+#: blocks/billing-page/block.js:22
+#: blocks/billing-page/block.js:39
+msgid "Membership Billing Page"
+msgstr ""
+
+#: blocks/billing-page/block.js:23
+msgid "Displays the member's billing information and allows them to update the payment method."
+msgstr ""
+
+#: blocks/cancel-page/block.js:23
+msgid "Generates the Membership Cancel page."
+msgstr ""
+
+#: blocks/checkout-button/block.js:31
+msgid "Membership Checkout Button"
+msgstr ""
+
+#: blocks/checkout-button/block.js:32
+msgid "Displays a button-styled link to Membership Checkout for the specified level."
+msgstr ""
+
+#: blocks/checkout-button/block.js:41
+msgid "buy"
+msgstr ""
+
+#: blocks/checkout-button/block.js:42
+msgid "level"
+msgstr ""
+
+#: blocks/checkout-button/block.js:68
+#: blocks/checkout-button/inspector.js:31
+msgid "Button Text"
+msgstr ""
+
+#: blocks/checkout-button/block.js:79
+#: blocks/checkout-button/inspector.js:48
+msgid "CSS Class"
+msgstr ""
+
+#: blocks/checkout-button/inspector.js:32
+msgid "Text for checkout button"
+msgstr ""
+
+#: blocks/checkout-button/inspector.js:40
+msgid "The level to link to for checkout button"
+msgstr ""
+
+#: blocks/checkout-button/inspector.js:49
+msgid "Additional styling for checkout button"
+msgstr ""
+
+#: blocks/checkout-page/block.js:28
+#: blocks/checkout-page/block.js:52
+msgid "Membership Checkout Form"
+msgstr ""
+
+#: blocks/checkout-page/block.js:29
+msgid "Displays the Membership Checkout form."
+msgstr ""
+
+#: blocks/checkout-page/inspector.js:32
+msgid "Choose a default level for Membership Checkout."
+msgstr ""
+
+#: blocks/confirmation-page/block.js:23
+msgid "Displays the member's Membership Confirmation after Membership Checkout."
+msgstr ""
+
+#: blocks/invoice-page/block.js:23
+msgid "Displays the member's  Membership Invoices."
+msgstr ""
+
+#: blocks/invoice-page/block.js:39
+msgid "Membership Invoices"
+msgstr ""
+
+#: blocks/levels-page/block.js:22
+#: blocks/levels-page/block.js:39
+msgid "Membership Levels List"
+msgstr ""
+
+#: blocks/levels-page/block.js:23
+msgid "Displays a list of Membership Levels. To change the order, go to Memberships > Settings > Levels."
+msgstr ""
+
+#: blocks/login/block.js:23
+#: blocks/login/block.js:47
+msgid "Log in Form"
+msgstr ""
+
+#: blocks/login/block.js:24
+msgid "Displays a Log In Form for Paid Memberships Pro."
+msgstr ""
+
+#: blocks/login/block.js:36
+msgid "login"
+msgstr ""
+
+#: blocks/login/block.js:37
+msgid "form"
+msgstr ""
+
+#: blocks/login/block.js:38
+msgid "log in"
+msgstr ""
+
+#: blocks/login/inspector.js:29
+msgid "Display 'Welcome' content when logged in."
+msgstr ""
+
+#: blocks/login/inspector.js:38
+msgid "Display the 'Log In Widget' menu."
+msgstr ""
+
+#: blocks/login/inspector.js:39
+msgid "Assign the menu under Appearance > Menus."
+msgstr ""
+
+#: blocks/login/inspector.js:48
+msgid "Display a 'Log Out' link."
+msgstr ""
+
+#: blocks/member-profile-edit/block.js:17
+#: blocks/member-profile-edit/block.js:35
+msgid "Member Profile Edit"
+msgstr ""
+
+#: blocks/member-profile-edit/block.js:18
+msgid "Allow member profile editing."
+msgstr ""
+
+#: blocks/member-profile-edit/block.js:27
+msgid "member"
+msgstr ""
+
+#: blocks/member-profile-edit/block.js:28
+msgid "profile"
+msgstr ""
+
+#: blocks/membership/block.js:32
+msgid "Require Membership Block"
+msgstr ""
+
+#: blocks/membership/block.js:33
+msgid "Control the visibility of nested blocks for members or non-members."
+msgstr ""
+
+#: blocks/membership/block.js:62
+#: blocks/membership/block.js:74
+msgid "Select levels to show content to:"
 msgstr ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is to discuss considering updating the master language file, `/languages/paid-memberships-pro.pot`, with WP-CLI and to inspect the final rendered file for comparison between this method and the current `gettext` method.

### Other information:

Command Used: [wp make-pot](https://developer.wordpress.org/cli/commands/i18n/make-pot/)



```
wp i18n make-pot . --ignore-domain --merge --headers='{"Report-Msgid-Bugs-To":"info@paidmembershipspro.com","Last-Translator":"Paid Memberships Pro <info@paidmembershipspro.com>","Language-Team":"Paid Memberships Pro <info@paidmembershipspro.com>"}' languages/paid-memberships-pro.pot
```

`--ignore-domain` used for instances where the text domain for a string is created dynamically, e.g. `__( 'Deactivate %s' ), $plugin_data['Name'] )`

`--merge` used to update and add to the current master file instead that allows file location references for a string that exists for previous versions are kept and not replaced.

<!-- Mark completed items with an [x] -->
