### PR TITLE
BUG FIX: Adjusted deprecated function

### DIFF
--- a/js/pmpro-login.js
+++ b/js/pmpro-login.js
@@ -12,7 +12,13 @@ jQuery(document).ready(function(){
 		
 		var strength;		
 		if ( pass1 != '' ) {
-			strength = wp.passwordStrength.meter( pass1, wp.passwordStrength.userInputDisallowedList(), pass1 );
+			// Call the disallowed list method corresponding to appropriate WP version.
+			const disallowedList = ( 'function' == typeof wp.passwordStrength.userInputDisallowedList )
+				? wp.passwordStrength.userInputDisallowedList()
+				: wp.passwordStrength. userInputBlacklist();
+
+			strength = wp.passwordStrength.meter( pass1, disallowedList, pass1 );
+
 		} else {
 			strength = -1;
 		}

--- a/js/pmpro-login.js
+++ b/js/pmpro-login.js
@@ -12,7 +12,7 @@ jQuery(document).ready(function(){
 		
 		var strength;		
 		if ( pass1 != '' ) {
-			strength = wp.passwordStrength.meter( pass1, wp.passwordStrength.userInputBlacklist(), pass1 );
+			strength = wp.passwordStrength.meter( pass1, wp.passwordStrength.userInputDisallowedList(), pass1 );
 		} else {
 			strength = -1;
 		}


### PR DESCRIPTION
BUG FIX: Use wp.passwordStrength.userInputDisallowedList() instead of deprecated wp.passwordStrength.userInputBlacklist() function.

This has been deprecated since WordPress 5.5.0