### PR TITLE
Username column on orders page is now User, shows email

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1319,7 +1319,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 			<tr class="thead">
 				<th><?php esc_html_e( 'ID', 'paid-memberships-pro' ); ?></th>
 				<th><?php esc_html_e( 'Code', 'paid-memberships-pro' ); ?></th>
-				<th><?php esc_html_e( 'Username', 'paid-memberships-pro' ); ?></th>
+				<th><?php esc_html_e( 'User', 'paid-memberships-pro' ); ?></th>
 				<?php do_action( 'pmpro_orders_extra_cols_header', $order_ids ); ?>
 				<th><?php esc_html_e( 'Level', 'paid-memberships-pro' ); ?></th>
 				<th><?php esc_html_e( 'Total', 'paid-memberships-pro' ); ?></th>
@@ -1387,7 +1387,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					<td class="username column-username">
 						<?php $order->getUser(); ?>
 						<?php if ( ! empty( $order->user ) ) { ?>
-							<a href="user-edit.php?user_id=<?php echo esc_attr( $order->user->ID ); ?>"><?php echo esc_html( $order->user->user_login ); ?></a>
+							<a href="user-edit.php?user_id=<?php echo esc_attr( $order->user->ID ); ?>"><?php echo esc_html( $order->user->user_login ); ?> (<?php echo esc_html( $order->user->user_email ); ?>)</a>
 						<?php } elseif ( $order->user_id > 0 ) { ?>
 							[<?php esc_html_e( 'deleted', 'paid-memberships-pro' ); ?>]
 						<?php } else { ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Change the existing "username" column on the orders list table to "user". In each row, show the user's display name and email address.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1516 .

### How to test the changes in this Pull Request:
View orders page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
