### PR TITLE
add method to get first order by subscription id

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -337,6 +337,24 @@
 		}
 
 		/**
+		 * Returns the first order using the given subscription_transaction_id.
+		 */
+		function getFirstMemberOrderBySubscriptionTransactionID($subscription_transaction_id)
+		{
+			//did they pass a sub id?
+			if(empty($subscription_transaction_id))
+				return false;
+
+			global $wpdb;
+			$id = $wpdb->get_var("SELECT id FROM $wpdb->pmpro_membership_orders WHERE subscription_transaction_id = '" . esc_sql($subscription_transaction_id) . "' ORDER BY id ASC LIMIT 1");
+
+			if($id)
+				return $this->getMemberOrderByID($id);
+			else
+				return false;
+		}
+		
+		/**
 		 * Returns the last order using the given paypal token.
 		 */
 		function getMemberOrderByPayPalToken($token)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a method to get the first order by subscription id, useful to:
- get the initial payment order for a renewal order
- check if an order is an initial payment or a renewal
- ...

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
