### PR TITLE
Added Email Templates as a link on dashboard for getting started.

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -143,6 +143,10 @@ function pmpro_dashboard_welcome_callback() { ?>
     				<li><a href="<?php echo admin_url( 'admin.php?page=pmpro-emailsettings' );?>"><i class="dashicons dashicons-email"></i> <?php echo esc_attr_e( 'Confirm Email Settings', 'paid-memberships-pro' );?></a></li>
     			<?php } ?>
 
+				<?php if ( current_user_can( 'pmpro_emailtemplates' ) ) { ?>
+					<li><a href="<?php echo admin_url( 'admin.php?page=pmpro-emailtemplates' );?>"><i class="dashicons dashicons-editor-spellcheck"></i> <?php echo esc_attr_e( 'Customize Email Templates', 'paid-memberships-pro' );?></a></li>
+				<?php } ?>
+
     			<?php if ( current_user_can( 'pmpro_advancedsettings' ) ) { ?>
     				<li><a href="<?php echo admin_url( 'admin.php?page=pmpro-advancedsettings' );?>"><i class="dashicons dashicons-admin-settings"></i> <?php echo esc_attr_e( 'View Advanced Settings', 'paid-memberships-pro' ); ?></a></li>
     			<?php } ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Dashboard setup steps should include a link to the new email templates editing page in the admin.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Navigate to Memberships > Dashboard
2. See the new link under "Other Settings" in the main box.
3. That link should take you to the Email Templates admin screen.
