### PR TITLE
Add filter for subscriptions created w/o subscribe

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2978,7 +2978,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'pending_setup_intent.payment_method',
 				),
 			);
-			$order->subscription = Stripe_Subscription::create( $params );
+			$order->subscription = Stripe_Subscription::create( apply_filters( 'pmpro_stripe_create_subscription_params_array', $params ) );
 		} catch ( Stripe\Error\Base $e ) {
 			$order->error = $e->getMessage();
 			return false;


### PR DESCRIPTION
The "subscribe" function has a filter (pmpro_stripe_create_subscription_array) for the parameters that it passes when it creates the subscription.  However, the standard Checkout page does not use that route through the code.  The Checkout page uses a route that goes through the "create_subscription" function.  This pull request adds a filter (pmpro_stripe_create_subscription_params_array) to the "Stripe_Subscription::create($params) function call inside the "create_subscription" function.  Thereby allowing more flexibility in how the subscription is setup.

### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The "subscribe" function has a filter (pmpro_stripe_create_subscription_array) for the parameters that it passes when it creates the subscription.  However, the standard Checkout page does not use that route through the code.  The Checkout page uses a route that goes through the "create_subscription" function.  This change adds a filter (pmpro_stripe_create_subscription_params_array) to the "Stripe_Subscription::create($params) function call inside the "create_subscription" function.  Thereby allowing more flexibility in how the subscription is setup.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.  Buy a Subscription with the Checkout page
2. Now write a function that hooks into the new "pmpro_stripe_create_subscription_params_array" filter
3. Buy another Subscription with the Checkout page

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
The "subscribe" function has a filter (pmpro_stripe_create_subscription_array) for the parameters that it passes when it creates the subscription.  However, the standard Checkout page does not use that route through the code.  The Checkout page uses a route that goes through the "create_subscription" function.  This change adds a filter (pmpro_stripe_create_subscription_params_array) to the "Stripe_Subscription::create($params) function call inside the "create_subscription" function.  Thereby allowing more flexibility in how the subscription is setup.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
