### PR TITLE
accounting for $include_active in level cache

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1181,6 +1181,8 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	// remove levels cache for user
 	$cache_key = 'user_' . $user_id . '_levels';
 	wp_cache_delete( $cache_key, 'pmpro' );
+	wp_cache_delete( $cache_key . '_all', 'pmpro' );
+	wp_cache_delete( $cache_key . '_active', 'pmpro' );
 
 	// update user data and call action
 	pmpro_set_current_user();
@@ -2006,7 +2008,7 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 	 * reduces future MySQL requests. If there is an external object cache like Redis then it will be
 	 * persisted until the user level changes.
 	 **/
-	$cache_key = 'user_' . $user_id . '_levels';
+	$cache_key = 'user_' . $user_id . '_levels' . ( $include_inactive ? '_all' : '_active' );
     $levels = wp_cache_get( $cache_key, 'pmpro' );
 	
 	if ( $levels === false ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Account for `$include_active` in `pmpro_getMembershipLevelsForUser()` cache.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

resolves #984 

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
