### PR TITLE
Fixed pw reset link in new user notification email for plain permalinks

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -818,9 +818,9 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login ) {
 		$login_url = get_permalink( $login_page_id );
 		if ( strpos( $login_url, '?' ) ) {
 			// Login page permalink contains a '?', so we need to replace the '?' already in the login URL with '&'.
-			$message = str_replace( site_url( 'wp-login.php' ) . '?', site_url( 'wp-login.php' ) . '&', $message );
+			$message = str_replace( network_site_url( 'wp-login.php' ) . '?', $login_url . '&', $message );
 		}
-		$message = str_replace( site_url( 'wp-login.php' ), $login_url, $message );
+		$message = str_replace( network_site_url( 'wp-login.php' ), $login_url, $message );
 	}
 
 	return $message;

--- a/includes/login.php
+++ b/includes/login.php
@@ -826,7 +826,7 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login ) {
 	return $message;
 }
 add_filter( 'retrieve_password_message', 'pmpro_password_reset_email_filter', 20, 3 );
-add_filter( 'wp_new_user_notification_email', 'pmpro_new_user_notification_email_filter', 10, 3 );
+add_filter( 'wp_new_user_notification_email', 'pmpro_password_reset_email_filter', 10, 3 );
 
 /**
  * Authenticate the frontend user login.

--- a/includes/login.php
+++ b/includes/login.php
@@ -811,7 +811,7 @@ add_action( 'login_form_resetpass', 'pmpro_do_password_reset' );
  *
  * @since 2.3
  */
-function pmpro_password_reset_email_filter( $message, $key, $user_login, $user_data ) {
+function pmpro_password_reset_email_filter( $message, $key, $user_login ) {
 
 	$login_page_id = pmpro_getOption( 'login_page_id' );
     if ( ! empty ( $login_page_id ) ) {
@@ -825,24 +825,7 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login, $user_d
 
 	return $message;
 }
-add_filter( 'retrieve_password_message', 'pmpro_password_reset_email_filter', 20, 4 );
-
-/**
- * Replace the default login URL in the new user notification email
- * with the membership account page login URL instead.
- *
- * @since 2.3.4
- */
-function pmpro_new_user_notification_email_filter( $message, $user, $blogname ) {
-
-	$login_page_id = pmpro_getOption( 'login_page_id' );
-    if ( ! empty ( $login_page_id ) ) {
-        $login_url = get_permalink( $login_page_id );
-		$message = str_replace( network_site_url( 'wp-login.php' ), $login_url, $message );
-	}
-
-	return $message;
-}
+add_filter( 'retrieve_password_message', 'pmpro_password_reset_email_filter', 20, 3 );
 add_filter( 'wp_new_user_notification_email', 'pmpro_new_user_notification_email_filter', 10, 3 );
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed password reset link in new user notification email when using plain permalinks. Also removed duplicate function.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
