### PR TITLE
Use create_subscription() when creating a subscription

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2154,7 +2154,7 @@ class PMProGateway_stripe extends PMProGateway {
 		// subscribe to the plan
 		try {
 			$subscription = array( "plan" => $order->code );
-			$result       = $this->customer->subscriptions->create( apply_filters( 'pmpro_stripe_create_subscription_array', $subscription ) );
+			$result       = $this->create_subscription( $order );
 		} catch ( \Throwable $e ) {
 			//try to delete the plan
 			$plan->delete();
@@ -2978,7 +2978,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'pending_setup_intent.payment_method',
 				),
 			);
-			$order->subscription = Stripe_Subscription::create( $params );
+			$order->subscription = Stripe_Subscription::create( apply_filters( 'pmpro_stripe_create_subscription_array', $params ) );
 		} catch ( Stripe\Error\Base $e ) {
 			$order->error = $e->getMessage();
 			return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

Check out for a level with a recurring subscription and make sure the subscription is still created.

### Other information:

<!-- Mark completed items with an [x] -->

### Changelog entry

> REFACTOR: Now using the create_subscription() method whenever creating a subscription to avoid redundant code.
