### PR TITLE
Paypal Express fix cURL error 61 (encoding error...) and provides idempotency

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -7,6 +7,16 @@
 
 	class PMProGateway_paypalexpress extends PMProGateway
 	{
+		/** @var int Maximum number of request retries */
+		protected static $maxNetworkRetries = 5;
+
+		/** @var float Maximum delay between retries, in seconds */
+		protected static $maxNetworkRetryDelay = 2.0;
+
+		/** @var float Initial delay between retries, in seconds */
+		protected static $initialNetworkRetryDelay = 0.5;
+
+
 		function __construct($gateway = NULL)
 		{
 			$this->gateway = $gateway;
@@ -1011,13 +1021,50 @@
 
 		/**
 		 * PAYPAL Function
-		 * Send HTTP POST Request
+		 * Send HTTP POST Request with retries
+		 *
+		 * @param string    The API method name
+		 * @param string    The POST Message fields in &name=value pair format
+		 *
+		 * @return array    Parsed HTTP Response body
+		 */
+		function PPHttpPost( $methodName_, $nvpStr_ ) {
+			// Create a UUID for this request, to enable idempotency which is supported
+			// by PayPal Express even if it's legacy (thus it's not reported in the docs)
+			// https://developer.paypal.com/docs/business/develop/idempotency/
+			$uuid = self::RandomGenerator_uuid();
+
+			$numRetries = 0;
+			do {
+				$httpParsedResponseAr = $this->PPHttpPost_DontDieOnError( $methodName_, $nvpStr_, $uuid );
+				if ( is_wp_error( $httpParsedResponseAr ) ) {
+					$numRetries++;
+					sleep( self::sleepTime( $numRetries ) );
+				} else {
+					break;
+				}
+			} while ( $numRetries <= self::$maxNetworkRetries );
+
+			// If we still have an error even with the retries, there's not much we can do.
+			if ( is_wp_error( $httpParsedResponseAr ) ) {
+				// exiting is never a good user experience and it's hard to debug, but we can
+				// at least leave a trace in error log to make it easier to see this happening
+				error_log( "Unable to complete $methodName_ request with $nvpStr_: " . $httpParsedResponseAr->get_error_message() );
+				die( "Unable to complete $methodName_ request with $nvpStr_: " . $httpParsedResponseAr->get_error_message() );
+			}
+
+			return $httpParsedResponseAr;
+		}
+        
+        /**
+		 * PAYPAL Function
+		 * Send HTTP POST Request with uuid
 		 *
 		 * @param	string	The API method name
 		 * @param	string	The POST Message fields in &name=value pair format
-		 * @return	array	Parsed HTTP Response body
+		 * @return	array|\WP_Error	Parsed HTTP Response body
 		 */
-		function PPHttpPost($methodName_, $nvpStr_) {
+		function PPHttpPost_DontDieOnError($methodName_, $nvpStr_, $uuid) {
 			global $gateway_environment;
 			$environment = $gateway_environment;
 
@@ -1042,24 +1089,77 @@
 					'body' => $nvpreq,
 					'headers'     => array(
 						'content-type'      => 'application/json',
+						'PayPal-Request-Id' => $uuid,
 					),
 			    )
 			);
 
 			if ( is_wp_error( $response ) ) {
-			   $error_message = $response->get_error_message();
-			   die( "methodName_ failed: $error_message" );
-			} else {
-				//extract the response details
-				$httpParsedResponseAr = array();
-				parse_str(wp_remote_retrieve_body($response), $httpParsedResponseAr);
-
-				//check for valid response
-				if((0 == sizeof($httpParsedResponseAr)) || !array_key_exists('ACK', $httpParsedResponseAr)) {
-					exit("Invalid HTTP Response for POST request($nvpreq) to $API_Endpoint.");
-				}
+                return $response;
 			}
+            
+            //extract the response details
+            $httpParsedResponseAr = array();
+            parse_str(wp_remote_retrieve_body($response), $httpParsedResponseAr);
+
+            //check for valid response
+            if((0 == sizeof($httpParsedResponseAr)) || !array_key_exists('ACK', $httpParsedResponseAr)) {
+	            return new WP_Error( 1, "Invalid HTTP Response for POST request($nvpreq) to $API_Endpoint." );
+            }
 
 			return $httpParsedResponseAr;
+		}
+
+		/**
+		 * Provides the number of seconds to wait before retrying a request.
+		 * Inspired by Stripe\HttpClient\CurlClient::sleepTime
+		 *
+		 * @param int $numRetries
+		 *
+		 * @return int
+		 */
+		public static function sleepTime( $numRetries ) {
+			// Apply exponential backoff with $initialNetworkRetryDelay on the
+			// number of $numRetries so far as inputs. Do not allow the number to exceed
+			// $maxNetworkRetryDelay.
+			$sleepSeconds = \min(
+				self::$maxNetworkRetryDelay * 1.0 * 2 ** ( $numRetries - 1 ),
+				self::$maxNetworkRetryDelay
+			);
+
+			// Apply some jitter by randomizing the value in the range of
+			// ($sleepSeconds / 2) to ($sleepSeconds).
+			$sleepSeconds *= 0.5 * ( 1 + self::randFloat() );
+
+			// But never sleep less than the base sleep seconds.
+			$sleepSeconds = \max( self::$initialNetworkRetryDelay, $sleepSeconds );
+
+			return $sleepSeconds;
+		}
+
+		/**
+		 * Returns a random value between 0 and $max.
+		 * From Stripe\Util\RandomGenerator::randFloat()
+		 *
+		 * @param float $max (optional)
+		 *
+		 * @return float
+		 */
+		public static function randFloat( $max = 1.0 ) {
+			return \mt_rand() / \mt_getrandmax() * $max;
+		}
+
+		/**
+		 * Returns a v4 UUID.
+		 * From Stripe\Util\RandomGenerator::uuid()
+		 *
+		 * @return string
+		 */
+		public static function RandomGenerator_uuid() {
+			$arr    = \array_values( \unpack( 'N1a/n4b/N1c', \openssl_random_pseudo_bytes( 16 ) ) );
+			$arr[2] = ( $arr[2] & 0x0fff ) | 0x4000;
+			$arr[3] = ( $arr[3] & 0x3fff ) | 0x8000;
+
+			return \vsprintf( '%08x-%04x-%04x-%04x-%04x%08x', $arr );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1810.

It still die if everything goes wrong (network issues, paypal endpoint down, whatever...) but at least it's logging something to debug.log. And, of course, this fixes cUrl error 61 and provides some legacy idempotency.

### How to test the changes in this Pull Request:

1. Find an architecture in which you are able to face cURL error 61 and replicate the issue (ask @mircobabini)
2. Retry with this patch in place

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
