### PR TITLE
Tweak changelog to show Stripe fee info

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 == Changelog ==
 = 2.6 - 2021-08-12 =
-* FEATURE: Updated Stripe integration to use Stripe Connect.
+* FEATURE: Updated Stripe integration to use Stripe Connect. See [Gateway Fees](https://www.paidmembershipspro.com/gateway/stripe/#tab-fees) for information about transaction fees for Stripe Connect and our platform fee for those without an active Plus/Unlimited license.
 * FEATURE: Improved REST API endpoints to support Zapier integration natively.
 * FEATURE: You can now set levels to expire after a certain number of hours, and can set users to expire at a specific time down to the minute.
 * FEATURE: The Member History Add On has been merged into the core PMPro plugin. A table of the user's membership and order history is shown on the edit user page of the admin dashboard.

--- a/readme.txt
+++ b/readme.txt
@@ -156,7 +156,7 @@ Not sure? You can find out by doing a bit a research.
 
 == Changelog ==
 = 2.6 - 2021-08-12 =
-* FEATURE: Updated Stripe integration to use Stripe Connect.
+* FEATURE: Updated Stripe integration to use Stripe Connect. See [Gateway Fees](https://www.paidmembershipspro.com/gateway/stripe/#tab-fees) for information about transaction fees for Stripe Connect and our platform fee for those without an active Plus/Unlimited license.
 * FEATURE: Improved REST API endpoints to support Zapier integration natively.
 * FEATURE: You can now set levels to expire after a certain number of hours, and can set users to expire at a specific time down to the minute.
 * FEATURE: The Member History Add On has been merged into the core PMPro plugin. A table of the user's membership and order history is shown on the edit user page of the admin dashboard.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a text-only change to the changelog to include additional info + link for Stripe fees and our added platform fee.