### PR TITLE
Hide gateways passwords behind asterisks

### DIFF
--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -123,7 +123,7 @@ class PMProGateway_authorizenet extends PMProGateway
 			<label for="transactionkey"><?php _e('Transaction Key', 'paid-memberships-pro' );?>:</label>
 		</th>
 		<td>
-			<input type="password" id="transactionkey" name="transactionkey" value="<?php echo esc_attr($values['transactionkey'])?>" class="regular-text code" />
+			<input type="text" id="transactionkey" name="transactionkey" value="<?php echo esc_attr($values['transactionkey'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 		</td>
 	</tr>
 	<tr class="gateway gateway_authorizenet" <?php if($gateway != "authorizenet") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -123,7 +123,7 @@ class PMProGateway_authorizenet extends PMProGateway
 			<label for="transactionkey"><?php _e('Transaction Key', 'paid-memberships-pro' );?>:</label>
 		</th>
 		<td>
-			<input type="text" id="transactionkey" name="transactionkey" value="<?php echo esc_attr($values['transactionkey'])?>" class="regular-text code" />
+			<input type="password" id="transactionkey" name="transactionkey" value="<?php echo esc_attr($values['transactionkey'])?>" class="regular-text code" />
 		</td>
 	</tr>
 	<tr class="gateway gateway_authorizenet" <?php if($gateway != "authorizenet") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -329,7 +329,7 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 				<label for="braintree_privatekey"><?php _e('Private Key', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="text" id="braintree_privatekey" name="braintree_privatekey" value="<?php echo esc_attr($values['braintree_privatekey'])?>" class="regular-text code" />
+				<input type="password" id="braintree_privatekey" name="braintree_privatekey" value="<?php echo esc_attr($values['braintree_privatekey'])?>" class="regular-text code" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_braintree" <?php if($gateway != "braintree") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -329,7 +329,7 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 				<label for="braintree_privatekey"><?php _e('Private Key', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="password" id="braintree_privatekey" name="braintree_privatekey" value="<?php echo esc_attr($values['braintree_privatekey'])?>" class="regular-text code" />
+				<input type="text" id="braintree_privatekey" name="braintree_privatekey" value="<?php echo esc_attr($values['braintree_privatekey'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_braintree" <?php if($gateway != "braintree") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -337,7 +337,7 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 				<label for="braintree_encryptionkey"><?php _e('Client-Side Encryption Key', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<textarea id="braintree_encryptionkey" name="braintree_encryptionkey" autocomplete="off" class="pmpro-admin-secure-key" rows="3" cols="50" class="large-text code"><?php echo esc_textarea($values['braintree_encryptionkey'])?></textarea>
+				<textarea id="braintree_encryptionkey" name="braintree_encryptionkey" autocomplete="off" rows="3" cols="50" class="large-text code pmpro-admin-secure-key"><?php echo esc_textarea($values['braintree_encryptionkey'])?></textarea>
 			</td>
 		</tr>
 		<tr class="gateway gateway_braintree" <?php if($gateway != "braintree") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -337,7 +337,7 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 				<label for="braintree_encryptionkey"><?php _e('Client-Side Encryption Key', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<textarea id="braintree_encryptionkey" name="braintree_encryptionkey" rows="3" cols="50" class="large-text code"><?php echo esc_textarea($values['braintree_encryptionkey'])?></textarea>
+				<textarea id="braintree_encryptionkey" name="braintree_encryptionkey" autocomplete="off" class="pmpro-admin-secure-key" rows="3" cols="50" class="large-text code"><?php echo esc_textarea($values['braintree_encryptionkey'])?></textarea>
 			</td>
 		</tr>
 		<tr class="gateway gateway_braintree" <?php if($gateway != "braintree") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_cybersource.php
+++ b/classes/gateways/class.pmprogateway_cybersource.php
@@ -102,7 +102,7 @@
 				<label for="cybersource_securitykey"><?php _e('Transaction Security Key', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<textarea id="cybersource_securitykey" name="cybersource_securitykey" autocomplete="off" class="pmpro-admin-secure-key" rows="3" cols="50" class="large-text code"><?php echo esc_textarea($values['cybersource_securitykey']);?></textarea>
+				<textarea id="cybersource_securitykey" name="cybersource_securitykey" autocomplete="off" rows="3" cols="50" class="large-text code pmpro-admin-secure-key"><?php echo esc_textarea($values['cybersource_securitykey']);?></textarea>
 			</td>
 		</tr>
 		<?php

--- a/classes/gateways/class.pmprogateway_cybersource.php
+++ b/classes/gateways/class.pmprogateway_cybersource.php
@@ -102,7 +102,7 @@
 				<label for="cybersource_securitykey"><?php _e('Transaction Security Key', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<textarea id="cybersource_securitykey" name="cybersource_securitykey" rows="3" cols="50" class="large-text code"><?php echo esc_textarea($values['cybersource_securitykey']);?></textarea>
+				<textarea id="cybersource_securitykey" name="cybersource_securitykey" autocomplete="off" class="pmpro-admin-secure-key" rows="3" cols="50" class="large-text code"><?php echo esc_textarea($values['cybersource_securitykey']);?></textarea>
 			</td>
 		</tr>
 		<?php

--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -169,7 +169,7 @@
 				<label for="apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" class="regular-text code" />
+				<input type="password" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" class="regular-text code" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -169,7 +169,7 @@
 				<label for="apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="password" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" class="regular-text code" />
+				<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -178,7 +178,7 @@
 				<label for="apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="password" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" class="regular-text code" />
+				<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -178,7 +178,7 @@
 				<label for="apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" class="regular-text code" />
+				<input type="password" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" class="regular-text code" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -170,7 +170,7 @@
 				<label for="apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="text" id="apipassword" name="apipassword" size="60" value="<?php echo esc_attr($values['apipassword'])?>" />
+				<input type="password" id="apipassword" name="apipassword" size="60" value="<?php echo esc_attr($values['apipassword'])?>" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -170,7 +170,7 @@
 				<label for="apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="password" id="apipassword" name="apipassword" size="60" value="<?php echo esc_attr($values['apipassword'])?>" />
+				<input type="text" id="apipassword" name="apipassword" size="60" value="<?php echo esc_attr($values['apipassword'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 			</td>
 		</tr>
 		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -348,7 +348,7 @@ class PMProGateway_stripe extends PMProGateway {
                 <label for="stripe_secretkey"><?php _e( 'Secret Key', 'paid-memberships-pro' ); ?>:</label>
             </th>
             <td>
-                <input type="text" id="stripe_secretkey" name="stripe_secretkey" value="<?php echo esc_attr( $values['stripe_secretkey'] ) ?>" class="regular-text code" />
+                <input type="password" id="stripe_secretkey" name="stripe_secretkey" value="<?php echo esc_attr( $values['stripe_secretkey'] ) ?>" class="regular-text code" />
             </td>
         </tr>
         <tr class="gateway gateway_stripe" <?php if ( $gateway != "stripe" ) { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -348,7 +348,7 @@ class PMProGateway_stripe extends PMProGateway {
                 <label for="stripe_secretkey"><?php _e( 'Secret Key', 'paid-memberships-pro' ); ?>:</label>
             </th>
             <td>
-                <input type="password" id="stripe_secretkey" name="stripe_secretkey" value="<?php echo esc_attr( $values['stripe_secretkey'] ) ?>" class="regular-text code" />
+                <input type="text" id="stripe_secretkey" name="stripe_secretkey" value="<?php echo esc_attr( $values['stripe_secretkey'] ) ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
             </td>
         </tr>
         <tr class="gateway gateway_stripe" <?php if ( $gateway != "stripe" ) { ?>style="display: none;"<?php } ?>>

--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -129,7 +129,7 @@
 				<label for="twocheckout_apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="text" id="twocheckout_apipassword" name="twocheckout_apipassword" value="<?php echo esc_attr($values['twocheckout_apipassword'])?>" class="regular-text code" />
+				<input type="password" id="twocheckout_apipassword" name="twocheckout_apipassword" value="<?php echo esc_attr($values['twocheckout_apipassword'])?>" class="regular-text code" />
 				<p class="description"><?php esc_html_e( 'Password for the API user created.', 'paid-memberships-pro' ); ?></p>
 			</td>
 		</tr>

--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -129,7 +129,7 @@
 				<label for="twocheckout_apipassword"><?php _e('API Password', 'paid-memberships-pro' );?>:</label>
 			</th>
 			<td>
-				<input type="password" id="twocheckout_apipassword" name="twocheckout_apipassword" value="<?php echo esc_attr($values['twocheckout_apipassword'])?>" class="regular-text code" />
+				<input type="text" id="twocheckout_apipassword" name="twocheckout_apipassword" value="<?php echo esc_attr($values['twocheckout_apipassword'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 				<p class="description"><?php esc_html_e( 'Password for the API user created.', 'paid-memberships-pro' ); ?></p>
 			</td>
 		</tr>

--- a/css/admin.css
+++ b/css/admin.css
@@ -158,6 +158,10 @@
 	max-width: none;
 }
 
+.admin_page_pmpro-paymentsettings .pmpro-admin-secure-key {
+	-webkit-text-security: circle;
+}
+
 /* advanced settings */
 .admin_page_pmpro-advancedsettings .form-table select:not(.admin_page_pmpro-advancedsettings .form-table select#tospage) {
 	max-width: none;

--- a/css/admin.css
+++ b/css/admin.css
@@ -159,7 +159,7 @@
 }
 
 .admin_page_pmpro-paymentsettings .pmpro-admin-secure-key {
-	-webkit-text-security: circle;
+	-webkit-text-security: disc;
 }
 
 /* advanced settings */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hide with ******* the PayPal's gateways configuration passwords. Still recoverable using inspection of course.

Resolves #268.

### Notes (!!)

1. The only one still untouched is the `cybersource_securitykey` which is a textarea. [Can be hidden using javascript](https://stackoverflow.com/questions/16058008/is-there-a-known-way-to-have-a-textarea-with-the-password-type).
1. We DON'T want to encrypt the fields, just use asterisks to hide values.

### Todos

> Ideally we would do this to the API key fields for other gateways at the same time.
> 
> I also think it would be good to add an eye icon to reveal the API key, similar to what WP does on the default login page now.
> 
> I also wonder if we should set an attribute autocomplete="one-time-code" in the input to keep browsers from trying to save or restore these values. More info here: https://stackoverflow.com/a/62509392/1154321
> 
> ~@ideadude