### PR TITLE
New function to escape prices and allow certain html. New filter pmpro_escape_price

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -333,7 +333,7 @@ function pmpro_dashboard_report_recent_orders_callback() {
 								<?php }
 							?>
                         </td>
-        				<td><?php echo pmpro_formatPrice( $order->total ); ?></td>
+        				<td><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); ?></td>
         				<td>
                             <?php echo $order->gateway; ?>
                             <?php if ( $order->gateway_environment == 'test' ) {

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1408,7 +1408,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							<?php }
 						?>
 					</td>
-					<td><?php echo esc_html( pmpro_formatPrice( $order->total ) ); ?></td>
+					<td><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); ?></td>
 					<td>
 						<?php
 						if ( ! empty( $order->payment_type ) ) {

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -69,7 +69,7 @@ function pmpro_report_sales_widget() {
 					<?php } ?>
 				</th>
 				<td><?php echo esc_html( number_format_i18n( pmpro_getSales( $report_type ) ) ); ?></td>
-				<td><?php echo esc_html(pmpro_formatPrice( pmpro_getRevenue( $report_type ) ) ); ?></td>
+				<td><?php echo pmpro_escape_price( pmpro_formatPrice( pmpro_getRevenue( $report_type ) ) ); ?></td>
 			</tr>
 			<?php
 				//sale prices stats
@@ -82,9 +82,9 @@ function pmpro_report_sales_widget() {
 					}
 			?>
 				<tr class="pmpro_report_tr_sub" style="display: none;">
-					<th scope="row">- <?php echo esc_html( pmpro_formatPrice( $price ) );?></th>
+					<th scope="row">- <?php echo pmpro_escape_price( pmpro_formatPrice( $price ) );?></th>
 					<td><?php echo esc_html( number_format_i18n( $quantity ) ); ?></td>
-					<td><?php echo esc_html( pmpro_formatPrice( $price * $quantity ) ); ?></td>
+					<td><?php echo pmpro_escape_price( pmpro_formatPrice( $price * $quantity ) ); ?></td>
 				</tr>
 			<?php
 			}

--- a/adminpages/templates/orders-email.php
+++ b/adminpages/templates/orders-email.php
@@ -62,7 +62,7 @@
 				</tr>
 				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
 					<th colspan="2" style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php _e('Total', 'paid-memberships-pro' ); ?></th>
-					<th style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo pmpro_formatPrice($order->total); ?></th>
+					<th style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); ?></th>
 				</tr>
 			</table>
 		</td>

--- a/adminpages/templates/orders-print.php
+++ b/adminpages/templates/orders-print.php
@@ -91,7 +91,7 @@
 			</tr>
 			<tr>
 				<th colspan="2" class="alignright"><?php _e('Total', 'paid-memberships-pro' ); ?></th>
-				<th class="alignright"><?php echo pmpro_formatPrice( $order->total ); ?></th>
+				<th class="alignright"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); ?></th>
 			</tr>
 		</table>
 	</main>

--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -101,7 +101,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 							if ( $revenue > 0 ) {
 								?>
 								<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Sales and Revenue', 'paid-memberships-pro' ); ?></h3>
-								<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( 'Your membership site made <strong>%1$s</strong> in revenue %2$s.', 'paid-memberships-pro' ), esc_html( pmpro_formatPrice( $revenue ) ), esc_html( $term ) ); ?></p>
+								<p style="margin:0px 0px 15px 0px;padding:0px;"><?php printf( __( 'Your membership site made <strong>%1$s</strong> in revenue %2$s.', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $revenue ) ), esc_html( $term ) ); ?></p>
 							<?php } else { ?>
 								<h3 style="color:#2997c8;font-size:20px;line-height:30px;margin:0px 0px 15px 0px;padding:0px;"><?php esc_html_e( 'Signups and Cancellations', 'paid-memberships-pro' ); ?></h3>
 							<?php } ?>

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -543,7 +543,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		} else {
 			// Display the member's initial payment.
 			if ( (float)$item['initial_payment'] > 0 ) {
-				$fee .= pmpro_formatPrice( $item['initial_payment'] );
+				$fee .= pmpro_escape_price( pmpro_formatPrice( $item['initial_payment'] ) );
 			}
 			// If there is a recurring payment, show a plus sign.
 			if ( (float)$item['initial_payment'] > 0 && (float)$item['billing_amount'] > 0 ) {
@@ -551,7 +551,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			}
 			// If there is a recurring payment, show the recurring payment amount and cycle.
 			if ( (float)$item['billing_amount'] > 0 ) {
-				$fee .= pmpro_formatPrice( $item['billing_amount'] );
+				$fee .= pmpro_escape_price( pmpro_formatPrice( $item['billing_amount'] ) );
 				$fee .= esc_html( ' per ', 'paid-memberships-pro' );
 				if ( $item['cycle_number'] > 1 ) {
 					$fee .= $item['cycle_number'] . " " . $item['cycle_period'] . "s";

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2758,6 +2758,35 @@ function pmpro_formatPrice( $price ) {
 	return apply_filters( 'pmpro_format_price', $formatted, $price, $pmpro_currency, $pmpro_currency_symbol );
 }
 
+/**
+ * Filter a sanitized price for display with only the allowed HTML.
+ *
+ * @since 2.5.7
+ *
+ * @param string $price A price value.
+ * @return string $price The escaped price with allowed HTML. 
+ *
+ */
+function pmpro_escape_price( $price ) {
+	$allowed_price_html = apply_filters( 
+		'pmpro_escape_price_html', 
+		array(
+			'div' => array (
+				'class' => array(),
+				'id' => array(),
+			),
+			'span' => array (
+				'class' => array(),
+				'id' => array(),
+			),
+			'sup' => array (
+				'class' => array(),
+				'id' => array(),
+			),
+		)
+	);
+	return wp_kses( $price, $allowed_price_html );
+}
 
 /**
  * Function to trim trailing zeros from an amount.

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -61,11 +61,11 @@
 						<?php
 							$level = $current_user->membership_level;
 							if($current_user->membership_level->cycle_number > 1) {
-								printf(__('%s every %d %s.', 'paid-memberships-pro' ), pmpro_formatPrice($level->billing_amount), $level->cycle_number, pmpro_translate_billing_period($level->cycle_period, $level->cycle_number));
+								printf(__('%s every %d %s.', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice($level->billing_amount) ), $level->cycle_number, pmpro_translate_billing_period($level->cycle_period, $level->cycle_number));
 							} elseif($current_user->membership_level->cycle_number == 1) {
-								printf(__('%s per %s.', 'paid-memberships-pro' ), pmpro_formatPrice($level->billing_amount), pmpro_translate_billing_period($level->cycle_period));
+								printf(__('%s per %s.', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice($level->billing_amount) ), pmpro_translate_billing_period($level->cycle_period));
 							} else {
-								echo pmpro_formatPrice($current_user->membership_level->billing_amount);
+								echo pmpro_escape_price( pmpro_formatPrice($current_user->membership_level->billing_amount) );
 							}
 						?>
 

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -95,17 +95,17 @@
 			<strong><?php _e('Total Billed', 'paid-memberships-pro' );?></strong>
 			<p><?php if($pmpro_invoice->total != '0.00') { ?>
 				<?php if(!empty($pmpro_invoice->tax)) { ?>
-					<?php _e('Subtotal', 'paid-memberships-pro' );?>: <?php echo pmpro_formatPrice($pmpro_invoice->subtotal);?><br />
-					<?php _e('Tax', 'paid-memberships-pro' );?>: <?php echo pmpro_formatPrice($pmpro_invoice->tax);?><br />
+					<?php _e('Subtotal', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->subtotal) );?><br />
+					<?php _e('Tax', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->tax) );?><br />
 					<?php if(!empty($pmpro_invoice->couponamount)) { ?>
-						<?php _e('Coupon', 'paid-memberships-pro' );?>: (<?php echo pmpro_formatPrice($pmpro_invoice->couponamount);?>)<br />
+						<?php _e('Coupon', 'paid-memberships-pro' );?>: (<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->couponamount) );?>)<br />
 					<?php } ?>
-					<strong><?php _e('Total', 'paid-memberships-pro' );?>: <?php echo pmpro_formatPrice($pmpro_invoice->total);?></strong>
+					<strong><?php _e('Total', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?></strong>
 				<?php } else { ?>
-					<?php echo pmpro_formatPrice($pmpro_invoice->total);?>
+					<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?>
 				<?php } ?>
 			<?php } else { ?>
-				<small class="<?php echo pmpro_get_element_class( 'pmpro_grey' ); ?>"><?php echo esc_html( pmpro_formatPrice(0) );?></small>
+				<small class="<?php echo pmpro_get_element_class( 'pmpro_grey' ); ?>"><?php echo pmpro_escape_price( pmpro_formatPrice(0) );?></small>
 			<?php } ?></p>
 		</div> <!-- end pmpro_invoice-total -->
 

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -85,17 +85,17 @@
 				<strong><?php _e('Total Billed', 'paid-memberships-pro' );?></strong>
 				<p><?php if($pmpro_invoice->total != '0.00') { ?>
 					<?php if(!empty($pmpro_invoice->tax)) { ?>
-						<?php _e('Subtotal', 'paid-memberships-pro' );?>: <?php echo pmpro_formatPrice($pmpro_invoice->subtotal);?><br />
-						<?php _e('Tax', 'paid-memberships-pro' );?>: <?php echo pmpro_formatPrice($pmpro_invoice->tax);?><br />
+						<?php _e('Subtotal', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->subtotal) ); ?><br />
+						<?php _e('Tax', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->tax) );?><br />
 						<?php if(!empty($pmpro_invoice->couponamount)) { ?>
-							<?php _e('Coupon', 'paid-memberships-pro' );?>: (<?php echo pmpro_formatPrice($pmpro_invoice->couponamount);?>)<br />
+							<?php _e('Coupon', 'paid-memberships-pro' );?>: (<?php echo pmpro_escape_price (pmpro_formatPrice($pmpro_invoice->couponamount) );?>)<br />
 						<?php } ?>
-						<strong><?php _e('Total', 'paid-memberships-pro' );?>: <?php echo pmpro_formatPrice($pmpro_invoice->total);?></strong>
+						<strong><?php _e('Total', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?></strong>
 					<?php } else { ?>
-						<?php echo pmpro_formatPrice($pmpro_invoice->total);?>
+						<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?>
 					<?php } ?>
 				<?php } else { ?>
-					<small class="<?php echo pmpro_get_element_class( 'pmpro_grey' ); ?>"><?php echo pmpro_formatPrice(0);?></small>
+					<small class="<?php echo pmpro_get_element_class( 'pmpro_grey' ); ?>"><?php echo pmpro_escape_price( pmpro_formatPrice(0) ); ?></small>
 				<?php } ?></p>
 			</div> <!-- end pmpro_invoice-total -->
 		</div> <!-- end pmpro_invoice_details -->

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -239,7 +239,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 						<tr id="pmpro_account-invoice-<?php echo $invoice->code; ?>">
 							<td><a href="<?php echo pmpro_url("invoice", "?invoice=" . $invoice->code)?>"><?php echo date_i18n(get_option("date_format"), $invoice->getTimestamp())?></a></td>
 							<td><?php if(!empty($invoice->membership_level)) echo $invoice->membership_level->name; else echo __("N/A", 'paid-memberships-pro' );?></td>
-							<td><?php echo pmpro_formatPrice($invoice->total)?></td>
+							<td><?php echo pmpro_escape_price( pmpro_formatPrice($invoice->total) ); ?></td>
 							<td><?php echo $display_status; ?></td>
 						</tr>
 						<?php

--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -128,7 +128,7 @@ function pmpro_member_shortcode($atts, $content=null, $code='')
 		if(empty($r) || $r == '0.00')
 			$r = '';
 		else
-			$r = pmpro_formatPrice($r);
+			$r = pmpro_escape_price( pmpro_formatPrice($r) );
 	}
 
 	/** 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Occasionally, sites using HTML markup in their level cost text or via the pmpro_format_price filter would not display as HTML but rather output on the screen. This PR adds a new function to escape prices using the wp_kses filter and a filter to allow additional HTML via the pmpro_escape_price filter. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Add a custom gist to your site that uses pmpro_format_price and adds raw HTML to the price format. 
2. View the Memberships > Dashboard WordPress admin page and see that there is HTML output as plain text.
3. Switch to this updated code. The HTML is now rendering as expected.

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Added pmpro_escape_price filter to allow HTML to be used in formatting prices for display.
