### PR TITLE
Also checking for the .org version of Email Templates Admin Editor in deprecation script.

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -65,6 +65,10 @@ function pmpro_check_for_deprecated_add_ons() {
 		'pmpro-email-templates' => array(
 			'file' => 'pmpro-email-templates.php',
 			'label' => 'Email Templates'
+		),
+		'pmpro-email-templates-addon' => array(
+			'file' => 'pmpro-email-templates.php',
+			'label' => 'Email Templates'
 		)
 	);
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The deprecation for Email Templates Admin Editor needs to include the case if a user installed via WP.org (the folder name is different in this one - odd, old issue we don't have to worry about anymore!).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Use the .org version and/or change the folder name to 'pmpro-email-templates-addon'.
2. Go to the dashboard.
3. The email templates admin editor Add On should deactivate and the word "Email Templates" should be included in the notice on dashboard pages. 
