### PR TITLE
Admin page: orders.php > Remove trailing space

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1545,8 +1545,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 						}
 						?>
 						<br/>
-						<?php esc_html_e( 'Subscription', 'paid-memberships-pro' ); ?>
-						:
+						<?php esc_html_e( 'Subscription', 'paid-memberships-pro' ); ?>:
 						<?php
 						if ( ! empty( $order->subscription_transaction_id ) ) {
 							echo esc_html( $order->subscription_transaction_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avoid the highlighted trailing space:

<img width="233" alt="Screenshot 2021-09-01 at 09 30 53" src="https://user-images.githubusercontent.com/636911/131630708-9df3768c-dc2c-46e7-87e2-aaf8c4ef9c85.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
