### PR TITLE
Fix for other Elementor restriction plugins

### DIFF
--- a/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
@@ -57,7 +57,12 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
             return $should_render;
         }
 
-		$should_render = $this->pmpro_elementor_has_access( $element );
+		// Make sure not to override other plugins logic.
+		$pmpro_should_render = $this->pmpro_elementor_has_access( $element );
+		
+		if ( $pmpro_should_render === false ) {
+			$should_render = $pmpro_should_render;
+		}
 
 		return apply_filters( 'pmpro_elementor_section_access', $should_render, $element );
 	}


### PR DESCRIPTION
This logic overrides other restriction plugins by setting the render to be always true even though there is no PMPRO restriction setting

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

It breaks other Elementor restriction logic plugins

### How to test the changes in this Pull Request:

1. Install Visibility Logic for Elementor 
2. Apply a restriction to a section
3. You will see it is always visible due to the logic in PMPRO not taking into account the filter variable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Make sure PMPRO restrict logic does not to override other plugins restriction logic.
