### PR TITLE
Orders user email outside hyperlink; adjustments to price parts for sanitization and frontend styling

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1387,7 +1387,8 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					<td class="username column-username">
 						<?php $order->getUser(); ?>
 						<?php if ( ! empty( $order->user ) ) { ?>
-							<a href="user-edit.php?user_id=<?php echo esc_attr( $order->user->ID ); ?>"><?php echo esc_html( $order->user->user_login ); ?> (<?php echo esc_html( $order->user->user_email ); ?>)</a>
+							<a href="user-edit.php?user_id=<?php echo esc_attr( $order->user->ID ); ?>"><?php echo esc_html( $order->user->user_login ); ?></a><br />
+							<?php echo esc_html( $order->user->user_email ); ?>
 						<?php } elseif ( $order->user_id > 0 ) { ?>
 							[<?php esc_html_e( 'deleted', 'paid-memberships-pro' ); ?>]
 						<?php } else { ?>

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -294,7 +294,7 @@ select.pmpro_error {
 .pmpro_price_part_label:after {
 	content: ": ";
 }
-span.pmpro_price_part_sub {
+.pmpro_price_part_sub {
 	font-size: 75%;
 }
 span.pmpro_price_part_sub:before {

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -286,8 +286,20 @@ select.pmpro_error {
 .pmpro_price_part_span {
 	display: block;
 }
+.pmpro_price_part-total {
+	border-top: 1px solid #CCC;
+	margin-top: 5px;
+	padding-top: 5px;
+}
 .pmpro_price_part_label:after {
 	content: ": ";
+}
+span.pmpro_price_part_sub {
+	font-size: 75%;
+}
+span.pmpro_price_part_sub:before {
+	content: "\2022";
+	padding-right: 5px;
 }
 
 /*---------------------------------------

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2873,17 +2873,17 @@ function pmpro_get_price_parts( $pmpro_invoice, $format = 'array' ) {
 		$pmpro_price = '';
 		if ( $format == 'span' ) {
 			foreach ( $pmpro_price_parts_with_total as $key => $pmpro_price_part ) {
-				$pmpro_price .= '<span class="' . pmpro_get_element_class( 'pmpro_price_part_span pmpro_price_part-' . $key, 'pmpro_price_part-' . $key ) . '"><span class="' . pmpro_get_element_class( 'pmpro_price_part_label' ) . '">' . esc_html( $pmpro_price_part['label'] ) . '</span> <span class="' . pmpro_get_element_class( 'pmpro_price_part_price' ) . '">' . esc_html( $pmpro_price_part['value'] ) . '</span></span>';
+				$pmpro_price .= '<span class="' . pmpro_get_element_class( 'pmpro_price_part_span pmpro_price_part-' . sanitize_html_class( $key ), 'pmpro_price_part-' . sanitize_html_class( $key ) ) . '"><span class="' . pmpro_get_element_class( 'pmpro_price_part_label' ) . '">' . esc_html( $pmpro_price_part['label'] ) . '</span> <span class="' . pmpro_get_element_class( 'pmpro_price_part_price' ) . '">' . esc_html( $pmpro_price_part['value'] ) . '</span></span>';
 			}
 		} elseif ( $format == 'list' ) {
 			$pmpro_price .= '<ul class="' . pmpro_get_element_class( 'pmpro_price_part_list' ) . '">';
 			foreach ( $pmpro_price_parts_with_total as $key => $pmpro_price_part ) {
-				$pmpro_price .= '<li class="' . pmpro_get_element_class( 'pmpro_price_part-' . $key, 'pmpro_price_part-' . $key ) . '"><span class="' . pmpro_get_element_class( 'pmpro_price_part_label' ) . '">' . esc_html( $pmpro_price_part['label'] ) . '</span> <span class="' . pmpro_get_element_class( 'pmpro_price_part_price' ) . '">' . esc_html( $pmpro_price_part['value'] ) . '</span></li>';
+				$pmpro_price .= '<li class="' . pmpro_get_element_class( 'pmpro_price_part-' . sanitize_html_class( $key ), 'pmpro_price_part-' . sanitize_html_class( $key ) ) . '"><span class="' . pmpro_get_element_class( 'pmpro_price_part_label' ) . '">' . esc_html( $pmpro_price_part['label'] ) . '</span> <span class="' . pmpro_get_element_class( 'pmpro_price_part_price' ) . '">' . esc_html( $pmpro_price_part['value'] ) . '</span></li>';
 			}
 		} else {
 			// Default to each line separate by breaks.
 			foreach ( $pmpro_price_parts_with_total as $key => $pmpro_price_part ) {
-				$pmpro_price .= '<span class="' . pmpro_get_element_class( 'pmpro_price_part-' . $key, 'pmpro_price_part-' . $key ) . '"><span class="' . pmpro_get_element_class( 'pmpro_price_part_label' ) . '">' . esc_html( $pmpro_price_part['label'] ) . '</span> <span class="' . pmpro_get_element_class( 'pmpro_price_part_price' ) . '">' . esc_html( $pmpro_price_part['value'] ) . '</span></span><br />';
+				$pmpro_price .= '<span class="' . pmpro_get_element_class( 'pmpro_price_part-' . sanitize_html_class( $key ), 'pmpro_price_part-' . sanitize_html_class( $key ) ) . '"><span class="' . pmpro_get_element_class( 'pmpro_price_part_label' ) . '">' . esc_html( $pmpro_price_part['label'] ) . '</span> <span class="' . pmpro_get_element_class( 'pmpro_price_part_price' ) . '">' . esc_html( $pmpro_price_part['value'] ) . '</span></span><br />';
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Moved the email address added to the Orders admin screen outside the hyperlink to the Edit User screen
- Adjusted and added new CSS selector for a new `pmpro_price_part_sub` where the price part item should be displayed as a nested/depth 2 appearance.
- Adjusted the `pmpro_get_price_parts` function to sanitize the part's 'key' before using in the generated CSS selector so it would be valid CSS. 
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

