### PR TITLE
Initial steps toward a return function for invoice/order prices parts

### DIFF
--- a/adminpages/templates/orders-email.php
+++ b/adminpages/templates/orders-email.php
@@ -20,7 +20,7 @@
 	</tr>
 	<?php if(!empty($order->billing->name)): ?>
 		<tr>
-			<td>
+			<td style="padding-bottom:10px;">
 				<strong><?php _e( 'Bill to:', 'paid-memberships-pro' ); ?></strong><br>
 				<?php
 					echo pmpro_formatAddress(
@@ -41,7 +41,7 @@
 	<tbody>
 	<tr>
 		<td colspan="2">
-			<table style="width:100%;border-width:1px;border-style:solid;border-collapse:collapse;">
+			<table style="width:100%;border-width:0px;border-collapse:collapse;">
 				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
 					<th style="text-align:center;border-width:1px;border-style:solid;border-collapse:collapse;"><?php _e('ID', 'paid-memberships-pro' ); ?></th>
 					<th style="border-width:1px;border-style:solid;border-collapse:collapse;"><?php _e('Item', 'paid-memberships-pro' ); ?></th>
@@ -50,19 +50,19 @@
 				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
 					<td style="text-align:center;border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo $level->id; ?></td>
 					<td style="border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo $level->name; ?></td>
-					<td style="text-align:right;"><?php echo $order->subtotal; ?></td>
+					<td style="border-width:1px;border-style:solid;border-collapse:collapse;text-align:right;"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->subtotal ) ); ?></td>
 				</tr>
-				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
-					<th colspan="2" style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php _e('Subtotal', 'paid-memberships-pro' ); ?></th>
-					<td style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo $order->subtotal; ?></td>
-				</tr>
-				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
-					<th colspan="2" style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php _e('Tax', 'paid-memberships-pro' ); ?></th>
-					<td style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo $order->tax; ?></td>
-				</tr>
-				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
-					<th colspan="2" style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php _e('Total', 'paid-memberships-pro' ); ?></th>
-					<th style="text-align:right;border-width:1px;border-style:solid;border-collapse:collapse;"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); ?></th>
+				<tr style="border-width:0px;border-collapse:collapse;">
+					<th colspan="2" style="text-align:right;border-width:0px;border-collapse:collapse;"></th>
+					<td style="text-align:right;border-width:0px;border-collapse:collapse;padding-top:10px;">
+						<?php
+							if ( $order->total != '0.00' ) {
+								echo pmpro_display_price_parts( $order );
+							} else {
+								echo pmpro_escape_price( pmpro_formatPrice(0) );
+							}
+						?>
+					</td>
 				</tr>
 			</table>
 		</td>

--- a/adminpages/templates/orders-print.php
+++ b/adminpages/templates/orders-print.php
@@ -70,7 +70,7 @@
 				$order->billing->phone
 			); ?>
 		</p>
-		<table class="invoice">
+		<table class="invoice" style="border-width:0px;border-collapse:collapse;">
 			<tr>
 				<th><?php _e('ID', 'paid-memberships-pro' ); ?></th>
 				<th><?php _e('Item', 'paid-memberships-pro' ); ?></th>
@@ -79,19 +79,18 @@
 			<tr>
 				<td class="aligncenter"><?php echo $level->id; ?></td>
 				<td><?php echo $level->name; ?></td>
-				<td class="alignright"><?php echo $order->subtotal; ?></td>
+				<td class="alignright"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->subtotal ) ); ?></td>
 			</tr>
-			<tr>
-				<th colspan="2" class="alignright"><?php _e('Subtotal', 'paid-memberships-pro' ); ?></th>
-				<td class="alignright"><?php echo $order->subtotal; ?></td>
-			</tr>
-			<tr>
-				<th colspan="2" class="alignright"><?php _e('Tax', 'paid-memberships-pro' ); ?></th>
-				<td class="alignright"><?php echo $order->tax; ?></td>
-			</tr>
-			<tr>
-				<th colspan="2" class="alignright"><?php _e('Total', 'paid-memberships-pro' ); ?></th>
-				<th class="alignright"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); ?></th>
+			<tr style="border-width:0px;border-collapse:collapse;">
+				<td colspan="3" style="border-width:0px;border-collapse:collapse;text-align:right;">
+					<?php
+						if ( $order->total != '0.00' ) {
+							echo pmpro_display_price_parts( $order );
+						} else {
+							echo pmpro_escape_price( pmpro_formatPrice(0) );
+						}
+					?>
+				</td>
 			</tr>
 		</table>
 	</main>

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -279,6 +279,14 @@ select.pmpro_error {
 #pmpro_message_bottom {
 	margin-bottom: 1em;
 }
+
+/*---------------------------------------
+	Display Price Parts
+---------------------------------------*/
+.pmpro_price_part_label:after {
+	content: ": ";
+}
+
 /*---------------------------------------
 	Membership Checkout
 ---------------------------------------*/

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2724,6 +2724,41 @@ function pmpro_is_ready() {
 }
 
 /**
+ * Display Invoice Price Data with Parts
+ *
+ */
+function pmpro_display_price_parts( $pmpro_invoice ) {
+	$pmpro_display_price_parts = array();
+
+	if ( ! empty( $pmpro_invoice->subtotal ) && $pmpro_invoice->subtotal != $pmpro_invoice->total ) {
+		$pmpro_display_price_parts['subtotal'] = sprintf( __('<span class="%s">%s</span> %s', 'paid-memberships-pro' ), pmpro_get_element_class( 'pmpro_price_part_label' ), __( 'Subtotal', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $pmpro_invoice->subtotal ) ) );
+	}
+
+	if ( ! empty( $pmpro_invoice->tax ) ) {
+		$pmpro_display_price_parts['tax'] = sprintf( __('<span class="%s">%s</span> %s', 'paid-memberships-pro' ), pmpro_get_element_class( 'pmpro_price_part_label' ), __( 'Tax', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $pmpro_invoice->tax ) ) );
+	}
+
+	if ( ! empty( $pmpro_invoice->couponamount ) ) {
+		$pmpro_display_price_parts['couponamount'] = sprintf( __('<span class="%s">%s</span> %s', 'paid-memberships-pro' ), pmpro_get_element_class( 'pmpro_price_part_label' ), __( 'Coupon', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $pmpro_invoice->couponamount ) ) );
+	}
+
+	if ( ! empty( $pmpro_invoice->total ) ) {
+		$pmpro_display_price_parts['total'] = sprintf( __('<span class="%s">%s</span> %s', 'paid-memberships-pro' ), pmpro_get_element_class( 'pmpro_price_part_label' ), __( 'Total', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $pmpro_invoice->total ) ) );
+	}
+
+	$pmpro_display_price_parts_separator = '<br />';
+
+	$pmpro_display_price_parts = apply_filters( 'pmpro_display_price_parts', $pmpro_display_price_parts, $pmpro_display_price_parts_separator, $pmpro_invoice );
+
+	$pmpro_display_price = '';
+	foreach ( $pmpro_display_price_parts as $pmpro_display_price_part ) {
+		$pmpro_display_price .= $pmpro_display_price_part . $pmpro_display_price_parts_separator;
+	}
+
+	return $pmpro_display_price;
+}
+
+/**
  * Format a price per the currency settings.
  *
  * @since  1.7.15

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -93,20 +93,15 @@
 
 		<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice-total' ); ?>">
 			<strong><?php _e('Total Billed', 'paid-memberships-pro' );?></strong>
-			<p><?php if($pmpro_invoice->total != '0.00') { ?>
-				<?php if(!empty($pmpro_invoice->tax)) { ?>
-					<?php _e('Subtotal', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->subtotal) );?><br />
-					<?php _e('Tax', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->tax) );?><br />
-					<?php if(!empty($pmpro_invoice->couponamount)) { ?>
-						<?php _e('Coupon', 'paid-memberships-pro' );?>: (<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->couponamount) );?>)<br />
-					<?php } ?>
-					<strong><?php _e('Total', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?></strong>
-				<?php } else { ?>
-					<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?>
-				<?php } ?>
-			<?php } else { ?>
-				<?php echo pmpro_escape_price( pmpro_formatPrice(0) ); ?>
-			<?php } ?></p>
+			<p>
+				<?php
+					if ( $pmpro_invoice->total != '0.00' ) {
+						echo pmpro_display_price_parts( $pmpro_invoice );
+					} else {
+						echo pmpro_escape_price( pmpro_formatPrice(0) );
+					}
+				?>
+			</p>
 		</div> <!-- end pmpro_invoice-total -->
 
 	</div> <!-- end pmpro_invoice -->

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -83,20 +83,15 @@
 
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice-total' ); ?>">
 				<strong><?php _e('Total Billed', 'paid-memberships-pro' );?></strong>
-				<p><?php if($pmpro_invoice->total != '0.00') { ?>
-					<?php if(!empty($pmpro_invoice->tax)) { ?>
-						<?php _e('Subtotal', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->subtotal) ); ?><br />
-						<?php _e('Tax', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->tax) );?><br />
-						<?php if(!empty($pmpro_invoice->couponamount)) { ?>
-							<?php _e('Coupon', 'paid-memberships-pro' );?>: (<?php echo pmpro_escape_price (pmpro_formatPrice($pmpro_invoice->couponamount) );?>)<br />
-						<?php } ?>
-						<strong><?php _e('Total', 'paid-memberships-pro' );?>: <?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?></strong>
-					<?php } else { ?>
-						<?php echo pmpro_escape_price( pmpro_formatPrice($pmpro_invoice->total) );?>
-					<?php } ?>
-				<?php } else { ?>
-					<?php echo pmpro_escape_price( pmpro_formatPrice(0) ); ?>
-				<?php } ?></p>
+				<p>
+					<?php
+						if ( $pmpro_invoice->total != '0.00' ) {
+							echo pmpro_display_price_parts( $pmpro_invoice );
+						} else {
+							echo pmpro_escape_price( pmpro_formatPrice(0) );
+						}
+					?>
+				</p>
 			</div> <!-- end pmpro_invoice-total -->
 		</div> <!-- end pmpro_invoice_details -->
 		<hr />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a function to return a complex price with all the separate "parts" along with a new filter `pmpro_display_price_parts` to insert additional price data, such as the tax information that our forthcoming AvaTax Integration will add. This could also be used to show price data like a Donation amount, variable price-adjusting field through Register Helper, and more.

### How to test the changes in this Pull Request:

1. Create an order that has a subtotal, tax, and total.
2. Check the Membership Confirmation page, Invoice page, Order Print and Email (from admin).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added function to return a complete price block with breakdown of price parts for an order/invoice total.
* ENHANCEMENT: Added filter `pmpro_display_price_parts` to allow custom code and other plugins to insert parts into a displayed price total. 

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
