### PR TITLE
Updating conditional for Billing Address on Invoice and Confirmation page

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -61,7 +61,7 @@
 	</ul>
 	<hr />
 	<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice_details' ); ?>">
-		<?php if(!empty($pmpro_invoice->billing->name)) { ?>
+		<?php if(!empty($pmpro_invoice->billing->street)) { ?>
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice-billing-address' ); ?>">
 				<strong><?php _e('Billing Address', 'paid-memberships-pro' );?></strong>
 				<p>

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -51,7 +51,7 @@
 
 		<hr />
 		<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice_details' ); ?>">
-			<?php if(!empty($pmpro_invoice->billing->name)) { ?>
+			<?php if(!empty($pmpro_invoice->billing->street)) { ?>
 				<div class="<?php echo pmpro_get_element_class( 'pmpro_invoice-billing-address' ); ?>">
 					<strong><?php _e('Billing Address', 'paid-memberships-pro' );?></strong>
 					<p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we updated to pull billing information from user meta, the billing address shown on the Invoice was not displaying because the conditional relies on the "Billing Name" field. This update will instead have the Billing Address shown on Confirmation and Invoice pages based on whether the Billing Street field is present.
