### PR TITLE
Fixed query parameter in pmpro_search_filter

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -145,7 +145,7 @@ function pmpro_search_filter($query)
     if( ! $query->is_admin && $query->is_search && empty( $query->query['post_parent'] ) ) {
         //avoiding post_parent queries for now
 		if( empty( $query->query_vars['post_parent'] ) ) {
-			$query->set( 'post__not_in', array_merge( $query->get('post__not_in'), $pmpro_pages ) );
+			$query->set( 'post__not_in', array_merge( $query->get('post__not_in'), array_values( $pmpro_pages ) ) );
 		}
     }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Do not pass associative array `$pmpro_pages` into query parameter `post__not_in`. Instead, just pass the page IDs.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1634 .


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
