### PR TITLE
Removing the small HTML wrapper for $0.00. It isn't needed.

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -105,7 +105,7 @@
 					<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?>
 				<?php } ?>
 			<?php } else { ?>
-				<small class="<?php echo pmpro_get_element_class( 'pmpro_grey' ); ?>"><?php echo pmpro_escape_price( pmpro_formatPrice(0) );?></small>
+				<?php echo pmpro_escape_price( pmpro_formatPrice(0) ); ?>
 			<?php } ?></p>
 		</div> <!-- end pmpro_invoice-total -->
 

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -95,7 +95,7 @@
 						<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?>
 					<?php } ?>
 				<?php } else { ?>
-					<small class="<?php echo pmpro_get_element_class( 'pmpro_grey' ); ?>"><?php echo pmpro_escape_price( pmpro_formatPrice(0) ); ?></small>
+					<?php echo pmpro_escape_price( pmpro_formatPrice(0) ); ?>
 				<?php } ?></p>
 			</div> <!-- end pmpro_invoice-total -->
 		</div> <!-- end pmpro_invoice_details -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

These was a lingering <small> HTML tag wrapping the $0.00 amounts on invoices and confirmation page. This was an unnecessary design element and I have removed it.
  
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out for a free level
2. View the invoice from your Membership Account page
3. Pricing should appear just the same as other values. 
