### PR TITLE
Added pmpro_after_all_membesrhip_level_changes

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1211,16 +1211,24 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
  */
 function pmpro_do_action_after_all_membership_level_changes( $filter_contents = null ) {
 	global $pmpro_old_user_levels;
+	if ( empty( $pmpro_old_user_levels ) ) {
+		// No level changes occured, return.
+		return $filter_contents;
+	}
+
+	// Clear global so that we don't run twice for same level changes
+	$pmpro_old_user_levels_copy = $pmpro_old_user_levels;
+	$pmpro_old_user_levels = null;
+
 	/**
 	 * Run code after all membership level changes have occured. Users who have had changes
 	 * will be stored in the global $pmpro_old_user_levels array.
 	 *
 	 * @since  2.6
+	 * @param array $pmpro_old_user_levels_copy array of user_id => array( old_level_objs )
 	 */
-	do_action( 'pmpro_after_all_membership_level_changes' );
+	do_action( 'pmpro_after_all_membership_level_changes', $pmpro_old_user_levels_copy );
 
-	// Start fresh for next call.
-	unset( $pmpro_old_user_levels );
 	return $filter_contents;
 }
 add_action( 'template_redirect', 'pmpro_do_action_after_all_membership_level_changes', 2 );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1210,6 +1210,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
  * @param mixed $filter_contents to not break the wp_redirect filter.
  */
 function pmpro_do_action_after_all_membership_level_changes( $filter_contents = null ) {
+	global $pmpro_old_user_levels;
 	/**
 	 * Run code after all membership level changes have occured. Users who have had changes
 	 * will be stored in the global $pmpro_old_user_levels array.
@@ -1217,6 +1218,9 @@ function pmpro_do_action_after_all_membership_level_changes( $filter_contents = 
 	 * @since  2.6
 	 */
 	do_action( 'pmpro_after_all_membership_level_changes' );
+
+	// Start fresh for next call.
+	unset( $pmpro_old_user_levels );
 	return $filter_contents;
 }
 add_action( 'template_redirect', 'pmpro_do_action_after_all_membership_level_changes', 2 );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1015,6 +1015,14 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	// get all active membershipships for this user
 	$old_levels = pmpro_getMembershipLevelsForUser( $user_id );
 
+	global $pmpro_old_user_levels;
+	if ( empty( $pmpro_old_user_levels ) ) {
+		$pmpro_old_user_levels = array();
+	}
+	if ( ! array_key_exists( $user_id, $pmpro_old_user_levels ) ) {
+		$pmpro_old_user_levels[$user_id] = empty( $old_levels ) ? array() : $old_levels;
+	}
+
 		// get level id
 	if ( is_array( $level ) ) {
 		$level_id = $level['membership_id'];    // custom level
@@ -1195,6 +1203,26 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	do_action( 'pmpro_after_change_membership_level', $level_id, $user_id, $cancel_level );
 	return true;
 }
+
+/**
+ * Runs after all membership level changes have been performed.
+ *
+ * @param mixed $filter_contents to not break the wp_redirect filter.
+ */
+function pmpro_do_action_after_all_membership_level_changes( $filter_contents = null ) {
+	/**
+	 * Run code after all membership level changes have occured. Users who have had changes
+	 * will be stored in the global $pmpro_old_user_levels array.
+	 *
+	 * @since  2.6
+	 */
+	do_action( 'pmpro_after_all_membership_level_changes' );
+	return $filter_contents;
+}
+add_action( 'template_redirect', 'pmpro_do_action_after_all_membership_level_changes', 2 );
+add_filter( 'wp_redirect', 'pmpro_do_action_after_all_membership_level_changes', 100 );
+add_action( 'pmpro_membership_post_membership_expiry', 'pmpro_do_action_after_all_membership_level_changes' );
+add_action( 'shutdown', 'pmpro_do_action_after_all_membership_level_changes' );
 
 /**
  * Function to list WordPress categories in hierarchical format.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

resolves #1628

### Usage:
To use this action, you would:
1. Hook into `pmpro_after_all_membesrhip_level_changes`
2. Loop through `$pmpro_old_user_levels` array arg passed into function, and for each user:
3. -- Get their old levels from the `$pmpro_old_user_levels` array. Use this to determine what courses/audiences/etc they were subscribed to (`$unsubscribes`)
4. -- Get their current levels by calling `pmpro_getMembershipLevelsForUser()`. Use this to determine what courses/audiences/etc they should now be subscribed to (`$subscribes`)
5. -- `array_unique()` both `$subscribes` and `$unsubscribes`
5. -- Subscribe users to all courses/audiences/etc in `array_diff( $subscribes, $unsubscribes )`
6. -- Optionally remove users from all courses/audiences/etc in `array_diff( $unsubscribes, $subscribes )`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
