### PR TITLE
BUG FIX: Fixed issue with admin change email

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -335,20 +335,23 @@ function pmpro_membership_level_profile_fields_update()
 	//emails if there was a change
 	if(!empty($level_changed) || !empty($expiration_changed))
 	{
+
+
 		//email to admin
 		$pmproemail = new PMProEmail();
-		if(!empty($expiration_changed))
+		if(!empty($expiration_changed)) {
 			$pmproemail->expiration_changed = true;
-		$pmproemail->sendAdminChangeAdminEmail(get_userdata($user_ID));
+			$pmproemail->sendAdminChangeAdminEmail(get_userdata($user_ID));
+		}
 
 		//send email
-		if(!empty($_REQUEST['send_admin_change_email']))
-		{
+		if(!empty($_REQUEST['send_admin_change_email'])) {
 			//email to member
 			$pmproemail = new PMProEmail();
-			if(!empty($expiration_changed))
+			if(!empty($expiration_changed)) {
 				$pmproemail->expiration_changed = true;
-			$pmproemail->sendAdminChangeEmail(get_userdata($user_ID));
+				$pmproemail->sendAdminChangeEmail(get_userdata($user_ID));
+			}
 		}
 	}
 }


### PR DESCRIPTION
BUG FIX: Fixed an issue where the admin changed user level was always sent to the admin when the user is updated (even without changing level).

This doesn't affect the user's level and was just caused by the sendAdminChangeAdminEmail method not being wrapped within the if conditional.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

**Before pulling this into dev/master, please do the following tests.**

1. Edit a user/member within the WordPress dashboard.
2. Just click save, an admin should receive an email. (Only admins receive the email).
3. User's level status or level itself doesn't change at all.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

