### PR TITLE
Better returns when there is an error getting or creating apple pay domain

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3378,7 +3378,7 @@ class PMProGateway_stripe extends PMProGateway {
 			//throw $th;
 			return false;
 		}
-
+		return $create;
 	}
 
 	/**

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3358,7 +3358,7 @@ class PMProGateway_stripe extends PMProGateway {
 		try {
 			$apple_pay_domains = Stripe_ApplePayDomain::all( [ 'limit' => apply_filters( 'pmpro_stripe_apple_pay_domain_retrieve_limit', $limit ) ] );
 		} catch (\Throwable $th) {
-			$apple_pay_domains = $th->getMessage();
+			$apple_pay_domains = array();
 	   	}
 
 		return $apple_pay_domains;
@@ -3376,7 +3376,7 @@ class PMProGateway_stripe extends PMProGateway {
 			]);
 		} catch (\Throwable $th) {
 			//throw $th;
-			return $th->getMessage();
+			return false;
 		}
 
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Return `false` or `array()` when there is an error getting or creating Apple Pay domains with Stripe so that `empty()` checks work as expected.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
