### PR TITLE
Fixing data erasure and data export request action for login page.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -339,6 +339,12 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 			case 'recovered':
 				$message = __( 'Check your email for the confirmation link.', 'paid-memberships-pro' );
 				break;
+			case 'confirmaction':
+				// Check if we are processing a confirmaction for a Data Request.
+				$request_id = pmpro_confirmaction_handler();
+				$message = _wp_privacy_account_request_confirmed_message( $request_id );
+				$msgt = 'pmpro_success';
+				break;
 		}
 	}
 
@@ -438,7 +444,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 
 	// Note we don't show messages on the widget form.
 	if ( $message && $location !== 'widget' ) {
-		echo '<div class="' . pmpro_get_element_class( 'pmpro_message ' . $msgt, esc_attr( $msgt ) ) . '">'. esc_html( $message ) .'</div>';
+		echo '<div class="' . pmpro_get_element_class( 'pmpro_message ' . $msgt, esc_attr( $msgt ) ) . '">'. wp_kses_post( $message ) .'</div>';
 	}
 
 	// Get the form title HTML tag.
@@ -1008,4 +1014,6 @@ function pmpro_confirmaction_handler() {
 
 	/** This action is documented in wp-login.php */
 	do_action( 'user_request_action_confirmed', $request_id );
+
+	return $request_id;
 }

--- a/preheaders/account.php
+++ b/preheaders/account.php
@@ -10,16 +10,6 @@ if ( ! is_user_logged_in() ) {
 	}
 }
 
-// Check if we are processing a confirmaction for a Data Request.
-$request_id = pmpro_confirmaction_handler();
-if ( $request_id ) {
-	$pmpro_msg = _wp_privacy_account_request_confirmed_message( $request_id );
-	$pmpro_msgt = 'pmpro_success';
-} else {
-	$pmpro_msg = 'What?';
-	$pmpro_msgt = 'pmpro_error';
-}
-
 // Make sure the membership level is set for the user.
 if( $current_user->ID ) {
     $current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Data Erasure and Data Export requests were not properly being submitted nor showing a message to the user that the request was confirmed, even though the requests were successfully being processed in some cases. The action should have been added to the login page so that both logged out and logged in users could complete requests.

### How to test the changes in this Pull Request:

1. Submit a user's email on the Tools > Erase Personal Data.
2. Check your email for the confirmation link
3. Click the link. You should be taken to the login page with the confirmation message shown.

I have tested this both when logged in to the account requests the erasure/export as well as for a logged out user.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Resolved issue with Data Erasure and Data Export requests to show correct message to user on login page.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
