### PR TITLE
Adding deprecation notice to public static webhook methods in Stripe …

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -831,9 +831,9 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function get_webhooks( $limit = 10 ) {
-		if ( method_being_called_from_outside_class() ) {
-			_deprecated_function( __FUNCTION__, 'TBD' );
-		}
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
+
 		if ( ! class_exists( 'Stripe\WebhookEndpoint' ) ) {
 			// Load Stripe library.
 			new PMProGateway_stripe();
@@ -884,9 +884,9 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function create_webhook() {
-		if ( method_being_called_from_outside_class() ) {
-			_deprecated_function( __FUNCTION__, 'TBD' );
-		}
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
+
 		try {
 			$create = Stripe_Webhook::create([
 				'url' => self::get_site_webhook_url(),
@@ -914,9 +914,8 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function does_webhook_exist( $force = false ) {
-		if ( method_being_called_from_outside_class() ) {
-			_deprecated_function( __FUNCTION__, 'TBD' );
-		}
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
 
 		static $cached_webhook = null;
 		if ( ! empty( $cached_webhook ) && ! $force ) {
@@ -963,9 +962,8 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function check_missing_webhook_events( $webhook_events ) {
-		if ( method_being_called_from_outside_class() ) {
-			_deprecated_function( __FUNCTION__, 'TBD' );
-		}
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
 
 		// Get required events
 		$pmpro_webhook_events = self::webhook_events();
@@ -993,9 +991,8 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function update_webhook_events() {
-		if ( method_being_called_from_outside_class() ) {
-			_deprecated_function( __FUNCTION__, 'TBD' );
-		}
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
 
 		// Also checks database to see if it's been saved.
 		$webhook = self::does_webhook_exist();
@@ -1042,9 +1039,8 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function delete_webhook( $webhook_id, $secretkey = false ) {
-		if ( method_being_called_from_outside_class() ) {
-			_deprecated_function( __FUNCTION__, 'TBD' );
-		}
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
 
 		if ( empty( $secretkey ) ) {
 			$secretkey = self::get_secretkey();
@@ -3421,21 +3417,5 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		return intval( $price * $currency_unit_multiplier );
-	}
-	/**
-	 * Determine whether the calling method was called from
-	 * inside or outside of the Stripe Gateway class.
-	 *
-	 * Useful for preparing to change method visibility from
-	 * public to private.
-	 *
-	 * @return bool
-	 */
-	static private function method_being_called_from_outside_class() {
-		$backtrace = debug_backtrace();
-
-		// $backtrace[0] is the call to this method.
-		// $backtrace[1] is the call to the public method that called this one.
-		return false === strpos( $backtrace[1]['file'], 'class.pmprogateway_stripe.php' );
 	}
 }

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -828,8 +828,12 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get available webhooks
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
-	static function get_webhooks( $limit = 10 ) {		
+	static function get_webhooks( $limit = 10 ) {
+		if ( method_being_called_from_outside_class() ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
 		if ( ! class_exists( 'Stripe\WebhookEndpoint' ) ) {
 			// Load Stripe library.
 			new PMProGateway_stripe();
@@ -877,8 +881,12 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Create webhook with relevant events
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function create_webhook() {
+		if ( method_being_called_from_outside_class() ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
 		try {
 			$create = Stripe_Webhook::create([
 				'url' => self::get_site_webhook_url(),
@@ -903,8 +911,13 @@ class PMProGateway_stripe extends PMProGateway {
 	 * See if a webhook is registered with Stripe.
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function does_webhook_exist( $force = false ) {
+		if ( method_being_called_from_outside_class() ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
+
 		static $cached_webhook = null;
 		if ( ! empty( $cached_webhook ) && ! $force ) {
 			return $cached_webhook;
@@ -947,8 +960,12 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get a list of events that are missing between the created existing webhook and required webhook events for Paid Memberships Pro.
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function check_missing_webhook_events( $webhook_events ) {
+		if ( method_being_called_from_outside_class() ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
 
 		// Get required events
 		$pmpro_webhook_events = self::webhook_events();
@@ -973,8 +990,12 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Update required webhook enabled events.
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function update_webhook_events() {
+		if ( method_being_called_from_outside_class() ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
 
 		// Also checks database to see if it's been saved.
 		$webhook = self::does_webhook_exist();
@@ -1018,8 +1039,13 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Delete an existing webhook.
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
 	 */
 	static function delete_webhook( $webhook_id, $secretkey = false ) {
+		if ( method_being_called_from_outside_class() ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
+
 		if ( empty( $secretkey ) ) {
 			$secretkey = self::get_secretkey();
 		}
@@ -3395,5 +3421,21 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		return intval( $price * $currency_unit_multiplier );
+	}
+	/**
+	 * Determine whether the calling method was called from
+	 * inside or outside of the Stripe Gateway class.
+	 *
+	 * Useful for preparing to change method visibility from
+	 * public to private.
+	 *
+	 * @return bool
+	 */
+	static private function method_being_called_from_outside_class() {
+		$backtrace = debug_backtrace();
+
+		// $backtrace[0] is the call to this method.
+		// $backtrace[1] is the call to the public method that called this one.
+		return false === strpos( $backtrace[1]['file'], 'class.pmprogateway_stripe.php' );
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3782,3 +3782,23 @@ function pmpro_kses_allowed_html( $allowed_html, $context ) {
 	return $allowed_html;
 }
 add_filter( 'wp_kses_allowed_html', 'pmpro_kses_allowed_html', 10, 2 );
+
+/**
+ * Show deprecation warning if calling function was called publically.
+ *
+ * Useful for preparing to change method visibility from public to private.
+ *
+ * @param string $deprecation_notice_version to show.
+ * @return bool
+ */
+function pmpro_method_should_be_private( $deprecated_notice_version ) {
+	$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+
+	// Check whether the caller of this function is in the same file (class)
+	// as the caller of the previous function.
+	if ( $backtrace[0]['file'] !== $backtrace[1]['file'] ) {
+		_deprecated_function( $backtrace[1]['function'], $deprecated_notice_version );
+		return true;
+	}
+	return false;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Create a new method method_being_called_from_outside_class() in Stripe class, and use it to deprecate some public static methods that should be made private non-static.