### PR TITLE
Made username the first column in the members list

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -72,9 +72,8 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function get_columns() {
 		$columns = array(
-			// 'cb'            => '<input type="checkbox" />',
-			'ID'				=> 'ID',
 			'username'			=> 'Username',
+			'ID'				=> 'ID',
 			'first_name'		=> 'First Name',
 			'last_name'			=> 'Last Name',
 			'display_name'		=> 'Display Name',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Make the Username the first column in the members list. This ensures that the Members List view on mobile will still populate even if the ID column is being hidden.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1751

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
