### PR TITLE
Keep filters on item delete

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -157,6 +157,9 @@ $condition = apply_filters( 'pmpro_admin_orders_query_condition', $condition, $f
 // deleting?
 if ( ! empty( $_REQUEST['delete'] ) ) {
 	$dorder = new MemberOrder( intval( $_REQUEST['delete'] ) );
+
+	$_SERVER['REQUEST_URI'] = remove_query_arg( array( 'delete' ), $_SERVER['REQUEST_URI'] );
+	
 	if ( $dorder->deleteMe() ) {
 		$pmpro_msg  = __( 'Order deleted successfully.', 'paid-memberships-pro' );
 		$pmpro_msgt = 'success';
@@ -1358,8 +1361,9 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							</span> |
 							<span class="delete">
 							<?php $delete_prompt = sprintf( __( 'Deleting orders is permanent and can affect active users. Are you sure you want to delete order %s?', 'paid-memberships-pro' ), str_replace( "'", '', $order->code ) ); ?>
-								<a href='javascript:pmpro_askfirst("<?php echo esc_attr
-								( $delete_prompt ) ?>", "admin.php?page=pmpro-orders&delete=<?php echo $order->id; ?>"); void(0);'><?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?></a>
+								<a href='javascript:pmpro_askfirst("<?php echo esc_attr( $delete_prompt ) ?>", "<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'delete' => $order->id ), $_SERVER['REQUEST_URI'] ) ); ?>"); void(0);'>
+                                    <?php esc_html_e( 'Delete', 'paid-memberships-pro' ); ?>
+                                </a>
 							</span> |
 							<span class="print">
 								<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'order' => $order->id ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When deleting an order, the current filters (order status, search, ...) are lost. This PR, after cleaning up the REQUEST_URI from the 'delete' key, permits the usage of add_query_arg to keep the filters.

A future enhancement would be to handle the request differently, the way the whole wordpress' core does.
After the 'delete' action is handled, we should redirect to 'deleted' => 1.

Reference: https://github.com/WordPress/WordPress/blob/master/wp-admin/edit.php#L457

### How to test the changes in this Pull Request:

1. Create two orders
2. Filter in some way
3. Delete an order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
