### PR TITLE
Avoid a redirect loop if login page is deleted.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -114,8 +114,12 @@ function pmpro_login_url_filter( $login_url='', $redirect='' ) {
 	// Check for a PMPro Login page.
 	$login_page_id = pmpro_getOption( 'login_page_id' );
 	if ( ! empty ( $login_page_id ) ) {
-		$login_url = get_permalink( $login_page_id );
-
+		$login_page_permalink = get_permalink( $login_page_id );
+		// If the page or permalink is unavailable, don't override the url here.
+		if ( $login_page_permalink ) {
+			$login_url = $login_page_permalink;
+		}
+		
 		if ( ! empty( $redirect ) ) {
 			$login_url = add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url ) ;
 		}


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If we can't get a permalink to redirect to, don't override the url on the filter.

Resolves #1519

### How to test the changes in this Pull Request:

1. Delete the login page.
2. When not logged in, load /wp-admin/
3. Does it loop redirect?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
