### PR TITLE
Sets keys in the array returned from pmpro_sort_levels_by_order() to correspond to the level ids. Some code expects that for level arrays.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2374,9 +2374,9 @@ function pmpro_sort_levels_by_order( $pmpro_levels ) {
 	foreach ( $sort_order as $level_id ) {
 		foreach ( $pmpro_levels as $key => $level ) {
 			if ( ! empty ( $level->id ) && $level_id == $level->id ) {
-				$reordered_levels[] = $pmpro_levels[$key];
+				$reordered_levels[$level_id] = $pmpro_levels[$key];
 			} elseif ( ! empty( $level ) && is_string( $level ) && $level_id == $level ) {
-				$reordered_levels[] = $pmpro_levels[$key];
+				$reordered_levels[$level_id] = $pmpro_levels[$key];
 			}
 		}
 	}


### PR DESCRIPTION
Before this fix, we were resetting the array keys in the array passed out of this function. And so on the level page, we would set the $pmpro_levels global var to use the ordered (and re-keyed) array. This caused issues later when the pmpro_getLevel() function expected the $pmpro_levels array to have keys corresponding to the level ids. $pmpro_levels[1] may or may not be level 1.

We thought about changing the $pmpro_getLevel function to not have that expectation, but that's a bigger change and it is useful to have the level arrays keyed this way. It's worth trying to maintain IMO.

For now, this one commit should fix the issues that have come up since the introduction of the pmpro_sort_levels_by_order() function.