### PR TITLE
First pass for marking Stripe methods as deprecated

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -71,8 +71,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return bool
 	 * @since 1.8.6.8.1
 	 * @since 1.8.13.6 - Add json dependency
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	public static function dependencies() {
+		pmpro_method_should_be_private( 'TBD' );
+
 		global $msg, $msgt, $pmpro_stripe_error;
 
 		if ( version_compare( PHP_VERSION, '5.3.29', '<' ) ) {
@@ -116,7 +119,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @since 1.8
 	 * Moved into a method in version 1.8 so we only load it when needed.
 	 */
-	function loadStripeLibrary() {
+	public static function loadStripeLibrary() {
 		//load Stripe library if it hasn't been loaded already (usually by another plugin using Stripe)
 		if ( ! class_exists( "Stripe\Stripe" ) ) {
 			require_once( PMPRO_DIR . "/includes/lib/Stripe/init.php" );
@@ -128,7 +131,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function init() {
+	public static function init() {
 		//make sure Stripe is a gateway option
 		add_filter( 'pmpro_gateways', array( 'PMProGateway_stripe', 'pmpro_gateways' ) );
 
@@ -252,7 +255,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_gateways( $gateways ) {
+	public static function pmpro_gateways( $gateways ) {
 		if ( empty( $gateways['stripe'] ) ) {
 			$gateways['stripe'] = __( 'Stripe', 'paid-memberships-pro' );
 		}
@@ -265,7 +268,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function getGatewayOptions() {
+	public static function getGatewayOptions() {
 		$options = array(
 			'sslseal',
 			'nuclear_HTTPS',
@@ -296,7 +299,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_payment_options( $options ) {
+	public static function pmpro_payment_options( $options ) {
 		//get stripe options
 		$stripe_options = self::getGatewayOptions();
 
@@ -311,7 +314,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_payment_option_fields( $values, $gateway ) {
+	public static function pmpro_payment_option_fields( $values, $gateway ) {
 		$stripe = new PMProGateway_stripe();
 
 		// Show connect fields.
@@ -518,6 +521,15 @@ class PMProGateway_stripe extends PMProGateway {
 		<?php
 	}
 
+	/**
+	 * Shows settings for connecting to Stripe.
+	 *
+	 * @since TBD.
+	 *
+	 * @param bool $livemode True if live credentials, false if sandbox.
+	 * @param array $values Current settings.
+	 * @param string $gateway currently being shown.
+	 */
 	private function show_connect_payment_option_fields( $livemode = true, $values, $gateway ) {
 		$gateway_environment = $this->gateway_environment;
 
@@ -647,7 +659,7 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * AJAX callback to create webhooks.
 	 */
-	static function wp_ajax_pmpro_stripe_create_webhook( $silent = false ) {
+	public static function wp_ajax_pmpro_stripe_create_webhook( $silent = false ) {
 		$secretkey = sanitize_text_field( $_REQUEST['secretkey'] );
 		
 		$stripe = new PMProGateway_stripe();
@@ -683,7 +695,7 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * AJAX callback to disable webhooks.
 	 */
-	static function wp_ajax_pmpro_stripe_delete_webhook( $silent = false ) {
+	public static function wp_ajax_pmpro_stripe_delete_webhook( $silent = false ) {
 		$secretkey = sanitize_text_field( $_REQUEST['secretkey'] );
 		
 		$stripe = new PMProGateway_stripe();
@@ -721,7 +733,7 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * AJAX callback to rebuild webhook.
 	 */
-	static function wp_ajax_pmpro_stripe_rebuild_webhook() {
+	public static function wp_ajax_pmpro_stripe_rebuild_webhook() {
 		// First try to delete the webhook.
 		$r = self::wp_ajax_pmpro_stripe_delete_webhook( true ) ;
 		if ( $r['success'] ) {
@@ -741,7 +753,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_checkout_after_preheader( $order ) {
+	public static function pmpro_checkout_after_preheader( $order ) {
 		global $gateway, $pmpro_level, $current_user, $pmpro_requirebilling, $pmpro_pages, $pmpro_currency;
 
 		$default_gateway = pmpro_getOption( "gateway" );
@@ -789,7 +801,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Don't require the CVV.
 	 * Don't require address fields if they are set to hide.
 	 */
-	static function pmpro_required_billing_fields( $fields ) {
+	public static function pmpro_required_billing_fields( $fields ) {
 		global $pmpro_stripe_lite, $current_user, $bemail, $bconfirmemail;
 
 		//CVV is not required if set that way at Stripe. The Stripe JS will require it if it is required.
@@ -828,7 +840,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get available webhooks
 	 * 
 	 * @since 2.4
-	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function get_webhooks( $limit = 10 ) {
 		// Show deprecation warning if called publically.
@@ -858,8 +870,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get current webhook URL for website to compare.
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function get_site_webhook_url() {
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
 		return admin_url( 'admin-ajax.php' ) . '?action=stripe_webhook';
 	}
 
@@ -867,8 +882,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 * List of current enabled events required for PMPro to work.
 	 * 
 	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function webhook_events() {
+		// Show deprecation warning if called publically.
+		pmpro_method_should_be_private( 'TBD' );
 		return apply_filters( 'pmpro_stripe_webhook_events', array(
 			'invoice.payment_succeeded',
 			'invoice.payment_action_required',
@@ -881,7 +899,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Create webhook with relevant events
 	 * 
 	 * @since 2.4
-	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function create_webhook() {
 		// Show deprecation warning if called publically.
@@ -911,7 +929,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * See if a webhook is registered with Stripe.
 	 * 
 	 * @since 2.4
-	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function does_webhook_exist( $force = false ) {
 		// Show deprecation warning if called publically.
@@ -959,7 +977,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get a list of events that are missing between the created existing webhook and required webhook events for Paid Memberships Pro.
 	 * 
 	 * @since 2.4
-	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function check_missing_webhook_events( $webhook_events ) {
 		// Show deprecation warning if called publically.
@@ -988,7 +1006,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Update required webhook enabled events.
 	 * 
 	 * @since 2.4
-	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function update_webhook_events() {
 		// Show deprecation warning if called publically.
@@ -1036,7 +1054,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Delete an existing webhook.
 	 * 
 	 * @since 2.4
-	 * @deprecated TBD. Only deprecated for public use, will be changed to private nonstatic in a future version.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function delete_webhook( $webhook_id, $secretkey = false ) {
 		// Show deprecation warning if called publically.
@@ -1066,7 +1084,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_checkout_order( $morder ) {
+	public static function pmpro_checkout_order( $morder ) {
 
 		// Create a code for the order.
 		if ( empty( $morder->code ) ) {
@@ -1121,7 +1139,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_after_checkout( $user_id, $morder ) {
+	public static function pmpro_after_checkout( $user_id, $morder ) {
 		global $gateway;
 
 		if ( $gateway == "stripe" ) {
@@ -1135,7 +1153,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Check settings if billing address should be shown.
 	 * @since 1.8
 	 */
-	static function pmpro_include_billing_address_fields( $include ) {
+	public static function pmpro_include_billing_address_fields( $include ) {
 		//check settings RE showing billing address
 		if ( ! pmpro_getOption( "stripe_billingaddress" ) ) {
 			$include = false;
@@ -1148,7 +1166,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Use our own payment fields at checkout. (Remove the name attributes.)
 	 * @since 1.8
 	 */
-	static function pmpro_include_payment_information_fields( $include ) {
+	public static function pmpro_include_payment_information_fields( $include ) {
 		//global vars
 		global $pmpro_requirebilling, $pmpro_show_discount_code, $discount_code, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
 
@@ -1239,7 +1257,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function user_profile_fields( $user ) {
+	public static function user_profile_fields( $user ) {
 		global $wpdb, $current_user, $pmpro_currency_symbol;
 
 		// Get the user's last order.
@@ -1262,7 +1280,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_activation() {
+	public static function pmpro_activation() {
 		pmpro_maybe_schedule_event( time(), 'daily', 'pmpro_cron_stripe_subscription_updates' );
 	}
 
@@ -1274,7 +1292,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_deactivation() {
+	public static function pmpro_deactivation() {
 		wp_clear_scheduled_hook( 'pmpro_cron_stripe_subscription_updates' );
 	}
 
@@ -1286,7 +1304,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8
 	 */
-	static function pmpro_cron_stripe_subscription_updates() {
+	public static function pmpro_cron_stripe_subscription_updates() {
 		global $wpdb;
 
 		//get all updates for today (or before today)
@@ -1353,7 +1371,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * because of an expired credit card/etc and a user checks out to renew their subscription
 	 * instead of updating their billing information via the billing info page.
 	 */
-	static function pmpro_checkout_before_processing() {
+	public static function pmpro_checkout_before_processing() {
 		global $wpdb, $current_user;
 
 		// we're only worried about cases where the user is logged in
@@ -1432,7 +1450,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Updated in v2.1 to work with Stripe v3 payment intents.
 	 * @since 1.4
 	 */
-	function process( &$order ) {
+	public function process( &$order ) {
 		$customer = $this->update_customer_at_checkout( $order );
 		if ( empty( $customer ) ) {
 			// There was an issue creating/updating the Stripe customer.
@@ -1486,8 +1504,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Make a one-time charge with Stripe
 	 *
 	 * @since 1.4
+	 * @deprecated TBD. Use process_charges() instead.
 	 */
 	function charge( &$order ) {
+		_deprecated_function( __FUNCTION__, 'TBD' );
 		global $pmpro_currency;
 
 		//create a code for the order
@@ -1566,7 +1586,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get a Stripe Customer object and update it.
 	 *
 	 * @since 1.4
-	 * @deprecated TBD. Use update_customer_from_user().
+	 * @deprecated TBD. Use get_customer_for_user() or update_customer_from_user().
 	 *
 	 * @return Stripe_Customer|false
 	 */
@@ -1621,7 +1641,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @param int $user_id to get Stripe_Customer for.
 	 * @return Stripe_Customer|null
 	 */
-	function get_customer_for_user( $user_id ) {
+	public function get_customer_for_user( $user_id ) {
 		// Pull Stripe customer ID from user meta.
 		$customer_id = get_user_meta( $user_id, 'pmpro_stripe_customerid', true );
 
@@ -1898,7 +1918,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @param int $user_id to create/update Stripe customer for.
 	 * @return Stripe_Customer|false
 	 */
-	function update_customer_from_user( $user_id ) {
+	public function update_customer_from_user( $user_id ) {
 		$user = get_userdata( $user_id );
 
 		if ( empty( $user->ID ) ) {
@@ -1971,9 +1991,8 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @param Stripe_Customer $customer to update default payment method for.
 	 * @param Stripe_PaymentMethod $payment_method to set as default.
 	 * @return Stripe_Customer|string error message.
-	 * 
 	 */
-	function set_default_payment_method_for_customer( $customer, $payment_method ) {
+	public function set_default_payment_method_for_customer( $customer, $payment_method ) {
 		if ( ! empty( $customer->invoice_settings->default_payment_method ) && $customer->invoice_settings->default_payment_method === $payment_method->id ) {
 			// Payment method already correct, no need to update.
 			return $customer;
@@ -2001,8 +2020,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get a Stripe subscription from a PMPro order
 	 *
 	 * @since 1.8
+	 * @deprecated TBD. Need to write replacement methods for this.
 	 */
 	function getSubscription( &$order ) {
+		_deprecated_function( __FUNCTION__, 'TBD' );
 		global $wpdb;
 
 		//no order?
@@ -2068,7 +2089,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 2.3
 	 */
-	function getSubscriptionStatus( &$order ) {
+	public function getSubscriptionStatus( &$order ) {
 		$subscription = $this->getSubscription( $order );
 		
 		if ( ! empty( $subscription ) ) {
@@ -2085,8 +2106,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * See method create_setup_intent().
 	 *
 	 * @since 1.4
+	 * @deprecated TBD. Use process_subscriptions() instead.
 	 */
 	function subscribe( &$order, $checkout = true ) {
+		_deprecated_function( __FUNCTION__, 'TBD' );
 		global $pmpro_currency;
 
 		//create a code for the order
@@ -2293,8 +2316,12 @@ class PMProGateway_stripe extends PMProGateway {
 
 	/**
 	 * Helper method to save the subscription ID to make sure the membership doesn't get cancelled by the webhook
+	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
-	static function ignoreCancelWebhookForThisSubscription( $subscription_id, $user_id = null ) {
+	public static function ignoreCancelWebhookForThisSubscription( $subscription_id, $user_id = null ) {
+		pmpro_method_should_be_private( 'TBD' );
+
 		if ( empty( $user_id ) ) {
 			global $current_user;
 			$user_id = $current_user->ID;
@@ -2315,8 +2342,11 @@ class PMProGateway_stripe extends PMProGateway {
 
 	/**
 	 * Helper method to process a Stripe subscription update
+	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	static function updateSubscription( $update, $user_id ) {
+		pmpro_method_should_be_private( 'TBD' );
 		global $wpdb;
 
 		//get level for user
@@ -2405,7 +2435,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.4
 	 */
-	function update( &$order ) {
+	public function update( &$order ) {
 		$customer = $this->update_customer_at_checkout( $order );
 		if ( empty( $customer ) ) {
 			// There was an issue creating/updating the Stripe customer.
@@ -2440,8 +2470,12 @@ class PMProGateway_stripe extends PMProGateway {
 	
 	/**
 	 * Update the payment method for a subscription.
+	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	function update_payment_method_for_subscriptions( &$order ) {
+		pmpro_method_should_be_private( 'TBD' );
+
 		// get customer
 		$customer = $this->update_customer_at_checkout( $order );
 		
@@ -2479,7 +2513,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.4
 	 */
-	function cancel( &$order, $update_status = true ) {
+	public function cancel( &$order, $update_status = true ) {
 		global $pmpro_stripe_event;
 
 		//no matter what happens below, we're going to cancel the order in our system
@@ -2531,8 +2565,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Helper method to cancel a subscription at Stripe and also clear up any upaid invoices.
 	 *
 	 * @since 1.8
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	function cancelSubscriptionAtGateway( $subscription, $preserve_local_membership = false ) {
+		pmpro_method_should_be_private( 'TBD' );
+
 		// Check if a valid sub.
 		if ( empty( $subscription ) || empty( $subscription->id ) ) {
 			return false;
@@ -2593,7 +2630,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 1.8.6
 	 */
-	static function pmpro_next_payment( $timestamp, $user_id, $order_status ) {
+	public static function pmpro_next_payment( $timestamp, $user_id, $order_status ) {
 		//find the last order for this user
 		if ( ! empty( $user_id ) ) {
 			//get last order
@@ -2626,12 +2663,15 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Refund a payment or invoice
 	 *
+	 * @deprecated TBD.
+	 *
 	 * @param object &$order Related PMPro order object.
 	 * @param string $transaction_id Payment or Invoice id to void.
 	 *
 	 * @return bool                     True or false if the void worked
 	 */
-	function void( &$order, $transaction_id = null ) {
+	public function void( &$order, $transaction_id = null ) {
+		_deprecated_function( __FUNCTION__, 'TBD' );
 		//stripe doesn't differentiate between voids and refunds, so let's just pass on to the refund function
 		return $this->refund( $order, $transaction_id );
 	}
@@ -2639,12 +2679,15 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Refund a payment or invoice
 	 *
+	 * @deprecated TBD.
+	 *
 	 * @param object &$order Related PMPro order object.
 	 * @param string $transaction_id Payment or invoice id to void.
 	 *
 	 * @return bool                   True or false if the refund worked.
 	 */
-	function refund( &$order, $transaction_id = null ) {
+	public function refund( &$order, $transaction_id = null ) {
+		_deprecated_function( __FUNCTION__, 'TBD' );
 		//default to using the payment id from the order
 		if ( empty( $transaction_id ) && ! empty( $order->payment_transaction_id ) ) {
 			$transaction_id = $order->payment_transaction_id;
@@ -2715,7 +2758,11 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 	}
 
+	/**
+	 * @deprecated TBD. Use get_payment_method() instead.
+	 */
 	function set_payment_method( &$order, $force = false ) {
+		_deprecated_function( __FUNCTION__, 'TBD', 'get_payment_method' );
 		if ( ! empty( $this->payment_method ) && ! $force ) {
 			return true;
 		}
@@ -2731,8 +2778,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	function get_payment_method( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		if ( ! empty( $order->payment_method_id ) ) {
 			try {
 				$payment_method = Stripe_PaymentMethod::retrieve( $order->payment_method_id );
@@ -2755,7 +2805,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $payment_method;
 	}
 
+	/**
+	 * @deprecated TBD. Use get_customer_for_user() or update_customer_from_user().
+	 */
 	function set_customer( &$order, $force = false ) {
+		_deprecated_function( __FUNCTION__, 'TBD', 'get_customer_for_user()' );
 		if ( ! empty( $this->customer ) && ! $force ) {
 			return true;
 		}
@@ -2764,7 +2818,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $this->customer;
 	}
 
+	/**
+	 * @deprecated TBD. Use set_default_payment_method_for_customer().
+	 */
 	function attach_payment_method_to_customer( &$order ) {
+		_deprecated_function( __FUNCTION__, 'TBD', 'set_default_payment_method_for_customer()' );
 		$customer = $this->update_customer_at_checkout( $order );
 
 		if ( ! empty( $customer->invoice_settings->default_payment_method ) &&
@@ -2790,8 +2848,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private in a future version.
+	 */
 	function process_charges( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		if ( 0 == floatval( $order->InitialPayment ) ) {
 			return true;
 		}
@@ -2808,8 +2869,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Use get_payment_intent() instead.
+	 */
 	function set_payment_intent( &$order, $force = false ) {
-
+		_deprecated_function( __FUNCTION__, 'TBD', 'get_payment_intent()' );
 		if ( ! empty( $order->stripe_payment_intent ) && ! $force ) {
 			return true;
 		}
@@ -2825,8 +2889,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private in a future version.
+	 */
 	function get_payment_intent( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		if ( ! empty( $order->payment_intent_id ) ) {
 			try {
 				$payment_intent = Stripe_PaymentIntent::retrieve( $order->payment_intent_id );
@@ -2853,7 +2920,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $payment_intent;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private in a future version.
+	 */
 	function create_payment_intent( &$order ) {
+		pmpro_method_should_be_private( 'TBD' );
 		global $pmpro_currency;
 
 		$amount          = $order->InitialPayment;
@@ -2899,8 +2970,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $payment_intent;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private in a future version.
+	 */
 	function process_subscriptions( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		if ( ! pmpro_isLevelRecurring( $order->membership_level ) ) {
 			return true;
 		}
@@ -2951,7 +3025,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Will only be deprecated once we are using Prices.
+	 */
 	function create_plan( &$order ) {
+		// _deprecated_function( __FUNCTION__, 'TBD' );
 		global $pmpro_currency;
 
 		//figure out the amounts
@@ -3035,8 +3113,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $order->plan;
 	}
 
+	/**
+	 * @deprecated TBD. Will only be deprecated once we create a function with better params.
+	 */
 	function create_subscription( &$order ) {
-
+		// _deprecated_function( __FUNCTION__, 'TBD' );
 		//subscribe to the plan
 		try {
 			$params              = array(
@@ -3068,7 +3149,11 @@ class PMProGateway_stripe extends PMProGateway {
 
 	}
 
+	/**
+	 * @deprecated TBD. Will only be deprecated once we are using Prices.
+	 */
 	function delete_plan( &$order ) {
+		// _deprecated_function( __FUNCTION__, 'TBD' );
 		try {
 			// Delete the product first while we have a reference to it...
 			if ( ( ! empty( $order->plan->product ) ) && ( ! $this->archive_product( $order ) ) ) {
@@ -3093,7 +3178,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Will only be deprecated once we start re-using products.
+	 */
 	function archive_product( &$order ) {
+		// _deprecated_function( __FUNCTION__, 'TBD' );
 		try {
 			$product = Stripe_Product::update( $order->plan->product, array( 'active' => false ) );
 		} catch ( Stripe\Error\Base $e ) {
@@ -3110,8 +3199,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	function get_setup_intent( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		if ( ! empty( $order->setup_intent_id ) ) {
 			try {
 				$setup_intent = Stripe_SetupIntent::retrieve( $order->setup_intent_id );
@@ -3138,8 +3230,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $setup_intent;
 	}
 
+	/**
+	 * @deprecated TBD. Use get_setup_intent() instead.
+	 */
 	function set_setup_intent( &$order, $force = false ) {
-
+		_deprecated_function( __FUNCTION__, 'TBD', 'get_setup_intent()' );
 		if ( ! empty( $this->setup_intent ) && ! $force ) {
 			return true;
 		}
@@ -3155,8 +3250,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	function create_setup_intent( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		$this->create_plan( $order );
 		$this->subscription = $this->create_subscription( $order );
 		$this->delete_plan( $order );
@@ -3168,8 +3266,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $this->subscription->pending_setup_intent;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	function confirm_payment_intent( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		try {
 			$params = array(
 				'expand' => array(
@@ -3199,8 +3300,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return true;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	function confirm_setup_intent( &$order ) {
-
+		pmpro_method_should_be_private( 'TBD' );
 		if ( empty( $this->setup_intent ) ) {
 			return true;
 		}
@@ -3216,8 +3320,11 @@ class PMProGateway_stripe extends PMProGateway {
 
 	/**
  	 * Get available Apple Pay domains.
+	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
  	 */
 	function pmpro_get_apple_pay_domains( $limit = 10 ) {
+		pmpro_method_should_be_private( 'TBD' );
 		try {
 			$apple_pay_domains = Stripe_ApplePayDomain::all( [ 'limit' => apply_filters( 'pmpro_stripe_apple_pay_domain_retrieve_limit', $limit ) ] );
 		} catch (\Throwable $th) {
@@ -3231,8 +3338,10 @@ class PMProGateway_stripe extends PMProGateway {
  	 * Register domain with Apple Pay.
  	 * 
  	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
  	 */
 	function pmpro_create_apple_pay_domain() {
+		pmpro_method_should_be_private( 'TBD' );
 		try {
 			$create = Stripe_ApplePayDomain::create([
 				'domain_name' => $_SERVER['HTTP_HOST'],
@@ -3248,8 +3357,10 @@ class PMProGateway_stripe extends PMProGateway {
  	 * See if domain is registered with Apple Pay.
  	 * 
  	 * @since 2.4
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
  	 */
 	function pmpro_does_apple_pay_domain_exist() {
+		pmpro_method_should_be_private( 'TBD' );
 		$apple_pay_domains = $this->pmpro_get_apple_pay_domains();
 
 		if ( empty( $apple_pay_domains ) ) {
@@ -3289,7 +3400,11 @@ class PMProGateway_stripe extends PMProGateway {
 		}
    }
 
+   /**
+	* @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+    */
    function get_account() {
+		pmpro_method_should_be_private( 'TBD' );
 		try {
 			$account = Stripe_Account::retrieve();
 		} catch ( Stripe\Error\Base $e ) {
@@ -3307,7 +3422,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $account;
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	static function get_account_country() {
+		pmpro_method_should_be_private( 'TBD' );
 		$account_country = get_transient( 'pmpro_stripe_account_country' );
 		if ( empty( $account_country ) ) {
 			$stripe = new PMProGateway_stripe();
@@ -3320,7 +3439,11 @@ class PMProGateway_stripe extends PMProGateway {
 		return $account_country ?: 'US';
 	}
 
+	/**
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 */
 	function clean_up( &$order ) {
+		pmpro_method_should_be_private( 'TBD' );
 		if ( ! empty( $this->payment_intent ) && 'succeeded' == $this->payment_intent->status ) {
 			$order->payment_transaction_id = $this->payment_intent->charges->data[0]->id;
 		}
@@ -3333,9 +3456,12 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Get percentage of Stripe payment to charge as application fee.
 	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 *
 	 * @return int percentage to charge for application fee.
 	 */
 	static function get_application_fee_percentage() {
+		pmpro_method_should_be_private( 'TBD' );
 		$application_fee_percentage = pmpro_license_isValid( null, 'plus' ) ? 0 : 1;
 		$application_fee_percentage = apply_filters( 'pmpro_set_application_fee_percentage', $application_fee_percentage );
 		return round( floatval( $application_fee_percentage ), 2 );
@@ -3344,11 +3470,14 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Add application fee to params to be sent to Stripe.
 	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 *
 	 * @param  array $params to be sent to Stripe.
 	 * @param  bool  $add_percent true if percentage should be added, false if actual amount.
 	 * @return array params with application fee if applicable.
 	 */
 	static function add_application_fee_amount( $params ) {
+		pmpro_method_should_be_private( 'TBD' );
 		if ( empty( $params['amount'] ) || self::using_legacy_keys() ) {
 			return $params;
 		}
@@ -3366,7 +3495,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @return void
 	 */
-	static function stripe_connect_save_options() {
+	public static function stripe_connect_save_options() {
 		// Is user have permission to edit give setting.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
@@ -3427,7 +3556,7 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 	}
 
-	static function stripe_connect_show_errors() {
+	public static function stripe_connect_show_errors() {
 		global $pmpro_stripe_error;
 		if ( ! empty( $pmpro_stripe_error ) ) {
 			$class   = 'notice notice-error pmpro-stripe-connect-message';
@@ -3438,7 +3567,7 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Disconnects user from the Stripe Connected App.
 	 */
-	static function stripe_connect_deauthorize() {
+	public static function stripe_connect_deauthorize() {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
@@ -3483,8 +3612,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * We should if the site is using legacy keys already or
 	 * if a filter has been set.
 	 * @since 2.6
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
 	public static function show_legacy_keys_settings() {
+		pmpro_method_should_be_private( 'TBD' );
 		$r = self::using_legacy_keys();
 		$r = apply_filters( 'pmpro_stripe_show_legacy_keys_settings', $r );
 		return $r;
@@ -3532,9 +3663,12 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Get the Stripe secret key based on gateway environment.
 	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 *
 	 * @return The Stripe secret key.
 	 */
 	public static function get_secretkey() {
+		pmpro_method_should_be_private( 'TBD' );
 		$secretkey = '';
 		if ( self::using_legacy_keys() ) {
 			$secretkey = pmpro_getOption( 'stripe_secretkey' ); 
@@ -3546,7 +3680,15 @@ class PMProGateway_stripe extends PMProGateway {
 		return $secretkey;
 	}
 
+	/**
+	 * Get the Stripe publishable key based on gateway environment.
+	 *
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
+	 *
+	 * @return The Stripe publishable key.
+	 */
 	static function get_publishablekey() {
+		pmpro_method_should_be_private( 'TBD' );
 		$publishablekey = '';
 		if ( self::using_legacy_keys() ) {
 			$publishablekey = pmpro_getOption( 'stripe_publishablekey' ); 
@@ -3562,10 +3704,12 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Get the Stripe Connect User ID based on gateway environment.
 	 *
 	 * @since 2.6.0
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 *
 	 * @return string The Stripe Connect User ID.
 	 */
 	public static function get_connect_user_id() {
+		pmpro_method_should_be_private( 'TBD' );
 		return pmpro_getOption( 'gateway_environment' ) === 'live'
 			? pmpro_getOption( 'live_stripe_connect_user_id' )
 			: pmpro_getOption( 'sandbox_stripe_connect_user_id' );
@@ -3574,11 +3718,13 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Determine whether the webhook is working by checking for Stripe orders with invalid transaction IDs.
 	 *
-	 * @param string|null $gateway_environment to check webhooks for. Defaults to set gateway environment.
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 *
+	 * @param string|null $gateway_environment to check webhooks for. Defaults to set gateway environment.
 	 * @return bool Whether the webhook is working.
 	 */
 	public static function webhook_is_working( $gateway_environment = null ) {
+		pmpro_method_should_be_private( 'TBD' );
 		global $wpdb;
 
 		if ( empty( $gateway_environment ) ) {
@@ -3624,8 +3770,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @param environment The gateway environment (live or sandbox) to check for.
 	 * @returns HTML with the date of the last webhook or an error message.
 	 * @since 2.6
+	 * @deprecated TBD. Only deprecated for public use, will be changed to private non-static in a future version.
 	 */
-	public static function get_last_webhook_date( $environment = 'live' ) {	
+	public static function get_last_webhook_date( $environment = 'live' ) {
+		pmpro_method_should_be_private( 'TBD' );
 		$last_webhook = get_option( 'pmpro_stripe_last_webhook_received_' . $environment );
 		if ( ! empty( $last_webhook ) ) {
 			echo '<p>' . esc_html__( 'Last webhook received at', 'paid-memberships-pro' ) . ': ' . esc_html( $last_webhook ) . ' GMT.</p>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This is a first pass at marking functions as deprecated, either to stop using them entirely or just to eventually make them private.

I leaned towards deprecating more methods than fewer, since it is easy to reverse this decision later on and just remove the deprecation warning if there is a use case that we still want to support. There are also still changes that need to be made to stop using deprecated methods in the class, which will be done in a future PR. These functions include:
- getSubscription()
- set_payment_intent()
- set_setup_intent()

Happy to discuss any of these choices, but they can all be undone later without much worry.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
