### PR TITLE
Keep filters on admin item delete (orders, discounts)

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -363,6 +363,9 @@
 	}
 
 	require_once(dirname(__FILE__) . "/admin_header.php");
+
+    // Clean-up request uri from in-page actions
+    $_SERVER['REQUEST_URI'] = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQUEST_URI'] );
 ?>
 
 	<?php if($edit) { ?>
@@ -821,7 +824,7 @@
 												'page'   => 'pmpro-discountcodes',
 												'delete' => $code->id,
 											],
-											admin_url( 'admin.php' )
+											$_SERVER['REQUEST_URI']
 										),
 										'delete',
 										'pmpro_discountcodes_nonce'

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -365,7 +365,7 @@
 	require_once(dirname(__FILE__) . "/admin_header.php");
 
     // Clean-up request uri from in-page actions
-    $_SERVER['REQUEST_URI'] = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQUEST_URI'] );
+    $current_page_url = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQUEST_URI'] );
 ?>
 
 	<?php if($edit) { ?>
@@ -824,7 +824,7 @@
 												'page'   => 'pmpro-discountcodes',
 												'delete' => $code->id,
 											],
-											$_SERVER['REQUEST_URI']
+											$current_page_url
 										),
 										'delete',
 										'pmpro_discountcodes_nonce'

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -381,6 +381,8 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 	pmpro_add_email_order_modal();
 }
 
+// Clean-up request uri from in-page actions
+$_SERVER['REQUEST_URI'] = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQUEST_URI'] );
 ?>
 
 <?php if ( ! empty( $order ) ) { ?>
@@ -1384,7 +1386,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 										'action' => 'delete_order',
 										'delete' => $order->id,
 									],
-									admin_url( 'admin.php' )
+									$_SERVER['REQUEST_URI']
 								),
 								'delete_order',
 								'pmpro_orders_nonce'

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -382,7 +382,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 }
 
 // Clean-up request uri from in-page actions
-$_SERVER['REQUEST_URI'] = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQUEST_URI'] );
+$current_page_url = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQUEST_URI'] );
 ?>
 
 <?php if ( ! empty( $order ) ) { ?>
@@ -1386,7 +1386,7 @@ $_SERVER['REQUEST_URI'] = remove_query_arg( [ 'copy', 'delete' ], $_SERVER['REQU
 										'action' => 'delete_order',
 										'delete' => $order->id,
 									],
-									$_SERVER['REQUEST_URI']
+									$current_page_url
 								),
 								'delete_order',
 								'pmpro_orders_nonce'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When deleting an order, the current filters (order status, search, ...) are lost. This PR, after cleaning up the REQUEST_URI from the 'delete' key, permits the usage of add_query_arg to keep the filters.

A future enhancement would be to handle the request differently, the way the whole wordpress' core does.
After the 'delete' action is handled, we should redirect to 'deleted' => 1.

Reference: https://github.com/WordPress/WordPress/blob/master/wp-admin/edit.php#L457

### How to test the changes in this Pull Request:

1. Create two orders
2. Filter in some way
3. Delete an order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
