### PR TITLE
Adjusting default for expiration time filter to false; using the site time format to format the expiration time if applicable.

### DIFF
--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -126,18 +126,27 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 									<p><?php echo pmpro_getLevelCost($level, true, true);?></p>
 								</td>
 								<td class="<?php echo pmpro_get_element_class( 'pmpro_account-membership-expiration' ); ?>">
-								<?php
-									if($level->enddate){
-										$expiration_text = date_i18n( get_option( 'date_format' ), $level->enddate );
-										if( apply_filters( 'pmpro_show_time_on_expiration_date', true ) ){
-											$expiration_text = date_i18n( get_option( 'date_format' ).' - H:i', $level->enddate );
+									<?php
+										$expiration_text = '<p>';
+										if ( $level->enddate ) {
+											$expiration_text .= date_i18n( get_option( 'date_format' ), $level->enddate );
+											/**
+											 * Filter to include the expiration time with expiration date
+											 *
+											 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date (default: false).
+											 *
+											 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
+											 *
+											 */
+											if ( apply_filters( 'pmpro_show_time_on_expiration_date', false ) ) {
+												$expiration_text .= ' ' . date_i18n( get_option( 'time_format', __( 'g:i a' ) ), $level->enddate );
+											}
+										} else {
+											$expiration_text .= esc_html_e( '&#8212;', 'paid-memberships-pro' );
 										}
-									} else {
-										$expiration_text = "---";
-								    	
-								    }
-								    echo apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level );
-								?>
+										$expiration_text .= '</p>';
+										echo apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level );
+									?>
 								</td>
 							</tr>
 							<?php } ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The original granular expirations work was showing expiration time as the default. In our discussions, we decided that fewer sites will be offering hourly membership so defaulting to NOT show expiration time makes more sense.

[Here is an example of using the `pmpro_show_time_on_expiration_date` filter](https://gist.github.com/kimcoleman/0f9528f9871c733a43f44e998f61a49b).
