### PR TITLE
Allow users to view and delete existing subscription updates for users.

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2249,15 +2249,15 @@ class PMProGateway_stripe extends PMProGateway {
 							</span>
                             </div>
 							<script>
-							jQuery(document).ready(function () {
+							jQuery(function () {
 								//remove updates when clicking
-								jQuery('.updates_remove').click(function () {
+								jQuery('.updates_remove').on('click', function () {
 									jQuery(this).parent().parent().remove();
 								});
-								jQuery('form').bind('submit', function () {
+								jQuery('form').on('submit', function () {
 									// Makes sure that disabled select fields are still submitted.
 									jQuery(this).find(':input').prop('disabled', false);
-									});
+								});
 							});
 							</script>
 							<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1300,7 +1300,9 @@ class PMProGateway_stripe extends PMProGateway {
 		$current_month = date_i18n( "m" );
 		?>
             <h3><?php _e( "Subscription Updates", 'paid-memberships-pro' ); ?></h3>
+			<p><?php _e( "Subscription updates will be deprecated in a future version of PMPro, though your existing subscription updates will still trigger as expected. We now instead reccomend updating the subscription directly in Stripe.", 'paid-memberships-pro' ); ?></p>
             <table class="form-table">
+				<input type='hidden' name='pmpro_subscription_updates_visible' value='1' />
                 <tr>
                     <th><label for="membership_level"><?php _e( "Update", 'paid-memberships-pro' ); ?></label></th>
                     <td id="updates_td">
@@ -1401,8 +1403,15 @@ class PMProGateway_stripe extends PMProGateway {
 			return false;
 		}
 
-		//make sure some value was passed
+		//make sure subscription updates were shown.
+		if ( ! isset( $_POST['pmpro_subscription_updates_visible'] ) ) {
+			return;
+		}
+
+		// Check whether all updates were deleted.
 		if ( ! isset( $_POST['updates_when'] ) || ! is_array( $_POST['updates_when'] ) ) {
+			delete_user_meta( $user_id, 'pmpro_stripe_updates' );
+			delete_user_meta( $user_id, 'pmpro_stripe_next_on_date_update' );
 			return;
 		}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -857,7 +857,7 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( ! empty( $customer ) ) {
 			// Get the link to edit the customer.
 			echo '<hr>';
-			echo '<a target="_blank" href="https://dashboard.stripe.com/' . ( pmpro_getOption( 'gateway_environment' ) == 'sandbox' ? 'test/' : '' ) . 'customers/' . esc_attr( $customer->id ) . '">' . esc_html__( 'Edit customer in Stripe', 'paid-memberships-pro' ) . '</a>';
+			echo '<a target="_blank" href="' . esc_url( 'https://dashboard.stripe.com/' . ( pmpro_getOption( 'gateway_environment' ) == 'sandbox' ? 'test/' : '' ) . 'customers/' . $customer->id ) . '">' . esc_html__( 'Edit customer in Stripe', 'paid-memberships-pro' ) . '</a>';
 			if ( ! empty( $user->pmpro_stripe_updates ) && is_array( $user->pmpro_stripe_updates ) ) {
 				$stripe->user_profile_fields_subscription_updates( $user, $customer );
 			}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1304,7 +1304,7 @@ class PMProGateway_stripe extends PMProGateway {
             <table class="form-table">
 				<input type='hidden' name='pmpro_subscription_updates_visible' value='1' />
                 <tr>
-                    <th><label for="membership_level"><?php _e( "Update", 'paid-memberships-pro' ); ?></label></th>
+                    <th><label><?php _e( "Update", 'paid-memberships-pro' ); ?></label></th>
                     <td id="updates_td">
 						<?php
 						$updates = $user->pmpro_stripe_updates;
@@ -1355,17 +1355,17 @@ class PMProGateway_stripe extends PMProGateway {
 								<select name="updates_cycle_period[]" disabled>
 								  <?php
 								  foreach ( $cycles as $name => $value ) {
-									  echo "<option value='$value'";
+									  echo "<option value='" . esc_attr( $value ) . "'";
 									  if ( ! empty( $update['cycle_period'] ) && $update['cycle_period'] == $value ) {
 										  echo " selected='selected'";
 									  }
-									  echo ">$name</option>";
+									  echo ">" . esc_html( $name ) . "</option>";
 								  }
 								  ?>
 								</select>
 							</span>
                                 <span>
-								<a class="updates_remove" href="javascript:void(0);">Remove</a>
+								<a class="updates_remove" href="javascript:void(0);"><?php esc_html_e( 'Remove', 'paid-memberships-pro' ); ?></a>
 							</span>
                             </div>
 							<script>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Allow users to view and delete upcoming Stripe subscription updates for users so that there are not any surprises when the update occurs. Eventually, this UI should be deleted once subscription updates are entirely removed.

User profiles also now link to the Stripe Customer instead of to an individual subscription.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->