### PR TITLE
Improve localization for some strings - fixes 1604

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ log/*.txt
 tests/_build
 js/blocks.build.asset.php
 js/blocks.build.js.map
+.vscode/settings.json

--- a/includes/login.php
+++ b/includes/login.php
@@ -468,7 +468,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 				<div class="<?php echo pmpro_get_element_class( 'pmpro_login_wrap' ); ?>">
 					<?php
 						if ( ! pmpro_is_login_page() ) {
-							echo $before_title . esc_html__ 'Log In', 'paid-memberships-pro' ) . $after_title;
+							echo $before_title . esc_html__( 'Log In', 'paid-memberships-pro' ) . $after_title;
 						}
 					?>
 					<?php
@@ -490,7 +490,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_lost_password_wrap' ); ?>">
 				<?php
 					if ( ! pmpro_is_login_page() ) {
-						echo $before_title . esc_html__ 'Password Reset', 'paid-memberships-pro' ) . $after_title;
+						echo $before_title . esc_html__( 'Password Reset', 'paid-memberships-pro' ) . $after_title;
 					}
 				?>
 				<p class="<?php echo pmpro_get_element_class( 'pmpro_lost_password-instructions' ); ?>">
@@ -510,7 +510,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_reset_password_wrap' ); ?>">
 				<?php
 					if ( ! pmpro_is_login_page() ) {
-						echo $before_title . esc_html__ 'Reset Password', 'paid-memberships-pro' ) . $after_title;
+						echo $before_title . esc_html__( 'Reset Password', 'paid-memberships-pro' ) . $after_title;
 					}
 				?>
 				<?php pmpro_reset_password_form(); ?>

--- a/includes/login.php
+++ b/includes/login.php
@@ -468,7 +468,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 				<div class="<?php echo pmpro_get_element_class( 'pmpro_login_wrap' ); ?>">
 					<?php
 						if ( ! pmpro_is_login_page() ) {
-							echo $before_title . esc_html( 'Log In', 'paid-memberships-pro' ) . $after_title;
+							echo $before_title . esc_html__ 'Log In', 'paid-memberships-pro' ) . $after_title;
 						}
 					?>
 					<?php
@@ -490,7 +490,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_lost_password_wrap' ); ?>">
 				<?php
 					if ( ! pmpro_is_login_page() ) {
-						echo $before_title . esc_html( 'Password Reset', 'paid-memberships-pro' ) . $after_title;
+						echo $before_title . esc_html__ 'Password Reset', 'paid-memberships-pro' ) . $after_title;
 					}
 				?>
 				<p class="<?php echo pmpro_get_element_class( 'pmpro_lost_password-instructions' ); ?>">
@@ -510,7 +510,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_reset_password_wrap' ); ?>">
 				<?php
 					if ( ! pmpro_is_login_page() ) {
-						echo $before_title . esc_html( 'Reset Password', 'paid-memberships-pro' ) . $after_title;
+						echo $before_title . esc_html__ 'Reset Password', 'paid-memberships-pro' ) . $after_title;
 					}
 				?>
 				<?php pmpro_reset_password_form(); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Change escape function from `esc_html` to `esc_html__` to make text strings localized in `/includes/login.php`.

1. "Log In" string displayed in widget is now translatable.
2. "Reset Password" heading is now translatable on pages with `[pmpro_login]` shortcode that is not the assigned default Log In page in options.
3. "Password Reset" heading is now translatable on pages with `[pmpro_login]` shortcode that is not the assigned default Log In page in options

Resolves [1604](https://github.com/strangerstudios/paid-memberships-pro/issues/1604).

### How to test the changes in this Pull Request:

1. Go to Appearance > Themes and set active theme as Memberlite.
2. Go to Appearance > Widgets and add the "Log In - PMPro" widget to the "Post and Arches", "Pages", and "Footer Widgets" localtions
3. Go to Pages > Add New and create a page containing the shortcode `[pmpro_login}` and publish. (This is a different page to the default Log In page created during PMPro initial setup that is set under Memberships > Settings on the Pages tab).
4. Go to Settings > General and change Site Language to Français.
5. Visit any front end page that contains widgets, the title for the "Log In - PMPro" widget should not display the default English "Log In" string but the correct translated string in French (France).
6. Visit the alternative log in page created with URL paramaters `?action=reset_pass`, the "Password Reset" title should now display the correct translated string in French (France).
7. Visit the alternative log in page created with URL paramaters `?action=rp&key=fake_test_key&login=test_user_name`, the "Reset Password" title should now display the correct translated string in French (France).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.