### PR TITLE
BUG FIX: Remove hardcoded $ from email variable

### DIFF
--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -182,7 +182,7 @@ $pmpro_email_templates_defaults = array(
 
 <p>
 	Invoice #!!invoice_id!! on !!invoice_date!!<br />
-	Total Billed: $!!invoice_total!!
+	Total Billed: !!invoice_total!!
 </p>
 
 <p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ),


### PR DESCRIPTION
BUG FIX: Remove hardcoded dollar sign from default email template for checkout_check_admin.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
