### PR TITLE
Remove query string from URI path to prevent "File not found" errors

### DIFF
--- a/services/getfile.php
+++ b/services/getfile.php
@@ -23,13 +23,21 @@
 	require_once(dirname(__FILE__) . '/../classes/class.mimetype.php');
 	
 	global $wpdb;
-	
+
+	// Get the file path.
 	$uri = $_SERVER['REQUEST_URI'];
-	if($uri[0] == "/")
-		$uri = substr($uri, 1, strlen($uri) - 1);
+
+	// Remove the query string from the path.
+	$uri_parts = explode( $uri, '?' );
+	$uri       = $uri_parts[0];
+
+	// Take the / off of the 
+	if ( '/' === $uri[0] ) {
+		$uri = substr( $uri, 1, strlen( $uri ) - 1 );
+	}
 	
 	// decode the file in case it's encoded.
-	$uri = urldecode($uri);
+	$uri = urldecode( $uri );
 	
 	/*
 		Remove ../-like strings from the URI.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes #1670

Prevents "File not found." errors from showing by removing query parameters from the URI path used for the `file_exists()` call.

### How to test the changes in this Pull Request:

1. Lock down files by [enabling getfile.php](https://www.paidmembershipspro.com/locking-down-protecting-files-with-pmpro/)
2. Be logged into a member that should have access
3. Take a file URL and add a query string to it `some-file.zip?from=account-area`
4. File should be served like normal, you should NOT see a "File not found." error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent "File not found" errors when delivering files through `getfile.php` by removing query parameters from the file URI path.
