### PR TITLE
Hide Payment Request button when form submitted

### DIFF
--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -130,11 +130,21 @@ jQuery( document ).ready( function( $ ) {
 					});
 					// Handle payment request button confirmation.
 					paymentRequest.on('paymentmethod', function( event ) {
+						$('#pmpro_btn-submit').attr('disabled', 'disabled');
+						$('#pmpro_processing_message').css('visibility', 'visible');
+						$('#payment-request-button').hide();
+						event.complete('success');
 						pmpro_stripeResponseHandler( event );
 					});
 				}
 			}
 		});
+
+		// Find ALL <form> tags on your page
+		jQuery('form').submit(function(){
+			// Hide payment request button on form submit to prevent double charges.
+			jQuery('#payment-request-button').hide();
+		});	
 
 		function stripeUpdatePaymentRequestButton() {
 			jQuery.noConflict().ajax({


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Addresses issues that may cause double-charges for users who submit repeat checkout submissions too quickly.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

Set up ApplePay/Google Pay and verify that it is not possible to submit multiple payments before the first is processed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
