### PR TITLE
Admin change email

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1008,7 +1008,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	if ( ! is_array( $level ) ) {
 		// are they even changing?
 		if ( pmpro_hasMembershipLevel( $level, $user_id ) ) {
-			return true;
+			return;
 		}
 	}
 

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -335,20 +335,23 @@ function pmpro_membership_level_profile_fields_update()
 	//emails if there was a change
 	if(!empty($level_changed) || !empty($expiration_changed))
 	{
+
+
 		//email to admin
 		$pmproemail = new PMProEmail();
-		if(!empty($expiration_changed))
+		if(!empty($expiration_changed)) {
 			$pmproemail->expiration_changed = true;
-		$pmproemail->sendAdminChangeAdminEmail(get_userdata($user_ID));
+			$pmproemail->sendAdminChangeAdminEmail(get_userdata($user_ID));
+		}
 
 		//send email
-		if(!empty($_REQUEST['send_admin_change_email']))
-		{
+		if(!empty($_REQUEST['send_admin_change_email'])) {
 			//email to member
 			$pmproemail = new PMProEmail();
-			if(!empty($expiration_changed))
+			if(!empty($expiration_changed)) {
 				$pmproemail->expiration_changed = true;
-			$pmproemail->sendAdminChangeEmail(get_userdata($user_ID));
+				$pmproemail->sendAdminChangeEmail(get_userdata($user_ID));
+			}
 		}
 	}
 }

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -335,23 +335,20 @@ function pmpro_membership_level_profile_fields_update()
 	//emails if there was a change
 	if(!empty($level_changed) || !empty($expiration_changed))
 	{
-
-
 		//email to admin
 		$pmproemail = new PMProEmail();
-		if(!empty($expiration_changed)) {
+		if(!empty($expiration_changed))
 			$pmproemail->expiration_changed = true;
-			$pmproemail->sendAdminChangeAdminEmail(get_userdata($user_ID));
-		}
+		$pmproemail->sendAdminChangeAdminEmail(get_userdata($user_ID));
 
 		//send email
-		if(!empty($_REQUEST['send_admin_change_email'])) {
+		if(!empty($_REQUEST['send_admin_change_email']))
+		{
 			//email to member
 			$pmproemail = new PMProEmail();
-			if(!empty($expiration_changed)) {
+			if(!empty($expiration_changed))
 				$pmproemail->expiration_changed = true;
-				$pmproemail->sendAdminChangeEmail(get_userdata($user_ID));
-			}
+			$pmproemail->sendAdminChangeEmail(get_userdata($user_ID));
 		}
 	}
 }


### PR DESCRIPTION
BUG FIX: Fixes an issue where emails were sending out to admins when updating a user (and not changing the user's membership level).

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Before merging this in, navigate to edit user and update the user (without changing anything).
2. After merging this in, test this by doing the same in step 1.
3. You can now test by adjusting the user's membership level and ensure the email only sends now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX: Fixes an issue where level changed emails were sending out to admins when updating a user profile without changing their level.