### PR TITLE
PayPal Express: avoid double processing of the same review request

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -322,22 +322,28 @@
 
 				$morder = new MemberOrder();
 				$morder->getMemberOrderByPayPalToken(sanitize_text_field($_REQUEST['token']));
-				$morder->Token = $morder->paypal_token; $pmpro_paypal_token = $morder->paypal_token;
-				if($morder->Token)
-				{
-					if($morder->Gateway->getExpressCheckoutDetails($morder))
+				
+				if( $morder->status === 'token' ){
+					$morder->Token = $morder->paypal_token; $pmpro_paypal_token = $morder->paypal_token;
+					if($morder->Token)
 					{
-						$pmpro_review = true;
+						if($morder->Gateway->getExpressCheckoutDetails($morder))
+						{
+							$pmpro_review = true;
+						}
+						else
+						{
+							$pmpro_msg = $morder->error;
+							$pmpro_msgt = "pmpro_error";
+						}
 					}
 					else
 					{
-						$pmpro_msg = $morder->error;
+						$pmpro_msg = __("The PayPal Token was lost.", 'paid-memberships-pro' );
 						$pmpro_msgt = "pmpro_error";
 					}
-				}
-				else
-				{
-					$pmpro_msg = __("The PayPal Token was lost.", 'paid-memberships-pro' );
+				}else{
+					$pmpro_msg = __("Checkout was already processed.", 'paid-memberships-pro' );
 					$pmpro_msgt = "pmpro_error";
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When something goes wrong with PayPal Express, the subscribe() method returns an error, but the user will stay on that page. URL is something like /checkout/?level=1&review=X&token=EC-Y&PayerID=Z. If the user hits F5, the order (which status already changed to review or error) got set to review once again. So we just lose the progress information and since a level agreement is already set for that order, we are unable to restore it but manually. This PR is to avoid double processing the same review request.

### How to test the changes in this Pull Request:

1. Force an order to give error during subscribe()
2. Try to reload the error page
3. See the error (A successful Billing Agreement has already been created for this token) and check the order status (review).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Avoid PayPal double processing of the same review request.