### PR TITLE
Set `pmpro_visit` cookie http only and secure, if available

### DIFF
--- a/adminpages/reports/login.php
+++ b/adminpages/reports/login.php
@@ -416,11 +416,13 @@ function pmpro_report_track_values($type, $user_id = NULL) {
 		return false;
 
 	//set cookie for visits
-	if($type == "visits" && empty($_COOKIE['pmpro_visit']))
-        if(empty($_SERVER['HTTPS']))
-            setcookie("pmpro_visit", "1", NULL, COOKIEPATH, COOKIE_DOMAIN, false, true);
-        else
-            setcookie("pmpro_visit", "1", NULL, COOKIEPATH, COOKIE_DOMAIN, true, true);
+	if($type == "visits" && empty($_COOKIE['pmpro_visit'])) {
+        if (empty($_SERVER['HTTPS'])) {
+            setcookie("pmpro_visit", "1", null, COOKIEPATH, COOKIE_DOMAIN, false, true);
+        } else {
+            setcookie("pmpro_visit", "1", null, COOKIEPATH, COOKIE_DOMAIN, true, true);
+        }
+    }
 
 	//some vars for below
 	$now = current_time('timestamp');

--- a/adminpages/reports/login.php
+++ b/adminpages/reports/login.php
@@ -417,7 +417,10 @@ function pmpro_report_track_values($type, $user_id = NULL) {
 
 	//set cookie for visits
 	if($type == "visits" && empty($_COOKIE['pmpro_visit']))
-		setcookie("pmpro_visit", "1", NULL, COOKIEPATH, COOKIE_DOMAIN, false);	
+        if(empty($_SERVER['HTTPS']))
+            setcookie("pmpro_visit", "1", NULL, COOKIEPATH, COOKIE_DOMAIN, false, true);
+        else
+            setcookie("pmpro_visit", "1", NULL, COOKIEPATH, COOKIE_DOMAIN, true, true);
 
 	//some vars for below
 	$now = current_time('timestamp');


### PR DESCRIPTION
### All Submissions:

[x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
[x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
[x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Set cookie `pmpro_visit` as HttpOnly and secure if possible.
Resolve warning about:

> Cookie “pmpro_visit” will be soon rejected because it has the “SameSite” attribute set to “None” or an invalid value, without the “secure” attribute. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite

### Other information:

[x] Have you added an explanation of what your changes do and why you'd like us to include them?
[x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Set cookie `pmpro_visit` as HttpOnly and secure if possible.
