### PR TITLE
Fix warnings being generated when using PHP 8 and Divi

### DIFF
--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -15,11 +15,11 @@ class PMProDivi{
 
 	public function toggle( $modules ) {
 
-		if ( ! empty( $modules ) && is_object( $modules['et_pb_row'] ) ) {
+		if ( isset( $modules['et_pb_row'] ) && is_object( $modules['et_pb_row'] ) ) {
 			$modules['et_pb_row']->settings_modal_toggles['custom_css']['toggles']['paid-memberships-pro'] = __( 'Paid Memberships Pro', 'paid-memberships-pro' );
 		}
 
-		if ( ! empty( $modules ) && is_object( $modules['et_pb_section'] ) ) {
+		if ( isset( $modules['et_pb_section'] ) && is_object( $modules['et_pb_section'] ) ) {
 			$modules['et_pb_section']->settings_modal_toggles['custom_css']['toggles']['paid-memberships-pro'] = __( 'Paid Memberships Pro', 'paid-memberships-pro' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1658. Fixes the if statements that are supposed to check if `$modules['et_pb_row']` and `$modules['et_pb_section']` exist and are objects.

### How to test the changes in this Pull Request:

1. Use Divi theme.
2. Use PHP 8.
3. Open the Divi visual builder on a page.
4. Check your site's PHP error log to ensure there are no PHP warnings generated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed PHP warnings being generated when using Divi and PHP 8.
