### PR TITLE
Change status to receive new membership information

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -741,7 +741,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				LEFT JOIN `{$wpdb->pmpro_membership_levels}` AS `ml`
 					ON `ml`.`id` = `mu`.`membership_id`
 				WHERE
-					`mu`.`status` = 'active' 
+					`mu`.`status` IN ( 'active', 'cancelled', 'expired', 'admin_cancelled' ) 
 				ORDER BY
 					`mu`.`modified` DESC
 				LIMIT %d

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -722,17 +722,10 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
 			$level_status = sanitize_text_field( $params['level_status'] );
 
-			if ( empty( $level_status ) ) {
-				/**
-				 * Allow filtering via PHP for default statuses for cases where the level_status parameter isn't passed through.
-				 * 
-				 * @param array An array of valid membership statuses to filter results on.
-				 * 
-				 * @since TBD
-				 */
-				$level_status = apply_filters( 'pmpro_rest_recent_member_default_level_status', array( 'active', 'cancelled', 'expired', 'admin_cancelled' ) );
+			if ( empty( $params['level_status'] ) ) {
+				$level_status = array( 'active' );
 			} else {
-				$level_status = sanitize_text_field( trim( $level_status ) );
+				$level_status = sanitize_text_field( trim( $params['level_status'] ) );
 				$level_status = explode( ',', $level_status ); // Force it into an array so we can implode it in the query itself.
 			}
 


### PR DESCRIPTION
ENHANCEMENT: Add more membership statuses to trigger on when polling for membership information. This is useful for Zapier Application to trigger on more than just active accounts. This will help with cancelled and expired level changes too.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?