### PR TITLE
Ensure our admin scripts/styles only load on our pages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.6.1 - 2021-08-16 =
+* BUG FIX: Ensure our admin scripts/styles only load on PMPro admin pages.
+
 = 2.6 - 2021-08-12 =
 * FEATURE: Updated Stripe integration to use Stripe Connect.
 * FEATURE: Improved REST API endpoints to support Zapier integration natively.

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -94,6 +94,11 @@ add_action( 'wp_enqueue_scripts', 'pmpro_enqueue_scripts' );
  * Enqueue admin JavaScript and CSS
  */
 function pmpro_admin_enqueue_scripts() {
+	// Only enqueue PMPro admin scripts on our own pages.
+	if ( ! isset( $_GET['page'] ) || 0 !== strpos( $_GET['page'], 'pmpro' ) ) {
+		return;
+	}
+
     // Admin JS
     wp_register_script( 'pmpro_admin',
                         plugins_url( 'js/pmpro-admin.js', dirname(__FILE__) ),

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Paid Memberships Pro
  * Plugin URI: https://www.paidmembershipspro.com
  * Description: The most complete member management and membership subscriptions plugin for WordPress.
- * Version: 2.6
+ * Version: 2.6.1
  * Author: Stranger Studios
  * Author URI: https://www.strangerstudios.com
  * Text Domain: paid-memberships-pro
@@ -16,7 +16,7 @@
  */
 
 // version constant
-define( 'PMPRO_VERSION', '2.6' );
+define( 'PMPRO_VERSION', '2.6.1' );
 define( 'PMPRO_USER_AGENT', 'Paid Memberships Pro v' . PMPRO_VERSION . '; ' . site_url() );
 define( 'PMPRO_MIN_PHP_VERSION', '5.6' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios, kimannwall, andrewza, dlparker1005, paidmembershi
 Tags: memberships, members, subscriptions, ecommerce, user registration, member, membership, e-commerce, paypal, stripe, braintree, authorize.net, payflow, restrict access, restrict content, directory
 Requires at least: 5.2
 Tested up to: 5.8
-Stable tag: 2.6
+Stable tag: 2.6.1
 
 Get Paid with Paid Memberships Pro: The most complete member management and membership subscriptions plugin for your WordPress site.
 

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,9 @@ Not sure? You can find out by doing a bit a research.
 9. Membership Account page, display all sections or show specific sections using shortcode attributes.
 
 == Changelog ==
+= 2.6.1 - 2021-08-16 =
+* BUG FIX: Ensure our admin scripts/styles only load on PMPro admin pages.
+
 = 2.6 - 2021-08-12 =
 * FEATURE: Updated Stripe integration to use Stripe Connect.
 * FEATURE: Improved REST API endpoints to support Zapier integration natively.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1723.

### How to test the changes in this Pull Request:

1. Load any admin page that isn't ours
2. Confirm our admin script/css is not loaded
3. Load any admin page that is ours
4. Confirm our admin script/css is loaded

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Ensure our admin scripts/styles only load on PMPro admin pages
