### PR TITLE
Update Stripe connected status to consider legacy keys

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -329,14 +329,14 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		// Determine if the gateway is connected in live mode and set var.
-		if ( self::has_connect_credentials( 'live' ) ) {
+		if ( self::has_connect_credentials( 'live' ) || ( self::using_legacy_keys() && ! empty( pmpro_getOption( 'stripe_secretkey' ) ) && ! empty( pmpro_getOption( 'stripe_publishablekey' ) ) ) ) {
 			$live_connection_selector = 'pmpro_gateway-mode-connected';
 		} else {
 			$live_connection_selector = 'pmpro_gateway-mode-not-connected';
 		}
 
 		// Determine if the gateway is connected in test mode and set var.
-		if ( self::has_connect_credentials( 'sandbox' ) ) {
+		if ( self::has_connect_credentials( 'sandbox' ) || ( self::using_legacy_keys() && ! empty( pmpro_getOption( 'stripe_secretkey' ) ) && ! empty( pmpro_getOption( 'stripe_publishablekey' ) ) ) ) {
 			$test_connection_selector = 'pmpro_gateway-mode-connected';
 		} else {
 			$test_connection_selector = 'pmpro_gateway-mode-not-connected';
@@ -352,6 +352,8 @@ class PMProGateway_stripe extends PMProGateway {
 						<?php esc_html_e( 'Live Mode:', 'paid-memberships-pro' ); ?>
 						<?php if ( self::has_connect_credentials( 'live' ) ) {
 							esc_html_e( 'Connected', 'paid-memberships-pro' );
+						} elseif( self::using_legacy_keys() && ! empty( pmpro_getOption( 'stripe_secretkey' ) ) && ! empty( pmpro_getOption( 'stripe_publishablekey' ) ) ) {
+							esc_html_e( 'Connected with Legacy Keys', 'paid-memberships-pro' );
 						} else {
 							esc_html_e( 'Not Connected', 'paid-memberships-pro' );
 						} ?>
@@ -439,6 +441,8 @@ class PMProGateway_stripe extends PMProGateway {
 						<?php esc_html_e( 'Test Mode:', 'paid-memberships-pro' ); ?>
 						<?php if ( self::has_connect_credentials( 'sandbox' ) ) {
 							esc_html_e( 'Connected', 'paid-memberships-pro' );
+						} elseif( self::using_legacy_keys() && ! empty( pmpro_getOption( 'stripe_secretkey' ) ) && ! empty( pmpro_getOption( 'stripe_publishablekey' ) ) ) {
+							esc_html_e( 'Connected with Legacy Keys', 'paid-memberships-pro' );
 						} else {
 							esc_html_e( 'Not Connected', 'paid-memberships-pro' );
 						} ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If legacy keys are being used with Stripe, show that the site is connected to Stripe using legacy keys instead of showing that the site is not connected at all. This was causing confusion with users thinking that the Stripe integration was no longer working when using legacy keys.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
