### PR TITLE
Fixed missing membership data in billing failure email

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -549,6 +549,8 @@
 			
 			if(!$user || !$invoice)
 				return false;
+
+			$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $invoice->membership_id );
 			
 			$this->email = $user->user_email;
 			$this->subject = sprintf(__("Membership Payment Failed at %s", "paid-memberships-pro"), get_option("blogname"));
@@ -559,8 +561,8 @@
 								"user_login" => $user->user_login,
 								"sitename" => get_option("blogname"),
 								"siteemail" => pmpro_getOption("from_email"),
-								"membership_id" => $user->membership_level->id,
-								"membership_level_name" => $user->membership_level->name,
+								"membership_id" => $membership_level->id,
+								"membership_level_name" => $membership_level->name,
 								"display_name" => $user->display_name,
 								"user_email" => $user->user_email,									
 								"billing_name" => $invoice->billing->name,
@@ -596,6 +598,7 @@
 				return false;
 				
 			$user = get_userdata($invoice->user_id);
+			$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $invoice->membership_id );
 			
 			$this->email = $email;
 			$this->subject = sprintf(__("Membership Payment Failed For %s at %s", "paid-memberships-pro"), $user->display_name, get_option("blogname"));
@@ -606,8 +609,8 @@
 								"user_login" => $user->user_login,
 								"sitename" => get_option("blogname"),
 								"siteemail" => pmpro_getOption("from_email"),
-								"membership_id" => $user->membership_level->id,
-								"membership_level_name" => $user->membership_level->name,
+								"membership_id" => $membership_level->id,
+								"membership_level_name" => $membership_level->name,
 								"display_name" => $user->display_name,
 								"user_email" => $user->user_email,									
 								"billing_name" => $invoice->billing->name,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
`$user->membership_level` was returning the empty string before this change, causing the `!!membership_level_name!!` and `!!membership_id!!` email variables to show up blank. This change ensures that information is filled in if the user still has the membership level associated with the invoice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x]  Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
