### PR TITLE
Fixed issue where admin_change email could have double periods

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -892,18 +892,18 @@
 			$this->data = array("subject" => $this->subject, "name" => $user->display_name, "display_name" => $user->display_name, "user_login" => $user->user_login, "user_email" => $user->user_email, "sitename" => get_option("blogname"), "membership_id" => $membership_level_id, "membership_level_name" => $membership_level_name, "siteemail" => pmpro_getOption("from_email"), "login_link" => pmpro_login_url());
 
 			if(!empty($user->membership_level) && !empty($user->membership_level->ID)) {
-				$this->data["membership_change"] = sprintf(__("The new level is %s", 'paid-memberships-pro' ), $user->membership_level->name);
+				$this->data["membership_change"] = sprintf(__("The new level is %s", 'paid-memberships-pro' ), $user->membership_level->name) . '.';
 			} else {
-				$this->data["membership_change"] = __("Your membership has been cancelled", "paid-memberships-pro");
+				$this->data["membership_change"] = __("Your membership has been cancelled", "paid-memberships-pro") . '.';
 			}
 
 			if(!empty($user->membership_level->enddate))
 			{
-					$this->data["membership_change"] .= ". " . sprintf(__("This membership will expire on %s", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $user->membership_level->enddate));
+					$this->data["membership_change"] .= " " . sprintf(__("This membership will expire on %s", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $user->membership_level->enddate)) . '.';
 			}
 			elseif(!empty($this->expiration_changed))
 			{
-				$this->data["membership_change"] .= ". " . __("This membership does not expire", 'paid-memberships-pro' );
+				$this->data["membership_change"] .= " " . __("This membership does not expire", 'paid-memberships-pro' ) . '.';
 			}
 
 			$this->template = apply_filters("pmpro_email_template", "admin_change", $this);
@@ -942,18 +942,18 @@
 			$this->data = array("subject" => $this->subject, "name" => $user->display_name, "display_name" => $user->display_name, "user_login" => $user->user_login, "user_email" => $user->user_email, "sitename" => get_option("blogname"), "membership_id" => $membership_level_id, "membership_level_name" => $membership_level_name, "siteemail" => get_bloginfo("admin_email"), "login_link" => pmpro_login_url());
 
 			if(!empty($user->membership_level) && !empty($user->membership_level->ID)) {
-				$this->data["membership_change"] = sprintf(__("The new level is %s", 'paid-memberships-pro' ), $user->membership_level->name);
+				$this->data["membership_change"] = sprintf(__("The new level is %s", 'paid-memberships-pro' ), $user->membership_level->name) . '.';
 			} else {
-				$this->data["membership_change"] = __("Membership has been cancelled", 'paid-memberships-pro' );	
+				$this->data["membership_change"] = __("Membership has been cancelled", 'paid-memberships-pro' ) . '.';	
 			}
 			
 			if(!empty($user->membership_level) && !empty($user->membership_level->enddate))
 			{
-					$this->data["membership_change"] .= ". " . sprintf(__("This membership will expire on %s", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $user->membership_level->enddate));
+					$this->data["membership_change"] .= " " . sprintf(__("This membership will expire on %s", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $user->membership_level->enddate)) . '.';
 			}
 			elseif(!empty($this->expiration_changed))
 			{
-				$this->data["membership_change"] .= ". " . __("This membership does not expire", 'paid-memberships-pro' );
+				$this->data["membership_change"] .= " " . __("This membership does not expire", 'paid-memberships-pro' ) . '.';
 			}
 
 			$this->template = apply_filters("pmpro_email_template", "admin_change_admin", $this);

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -31,7 +31,7 @@ $pmpro_email_templates_defaults = array(
 		'description' => __( 'Admin Change', 'paid-memberships-pro'),
 		'body' => __( '<p>An administrator at !!sitename!! has changed your membership level.</p>
 		
-<p>!!membership_change!!.</p>
+<p>!!membership_change!!</p>
 		
 <p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>
 		
@@ -42,7 +42,7 @@ $pmpro_email_templates_defaults = array(
 		'description' => __('Admin Change (admin)', 'paid-memberships-pro'),
 		'body' => __( '<p>An administrator at !!sitename!! has changed a membership level for !!name!!.</p>
 
-<p>!!membership_change!!.</p>
+<p>!!membership_change!!</p>
 
 <p>Log in to your WordPress admin here: !!login_link!!</p>', 'paid-memberships-pro' )
 	),

--- a/includes/email.php
+++ b/includes/email.php
@@ -184,9 +184,6 @@ function pmpro_email_templates_get_template_data() {
 		$template_data['body'] = pmpro_email_templates_get_template_body($template);
 	}
 
-	// Temporary workaround for avoiding double period when using !!membership_change!!
-	$template_data['body'] = str_replace( '!!membership_change!!.', '!!membership_change!!', $template_data['body'] );
-
 	if (empty($template_data['subject']) && $template != "header" && $template != "footer") {
 		$template_data['subject'] = $pmpro_email_templates_defaults[$template]['subject'];
 	}
@@ -413,18 +410,18 @@ function pmpro_email_templates_email_data($data, $email) {
 
 		// Membership Information.
 		$new_data['membership_expiration'] = '';
-		$new_data["membership_change"] = __("Your membership has been cancelled.", "paid-memberships-pro");
+		$new_data["membership_change"] = __("Your membership has been cancelled", "paid-memberships-pro") . '.';
 		if ( empty( $user->membership_level ) ) { 
 			$user->membership_level = pmpro_getMembershipLevelForUser($user->ID, true);
 		}
 		if ( ! empty( $user->membership_level->name ) ) {
-			$new_data["membership_change"] = sprintf(__("The new level is %s.", "paid-memberships-pro"), $user->membership_level->name);
+			$new_data["membership_change"] = sprintf(__("The new level is %s.", "paid-memberships-pro"), $user->membership_level->name) . '.';
 			if ( ! empty($user->membership_level->enddate) ) {
 				$new_data['enddate'] = date_i18n( get_option( 'date_format' ), $user->membership_level->enddate );
 				$new_data['membership_expiration'] = "<p>" . sprintf( __("This membership will expire on %s.", "paid-memberships-pro"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) ) . "</p>\n";
-				$new_data["membership_change"] .= ". " . sprintf(__("This membership will expire on %s.", "paid-memberships-pro"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) );
+				$new_data["membership_change"] .= " " . sprintf(__("This membership will expire on %s", "paid-memberships-pro"), date_i18n( get_option( 'date_format' ), $user->membership_level->enddate ) ) . '.';
 			} else if ( ! empty( $email->expiration_changed ) ) {
-				$new_data["membership_change"] .= ". " . __("This membership does not expire.", "paid-memberships-pro");
+				$new_data["membership_change"] .= " " . __("This membership does not expire", "paid-memberships-pro") . '.';
 			}
 			
 		}
@@ -491,9 +488,6 @@ function pmpro_email_templates_email_data($data, $email) {
 		if(!isset($data[$key]))
 			$data[$key] = $value;
 	}
-
-	// Make sure to use this version of !!membership_change!! because of period issue.
-	$data['membership_change'] = $new_data['membership_change'];
 
 	return $data;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed issue where admin_change email could have double periods in the `!!membership_change!!` variable. We had workarounds for this built into PMPro Email Templates, but they were no longer working so we are now just doing it the right way.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
