### PR TITLE
Prevent echoing dash early on account page expiration field

### DIFF
--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -142,7 +142,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 												$expiration_text .= ' ' . date_i18n( get_option( 'time_format', __( 'g:i a' ) ), $level->enddate );
 											}
 										} else {
-											$expiration_text .= '&#8212;';
+											$expiration_text .= esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
 										}
 										$expiration_text .= '</p>';
 										echo apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level );

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -142,7 +142,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 												$expiration_text .= ' ' . date_i18n( get_option( 'time_format', __( 'g:i a' ) ), $level->enddate );
 											}
 										} else {
-											$expiration_text .= esc_html_e( '&#8212;', 'paid-memberships-pro' );
+											$expiration_text .= '&#8212;';
 										}
 										$expiration_text .= '</p>';
 										echo apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issue where custom code that filter on `pmpro_account_membership_expiration_text` may have an undesired dash before the intended content. For example, this tooltip will show a dash before the user's renewal date: https://www.paidmembershipspro.com/display-a-membership-renewal-date-to-your-recurring-members/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
