### PR TITLE
Fix PHP 8 fatal error that could occur in pmpro_email_templates_email_data

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -400,7 +400,7 @@ function pmpro_email_templates_email_data($data, $email) {
 	}
 
 	// Make sure we have the current membership level data.
-	if ( $user !== false ) {
+	if ( $user instanceof WP_User ) {
 		$user->membership_level = pmpro_getMembershipLevelForUser(
 			$user->ID,
 			true

--- a/includes/email.php
+++ b/includes/email.php
@@ -389,18 +389,23 @@ function pmpro_email_templates_test_template($email)
 /* Filter for Variables */
 function pmpro_email_templates_email_data($data, $email) {
 
-	global $current_user, $pmpro_currency_symbol, $wpdb;
+	global $pmpro_currency_symbol;
 
 	if ( ! empty( $data ) && ! empty( $data['user_login'] ) ) {
 		$user = get_user_by( 'login', $data['user_login'] );
 	} elseif ( ! empty( $email ) ) {
 		$user = get_user_by( 'email', $email->email );
 	} else {
-		$user = $current_user;
+		$user = wp_get_current_user();
 	}
 
-	//make sure we have the current membership level data
-	$user->membership_level = pmpro_getMembershipLevelForUser($user->ID, true);
+	// Make sure we have the current membership level data.
+	if ( $user !== false ) {
+		$user->membership_level = pmpro_getMembershipLevelForUser(
+			$user->ID,
+			true
+		);
+	}
 
 	//make sure data is an array
 	if(!is_array($data))


### PR DESCRIPTION
In PHP 8 this change was made:

> Attempting to write to a property of a non-object. Previously this implicitly created an stdClass object for null, false and empty strings.

https://www.php.net/manual/en/migration80.incompatible.php

Because of this, `pmpro_email_templates_email_data` is currently throwing fatal errors whenever the calls to [`get_user_by`](https://developer.wordpress.org/reference/functions/get_user_by/) within the function return `false`, because the attempt to set `$user->membership_level` will fail. And this has been happening to me on one of my sites recently, every time the admin activity email is supposed to be sent. (Because of the fatal error, it never actually gets sent.)

```
[16-Aug-2021 10:30:03 UTC] PHP Warning:  Attempt to read property "ID" on bool in /home/SITE_ROOT/public_html/wp-content/plugins/paid-memberships-pro/includes/email.php on line 403
[16-Aug-2021 10:30:03 UTC] PHP Fatal error:  Uncaught Error: Attempt to assign property "membership_level" on bool in /home/SITE_ROOT/public_html/wp-content/plugins/paid-memberships-pro/includes/email.php:403
Stack trace:
#0 /home/SITE_ROOT/public_html/wp-includes/class-wp-hook.php(303): pmpro_email_templates_email_data(NULL, Object(PMPro_Admin_Activity_Email))
#1 /home/SITE_ROOT/public_html/wp-includes/plugin.php(189): WP_Hook->apply_filters(NULL, Array)
#2 /home/SITE_ROOT/public_html/wp-content/plugins/paid-memberships-pro/classes/class.pmproemail.php(113): apply_filters('pmpro_email_dat...', NULL, Object(PMPro_Admin_Activity_Email))
#3 /home/SITE_ROOT/public_html/wp-content/plugins/paid-memberships-pro/classes/class-pmpro-admin-activity-email.php(417): PMProEmail->sendEmail()
#4 /home/SITE_ROOT/public_html/wp-content/plugins/paid-memberships-pro/scheduled/crons.php(291): PMPro_Admin_Activity_Email->sendAdminActivity()
#5 /home/SITE_ROOT/public_html/wp-includes/class-wp-hook.php(303): pmpro_cron_admin_activity_email()
#6 /home/SITE_ROOT/public_html/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters('', Array)
#7 /home/SITE_ROOT/public_html/wp-includes/plugin.php(518): WP_Hook->do_action(Array)
#8 /home/SITE_ROOT/public_html/wp-cron.php(138): do_action_ref_array('pmpro_cron_admi...', Array)
#9 {main}
```

This PR fixes that issue. It also removes an unused $wpdb global and switches to using [`wp_get_current_user`](https://developer.wordpress.org/reference/functions/wp_get_current_user/) in the function instead of the `$current_user` global, which seems to be the preferred way to get the current user since WP 4.5.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Fix PHP 8 fatal error that can occur in `pmpro_email_templates_email_data` when the calls to [`get_user_by`](https://developer.wordpress.org/reference/functions/get_user_by/) inside the function return `false`.
- Remove unused `$wpdb` global usage in `pmpro_email_templates_email_data`.
- Use standard [`wp_get_current_user`](https://developer.wordpress.org/reference/functions/wp_get_current_user/) function instead of `$current_user` global in `pmpro_email_templates_email_data`.

### How to test the changes in this Pull Request:

1. Use PHP 8 on your site.
2. Install Paid Memberships Pro.
3. Install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/).
4. Navigate to PMPro's "Advanced Settings" page: `/wp-admin/admin.php?page=pmpro-advancedsettings`.
5. Ensure that "Activity Email Frequency" is set to something other than "Never".
![image](https://user-images.githubusercontent.com/19592990/129806617-98377b20-21d9-41b8-a919-9dc895f6c768.png)
6. Navigate to WP Crontrol's "Cron Events" page: `/wp-admin/tools.php?page=crontrol_admin_manage_page`.
7. Find the `pmpro_cron_admin_activity_email` event and click "Run Now".
![image](https://user-images.githubusercontent.com/19592990/129806771-fb8a20c8-311b-436a-ad60-155fa5298304.png)
8. Check your site's PHP error log to ensure that no PHP 8 warnings or fatal errors have occurred.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fixed PHP 8 fatal error that could occur in `pmpro_email_templates_email_data`.
