### PR TITLE
PHP Notice - Issue #1592

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -132,6 +132,11 @@ function pmpro_url( $page = null, $querystring = '', $scheme = null ) {
 
 	global $pmpro_pages;
 
+	// BUG FIX: PHP Notice when PMPro pages haven't been configured
+	if ( ! isset( $pmpro_pages[ $page ] ) ) {
+	    return null;
+	}
+	
 	// start with the permalink
 	$url = get_permalink( $pmpro_pages[ $page ] );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -134,7 +134,7 @@ function pmpro_url( $page = null, $querystring = '', $scheme = null ) {
 
 	// BUG FIX: PHP Notice when PMPro pages haven't been configured
 	if ( ! isset( $pmpro_pages[ $page ] ) ) {
-	    return null;
+	    return '';
 	}
 	
 	// start with the permalink


### PR DESCRIPTION
BUG FIX: PHP Notice when PMPro pages haven't been configured

### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Return empty string value for URL until the specified `$page` value is set in the `$pmpro_pages` array.

Resoves #1592

### How to test the changes in this Pull Request:

1. Unit tests would be useful
2. `tail -f <path to apache|nginx logs>/error_log` (or `tail -f wp-content/debug.log` if WP debug logging is enabled
3. Activate PMPro and see that the `PHP Notice:  Trying to access array offset on value of type null in [...]/wp-content/plugins/paid-memberships-pro/includes/functions.php on line 136` PHP notice is no longer being printed.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
BUG FIX: PHP Notice due to PMPro page settings being unconfigured
