### PR TITLE
Fixed deprecated jQuery functions in pmpro-admin.js

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -43,7 +43,7 @@ function pmpro_toggle_elements_by_selector( selector, checked ) {
  * @since v2.1
  */
 jQuery(document).ready(function() {
-	jQuery( 'input[pmpro_toggle_trigger_for]' ).change( function() {		
+	jQuery( 'input[pmpro_toggle_trigger_for]' ).on( 'change', function() {
 		pmpro_toggle_elements_by_selector( jQuery( this ).attr( 'pmpro_toggle_trigger_for' ), jQuery( this ).prop( 'checked' ) );
 	});
 });
@@ -81,13 +81,13 @@ jQuery(document).ready(function() {
 	}
 
     // Disable the webhook buttons if the API keys aren't complete yet.
-    jQuery('#stripe_publishablekey,#stripe_secretkey').bind('change keyup', function() {
+    jQuery('#stripe_publishablekey,#stripe_secretkey').on('change keyup', function() {
         pmpro_stripe_check_api_keys();
     });    
     pmpro_stripe_check_api_keys();
     
     // AJAX call to create webhook.
-    jQuery('#pmpro_stripe_create_webhook').click(function(event){
+	jQuery('#pmpro_stripe_create_webhook').on( 'click', function(event){
         event.preventDefault();
                 
 		var postData = {
@@ -120,7 +120,7 @@ jQuery(document).ready(function() {
     });
     
     // AJAX call to delete webhook.
-    jQuery('#pmpro_stripe_delete_webhook').click(function(event){
+	jQuery('#pmpro_stripe_delete_webhook').on( 'click', function(event){
         event.preventDefault();
                 
 		var postData = {
@@ -153,7 +153,7 @@ jQuery(document).ready(function() {
 	});
 
 	// AJAX call to rebuild webhook.
-    jQuery('#pmpro_stripe_rebuild_webhook').click(function(event){
+	jQuery('#pmpro_stripe_rebuild_webhook').on( 'click', function(event){
         event.preventDefault();
                 
 		var postData = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed deprecated jQuery functions in `pmpro-admin.js`.

Note: Similar changes may have to be made in other core PMPro files and in Add Ons.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:
1. Install the "Enable jQuery Migrate Helper" plugin: https://wordpress.org/plugins/enable-jquery-migrate-helper/
2. Ensure all of the checkboxes in `Tools > jQuery Migrate` are checked
3. See that deprecation warnings from `pmpro-admin.js` are shown on PMPro admin pages are shown before changes, but not after

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
