### PR TITLE
Add a new action during checkout process, just before user auth

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -552,7 +552,15 @@ if ( ! empty( $pmpro_confirmed ) ) {
 			//make the user a subscriber
 			$wpuser->set_role( get_option( 'default_role', 'subscriber' ) );
 
+			/**
+			 * Allow hooking before the user authentication process when setting up new user.
+			 *
+			 * @since TBD
+			 *
+			 * @param int $user_id The user ID that is being setting up.
+			 */
 			do_action( 'pmpro_checkout_before_user_auth', $user_id );
+
 
 			//okay, log them in to WP
 			$creds                  = array();
@@ -560,7 +568,6 @@ if ( ! empty( $pmpro_confirmed ) ) {
 			$creds['user_password'] = $new_user_array['user_pass'];
 			$creds['remember']      = true;
 			$user                   = wp_signon( $creds, false );
-			
 			//setting some cookies
 			wp_set_current_user( $user_id, $username );
 			wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -552,13 +552,15 @@ if ( ! empty( $pmpro_confirmed ) ) {
 			//make the user a subscriber
 			$wpuser->set_role( get_option( 'default_role', 'subscriber' ) );
 
+			do_action( 'pmpro_checkout_before_user_auth', $user_id );
+
 			//okay, log them in to WP
 			$creds                  = array();
 			$creds['user_login']    = $new_user_array['user_login'];
 			$creds['user_password'] = $new_user_array['user_pass'];
 			$creds['remember']      = true;
 			$user                   = wp_signon( $creds, false );
-
+			
 			//setting some cookies
 			wp_set_current_user( $user_id, $username );
 			wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Useful to un-hook some security filters added by third party plugins to the 'authenticate' filter, which can break the atomic pmpro checkout process ending up with users not associated to orders and with no membership activated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
