### PR TITLE
ENHANCEMENT: Only update user meta that is passed through.

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -730,6 +730,35 @@ if ( ! empty( $pmpro_confirmed ) ) {
 				$ExpirationMonth,
 				$ExpirationYear
 			);
+			
+			// Check if billing details are available, if not adjust the arrays.
+			if ( empty( $baddress1 ) ) {
+				$meta_keys = array(
+					"pmpro_bfirstname",
+					"pmpro_blastname",
+					"pmpro_CardType",
+					"pmpro_AccountNumber",
+					"pmpro_ExpirationMonth",
+					"pmpro_ExpirationYear"
+				);
+
+				$meta_values = array(
+					$bfirstname,
+					$blastname,
+					$CardType,
+					hideCardNumber( $AccountNumber ),
+					$ExpirationMonth,
+					$ExpirationYear
+				);
+
+				// Check if firstname and last name fields are also empty. If they are empty, remove them from the array.
+				if ( empty( $bfirstname ) && empty( $blastname ) ) {
+					unset( $meta_keys[0] );
+					unset( $meta_keys[1] );
+					unset( $meta_values[0] );
+					unset( $meta_values[1] ); 
+				}
+			}
 			pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values );
 
 			//save first and last name fields

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -699,66 +699,56 @@ if ( ! empty( $pmpro_confirmed ) ) {
 
 			//save billing info ect, as user meta
 			$meta_keys   = array(
-				"pmpro_bfirstname",
-				"pmpro_blastname",
-				"pmpro_baddress1",
-				"pmpro_baddress2",
-				"pmpro_bcity",
-				"pmpro_bstate",
-				"pmpro_bzipcode",
-				"pmpro_bcountry",
-				"pmpro_bphone",
-				"pmpro_bemail",
 				"pmpro_CardType",
 				"pmpro_AccountNumber",
 				"pmpro_ExpirationMonth",
-				"pmpro_ExpirationYear"
+				"pmpro_ExpirationYear",
 			);
 			$meta_values = array(
-				$bfirstname,
-				$blastname,
-				$baddress1,
-				$baddress2,
-				$bcity,
-				$bstate,
-				$bzipcode,
-				$bcountry,
-				$bphone,
-				$bemail,
 				$CardType,
 				hideCardNumber( $AccountNumber ),
 				$ExpirationMonth,
-				$ExpirationYear
+				$ExpirationYear,
 			);
-			
-			// Check if billing details are available, if not adjust the arrays.
-			if ( empty( $baddress1 ) ) {
-				$meta_keys = array(
+
+			// Check if firstname and last name fields are set.
+			if ( ! empty( $bfirstname ) || ! empty( $blastname ) ) {
+				$meta_keys = array_merge( $meta_keys, array(
 					"pmpro_bfirstname",
 					"pmpro_blastname",
-					"pmpro_CardType",
-					"pmpro_AccountNumber",
-					"pmpro_ExpirationMonth",
-					"pmpro_ExpirationYear"
-				);
+				) );
 
-				$meta_values = array(
+				$meta_values = array_merge( $meta_values, array(
 					$bfirstname,
 					$blastname,
-					$CardType,
-					hideCardNumber( $AccountNumber ),
-					$ExpirationMonth,
-					$ExpirationYear
-				);
-
-				// Check if firstname and last name fields are also empty. If they are empty, remove them from the array.
-				if ( empty( $bfirstname ) && empty( $blastname ) ) {
-					unset( $meta_keys[0] );
-					unset( $meta_keys[1] );
-					unset( $meta_values[0] );
-					unset( $meta_values[1] ); 
-				}
+				) );
 			}
+
+			// Check if billing details are available, if not adjust the arrays.
+			if ( ! empty( $baddress1 ) ) {
+				$meta_keys = array_merge( $meta_keys, array(
+					"pmpro_baddress1",
+					"pmpro_baddress2",
+					"pmpro_bcity",
+					"pmpro_bstate",
+					"pmpro_bzipcode",
+					"pmpro_bcountry",
+					"pmpro_bphone",
+					"pmpro_bemail",
+				) );
+
+				$meta_values = array_merge( $meta_values, array(
+					$baddress1,
+					$baddress2,
+					$bcity,
+					$bstate,
+					$bzipcode,
+					$bcountry,
+					$bphone,
+					$bemail,
+				) );
+			}
+
 			pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values );
 
 			//save first and last name fields


### PR DESCRIPTION
ENHANCEMENT: Pass through billing data to pmpro_replaceUserMeta function that was captured during checkout. This prevents the checkout from trying to process non-existing data.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

This also fixes an issue where Paid Memberships Pro - WooCommerce Integration tries to sync data between WooCommerce and Paid Memberships Pro (Register Helper).