### PR TITLE
Better style Order History & Membership Levels History when empty

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -481,9 +481,15 @@ function pmpro_membership_history_profile_fields( $user ) {
 			?>
 			</tbody>
 			</table>
-			<?php } else { 
-				esc_html_e( 'No membership orders found.', 'paid-memberships-pro' );
-			} ?>
+			<?php } else { ?>
+                <table class="wp-list-table widefat striped fixed" width="100%" cellpadding="0" cellspacing="0" border="0">
+                    <tbody>
+                        <tr>
+                            <td><?php esc_html_e( 'No membership orders found.', 'paid-memberships-pro' ); ?></td>
+                        </tr>
+                    </tbody>
+                </table>
+			<?php } ?>
 		</div>
 		<div id="member-history-memberships" class="widgets-holder-wrap" style="display: none;">
 		<?php if ( $levelshistory ) { ?>
@@ -533,9 +539,15 @@ function pmpro_membership_history_profile_fields( $user ) {
 			?>
 			</tbody>
 			</table>
-			<?php } else { 
-				esc_html_e( 'No membership history found.', 'paid-memberships-pro');
-			} ?>
+			<?php } else { ?>
+                <table class="wp-list-table widefat striped fixed" width="100%" cellpadding="0" cellspacing="0" border="0">
+                    <tbody>
+                        <tr>
+                            <td><?php esc_html_e( 'No membership history found.', 'paid-memberships-pro'); ?></td>
+                        </tr>
+                    </tbody>
+                </table>
+			<?php } ?>
 		</div>
 		<script>
 			//tabs


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

From:
![Screenshot 2021-09-13 at 10 55 36](https://user-images.githubusercontent.com/636911/133055741-3e736d6b-c596-419e-936b-923eb5464383.png)

To:
![Screenshot 2021-09-13 at 10 55 15](https://user-images.githubusercontent.com/636911/133055730-548bfe84-3e70-4f27-ab70-e991bdce237d.png)

For _Order History_ and _Membership Level History_ too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ...: Better style Order History & Membership Levels History when empty