### PR TITLE
Use admin_url(...) instead of get_admin_url(null,...)

### DIFF
--- a/adminpages/admin_header.php
+++ b/adminpages/admin_header.php
@@ -193,7 +193,7 @@
 	?>
 	<script>
 		jQuery(document).ready(function() {
-			jQuery.get('<?php echo get_admin_url(NULL, "/admin-ajax.php?action=pmpro_notifications" . $specific_notification ); ?>', function(data) {
+			jQuery.get('<?php echo admin_url( "/admin-ajax.php?action=pmpro_notifications" . $specific_notification ); ?>', function(data) {
 				if(data && data != 'NULL')
 					jQuery('#pmpro_notifications').html(data);
 			});

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -724,7 +724,7 @@
 
 			<p class="submit topborder">
 				<input name="save" type="submit" class="button button-primary" value="Save Code" />
-				<input name="cancel" type="button" class="button" value="Cancel" onclick="location.href='<?php echo get_admin_url(NULL, '/admin.php?page=pmpro-discountcodes')?>';" />
+				<input name="cancel" type="button" class="button" value="Cancel" onclick="location.href='<?php echo admin_url( '/admin.php?page=pmpro-discountcodes')?>';" />
 			</p>
 			</form>
 		</div>
@@ -960,7 +960,7 @@
 		</table>
 
 		<?php
-			$pagination_url = get_admin_url( null, "/admin.php?page=pmpro-discountcodes&s=" . $s );
+			$pagination_url = admin_url( "/admin.php?page=pmpro-discountcodes&s=" . $s );
 			echo pmpro_getPaginationString( $pn, $totalrows, $limit, 1, $pagination_url, "&limit=$limit&pn=" );
 		?>
 

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -672,7 +672,7 @@
 
 		<p class="submit topborder">
 			<input name="save" type="submit" class="button button-primary" value="<?php _e('Save Level', 'paid-memberships-pro' ); ?>" />
-			<input name="cancel" type="button" class="button" value="<?php _e('Cancel', 'paid-memberships-pro' ); ?>" onclick="location.href='<?php echo add_query_arg( 'page', 'pmpro-membershiplevels' , get_admin_url(NULL, '/admin.php') ); ?>';" />
+			<input name="cancel" type="button" class="button" value="<?php _e('Cancel', 'paid-memberships-pro' ); ?>" onclick="location.href='<?php echo add_query_arg( 'page', 'pmpro-membershiplevels' , admin_url( '/admin.php') ); ?>';" />
 		</p>
 	</form>
 	</div>
@@ -790,7 +790,7 @@
 			</p>
 		</form>
 		<h1 class="wp-heading-inline"><?php esc_html_e( 'Membership Levels', 'paid-memberships-pro' ); ?></h1>
-		<a href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => -1 ), get_admin_url(null, 'admin.php' ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Level', 'paid-memberships-pro' ); ?></a>
+		<a href="<?php echo add_query_arg( array( 'page' => 'pmpro-membershiplevels', 'edit' => -1 ), admin_url( 'admin.php' ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Level', 'paid-memberships-pro' ); ?></a>
 		<hr class="wp-header-end">
 
 		<?php if(empty($_REQUEST['s']) && count($reordered_levels) > 1) { ?>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -966,7 +966,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 			"/>
 			<input name="save" type="submit" class="button-primary" value="<?php esc_attr_e( 'Save Order', 'paid-memberships-pro' ); ?>"/>
 			<input name="cancel" type="button" class="cancel button-secondary" value="<?php esc_attr_e( 'Cancel', 'paid-memberships-pro' ); ?>"
-				   onclick="location.href='<?php echo esc_url( get_admin_url( null, '/admin.php?page=pmpro-orders' ) ); ?>';"/>
+				   onclick="location.href='<?php echo esc_url( admin_url( '/admin.php?page=pmpro-orders' ) ); ?>';"/>
 		</p>
 
 	</form>
@@ -976,7 +976,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 	<form id="posts-filter" method="get" action="">
 
 		<h1 class="wp-heading-inline"><?php esc_html_e( 'Orders', 'paid-memberships-pro' ); ?></h1>
-		<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => -1 ), get_admin_url(null, 'admin.php' ) ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Order', 'paid-memberships-pro' ); ?></a>
+		<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => -1 ), admin_url( 'admin.php' ) ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Order', 'paid-memberships-pro' ); ?></a>
 
 		<?php
 		// build the export URL
@@ -1584,7 +1584,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 	</form>
 	<?php
 	// add normal args
-	$pagination_url = esc_url( add_query_arg( $url_params, get_admin_url( null, '/admin.php?page=pmpro-orders' ) ) );
+	$pagination_url = esc_url( add_query_arg( $url_params, admin_url( '/admin.php?page=pmpro-orders' ) ) );
 	echo pmpro_getPaginationString( $pn, $totalrows, $limit, 1, $pagination_url, "&limit=$limit&pn=" );
 	?>
 

--- a/adminpages/reports/login.php
+++ b/adminpages/reports/login.php
@@ -270,7 +270,7 @@ function pmpro_report_login_page()
 	</form>
 
 	<?php
-	echo pmpro_getPaginationString($pn, $totalrows, $limit, 1, get_admin_url(NULL, "/admin.php?page=pmpro-reports&report=login&s=" . urlencode($s)), "&l=$l&limit=$limit&pn=");
+	echo pmpro_getPaginationString($pn, $totalrows, $limit, 1, admin_url( "/admin.php?page=pmpro-reports&report=login&s=" . urlencode($s)), "&l=$l&limit=$limit&pn=");
 	?>
 <?php
 }

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -133,7 +133,7 @@ function pmpro_admin_bar_menu() {
 		array(
 			'id' => 'paid-memberships-pro',
 			'title' => __( '<span class="ab-icon"></span>Memberships', 'paid-memberships-pro' ),
-			'href' => get_admin_url( NULL, '/admin.php?page=' . $top_menu_page )
+			'href' => admin_url( '/admin.php?page=' . $top_menu_page )
 		) 
 	);
 
@@ -144,7 +144,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-dashboard',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Dashboard', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-dashboard' ) 
+				'href' => admin_url( '/admin.php?page=pmpro-dashboard' ) 
 			)
 		);
 	}
@@ -156,7 +156,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-members-list',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Members', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-memberslist' )
+				'href' => admin_url( '/admin.php?page=pmpro-memberslist' )
 			)
 		);
 	}
@@ -168,7 +168,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-orders',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Orders', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-orders' )
+				'href' => admin_url( '/admin.php?page=pmpro-orders' )
 			)
 		);
 	}
@@ -180,7 +180,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-reports',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Reports', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-reports' )
+				'href' => admin_url( '/admin.php?page=pmpro-reports' )
 			)
 		);
 	}
@@ -192,7 +192,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-membership-levels',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Settings', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-membershiplevels' )
+				'href' => admin_url( '/admin.php?page=pmpro-membershiplevels' )
 			)
 		);
 	}
@@ -204,7 +204,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-addons',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( 'Add Ons', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-addons' )
+				'href' => admin_url( '/admin.php?page=pmpro-addons' )
 			)
 		);
 	}
@@ -223,7 +223,7 @@ function pmpro_admin_bar_menu() {
 				'id' => 'pmpro-license',
 				'parent' => 'paid-memberships-pro',
 				'title' => __( '<span style="color: ' . $span_color . '; line-height: 26px;">License</span>', 'paid-memberships-pro' ),
-				'href' => get_admin_url( NULL, '/admin.php?page=pmpro-license' )
+				'href' => admin_url( '/admin.php?page=pmpro-license' )
 			)
 		);
 	}
@@ -399,7 +399,7 @@ function pmpro_add_action_links( $links ) {
 	}
 
 	$new_links = array(
-		'<a href="' . get_admin_url( NULL, 'admin.php?page=' . $top_menu_page ) . '">Settings</a>',
+		'<a href="' . admin_url( 'admin.php?page=' . $top_menu_page ) . '">Settings</a>',
 	);
 	return array_merge( $new_links, $links );
 }

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -803,7 +803,7 @@ if ( empty( $submit ) ) {
 	//show message if the payment gateway is not setup yet
 	if ( $pmpro_requirebilling && ! pmpro_getOption( "gateway", true ) ) {
 		if ( pmpro_isAdmin() ) {
-			$pmpro_msg = sprintf( __( 'You must <a href="%s">set up a Payment Gateway</a> before any payments will be processed.', 'paid-memberships-pro' ), get_admin_url( null, '/admin.php?page=pmpro-paymentsettings' ) );
+			$pmpro_msg = sprintf( __( 'You must <a href="%s">set up a Payment Gateway</a> before any payments will be processed.', 'paid-memberships-pro' ), admin_url( '/admin.php?page=pmpro-paymentsettings' ) );
 		} else {
 			$pmpro_msg = __( "A Payment Gateway must be set up before any payments will be processed.", 'paid-memberships-pro' );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use `admin_url(...)`, which is the `get_admin_url(null,...)` shortcut.

