### PR TITLE
Always fire pmpro_update_order/pmpro_updated_order

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -616,8 +616,11 @@
 			global $wpdb;
 			$this->sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET timestamp = '" . $date . "' WHERE id = '" . $this->id . "' LIMIT 1";
 
+			do_action('pmpro_update_order', $this);
 			if($wpdb->query($this->sqlQuery) !== "false") {
 				$this->timestamp = strtotime( $date );
+				do_action('pmpro_updated_order', $this);
+				
 				return $this->getMemberOrderByID($this->id);
 			} else {
 				return false;
@@ -863,12 +866,17 @@
 			if(empty($this->id))
 				return false;
 
-			$this->status = $newstatus;
 			$this->sqlQuery = "UPDATE $wpdb->pmpro_membership_orders SET status = '" . esc_sql($newstatus) . "' WHERE id = '" . $this->id . "' LIMIT 1";
-			if($wpdb->query($this->sqlQuery) !== false)
+			
+			do_action('pmpro_update_order', $this);
+			if($wpdb->query($this->sqlQuery) !== false){
+				$this->status = $newstatus;
+				do_action('pmpro_updated_order', $this);
+				
 				return true;
-			else
+			}else{
 				return false;
+			}
 		}
 
 		/**
@@ -925,8 +933,10 @@
 					$this->gateway,
 					$this->gateway_environment,
 					$this->subscription_transaction_id
-				);								
+				);
+				do_action('pmpro_update_order', $this);
 				$wpdb->query($sqlQuery);
+				do_action('pmpro_updated_order', $this);
 				
 				//cancel the gateway subscription first
 				if (is_object($this->Gateway)) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I was debugging on the order status flow in case of issues with PayPal Express. After a while, I was able to recall that the status can change even when the `MemberOrder::saveOrder()` method is not called, because of `updateStatus`. This PR adds the update/updated actions every time runs an update query on `$wpdb->pmpro_membership_orders`.

⚠️ Also noticed there is a useless updateStatus [here](https://github.com/strangerstudios/paid-memberships-pro/blob/d0a252dfa967dca080f95cedacb1982410ff6847/classes/class.memberorder.php#L940) because it's already done by the early query above, to avoid race conditions.
⚠️ Last but not least, [this note](https://github.com/strangerstudios/paid-memberships-pro/blob/d0a252dfa967dca080f95cedacb1982410ff6847/classes/class.memberorder.php#L957) should be updated: it says the truth, but it does not consider the early query above, which was probably added later.

By the way, after that early query, we should just try to update the Gateway. No more updateStatus, so I would delete this one: https://github.com/strangerstudios/paid-memberships-pro/blob/d0a252dfa967dca080f95cedacb1982410ff6847/classes/class.memberorder.php#L940

No related issue to resolve, but very useful to debug.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
