### PR TITLE
Adding span and class selectors when showing billing addresses so sites can customize the display.

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -413,6 +413,17 @@ select.pmpro_error {
 	padding-right: 10px;
 }
 
+.pmpro_invoice-field-billing_name,
+.pmpro_invoice-field-billing_street,
+.pmpro_invoice-field-billing_country,
+.pmpro_invoice-field-billing_phone {
+	display: block;
+}
+
+.pmpro_invoice-field-billing_city:after {
+	content: ',';
+}
+
 /*---------------------------------------
 	Membership Account
 ---------------------------------------*/

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -64,12 +64,16 @@
 		<?php if(!empty($pmpro_invoice->billing->name)) { ?>
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice-billing-address' ); ?>">
 				<strong><?php _e('Billing Address', 'paid-memberships-pro' );?></strong>
-				<p><?php echo esc_html( $pmpro_invoice->billing->name );?><br />
-				<?php echo esc_html( $pmpro_invoice->billing->street );?><br />
-				<?php if($pmpro_invoice->billing->city && $pmpro_invoice->billing->state) { ?>
-					<?php echo esc_html( $pmpro_invoice->billing->city );?>, <?php echo esc_html( $pmpro_invoice->billing->state );?> <?php echo esc_html( $pmpro_invoice->billing->zip );?> <?php echo esc_html( $pmpro_invoice->billing->country );?><br />
-				<?php } ?>
-				<?php echo formatPhone($pmpro_invoice->billing->phone)?>
+				<p>
+					<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_name' ); ?>"><?php echo $pmpro_invoice->billing->name; ?></span>
+					<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_street' ); ?>"><?php echo $pmpro_invoice->billing->street; ?></span>
+					<?php if ( $pmpro_invoice->billing->city && $pmpro_invoice->billing->state ) { ?>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_city' ); ?>"><?php echo $pmpro_invoice->billing->city; ?></span>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_state' ); ?>"><?php echo $pmpro_invoice->billing->state; ?></span>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_zip' ); ?>"><?php echo $pmpro_invoice->billing->zip; ?></span>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_country' ); ?>"><?php echo $pmpro_invoice->billing->country; ?></span>
+					<?php } ?>
+					<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_phone' ); ?>"><?php echo formatPhone($pmpro_invoice->billing->phone); ?></span>
 				</p>
 			</div> <!-- end pmpro_invoice-billing-address -->
 		<?php } ?>

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -54,12 +54,16 @@
 			<?php if(!empty($pmpro_invoice->billing->name)) { ?>
 				<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice-billing-address' ); ?>">
 					<strong><?php _e('Billing Address', 'paid-memberships-pro' );?></strong>
-					<p><?php echo $pmpro_invoice->billing->name?><br />
-					<?php echo $pmpro_invoice->billing->street?><br />
-					<?php if($pmpro_invoice->billing->city && $pmpro_invoice->billing->state) { ?>
-						<?php echo $pmpro_invoice->billing->city?>, <?php echo $pmpro_invoice->billing->state?> <?php echo $pmpro_invoice->billing->zip?> <?php echo $pmpro_invoice->billing->country?><br />
-					<?php } ?>
-					<?php echo formatPhone($pmpro_invoice->billing->phone)?>
+					<p>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_name' ); ?>"><?php echo $pmpro_invoice->billing->name; ?></span>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_street' ); ?>"><?php echo $pmpro_invoice->billing->street; ?></span>
+						<?php if($pmpro_invoice->billing->city && $pmpro_invoice->billing->state) { ?>
+							<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_city' ); ?>"><?php echo $pmpro_invoice->billing->city; ?></span>
+							<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_state' ); ?>"><?php echo $pmpro_invoice->billing->state; ?></span>
+							<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_zip' ); ?>"><?php echo $pmpro_invoice->billing->zip; ?></span>
+							<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_country' ); ?>"><?php echo $pmpro_invoice->billing->country; ?></span>
+						<?php } ?>
+						<span class="<?php echo pmpro_get_element_class( 'pmpro_invoice-field-billing_phone' ); ?>"><?php echo formatPhone($pmpro_invoice->billing->phone); ?></span>
 					</p>
 				</div> <!-- end pmpro_invoice-billing-address -->
 			<?php } ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR helps the plugin frontend pages to allow for better customization of how addresses are shown. In the current version, our address follows a very US-centric format. This method will instead allow CSS to modify the display of addresses, such as moving individual address pages to single lines or removing the "comma" added after the city name.  

### Changelog entry

* BUG FIX/ENHANCEMENT: Now wrapping the frontend address display with custom CSS selectors to allow for international custom address formatting. 
