### PR TITLE
Add CARDONFILE compatibility for Payflow Pro gateway

### DIFF
--- a/classes/gateways/class.pmprogateway_payflowpro.php
+++ b/classes/gateways/class.pmprogateway_payflowpro.php
@@ -320,7 +320,22 @@
 
 			//paypal profile stuff
 			$nvpStr = "";
+
+			// Only add CARDONFILE for initial charge if it's recurring.
+			if ( pmpro_isLevelRecurring( $order->membership_level ) ) {
+				/*
+				 * Card on File is now required.
+				 *
+				 * CITR: The customer just performed an action to make the transaction.
+				 * MITR: The customer passively approved during CITR to make this subsequent (recurring) transaction.
+				 *
+				 * @link https://developer.paypal.com/docs/payflow/integration-guide/card-on-file/
+				 */
+				$nvpStr .= "&CARDONFILE=CITR";
+			}
+
 			$nvpStr .="&AMT=" . $amount . "&TAXAMT=" . $amount_tax . "&CURRENCY=" . $pmpro_currency;
+
 			/* PayFlow Pro doesn't use IPN so this is a little confusing */
 			// $nvpStr .= "&NOTIFYURL=" . urlencode( add_query_arg( 'action', 'ipnhandler', admin_url('admin-ajax.php') ) );
 			//$nvpStr .= "&L_BILLINGTYPE0=RecurringPayments&L_BILLINGAGREEMENTDESCRIPTION0=" . $order->PaymentAmount;
@@ -390,7 +405,19 @@
 
 			//paypal profile stuff
 			$nvpStr = "&ACTION=A";
+
+			/*
+			 * Card on File is now required.
+			 *
+			 * CITR: The customer just performed an action to make the transaction.
+			 * MITR: The customer passively approved during CITR to make this subsequent (recurring) transaction.
+			 *
+			 * @link https://developer.paypal.com/docs/payflow/integration-guide/card-on-file/
+			 */
+			$nvpStr .="&CARDONFILE=CITR";
+
 			$nvpStr .="&AMT=" . $amount . "&TAXAMT=" . $amount_tax . "&CURRENCY=" . $pmpro_currency;
+
 			/* PayFlow Pro doesn't use IPN so this is a little confusing */
 			// $nvpStr .= "&NOTIFYURL=" . urlencode( add_query_arg( 'action', 'ipnhandler', admin_url('admin-ajax.php') ) );
 			//$nvpStr .= "&L_BILLINGTYPE0=RecurringPayments&L_BILLINGAGREEMENTDESCRIPTION0=" . $order->PaymentAmount;
@@ -497,6 +524,17 @@
 
 			//paypal profile stuff
 			$nvpStr = "&ORIGPROFILEID=" . $order->subscription_transaction_id . "&ACTION=M";
+
+			/*
+			 * Card on File is now required.
+			 *
+			 * CITR: The customer just performed an action to make the transaction.
+			 * MITR: The customer passively approved during CIT to make this subsequent (recurring) transaction.
+			 *
+			 * @link https://developer.paypal.com/docs/payflow/integration-guide/card-on-file/
+			 */
+			$nvpStr .= "&CARDONFILE=MITR";
+
 			/* PayFlow Pro doesn't use IPN so this is a little confusing */
 			// $nvpStr .= "&NOTIFYURL=" . urlencode( add_query_arg( 'action', 'ipnhandler', admin_url('admin-ajax.php') ) );
 

--- a/classes/gateways/class.pmprogateway_payflowpro.php
+++ b/classes/gateways/class.pmprogateway_payflowpro.php
@@ -533,7 +533,7 @@
 			 *
 			 * @link https://developer.paypal.com/docs/payflow/integration-guide/card-on-file/
 			 */
-			$nvpStr .= "&CARDONFILE=MITR";
+			$nvpStr .= "&CARDONFILE=CITR";
 
 			/* PayFlow Pro doesn't use IPN so this is a little confusing */
 			// $nvpStr .= "&NOTIFYURL=" . urlencode( add_query_arg( 'action', 'ipnhandler', admin_url('admin-ajax.php') ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This brings full compatibility/compliance with Card on File requirements for recurring transactions.

Fixes #1674 

### How to test the changes in this Pull Request:

1. Check out with a new recurring membership
2. All communication to Payflow should include `CARDONFILE=CITR`
3. All subsequent communication to Payflow to modify the profile should include `CARDONFILE=MITR`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add compatibility with new Payflow Pro compliance requirements for `CARDONFILE` parameter for recurring payments on memberships.