### PR TITLE
Now archiving Stripe products after checkout.

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3,6 +3,7 @@
 use Stripe\Customer as Stripe_Customer;
 use Stripe\Invoice as Stripe_Invoice;
 use Stripe\Plan as Stripe_Plan;
+use Stripe\Product as Stripe_Product;
 use Stripe\Charge as Stripe_Charge;
 use Stripe\PaymentIntent as Stripe_PaymentIntent;
 use Stripe\SetupIntent as Stripe_SetupIntent;
@@ -2144,7 +2145,10 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Create a new subscription with Stripe
+	 * Create a new subscription with Stripe.
+	 *
+	 * This function is not run as a part of the PMPro Checkout Process.
+	 * See method create_setup_intent().
 	 *
 	 * @since 1.4
 	 */
@@ -3134,6 +3138,11 @@ class PMProGateway_stripe extends PMProGateway {
 
 	function delete_plan( &$order ) {
 		try {
+			// Delete the product first while we have a reference to it...
+			if ( ( ! empty( $order->plan->product ) ) && ( ! $this->archive_product( $order ) ) ) {
+				return false;
+			}
+			// Then delete the plan.
 			$order->plan->delete();
 		} catch ( Stripe\Error\Base $e ) {
 			$order->error = $e->getMessage();
@@ -3146,6 +3155,23 @@ class PMProGateway_stripe extends PMProGateway {
 		} catch ( \Exception $e ) {
 			$order->error = $e->getMessage();
 
+			return false;
+		}
+
+		return true;
+	}
+
+	function archive_product( &$order ) {
+		try {
+			$product = Stripe_Product::update( $order->plan->product, array( 'active' => false ) );
+		} catch ( Stripe\Error\Base $e ) {
+			$order->error = $e->getMessage();
+			return false;
+		} catch ( \Throwable $e ) {
+			$order->error = $e->getMessage();
+			return false;
+		} catch ( \Exception $e ) {
+			$order->error = $e->getMessage();
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now archiving Stripe products after checkout.

Note: This solution is a half-measure. Ideally, we would have one product in Stripe per membership level and just create a new price for checkouts if necessary. This "archiving" solution will still create a stripe product for each checkout, but at least they will be under the archived tab. Products cannot be deleted once they have been used, which is why we are only archiving.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out for recurring level with Stripe
2. Check that Product in Stripe is archived.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
