### PR TITLE
Allow strike in notifications we push to the dashboard.

### DIFF
--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -44,6 +44,7 @@ function pmpro_notifications() {
 							'class' => array(),
 						),
 						'br' => array(),
+						'strike' => array(),
 					);
 					echo wp_kses( $notification->content, $allowed_html );
 				?>


### PR DESCRIPTION
Small update to the allowed HTML in our notifications to allow <strike> tag for crossout pricing when we run a promotion banner.