### PR TITLE
Separate logics for initial payment failed and subscription cancel

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -261,42 +261,29 @@ if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_
 				(2) The user doesn't currently have the level attached to this order.
 			*/
 
-			if ( $last_subscription_order->status == "cancelled" ) {
-				ipnlog( "We've already processed this cancellation. Probably originated from WP/PMPro. (Order #" . $last_subscription_order->id . ", Subscription Transaction ID #" . $recurring_payment_id . ")" );
-				
-				// Still check if there was an error.
-				if ( $initial_payment_status === "Failed" ) {
-					$cancelled = pmpro_cancelMembershipLevel( $last_subscription_order->membership_id, $last_subscription_order->user_id, 'error' );
-					
-					// If we couldn't cancel, still set the order status to error.
-					if ( $cancelled === null ) {
-						$last_subscription_order->updateStatus('error');
-					}
-				}
-			} elseif ( ! pmpro_hasMembershipLevel( $last_subscription_order->membership_id, $user->ID ) ) {
-				ipnlog( "This user has a different level than the one associated with this order. Their membership was probably changed by an admin or through an upgrade/downgrade. (Order #" . $last_subscription_order->id . ", Subscription Transaction ID #" . $recurring_payment_id . ")" );
+			// Check if there was an error
+			if ( $initial_payment_status === "Failed" ) {
+				// The user membership should already be in status error
+				$cancelled = pmpro_cancelMembershipLevel( $last_subscription_order->membership_id, $last_subscription_order->user_id, 'error' );
+
+				// The order should already be in status error
+				$last_subscription_order->updateStatus('error');
 			} else {
-				//if the initial payment failed, cancel with status error instead of cancelled
-				if ( $initial_payment_status === "Failed" ) {
-					$cancelled = pmpro_cancelMembershipLevel( $last_subscription_order->membership_id, $last_subscription_order->user_id, 'error' );
-					
-					// If we couldn't cancel, still set the order status to error.
-					if ( $cancelled === null ) {
-						$last_subscription_order->updateStatus('error');
-					}
+				if ( $last_subscription_order->status == "cancelled" ) {
+					ipnlog( "We've already processed this cancellation. Probably originated from WP/PMPro. (Order #" . $last_subscription_order->id . ", Subscription Transaction ID #" . $recurring_payment_id . ")" );
+				} elseif ( ! pmpro_hasMembershipLevel( $last_subscription_order->membership_id, $user->ID ) ) {
+					ipnlog( "This user has a different level than the one associated with this order. Their membership was probably changed by an admin or through an upgrade/downgrade. (Order #" . $last_subscription_order->id . ", Subscription Transaction ID #" . $recurring_payment_id . ")" );
 				} else {
-					pmpro_cancelMembershipLevel( $last_subscription_order->membership_id, $last_subscription_order->user_id, 'cancelled' );
+					ipnlog( "Cancelled membership for user with id = " . $last_subscription_order->user_id . ". Subscription transaction id = " . $recurring_payment_id . "." );
+
+					//send an email to the member
+					$myemail = new PMProEmail();
+					$myemail->sendCancelEmail( $user, $last_subscription_order->membership_id );
+
+					//send an email to the admin
+					$myemail = new PMProEmail();
+					$myemail->sendCancelAdminEmail( $user, $last_subscription_order->membership_id );
 				}
-
-				ipnlog( "Cancelled membership for user with id = " . $last_subscription_order->user_id . ". Subscription transaction id = " . $recurring_payment_id . "." );
-
-				//send an email to the member
-				$myemail = new PMProEmail();
-				$myemail->sendCancelEmail( $user, $last_subscription_order->membership_id );
-
-				//send an email to the admin
-				$myemail = new PMProEmail();
-				$myemail->sendCancelAdminEmail( $user, $last_subscription_order->membership_id );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Even if PayPal Express uses the same txn_type for subscription cancel and initial payment failure (with initial payment status = Failed) we should handle these two situations differently.

This is also avoiding some duplicates code, and resolves #1778.

### How to test the changes in this Pull Request:

1. 
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
