### PR TITLE
No longer calling $order->updateTimestamp() on orders adminpage

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -277,6 +277,14 @@ if ( ! empty( $_REQUEST['save'] ) ) {
 		global $allowedposttags;
 		$order->notes = wp_kses( wp_unslash( $_REQUEST['notes'] ), $allowedposttags );
 	}
+	if ( ! in_array( 'timestamp', $read_only_fields ) && isset( $_POST['ts_year'] ) && isset( $_POST['ts_month'] ) && isset( $_POST['ts_day'] ) && isset( $_POST['ts_hour'] ) && isset( $_POST['ts_minute'] ) ) {
+		$year   = intval( $_POST['ts_year'] );
+		$month  = intval( $_POST['ts_month'] );
+		$day    = intval( $_POST['ts_day'] );
+		$hour   = intval( $_POST['ts_hour'] );
+		$minute = intval( $_POST['ts_minute'] );
+		$order->timestamp = $date = get_gmt_from_date( $year . '-' . $month . '-' . $day . ' ' . $hour . ':' . $minute . ':00' , 'U' );;
+	}
 
 	// affiliate stuff
 	$affiliates = apply_filters( 'pmpro_orders_show_affiliate_ids', false );
@@ -298,15 +306,6 @@ if ( ! empty( $_REQUEST['save'] ) ) {
 	// save
 	if ( $order->saveOrder() !== false && $nonceokay ) {
 		$order_id = $order->id;
-		
-		// handle timestamp
-		if ( $order->updateTimestamp( intval( $_POST['ts_year'] ), intval( $_POST['ts_month'] ), intval( $_POST['ts_day'] ), intval( $_POST['ts_hour'] ) . ':' . intval( $_POST['ts_minute'] ) . ':00' ) !== false ) {
-			$pmpro_msg  = __( 'Order saved successfully.', 'paid-memberships-pro' );
-			$pmpro_msgt = 'success';
-		} else {
-			$pmpro_msg  = __( 'Error updating order timestamp.', 'paid-memberships-pro' );
-			$pmpro_msgt = 'error';
-		}
 	} else {
 		$pmpro_msg  = __( 'Error saving order.', 'paid-memberships-pro' );
 		$pmpro_msgt = 'error';

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -600,6 +600,10 @@
 		 * Change the timestamp of an order by passing in year, month, day, time.
 		 *
 		 * $time should be adjusted for local timezone.
+		 *
+		 * NOTE: This function should no longer be used. Instead, set the timestamp
+		 * for the order directly and call the MemberOrder->saveOrder() function.
+		 * This function is no longer used on the /adminpages/orders.php page.
 		 */
 		function updateTimestamp($year, $month, $day, $time = NULL)
 		{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We no longer have to wait until after the order is saved to call `$order->updateTimestamp()` on our `/adminpages/orders.php` page. Instead, the timestamp is now saved on `$order->saveOrder()` as expected.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
