### PR TITLE
Making sure to set these properties up on the order object to avoid w…

### DIFF
--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -144,6 +144,9 @@
 			//prep this order for the failure emails
 			$morder = new MemberOrder();
 			$morder->user_id = $user_id;
+			$morder->membership_id = $old_order->membership_id;
+			
+			$morder->billing = new stdClass();
 			$morder->billing->name = $fields['x_first_name'] . " " . $fields['x_last_name'];
 			$morder->billing->street = $fields['x_address'];
 			$morder->billing->city = $fields['x_city'];

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -254,6 +254,7 @@ if ( $webhookNotification->kind === Braintree_WebhookNotification::SUBSCRIPTION_
 	$morder->user_id = $user_id;
 	$morder->membership_id = $old_order->membership_id;
 	
+	$morder->billing = new stdClass();
 	$morder->billing->name = isset( $transaction->billing_details->first_name ) && isset( $transaction->billing_details->last_name ) ?
 		trim( $transaction->billing_details->first_name . " " . $transaction->billing_details->first_name ) :
 		$old_order->billing->name;

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -662,6 +662,7 @@ function pmpro_ipnFailedPayment( $last_order ) {
 	//create a blank order for the email
 	$morder          = new MemberOrder();
 	$morder->user_id = $last_order->user_id;
+	$morder->membership_id = $last_order->membership_id;
 
 	$user                   = new WP_User( $last_order->user_id );
 	$user->membership_level = pmpro_getMembershipLevelForUser( $user->ID );
@@ -669,6 +670,7 @@ function pmpro_ipnFailedPayment( $last_order ) {
 	//add billing information if appropriate
 	if ( $last_order->gateway == "paypal" )        //website payments pro
 	{
+		$morder->billing = new stdClass();
 		$morder->billing->name    = $_POST['address_name'];
 		$morder->billing->street  = $_POST['address_street'];
 		$morder->billing->city    = $_POST['address_city '];

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -299,9 +299,9 @@
 				//prep this order for the failure emails
 				$morder = new MemberOrder();
 				$morder->user_id = $user_id;
+				$morder->membership_id = $old_order->membership_id;
 				
 				$morder->billing = new stdClass();
-				
 				$morder->billing->name = $old_order->billing->name;
 				$morder->billing->street = $old_order->billing->street;
 				$morder->billing->city = $old_order->billing->city;


### PR DESCRIPTION
…arnings in the billing failed email and so all values are swapped into the email correctly.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

The billing failed emails sometimes were missing data or throwing PHP warnings because some expected values weren't present on the $invoice parameter passed in.

This update the gateway webhooks makes sure to set those values on the $order passed into the email class.

Note that we are not fixing the 2Checkout gateway, which has been deprecated.
--
 

<br class="Apple-interchange-newline">

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->



### How to test the changes in this Pull Request:

This is tough but:

1. Trigger a failed payment through a gateway.
2. Check the received emails.
3. Check for warnings in the error log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX: Fixed issues where membership data wasn't showing up in billing failed emails. Also avoiding warnings in those methods now.