### PR TITLE
Do not autoload email templates since we added that feature as default

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -204,8 +204,8 @@ function pmpro_email_templates_save_template_data() {
 	check_ajax_referer('pmproet', 'security');
 
 	//update this template's settings
-	pmpro_setOption('email_' . $_REQUEST['template'] . '_subject', stripslashes($_REQUEST['subject']));
-	pmpro_setOption('email_' . $_REQUEST['template'] . '_body', stripslashes($_REQUEST['body']));
+	pmpro_setOption('email_' . $_REQUEST['template'] . '_subject', stripslashes($_REQUEST['subject']), 'sanitize_text_field', false);
+	pmpro_setOption('email_' . $_REQUEST['template'] . '_body', stripslashes($_REQUEST['body']), 'sanitize_text_field', false);
 	delete_transient( 'pmproet_' . $_REQUEST['template'] );
 	esc_html_e( 'Template Saved', 'paid-memberships-pro' );
 	

--- a/includes/email.php
+++ b/includes/email.php
@@ -204,8 +204,8 @@ function pmpro_email_templates_save_template_data() {
 	check_ajax_referer('pmproet', 'security');
 
 	//update this template's settings
-	pmpro_setOption('email_' . $_REQUEST['template'] . '_subject', stripslashes($_REQUEST['subject']), 'sanitize_text_field', false);
-	pmpro_setOption('email_' . $_REQUEST['template'] . '_body', stripslashes($_REQUEST['body']), 'sanitize_text_field', false);
+	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_subject', stripslashes( $_REQUEST['subject'] ), 'sanitize_text_field', false );
+	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_body', stripslashes( $_REQUEST['body'] ), 'sanitize_textarea_field', false );
 	delete_transient( 'pmproet_' . $_REQUEST['template'] );
 	esc_html_e( 'Template Saved', 'paid-memberships-pro' );
 	

--- a/includes/email.php
+++ b/includes/email.php
@@ -204,8 +204,8 @@ function pmpro_email_templates_save_template_data() {
 	check_ajax_referer('pmproet', 'security');
 
 	//update this template's settings
-	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_subject', stripslashes( $_REQUEST['subject'] ), 'sanitize_text_field', false );
-	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_body', stripslashes( $_REQUEST['body'] ), 'sanitize_textarea_field', false );
+	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_subject', stripslashes( $_REQUEST['subject'] ) );
+	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_body', stripslashes( $_REQUEST['body'] ), 'sanitize_textarea_field' );
 	delete_transient( 'pmproet_' . $_REQUEST['template'] );
 	esc_html_e( 'Template Saved', 'paid-memberships-pro' );
 	

--- a/includes/email.php
+++ b/includes/email.php
@@ -205,7 +205,7 @@ function pmpro_email_templates_save_template_data() {
 
 	//update this template's settings
 	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_subject', stripslashes( $_REQUEST['subject'] ) );
-	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_body', stripslashes( $_REQUEST['body'] ), 'sanitize_textarea_field' );
+	pmpro_setOption( 'email_' . $_REQUEST['template'] . '_body', stripslashes( $_REQUEST['body'] ) );
 	delete_transient( 'pmproet_' . $_REQUEST['template'] );
 	esc_html_e( 'Template Saved', 'paid-memberships-pro' );
 	

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -84,7 +84,7 @@ function pmpro_getOption( $s, $force = false ) {
 	}
 }
 
-function pmpro_setOption( $s, $v = null, $sanitize_function = 'sanitize_text_field', $autoload = true  ) {
+function pmpro_setOption( $s, $v = null, $sanitize_function = 'sanitize_text_field', $autoload = false ) {
 	// no value is given, set v to the p var
 	if ( $v === null && isset( $_POST[ $s ] ) ) {
 		if ( is_array( $_POST[ $s ] ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -84,7 +84,7 @@ function pmpro_getOption( $s, $force = false ) {
 	}
 }
 
-function pmpro_setOption( $s, $v = null, $sanitize_function = 'sanitize_text_field' ) {
+function pmpro_setOption( $s, $v = null, $sanitize_function = 'sanitize_text_field', $autoload = true  ) {
 	// no value is given, set v to the p var
 	if ( $v === null && isset( $_POST[ $s ] ) ) {
 		if ( is_array( $_POST[ $s ] ) ) {
@@ -100,7 +100,7 @@ function pmpro_setOption( $s, $v = null, $sanitize_function = 'sanitize_text_fie
 		$v = trim( $v );
 	}
 
-	return update_option( 'pmpro_' . $s, $v );
+	return update_option( 'pmpro_' . $s, $v, $autoload );
 }
 
 function pmpro_get_slug( $post_id ) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since we added email templates as default feature for PMPro, I think autoload templates is not necessary.
We need a little change for `pmpro_setOption` function to achieve this.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Do not autoload all email templates by default on every request to WordPress.
