### PR TITLE
Remove 'couponamount' from REST API response

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -792,7 +792,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 					`o`.`billing_phone`,
 					`o`.`subtotal`,
 					`o`.`tax`,
-					`o`.`couponamount`,
 					`o`.`total`,
 					`o`.`status`,
 					`o`.`gateway`,


### PR DESCRIPTION
Enhancement: Remove 'couponamount' from REST API response for Zapier.