### PR TITLE
BUG FIX: Sometimes post's level is missing when adding class to post.

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -481,7 +481,9 @@ function pmpro_post_classes( $classes, $class, $post_id ) {
 		if( ! empty( $post_levels[1] ) ) {
 			$classes[] = 'pmpro-level-required';
 			foreach( $post_levels[1] as $post_level ) {
-				$classes[] = 'pmpro-level-' . $post_level[0];
+				if ( isset( $post_level[0] ) ) {
+					$classes[] = 'pmpro-level-' . $post_level[0];
+				} 	
 			}
 		}
 		if(!empty($post_levels[0]) && $post_levels[0] == true) {


### PR DESCRIPTION
BUG FIX: Fixed an issue when trying to add `pmpro-level-` to a post when the level no longer exists or was NULL.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

Screenshot reference:

![Screen Shot 2021-03-19 at 09 18 46](https://user-images.githubusercontent.com/12629136/111744603-24de0700-8894-11eb-8f8e-cd3142f41834.png)

I am unable to figure out exact steps to recreate this error.
