### PR TITLE
BUG FIX: Fixed warning when all_levels were empty

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2285,9 +2285,13 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 		if ( empty( $level_id ) ) {
 			$all_levels = pmpro_getAllLevels( false, false );
 
-			// Get lowest level ID.
-			$default_level =  min( array_keys( $all_levels ) );
-
+			if ( ! empty( $all_levels ) ) {
+				// Get lowest level ID.
+				$default_level =  min( array_keys( $all_levels ) );
+			} else {
+				$default_level = null;
+			}
+			
 			$level_id = apply_filters( 'pmpro_default_level', intval( $default_level ) );
 			
 			// Bail back to levels page if level ID is empty or less than 1.


### PR DESCRIPTION
BUG FIX: Fixed issue where the default_level was calling min() on an empty variable. Improve the logic.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?