### PR TITLE
BUG FIX: Fixed warning undefined constant.

### DIFF
--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -285,7 +285,7 @@ function pmpro_cron_admin_activity_email() {
 	if (
 		'day' === $frequency ||
 		( 'week' === $frequency && 'Mon' === date( 'D' ) ) ||
-		( 'month' === $frequency && 'Mon' === date( 'D' ) && 7 >= date( j ) )
+		( 'month' === $frequency && 'Mon' === date( 'D' ) && 7 >= date( 'j' ) )
 	) {
 		$pmproemail = new PMPro_Admin_Activity_Email();
 		$pmproemail->sendAdminActivity();


### PR DESCRIPTION
BUG FIX: Fixed warning of undefined constant for the admin activity email.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

See support ticket here - https://wordpress.org/support/topic/php-error-log-warning-use-of-undefined-constant-j/