### PR TITLE
Abstract admin actions and make them filterable for Discount Codes, Membership Levels, and Orders

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -818,6 +818,20 @@
 											<a title="<?php _e(' View Orders', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $code->id, 'filter' => 'with-discount-code' ), admin_url('admin.php' ) ); ?>"><?php _e( 'Orders', 'paid-memberships-pro' ); ?></a>
 										</span>
 									<?php } ?>
+                                    
+                                    <?php
+                                    // Set up the hover actions for this user
+                                    $actions = apply_filters( 'pmpro_discountcodes_row_actions', array(), $code );
+
+                                    $actions_html = array();
+                                    foreach( $actions as $action => $link ) {
+	                                    $actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
+                                    }
+
+                                    if( ! empty( $actions_html ) ) {
+	                                    echo ' | ' . implode( ' | ', $actions_html );
+                                    }
+                                    ?>
 								</div>
 							</td>
 							<td>

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -810,7 +810,7 @@
 										</span>
 									<?php } ?>
 
-                                    <?php
+									<?php
 									$delete_text = esc_html(
 										sprintf(
 											// translators: %s is the Discount Code.
@@ -845,7 +845,7 @@
 												)
 											),
 											esc_html__( 'Edit', 'paid-memberships-pro' )
-                                    	),
+										),
 										'copy'   => sprintf(
 											'<a title="%1$s" href="%2$s">%3$s</a>',
 											esc_attr__( 'Copy', 'paid-memberships-pro' ),
@@ -860,7 +860,7 @@
 												)
 											),
 											esc_html__( 'Copy', 'paid-memberships-pro' )
-                                    	),
+										),
 										'delete' => sprintf(
 											'<a title="%1$s" href="%2$s">%3$s</a>',
 											esc_attr__( 'Delete', 'paid-memberships-pro' ),
@@ -884,33 +884,33 @@
 												)
 											),
 											esc_html__( 'Orders', 'paid-memberships-pro' )
-                                    	);
+										);
 									}
 
-                                    /**
-                                     * Filter the extra actions for this discount code.
-                                     *
-                                     * @since TBD
-                                     *
-                                     * @param array  $actions The list of actions.
-                                     * @param object $code    The discount code data.
-                                     */
-                                    $actions = apply_filters( 'pmpro_discountcodes_row_actions', $actions, $code );
+									/**
+									 * Filter the extra actions for this discount code.
+									 *
+									 * @since TBD
+									 *
+									 * @param array  $actions The list of actions.
+									 * @param object $code    The discount code data.
+									 */
+									$actions = apply_filters( 'pmpro_discountcodes_row_actions', $actions, $code );
 
-                                    $actions_html = [];
+									$actions_html = [];
 
-                                    foreach ( $actions as $action => $link ) {
-	                                    $actions_html[] = sprintf(
-	                                    	'<span class="%1$s">%2$s</span>',
+									foreach ( $actions as $action => $link ) {
+										$actions_html[] = sprintf(
+											'<span class="%1$s">%2$s</span>',
 											esc_attr( $action ),
 											$link
-	                                    );
-                                    }
+										);
+									}
 
-                                    if ( ! empty( $actions_html ) ) {
-	                                    echo implode( ' | ', $actions_html );
-                                    }
-                                    ?>
+									if ( ! empty( $actions_html ) ) {
+										echo implode( ' | ', $actions_html );
+									}
+									?>
 								</div>
 							</td>
 							<td>

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -804,12 +804,6 @@
 							<td class="has-row-actions">
 								<a title="<?php echo sprintf( 'Edit Code: %s', $code->code ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-discountcodes', 'edit' => $code->id ), admin_url('admin.php' ) ); ?>"><?php echo $code->code?></a>
 								<div class="row-actions">
-									<?php if ( (int)$uses > 0 ) { ?>
-										| <span class="orders">
-											<a title="<?php _e(' View Orders', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $code->id, 'filter' => 'with-discount-code' ), admin_url('admin.php' ) ); ?>"><?php _e( 'Orders', 'paid-memberships-pro' ); ?></a>
-										</span>
-									<?php } ?>
-
 									<?php
 									$delete_text = esc_html(
 										sprintf(

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -820,13 +820,13 @@
 									<?php } ?>
                                     
                                     <?php
-                                    // Set up the hover actions for this discount code
                                     /**
-                                     * Filter the extra actions for this discount code
+                                     * Filter the extra actions for this discount code.
                                      *
                                      * @since TBD
                                      *
-                                     * @param stdClass $code The discount code data
+                                     * @param array  $actions The list of actions.
+                                     * @param object $code    The discount code data.
                                      */
                                     $actions = apply_filters( 'pmpro_discountcodes_row_actions', array(), $code );
 

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -820,7 +820,14 @@
 									<?php } ?>
                                     
                                     <?php
-                                    // Set up the hover actions for this user
+                                    // Set up the hover actions for this discount code
+                                    /**
+                                     * Filter the extra actions for this discount code
+                                     *
+                                     * @since TBD
+                                     *
+                                     * @param stdClass $code The discount code data
+                                     */
                                     $actions = apply_filters( 'pmpro_discountcodes_row_actions', array(), $code );
 
                                     $actions_html = array();

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -353,10 +353,10 @@
 			$pmpro_msgt = "error";
 		}
 	}
-	
+
 	if( ! empty( $pmpro_msg ) && ! empty( $expiration_warning_flag ) ) {
 		$pmpro_msg .= ' <strong>' . sprintf( __( 'WARNING: A level was set with both a recurring billing amount and an expiration date. You only need to set one of these unless you really want this membership to expire after a specific time period. For more information, <a target="_blank" href="%s">see our post here</a>.', 'paid-memberships-pro' ), 'https://www.paidmembershipspro.com/important-notes-on-recurring-billing-and-expiration-dates-for-membership-levels/?utm_source=plugin&utm_medium=pmpro-discountcodes&utm_campaign=blog&utm_content=important-notes-on-recurring-billing-and-expiration-dates-for-membership-levels' ) . '</strong>';
-		
+
 		if( $pmpro_msgt == 'success' ) {
 			$pmpro_msgt = 'warning';
 		}
@@ -415,7 +415,7 @@
 						$copy ),
 						OBJECT
 					);
-					
+
 					$temp_code = $code;
 				}
 
@@ -427,7 +427,7 @@
 				{
 					$code = new stdClass();
 					$code->code = pmpro_getDiscountCode();
-					
+
 					if( ! empty( $copy ) && $copy > 0 ) {
 						$code->starts = $temp_code->starts;
 						$code->expires = $temp_code->expires;
@@ -793,7 +793,7 @@
 						<td colspan="6">
 							<?php echo esc_attr_e( 'Code not found.', 'paid-memberships-pro' ); ?>
 						</td>
-					</tr> 
+					</tr>
 					<?php } ?>
 					<?php
 						foreach($codes as $code) {
@@ -804,22 +804,89 @@
 							<td class="has-row-actions">
 								<a title="<?php echo sprintf( 'Edit Code: %s', $code->code ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-discountcodes', 'edit' => $code->id ), admin_url('admin.php' ) ); ?>"><?php echo $code->code?></a>
 								<div class="row-actions">
-									<span class="edit">
-										<a title="<?php _e( 'Edit', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-discountcodes', 'edit' => $code->id ), admin_url('admin.php' ) ); ?>"><?php _e( 'Edit', 'paid-memberships-pro' ); ?></a>
-									</span> |
-									<span class="copy">
-										<a title="<?php _e( 'Copy', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-discountcodes', 'edit' => -1, 'copy' => $code->id ), admin_url('admin.php' ) ); ?>"><?php _e( 'Copy', 'paid-memberships-pro' ); ?></a>
-									</span> |
-									<span class="delete">
-										<a title="<?php _e( 'Delete', 'paid-memberships-pro' ); ?>" href="javascript:pmpro_askfirst('<?php echo str_replace("'", "\'", sprintf(__('Are you sure you want to delete the %s discount code? The subscriptions for existing users will not change, but new users will not be able to use this code anymore.', 'paid-memberships-pro' ), $code->code));?>', '<?php echo wp_nonce_url(add_query_arg( array( 'page' => 'pmpro-discountcodes', 'delete' => $code->id), admin_url( 'admin.php' ) ), 'delete', 'pmpro_discountcodes_nonce'); ?>'); void(0);"><?php _e('Delete', 'paid-memberships-pro' ); ?></a>
-									</span>
 									<?php if ( (int)$uses > 0 ) { ?>
 										| <span class="orders">
 											<a title="<?php _e(' View Orders', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $code->id, 'filter' => 'with-discount-code' ), admin_url('admin.php' ) ); ?>"><?php _e( 'Orders', 'paid-memberships-pro' ); ?></a>
 										</span>
 									<?php } ?>
-                                    
+
                                     <?php
+									$delete_text = esc_html(
+										sprintf(
+											// translators: %s is the Discount Code.
+											__( 'Are you sure you want to delete the %s discount code? The subscriptions for existing users will not change, but new users will not be able to use this code anymore.', 'paid-memberships-pro' ),
+											$code->code
+										)
+									);
+
+									$delete_nonce_url = wp_nonce_url(
+										add_query_arg(
+											[
+												'page'   => 'pmpro-discountcodes',
+												'delete' => $code->id,
+											],
+											admin_url( 'admin.php' )
+										),
+										'delete',
+										'pmpro_discountcodes_nonce'
+									);
+
+									$actions = [
+										'edit'   => sprintf(
+											'<a title="%1$s" href="%2$s">%3$s</a>',
+											esc_attr__( 'Edit', 'paid-memberships-pro' ),
+											esc_url(
+												add_query_arg(
+													[
+														'page' => 'pmpro-discountcodes',
+														'edit' => $code->id,
+													],
+													admin_url( 'admin.php' )
+												)
+											),
+											esc_html__( 'Edit', 'paid-memberships-pro' )
+                                    	),
+										'copy'   => sprintf(
+											'<a title="%1$s" href="%2$s">%3$s</a>',
+											esc_attr__( 'Copy', 'paid-memberships-pro' ),
+											esc_url(
+												add_query_arg(
+													[
+														'page' => 'pmpro-discountcodes',
+														'edit' => - 1,
+														'copy' => $code->id,
+													],
+													admin_url( 'admin.php' )
+												)
+											),
+											esc_html__( 'Copy', 'paid-memberships-pro' )
+                                    	),
+										'delete' => sprintf(
+											'<a title="%1$s" href="%2$s">%3$s</a>',
+											esc_attr__( 'Delete', 'paid-memberships-pro' ),
+											'javascript:pmpro_askfirst(\'' . esc_js( $delete_text ) . '\', \'' . esc_js( $delete_nonce_url ) . '\'); void(0);',
+											esc_html__( 'Delete', 'paid-memberships-pro' )
+										),
+									];
+
+									if ( 0 < (int) $uses ) {
+										$actions['orders'] = sprintf(
+											'<a title="%1$s" href="%2$s">%3$s</a>',
+											esc_attr__( 'View Orders', 'paid-memberships-pro' ),
+											esc_url(
+												add_query_arg(
+													[
+														'page'          => 'pmpro-orders',
+														'discount-code' => $code->id,
+														'filter'        => 'with-discount-code',
+													],
+													admin_url( 'admin.php' )
+												)
+											),
+											esc_html__( 'Orders', 'paid-memberships-pro' )
+                                    	);
+									}
+
                                     /**
                                      * Filter the extra actions for this discount code.
                                      *
@@ -828,15 +895,20 @@
                                      * @param array  $actions The list of actions.
                                      * @param object $code    The discount code data.
                                      */
-                                    $actions = apply_filters( 'pmpro_discountcodes_row_actions', array(), $code );
+                                    $actions = apply_filters( 'pmpro_discountcodes_row_actions', $actions, $code );
 
-                                    $actions_html = array();
-                                    foreach( $actions as $action => $link ) {
-	                                    $actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
+                                    $actions_html = [];
+
+                                    foreach ( $actions as $action => $link ) {
+	                                    $actions_html[] = sprintf(
+	                                    	'<span class="%1$s">%2$s</span>',
+											esc_attr( $action ),
+											$link
+	                                    );
                                     }
 
-                                    if( ! empty( $actions_html ) ) {
-	                                    echo ' | ' . implode( ' | ', $actions_html );
+                                    if ( ! empty( $actions_html ) ) {
+	                                    echo implode( ' | ', $actions_html );
                                     }
                                     ?>
 								</div>

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -837,13 +837,13 @@
 						<span class="delete"><a title="<?php _e('Delete', 'paid-memberships-pro' ); ?>" href="javascript:pmpro_askfirst('<?php echo str_replace("'", "\'", sprintf(__("Are you sure you want to delete membership level %s? All subscriptions will be cancelled.", 'paid-memberships-pro' ), $level->name));?>', '<?php echo wp_nonce_url(add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'action' => 'delete_membership_level', 'deleteid' => $level->id ), admin_url( 'admin.php' ) ), 'delete_membership_level', 'pmpro_membershiplevels_nonce'); ?>'); void(0);"><?php _e('Delete', 'paid-memberships-pro' ); ?></a></span>
 
 						<?php
-						// Set up the hover actions for this level
 						/**
-						 * Filter the extra actions for this level
+						 * Filter the extra actions for this level.
 						 *
 						 * @since TBD
 						 *
-						 * @param stdClass $level The membership level data
+						 * @param array  $actions The list of actions.
+						 * @param object $level   The membership level data.
 						 */
 						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', array(), $level );
 

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -832,11 +832,66 @@
 				<td class="level_name has-row-actions">
 					<span class="level-name"><a href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => $level->id ), admin_url( 'admin.php' ) ); ?>"><?php esc_attr_e( $level->name ); ?></a></span>
 					<div class="row-actions">
-						<span class="edit"><a title="<?php _e('Edit', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => $level->id ), admin_url('admin.php' ) ); ?>"><?php _e('Edit', 'paid-memberships-pro' ); ?></a></span> |
-						<span class="copy"><a title="<?php _e('Copy', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => -1, 'copy' => $level->id ), admin_url( 'admin.php' ) ); ?>"><?php _e('Copy', 'paid-memberships-pro' ); ?></a></span> |
-						<span class="delete"><a title="<?php _e('Delete', 'paid-memberships-pro' ); ?>" href="javascript:pmpro_askfirst('<?php echo str_replace("'", "\'", sprintf(__("Are you sure you want to delete membership level %s? All subscriptions will be cancelled.", 'paid-memberships-pro' ), $level->name));?>', '<?php echo wp_nonce_url(add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'action' => 'delete_membership_level', 'deleteid' => $level->id ), admin_url( 'admin.php' ) ), 'delete_membership_level', 'pmpro_membershiplevels_nonce'); ?>'); void(0);"><?php _e('Delete', 'paid-memberships-pro' ); ?></a></span>
-
 						<?php
+						$delete_text = esc_html(
+							sprintf(
+								// translators: %s is the Level Name.
+								__( 'Are you sure you want to delete membership level %s? All subscriptions will be cancelled.', 'paid-memberships-pro' ),
+								$level->name
+							)
+						);
+
+						$delete_nonce_url = wp_nonce_url(
+							add_query_arg(
+								[
+									'page'   => 'pmpro-membershiplevels',
+									'action' => 'delete_membership_level',
+									'deleteid' => $level->id,
+								],
+								admin_url( 'admin.php' )
+							),
+							'delete_membership_level',
+							'pmpro_membershiplevels_nonce'
+						);
+
+						$actions = [
+							'edit'   => sprintf(
+								'<a title="%1$s" href="%2$s">%3$s</a>',
+								esc_attr__( 'Edit', 'paid-memberships-pro' ),
+								esc_url(
+									add_query_arg(
+										[
+											'page' => 'pmpro-membershiplevels',
+											'edit' => $level->id,
+										],
+										admin_url( 'admin.php' )
+									)
+								),
+								esc_html__( 'Edit', 'paid-memberships-pro' )
+							),
+							'copy'   => sprintf(
+								'<a title="%1$s" href="%2$s">%3$s</a>',
+								esc_attr__( 'Copy', 'paid-memberships-pro' ),
+								esc_url(
+									add_query_arg(
+										[
+											'page' => 'pmpro-membershiplevels',
+											'edit' => - 1,
+											'copy' => $level->id,
+										],
+										admin_url( 'admin.php' )
+									)
+								),
+								esc_html__( 'Copy', 'paid-memberships-pro' )
+							),
+							'delete' => sprintf(
+								'<a title="%1$s" href="%2$s">%3$s</a>',
+								esc_attr__( 'Delete', 'paid-memberships-pro' ),
+								'javascript:pmpro_askfirst(\'' . esc_js( $delete_text ) . '\', \'' . esc_js( $delete_nonce_url ) . '\'); void(0);',
+								esc_html__( 'Delete', 'paid-memberships-pro' )
+							),
+						];
+
 						/**
 						 * Filter the extra actions for this level.
 						 *
@@ -845,15 +900,20 @@
 						 * @param array  $actions The list of actions.
 						 * @param object $level   The membership level data.
 						 */
-						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', array(), $level );
+						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', $actions, $code );
 
-						$actions_html = array();
-						foreach( $actions as $action => $link ) {
-							$actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
+						$actions_html = [];
+
+						foreach ( $actions as $action => $link ) {
+							$actions_html[] = sprintf(
+								'<span class="%1$s">%2$s</span>',
+								esc_attr( $action ),
+								$link
+							);
 						}
 
-						if( ! empty( $actions_html ) ) {
-							echo ' | ' . implode( ' | ', $actions_html );
+						if ( ! empty( $actions_html ) ) {
+							echo implode( ' | ', $actions_html );
 						}
 						?>
 					</div>

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -835,6 +835,20 @@
 						<span class="edit"><a title="<?php _e('Edit', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => $level->id ), admin_url('admin.php' ) ); ?>"><?php _e('Edit', 'paid-memberships-pro' ); ?></a></span> |
 						<span class="copy"><a title="<?php _e('Copy', 'paid-memberships-pro' ); ?>" href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => -1, 'copy' => $level->id ), admin_url( 'admin.php' ) ); ?>"><?php _e('Copy', 'paid-memberships-pro' ); ?></a></span> |
 						<span class="delete"><a title="<?php _e('Delete', 'paid-memberships-pro' ); ?>" href="javascript:pmpro_askfirst('<?php echo str_replace("'", "\'", sprintf(__("Are you sure you want to delete membership level %s? All subscriptions will be cancelled.", 'paid-memberships-pro' ), $level->name));?>', '<?php echo wp_nonce_url(add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'action' => 'delete_membership_level', 'deleteid' => $level->id ), admin_url( 'admin.php' ) ), 'delete_membership_level', 'pmpro_membershiplevels_nonce'); ?>'); void(0);"><?php _e('Delete', 'paid-memberships-pro' ); ?></a></span>
+
+						<?php
+						// Set up the hover actions for this user
+						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', array(), $level );
+
+						$actions_html = array();
+						foreach( $actions as $action => $link ) {
+							$actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
+						}
+
+						if( ! empty( $actions_html ) ) {
+							echo ' | ' . implode( ' | ', $actions_html );
+						}
+						?>
 					</div>
 				</td>
 				<td>

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -900,7 +900,7 @@
 						 * @param array  $actions The list of actions.
 						 * @param object $level   The membership level data.
 						 */
-						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', $actions, $code );
+						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', $actions, $level );
 
 						$actions_html = [];
 

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -837,7 +837,14 @@
 						<span class="delete"><a title="<?php _e('Delete', 'paid-memberships-pro' ); ?>" href="javascript:pmpro_askfirst('<?php echo str_replace("'", "\'", sprintf(__("Are you sure you want to delete membership level %s? All subscriptions will be cancelled.", 'paid-memberships-pro' ), $level->name));?>', '<?php echo wp_nonce_url(add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'action' => 'delete_membership_level', 'deleteid' => $level->id ), admin_url( 'admin.php' ) ), 'delete_membership_level', 'pmpro_membershiplevels_nonce'); ?>'); void(0);"><?php _e('Delete', 'paid-memberships-pro' ); ?></a></span>
 
 						<?php
-						// Set up the hover actions for this user
+						// Set up the hover actions for this level
+						/**
+						 * Filter the extra actions for this level
+						 *
+						 * @since TBD
+						 *
+						 * @param stdClass $level The membership level data
+						 */
 						$actions = apply_filters( 'pmpro_membershiplevels_row_actions', array(), $level );
 
 						$actions_html = array();

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1383,10 +1383,11 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							<?php
 							// Set up the hover actions for this user
 							/**
-							 * Filter the extra actions for this user on this order
+							 * Filter the extra actions for this user on this order.
 							 *
-							 * @param stdClass $order->user The user data
-							 * @param MemberOrder $order The current order
+							 * @param array       $actions The list of actions.
+							 * @param object      $user    The user data.
+							 * @param MemberOrder $order   The current order.
 							 */
 							$actions = apply_filters( 'pmpro_orders_user_row_actions', array(), $order->user, $order );
 

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1382,18 +1382,14 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							</span>
 							<?php
 							// Set up the hover actions for this user
-							$actions      = apply_filters( 'pmpro_orders_user_row_actions', array(), $order->user, $order );
-							$action_count = count( $actions );
-							$i            = 0;
-							if ( $action_count ) {
-								$out = ' | ';
-								foreach ( $actions as $action => $link ) {
-									++ $i;
-									( $i == $action_count ) ? $sep = '' : $sep = ' | ';
-									$out .= "<span class='" . esc_attr( $action ) . "'>" . $link . $sep . "</span>";
-								}
-								echo $out;
+							$actions = apply_filters( 'pmpro_orders_user_row_actions', array(), $order->user, $order );
+
+							$actions_html = array();
+							foreach( $actions as $action => $link ) {
+								$actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
 							}
+
+							echo ' | ' . implode( ' | ', $actions_html );
 							?>
 						</div>
 					</td>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1389,7 +1389,9 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 								$actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
 							}
 
-							echo ' | ' . implode( ' | ', $actions_html );
+							if( ! empty( $actions_html ) ) {
+								echo ' | ' . implode( ' | ', $actions_html );
+							}
 							?>
 						</div>
 					</td>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -156,8 +156,14 @@ $condition = apply_filters( 'pmpro_admin_orders_query_condition', $condition, $f
 
 // deleting?
 if ( ! empty( $_REQUEST['delete'] ) ) {
+	// Check nonce for deleting.
+	$nonceokay = true;
+	if ( empty( $_REQUEST['pmpro_orders_nonce'] ) || ! check_admin_referer( 'delete_order', 'pmpro_orders_nonce' ) ) {
+		$nonceokay = false;
+	}
+
 	$dorder = new MemberOrder( intval( $_REQUEST['delete'] ) );
-	if ( $dorder->deleteMe() ) {
+	if ( $nonceokay && $dorder->deleteMe() ) {
 		$pmpro_msg  = __( 'Order deleted successfully.', 'paid-memberships-pro' );
 		$pmpro_msgt = 'success';
 	} else {
@@ -1362,26 +1368,87 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 						<a href="admin.php?page=pmpro-orders&order=<?php echo esc_attr( $order->id ); ?>"><?php echo esc_html( $order->code ); ?></a>
 						<br />
 						<div class="row-actions">
-							<span class="edit">
-								<a title="<?php esc_attr_e( 'Edit', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $order->id ), admin_url('admin.php' ) ) ); ?>"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a>
-							</span> |
-							<span class="copy">
-								<a title="<?php esc_attr_e( 'Copy', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => '-1', 'copy' => $order->id ), admin_url('admin.php' ) ) ); ?>"><?php esc_html_e( 'Copy', 'paid-memberships-pro' ); ?></a>
-							</span> |
-							<span class="delete">
-							<?php $delete_prompt = sprintf( __( 'Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?', 'paid-memberships-pro' ), str_replace( "'", '', $order->code ) ); ?>
-								<a href='javascript:pmpro_askfirst("<?php echo esc_attr
-								( $delete_prompt ) ?>", "admin.php?page=pmpro-orders&delete=<?php echo $order->id; ?>"); void(0);'><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
-							</span> |
-							<span class="print">
-								<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'order' => $order->id ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>
-							</span> |
-							<span class="email">
-								<a href="#TB_inline?width=600&height=200&inlineId=email_invoice" class="thickbox email_link"
-								   data-order="<?php echo esc_attr( $order->id ); ?>"><?php esc_html_e( 'Email', 'paid-memberships-pro' ); ?></a>
-							</span>
 							<?php
-							// Set up the hover actions for this user
+							$delete_text = esc_html(
+								sprintf(
+									// translators: %s is the Order Code.
+									__( 'Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?', 'paid-memberships-pro' ),
+									str_replace( "'", '', $order->code )
+								)
+							);
+
+							$delete_nonce_url = wp_nonce_url(
+								add_query_arg(
+									[
+										'page'   => 'pmpro-orders',
+										'action' => 'delete_order',
+										'delete' => $order->id,
+									],
+									admin_url( 'admin.php' )
+								),
+								'delete_order',
+								'pmpro_orders_nonce'
+							);
+
+							$actions = [
+								'edit'   => sprintf(
+									'<a title="%1$s" href="%2$s">%3$s</a>',
+									esc_attr__( 'Edit', 'paid-memberships-pro' ),
+									esc_url(
+										add_query_arg(
+											[
+												'page'  => 'pmpro-orders',
+												'order' => $order->id,
+											],
+											admin_url( 'admin.php' )
+										)
+									),
+									esc_html__( 'Edit', 'paid-memberships-pro' )
+								),
+								'copy'   => sprintf(
+									'<a title="%1$s" href="%2$s">%3$s</a>',
+									esc_attr__( 'Copy', 'paid-memberships-pro' ),
+									esc_url(
+										add_query_arg(
+											[
+												'page'  => 'pmpro-orders',
+												'order' => - 1,
+												'copy'  => $order->id,
+											],
+											admin_url( 'admin.php' )
+										)
+									),
+									esc_html__( 'Copy', 'paid-memberships-pro' )
+								),
+								'delete' => sprintf(
+									'<a title="%1$s" href="%2$s">%3$s</a>',
+									esc_attr__( 'Delete', 'paid-memberships-pro' ),
+									'javascript:pmpro_askfirst(\'' . esc_js( $delete_text ) . '\', \'' . esc_js( $delete_nonce_url ) . '\'); void(0);',
+									esc_html__( 'Delete', 'paid-memberships-pro' )
+								),
+								'print'   => sprintf(
+									'<a title="%1$s" href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a>',
+									esc_attr__( 'Print', 'paid-memberships-pro' ),
+									esc_url(
+										add_query_arg(
+											[
+												'action' => 'pmpro_orders_print_view',
+												'order'  => $order->id,
+											],
+											admin_url( 'admin-ajax.php' )
+										)
+									),
+									esc_html__( 'Print', 'paid-memberships-pro' )
+								),
+								'email'   => sprintf(
+									'<a title="%1$s" href="%2$s" data-order="%3$s" class="thickbox email_link">%4$s</a>',
+									esc_attr__( 'Email', 'paid-memberships-pro' ),
+									'#TB_inline?width=600&height=200&inlineId=email_invoice',
+									esc_attr( $order->id ),
+									esc_html__( 'Email', 'paid-memberships-pro' )
+								),
+							];
+
 							/**
 							 * Filter the extra actions for this user on this order.
 							 *
@@ -1389,15 +1456,20 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							 * @param object      $user    The user data.
 							 * @param MemberOrder $order   The current order.
 							 */
-							$actions = apply_filters( 'pmpro_orders_user_row_actions', array(), $order->user, $order );
+							$actions = apply_filters( 'pmpro_orders_user_row_actions', $actions, $order->user, $order );
 
-							$actions_html = array();
-							foreach( $actions as $action => $link ) {
-								$actions_html[] = "<span class='" . esc_attr( $action ) . "'>" . $link . "</span>";
+							$actions_html = [];
+
+							foreach ( $actions as $action => $link ) {
+								$actions_html[] = sprintf(
+									'<span class="%1$s">%2$s</span>',
+									esc_attr( $action ),
+									$link
+								);
 							}
 
-							if( ! empty( $actions_html ) ) {
-								echo ' | ' . implode( ' | ', $actions_html );
+							if ( ! empty( $actions_html ) ) {
+								echo implode( ' | ', $actions_html );
 							}
 							?>
 						</div>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1382,6 +1382,12 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							</span>
 							<?php
 							// Set up the hover actions for this user
+							/**
+							 * Filter the extra actions for this user on this order
+							 *
+							 * @param stdClass $order->user The user data
+							 * @param MemberOrder $order The current order
+							 */
 							$actions = apply_filters( 'pmpro_orders_user_row_actions', array(), $order->user, $order );
 
 							$actions_html = array();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1. Enhance code readability of extra row actions for orders
2. Add a filter for extra row actions on discountcodes and membershiplevels

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
