### PR TITLE
Remove check for condition which always 'true' because of prev check

### DIFF
--- a/includes/addons.php
+++ b/includes/addons.php
@@ -130,7 +130,7 @@ function pmpro_update_plugins_filter( $value ) {
 		}
 
 		// compare versions
-		if ( ! empty( $addon['License'] ) && version_compare( $plugin_data['Version'], $addon['Version'], '<' ) ) {
+		if ( version_compare( $plugin_data['Version'], $addon['Version'], '<' ) ) {
 			$value->response[ $plugin_file ] = pmpro_getPluginAPIObjectFromAddon( $addon );
 			$value->response[ $plugin_file ]->new_version = $addon['Version'];
 		} else {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Condition is always 'true' because 'empty( $addon['License'] ) || $addon['License'] == 'wordpress.org'' is already 'false' at this point (see **line 117**).

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Remove unused condition check.
