### PR TITLE
Remove unused variable which generates PHP Warning

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -393,12 +393,10 @@ add_filter('get_the_excerpt', 'pmpro_membership_get_excerpt_filter_start', 1);
 add_filter('get_the_excerpt', 'pmpro_membership_get_excerpt_filter_end', 100);
 
 function pmpro_comments_filter($comments, $post_id = NULL) {
-	global $post, $wpdb, $current_user;
+	global $current_user;
 
 	if(!$comments)
 		return $comments;	//if they are closed anyway, we don't need to check
-
-	global $post, $current_user;
 
 	$hasaccess = pmpro_has_membership_access(NULL, NULL, true);
 	if( is_array( $hasaccess ) ) {

--- a/includes/content.php
+++ b/includes/content.php
@@ -394,8 +394,6 @@ add_filter('get_the_excerpt', 'pmpro_membership_get_excerpt_filter_end', 100);
 
 function pmpro_comments_filter($comments, $post_id = NULL) {
 	global $post, $wpdb, $current_user;
-	if(!$post_id)
-		$post_id = $post->ID;
 
 	if(!$comments)
 		return $comments;	//if they are closed anyway, we don't need to check


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolve PHP Warning:
`PHP Warning:  Attempt to read property "ID" on null in .../wp-content/plugins/paid-memberships-pro/includes/content.php on line 398`

Actually, this var is unused in this function so can be safely removed.

### How to test the changes in this Pull Request:

This PHP Warning shows up by requesting non-post pages like `http://xxx.com/tag/<tag>/comments/feed/`.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Remove PHP Warning on non-post pages.
Also remove some unused/duplicate PHP code.
