### PR TITLE
New function pmpro_get_ordered_levels

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -363,6 +363,7 @@ if ( function_exists( 'pmpro_displayAds' ) && pmpro_displayAds() ) {
 
 								$sqlQuery = "SELECT * FROM $wpdb->pmpro_membership_levels ";
 								$levels = $wpdb->get_results($sqlQuery, OBJECT);
+								$levels = pmpro_get_ordered_levels( $levels );
 								foreach($levels as $level)
 								{
 							?>

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -537,6 +537,7 @@
 			<div class="pmpro_discount_levels">
 			<?php
 				$levels = $wpdb->get_results("SELECT * FROM $wpdb->pmpro_membership_levels");
+				$levels = pmpro_get_ordered_levels( $levels );
 				foreach($levels as $level)
 				{
 					//if this level is already managed for this discount code, use the code values

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1068,7 +1068,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 
 				<?php
 				// Note: only orders belonging to current levels can be filtered. There is no option for orders belonging to deleted levels
-				$levels = pmpro_getAllLevels( true, true );
+				$levels = pmpro_get_ordered_levels( pmpro_getAllLevels( true, true ) );
 				?>
 				<select id="l" name="l">
 					<?php foreach ( $levels as $level ) { ?>

--- a/adminpages/reports/login.php
+++ b/adminpages/reports/login.php
@@ -105,6 +105,7 @@ function pmpro_report_login_page()
 				<option value="all" <?php if($l == "all") { ?>selected="selected"<?php } ?>><?php _e('All Levels', 'paid-memberships-pro')?></option>
 				<?php
 					$levels = $wpdb->get_results("SELECT id, name FROM $wpdb->pmpro_membership_levels ORDER BY name");
+					$levels = pmpro_get_ordered_levels( $levels );
 					foreach($levels as $level)
 					{
 				?>

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -31,25 +31,7 @@ function pmpro_report_memberships_widget() {
 	global $wpdb;
 
 	//get levels to show stats on first 3
-	$pmpro_levels = pmpro_getAllLevels(true, true);
-
-	$pmpro_level_order = pmpro_getOption('level_order');
-
-	if(!empty($pmpro_level_order))
-	{
-		$order = explode(',',$pmpro_level_order);
-
-		//reorder array
-		$reordered_levels = array();
-		foreach($order as $level_id) {
-			foreach($pmpro_levels as $key=>$level) {
-				if($level_id == $level->id)
-					$reordered_levels[$key] = $pmpro_levels[$key];
-			}
-		}
-
-		$pmpro_levels = $reordered_levels;
-	}
+	$pmpro_levels = pmpro_get_ordered_levels( pmpro_getAllLevels(true, true) );
 
 	$pmpro_levels = apply_filters( 'pmpro_report_levels', $pmpro_levels );
 ?>
@@ -375,6 +357,7 @@ function pmpro_report_memberships_page()
 				<option value="free-levels" <?php if(isset($_REQUEST['level']) && $_REQUEST['level'] == "free-levels"){?> selected="selected" <?php }?>><?php _e( 'All Free Levels', 'paid-memberships-pro' ); ?></option>
 				<?php
 					$levels = $wpdb->get_results("SELECT id, name FROM $wpdb->pmpro_membership_levels ORDER BY name");
+					$levels = pmpro_get_ordered_levels( $levels );
 					foreach($levels as $level)
 					{
 				?>

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -311,6 +311,7 @@ function pmpro_report_sales_page()
 			<option value="" <?php if(!$l) { ?>selected="selected"<?php } ?>><?php _e('All Levels', 'paid-memberships-pro' );?></option>
 			<?php
 				$levels = $wpdb->get_results("SELECT id, name FROM $wpdb->pmpro_membership_levels ORDER BY name");
+				$levels = pmpro_get_ordered_levels( $levels );
 				foreach($levels as $level)
 				{
 			?>

--- a/includes/content.php
+++ b/includes/content.php
@@ -81,6 +81,9 @@ function pmpro_has_membership_access($post_id = NULL, $user_id = NULL, $return_m
 	}
 	else
 	{
+		// Reorder the $post_membership_levels to match sorted order.
+		$post_membership_levels = pmpro_get_ordered_levels( $post_membership_levels );
+
 		//we need to see if the user has access
 		foreach($post_membership_levels as $level)
 		{

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2300,6 +2300,40 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 	return $pmpro_level;
 }
 
+/**
+ * Get an ordered list of level objects or level IDs.
+ *
+ * @param array $pmpro_levels An array of level objects or level IDs to be reordered.
+ * @return array $pmpro_levels An ordered array of level objects or level IDs.
+ *
+ */
+function pmpro_get_ordered_levels( $pmpro_levels ) {
+	$pmpro_level_order = pmpro_getOption( 'level_order' );
+
+	// No custom sort order, just return.
+	if ( empty( $pmpro_level_order ) ) {
+		return $pmpro_levels;
+	}
+
+	// Convert the level order option to an array.
+	$order = explode( ',',$pmpro_level_order );
+
+	// Reorder the array.
+	$reordered_levels = array();
+	foreach ( $order as $level_id ) {
+		foreach ( $pmpro_levels as $key => $level ) {
+			if ( ! empty ( $level->id ) && $level_id == $level->id ) {
+				$reordered_levels[] = $pmpro_levels[$key];
+			} elseif ( ! empty( $level ) && is_string( $level ) && $level_id == $level ) {
+				$reordered_levels[] = $pmpro_levels[$key];
+			}
+		}
+	}
+	$pmpro_levels = $reordered_levels;
+
+	return $pmpro_levels;
+}
+
 function pmpro_getCheckoutButton( $level_id, $button_text = null, $classes = null ) {
 	if ( ! empty( $level_id ) ) {
 		// get level

--- a/includes/metaboxes.php
+++ b/includes/metaboxes.php
@@ -5,6 +5,7 @@
 function pmpro_page_meta() {
 	global $post, $wpdb;
 	$membership_levels = pmpro_getAllLevels( true, true );
+	$membership_levels = pmpro_get_ordered_levels( $membership_levels );
 	$page_levels = $wpdb->get_col( "SELECT membership_id FROM {$wpdb->pmpro_memberships_pages} WHERE page_id = '" . intval( $post->ID ) . "'" );
 ?>
     <ul id="membershipschecklist" class="list:category categorychecklist form-no-clear">

--- a/pages/levels.php
+++ b/pages/levels.php
@@ -1,26 +1,8 @@
 <?php 
 global $wpdb, $pmpro_msg, $pmpro_msgt, $current_user;
 
-$pmpro_levels = pmpro_getAllLevels(false, true);
-$pmpro_level_order = pmpro_getOption('level_order');
-
-if(!empty($pmpro_level_order))
-{
-	$order = explode(',',$pmpro_level_order);
-
-	//reorder array
-	$reordered_levels = array();
-	foreach($order as $level_id) {
-		foreach($pmpro_levels as $key=>$level) {
-			if($level_id == $level->id)
-				$reordered_levels[] = $pmpro_levels[$key];
-		}
-	}
-
-	$pmpro_levels = $reordered_levels;
-}
-
-$pmpro_levels = apply_filters("pmpro_levels_array", $pmpro_levels);
+$pmpro_levels = pmpro_get_ordered_levels( pmpro_getAllLevels(false, true) );
+$pmpro_levels = apply_filters( 'pmpro_levels_array', $pmpro_levels );
 
 if($pmpro_msg)
 {

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -181,7 +181,7 @@ global $all_membership_levels;
 // we sometimes refer to this array of levels
 // DEPRECATED: Remove this in v3.0.
 global $membership_levels;
-$membership_levels = pmpro_getAllLevels( true, true );
+$membership_levels = pmpro_get_ordered_levels( pmpro_getAllLevels( true, true ) );
 
 /*
 	Activation/Deactivation

--- a/preheaders/levels.php
+++ b/preheaders/levels.php
@@ -30,23 +30,12 @@ if (isset($_REQUEST['msg'])) {
 
 global $pmpro_levels, $pmpro_level_order;
 
-$pmpro_levels = pmpro_getAllLevels(false, true);
-$pmpro_level_order = pmpro_getOption('level_order');
 
-if(!empty($pmpro_level_order))
-{
-    $order = explode(',',$pmpro_level_order);
-
-    //reorder array
-    $reordered_levels = array();
-    foreach($order as $level_id) {
-        foreach($pmpro_levels as $key=>$level) {
-            if($level_id == $level->id)
-                $reordered_levels[$key] = $pmpro_levels[$key];
-        }
-    }
-
-    $pmpro_levels = $reordered_levels;
-}
-
-$pmpro_levels = apply_filters("pmpro_levels_array", $pmpro_levels);
+/**
+ * This actually isn't needed to draw the levels page.
+ * But, there may be custom code that relies on the ordered global of Membership Levels array here.
+ * We will evenutally deprecate this.
+ *
+ */
+$pmpro_levels = pmpro_get_ordered_levels( pmpro_getAllLevels(false, true) );
+$pmpro_levels = apply_filters( 'pmpro_levels_array', $pmpro_levels );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

New function `pmpro_get_ordered_levels` to reorder any retrieved array of levels (objects or IDs) based on the sorted option; updates to use this where level are listed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/paid-memberships-pro/issues/1122.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX/ENHANCEMENT: Now ordering all places we display a list of level or level names according to the admin-sorted level order.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
