### PR TITLE
Allowing order total to be set to 0 regardless of subtotal/tax

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -656,10 +656,12 @@
 			//calculate total
 			if(!empty($this->total))
 				$total = $this->total;
-			else {
+			elseif ( ! isset( $this->total ) || $this->total === '' ) {
 				$total = (float)$amount + (float)$tax;
 				$this->total = $total;
-			}			
+			} else {
+				$total = 0;
+			}
 			
 			//these fix some warnings/notices
 			if(empty($this->billing))


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If a user wants to manually set the total for an order to $0, this cannot currently be done if there are values in the subtotal/tax fields. This is a problem in cases such as AvaTax, which will calculate the subtotal/tax fields based off of the new total field after the order save is complete.

This PR allows users to enter `0` as a total and not have that value overwritten during the save function, just like this would work for any other total amount (ie subtotal 5, tax 1, total 10 currently saves successfully, total 0 should as well).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
