### PR TITLE
Fix user table sort

### DIFF
--- a/includes/init.php
+++ b/includes/init.php
@@ -206,7 +206,7 @@ function pmpro_sortable_column_query( $query ) {
 	$vars = $query->query_vars;
 
 	if ( $vars['orderby'] == 'level' ){
-		$order = pmpro_sanitize_with_safelist( $vars['order'], array( 'asc', 'desc' ) );
+		$order = pmpro_sanitize_with_safelist( $vars['order'], array( 'ASC', 'DESC' ) );
 		
 		if ( ! empty( $order ) ) {
 			$query->query_from .= " LEFT JOIN {$wpdb->prefix}pmpro_memberships_users AS pmpro_mu ON {$wpdb->prefix}users.ID = pmpro_mu.user_id AND pmpro_mu.status = 'active'";


### PR DESCRIPTION
`in_array()` is case sensitive

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1622 .
