### PR TITLE
Fixed issue where "All Time Sales" would always be 0

### DIFF
--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -479,7 +479,7 @@ function pmpro_getSales($period, $levels = NULL)
 	elseif($period == "this year")
 		$startdate = date_i18n("Y", current_time('timestamp')) . "-01-01";
 	else
-		$startdate = "";
+		$startdate = date_i18n("Y-m-d", 0);
 
 	$gateway_environment = pmpro_getOption("gateway_environment");
 
@@ -593,7 +593,7 @@ function pmpro_getRevenue($period, $levels = NULL)
 	elseif($period == "this year")
 		$startdate = date_i18n("Y", current_time('timestamp')) . "-01-01";
 	else
-		$startdate = "";
+		$startdate = date_i18n("Y-m-d", 0);
 
 	// Convert from local to UTC.
 	$startdate = get_gmt_from_date( $startdate );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed issue where "All Time Sales" would always be 0

### How to test the changes in this Pull Request:
Go to the reports page and see that all time sales is 0 before this fix, and has the correct numbers after.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
