### PR TITLE
BUG FIX: FIx warning in searches/pages when PMPro pages is not set.

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -147,7 +147,7 @@ function pmpro_search_filter($query)
     //hide pmpro pages from search results
     if( ! $query->is_admin && $query->is_search && empty( $query->query['post_parent'] ) ) {
         //avoiding post_parent queries for now
-		if( empty( $query->query_vars['post_parent'] ) ) {
+		if( empty( $query->query_vars['post_parent'] ) && is_array( $pmpro_pages ) ) {
 			$query->set( 'post__not_in', array_merge( $query->get('post__not_in'), array_values( $pmpro_pages ) ) );
 		}
     }

--- a/includes/content.php
+++ b/includes/content.php
@@ -147,7 +147,7 @@ function pmpro_search_filter($query)
     //hide pmpro pages from search results
     if( ! $query->is_admin && $query->is_search && empty( $query->query['post_parent'] ) ) {
         //avoiding post_parent queries for now
-		if( empty( $query->query_vars['post_parent'] ) && is_array( $pmpro_pages ) ) {
+		if( empty( $query->query_vars['post_parent'] ) && ! empty( $pmpro_pages ) ) {
 			$query->set( 'post__not_in', array_merge( $query->get('post__not_in'), array_values( $pmpro_pages ) ) );
 		}
     }


### PR DESCRIPTION
BUG FIX: Fix a warning when $pmpro_pages not set at all and searches occur. Check if $pmpro_pages is array.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
