### PR TITLE
BUG: Missing return statement in deprecated function

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -38,7 +38,7 @@ add_action( 'init', 'pmpro_init_check_for_deprecated_filters', 99 );
  *
  */
 function pmpro_getClassForField( $field ) {
-	pmpro_get_element_class( '', $field );
+	return pmpro_get_element_class( '', $field );
 }
 
 /**


### PR DESCRIPTION
The deprecated`pmpro_getClassForField` function was missing the return statement. As a result, the classes were not added to the fields.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves missing inputs classes in checkout form when **Paid Memberships Pro: Multiple Memberships per User** addon is used.

### How to test the changes in this Pull Request:

1. Activate **Paid Memberships Pro: Multiple Memberships per User** addon
2. Go to the checkout page
3. All required fields have the `pmpro_required` class

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUG FIX: Missing return statement in `pmpro_getClassForField` function.
