### PR TITLE
Stripe connect now handles live and sandbox separately.

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3548,7 +3548,9 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( self::using_legacy_keys() ) {
 			$secretkey = pmpro_getOption( 'stripe_secretkey' ); 
 		} else {
-			$secretkey = pmpro_getOption( 'gateway_environment' ) === 'live' ? pmpro_getOption( 'live_stripe_connect_secretkey' ) : pmpro_getOption( 'test_stripe_connect_secretkey' );
+			$secretkey = pmpro_getOption( 'gateway_environment' ) === 'live'
+				? pmpro_getOption( 'live_stripe_connect_secretkey' )
+				: pmpro_getOption( 'test_stripe_connect_secretkey' );
 		}
 		return $secretkey;
 	}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -389,6 +389,7 @@ class PMProGateway_stripe extends PMProGateway {
 					$connect_url = add_query_arg(
 						array(
 							'action' => 'disconnect',
+							'gateway' => 'stripe',
 							'gateway_environment' => 'test',
 							'stripe_user_id' => $values['test_stripe_connect_user_id'],
 							'return_url' => rawurlencode( admin_url( 'admin.php?page=pmpro-paymentsettings' ) ),

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3501,7 +3501,14 @@ class PMProGateway_stripe extends PMProGateway {
 		return $r;
 	}
 
-	static function has_connect_credentials( $gateway_environment = null ) {
+	/**
+	 * Determine whether the site has Stripe Connect credentials set based on gateway environment.
+	 *
+	 * @param null|string $gateway_environment The gateway environment to use, default uses the current saved setting.
+	 *
+	 * @return bool Whether the site has Stripe Connect credentials set.
+	 */
+	public static function has_connect_credentials( $gateway_environment = null ) {
 		if ( empty( $gateway_environment ) ) {
 			$gateway_engvironemnt = pmpro_getOption( 'pmpro_gateway_environment' );
 		}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3575,7 +3575,9 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return string The Stripe Connect User ID.
 	 */
 	public static function get_connect_user_id() {
-		return pmpro_getOption( 'gateway_environment' ) === 'live' ? pmpro_getOption( 'live_stripe_connect_user_id' ) : pmpro_getOption( 'test_stripe_connect_user_id' );
+		return pmpro_getOption( 'gateway_environment' ) === 'live'
+			? pmpro_getOption( 'live_stripe_connect_user_id' )
+			: pmpro_getOption( 'test_stripe_connect_user_id' );
 	}
 
 	static function webhook_is_working() {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -380,7 +380,7 @@ class PMProGateway_stripe extends PMProGateway {
         </tr>
 		<tr class="gateway gateway_stripe" <?php if ( $gateway != "stripe" ) { ?>style="display: none;"<?php } ?>>
             <th scope="row" valign="top">
-                <label> <?php esc_attr_e( 'Stripe Connection (Sandbox):', 'paid-memberships-pro' ); ?></label>
+                <label> <?php esc_html_e( 'Stripe Connection (Sandbox):', 'paid-memberships-pro' ); ?></label>
             </th>
 			<td>
 				<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -414,8 +414,8 @@ class PMProGateway_stripe extends PMProGateway {
 					<?php
 				}
 				?>
-				<input type='hidden' name='test_stripe_connect_user_id' id='test_stripe_connect_user_id' value='<?php echo esc_attr( $values['test_stripe_connect_user_id'] ) ?>'/>
-				<input type='hidden' name='test_stripe_connect_secretkey' id='test_stripe_connect_secretkey' value='<?php echo esc_attr( $values['test_stripe_connect_secretkey'] ) ?>'/>
+				<input type='hidden' name='test_stripe_connect_user_id' id='test_stripe_connect_user_id' value='<?php echo esc_attr( $values['test_stripe_connect_user_id'] ); ?>'/>
+				<input type='hidden' name='test_stripe_connect_secretkey' id='test_stripe_connect_secretkey' value='<?php echo esc_attr( $values['test_stripe_connect_secretkey'] ); ?>'/>
 				<input type='hidden' name='test_stripe_connect_publishablekey' id='test_stripe_connect_publishablekey' value='<?php echo esc_attr( $values['test_stripe_connect_publishablekey'] ) ?>'/>
 			</td>
         </tr>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3580,7 +3580,12 @@ class PMProGateway_stripe extends PMProGateway {
 			: pmpro_getOption( 'test_stripe_connect_user_id' );
 	}
 
-	static function webhook_is_working() {
+	/**
+	 * Determine whether the webhook is working by checking for Stripe orders with invalid transaction IDs.
+	 *
+	 * @return bool Whether the webhook is working.
+	 */
+	public static function webhook_is_working() {
 		global $wpdb;
 		$last_webhook       = get_option( 'pmpro_stripe_last_webhook_recieved' );
 		if ( empty( $last_webhook ) ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3558,7 +3558,9 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( self::using_legacy_keys() ) {
 			$publishablekey = pmpro_getOption( 'stripe_publishablekey' ); 
 		} else {
-			$publishablekey = pmpro_getOption( 'gateway_environment' ) === 'live' ? pmpro_getOption( 'live_stripe_connect_publishablekey' ) : pmpro_getOption( 'test_stripe_connect_publishablekey' );
+			$publishablekey = pmpro_getOption( 'gateway_environment' ) === 'live'
+				? pmpro_getOption( 'live_stripe_connect_publishablekey' )
+				: pmpro_getOption( 'test_stripe_connect_publishablekey' );
 		}
 		return $publishablekey;
 	}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -397,7 +397,7 @@ class PMProGateway_stripe extends PMProGateway {
 						$connect_url_base
 					);
 					?>
-					<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
+					<a href="<?php echo esc_url( $connect_url ); ?>" class="stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 					<br/><small><?php esc_html_e( 'This will disconnect all sites linked to this Stripe account.', 'paid-memberships-pro' ); ?></small>
 					<?php
 				} else {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -398,7 +398,7 @@ class PMProGateway_stripe extends PMProGateway {
 					);
 					?>
 					<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
-					<br/><small>This will disconnect all sites linked to this Stripe account.</small>
+					<br/><small><?php esc_html_e( 'This will disconnect all sites linked to this Stripe account.', 'paid-memberships-pro' ); ?></small>
 					<?php
 				} else {
 					$connect_url = add_query_arg(

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -340,7 +340,7 @@ class PMProGateway_stripe extends PMProGateway {
         </tr>
 		<tr class="gateway gateway_stripe" <?php if ( $gateway != "stripe" ) { ?>style="display: none;"<?php } ?>>
             <th scope="row" valign="top">
-                <label> <?php esc_attr_e( 'Stripe Connection (Live):', 'paid-memberships-pro' ); ?></label>
+                <label> <?php esc_html_e( 'Stripe Connection (Live):', 'paid-memberships-pro' ); ?></label>
             </th>
 			<td>
 				<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -410,7 +410,7 @@ class PMProGateway_stripe extends PMProGateway {
 						$connect_url_base
 					);
 					?>
-					<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="stripe-connect"><span><?php esc_html_e( 'Connect with Stripe', 'paid-memberships-pro' ); ?></span></a>
+					<a href="<?php echo esc_url( $connect_url ); ?>" class="stripe-connect"><span><?php esc_html_e( 'Connect with Stripe', 'paid-memberships-pro' ); ?></span></a>
 					<?php
 				}
 				?>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3391,7 +3391,7 @@ class PMProGateway_stripe extends PMProGateway {
 		
 		// Change current gateway to Stripe
 		pmpro_setOption( 'gateway', 'stripe' );
-		pmpro_setOption( 'gateway_environment', $_REQUEST['pmpro_stripe_connected_environment'] );
+		pmpro_setOption( 'gateway_environment', sanitize_text_field( $_REQUEST['pmpro_stripe_connected_environment'] ) );
 
 		$error = '';
 		if (

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -411,6 +411,7 @@ class PMProGateway_stripe extends PMProGateway {
 					$connect_url = add_query_arg(
 						array(
 							'action' => 'authorize',
+							'gateway' => 'stripe',
 							'gateway_environment' => 'test',
 							'return_url' => rawurlencode( admin_url( 'admin.php?page=pmpro-paymentsettings' ) ),
 						),

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -384,6 +384,13 @@ class PMProGateway_stripe extends PMProGateway {
             </th>
 			<td>
 				<?php
+				/**
+				 * Allow customization of the Stripe Connect URL used by Paid Memberships Pro.
+				 *
+				 * @since 2.6.0
+				 *
+				 * @param string $connect_url_base The Stripe Connect URL to be used.
+				 */
 				$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
 				if ( self::has_connect_credentials( 'sandbox' ) ) {
 					$connect_url = add_query_arg(

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3565,7 +3565,14 @@ class PMProGateway_stripe extends PMProGateway {
 		return $publishablekey;
 	}
 
-	static function get_connect_user_id() {
+	/**
+	 * Get the Stripe Connect User ID based on gateway environment.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @return string The Stripe Connect User ID.
+	 */
+	public static function get_connect_user_id() {
 		return pmpro_getOption( 'gateway_environment' ) === 'live' ? pmpro_getOption( 'live_stripe_connect_user_id' ) : pmpro_getOption( 'test_stripe_connect_user_id' );
 	}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3490,7 +3490,12 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 	}
 
-	static function using_legacy_keys() {
+	/**
+	 * Determine whether the site is using legacy Stripe keys.
+	 *
+	 * @return bool Whether the site is using legacy Stripe keys.
+	 */
+	public static function using_legacy_keys() {
 		$r = ! empty( pmpro_getOption( 'stripe_secretkey' ) ) && ! empty( pmpro_getOption( 'stripe_publishablekey' ) );
 		$r = apply_filters( 'pmpro_stripe_using_legacy_keys', $r );
 		return $r;

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3538,7 +3538,12 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 	}
 
-	static function get_secretkey() {
+	/**
+	 * Get the Stripe secret key based on gateway environment.
+	 *
+	 * @return The Stripe secret key.
+	 */
+	public static function get_secretkey() {
 		$secretkey = '';
 		if ( self::using_legacy_keys() ) {
 			$secretkey = pmpro_getOption( 'stripe_secretkey' ); 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Have separate connection buttons for live and sandbox modes of Stripe connect
- Fixed bugs where correct keys would not be used when using connect in live mode

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
