### PR TITLE
Add WP.com compatibiltiy for Jetpack SSO

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -13,12 +13,12 @@ function pmpro_compatibility_checker () {
         ),
         array(
             'file' => 'elementor.php',
-            'check_type' => 'constant', 
+            'check_type' => 'constant',
             'check_value' => 'ELEMENTOR_VERSION'
         ),
         array(
             'file' => 'beaver-builder.php',
-            'check_type' => 'constant', 
+            'check_type' => 'constant',
             'check_value' => 'FL_BUILDER_VERSION'
         ),
         array(
@@ -40,15 +40,41 @@ function pmpro_compatibility_checker () {
             'file' => 'divi.php',
             'check_type' => 'constant',
             'check_value' => 'ET_BUILDER_PLUGIN_DIR'
+        ),
+        array(
+            'file' => 'wp-com.php',
+            'check_type' => 'constant',
+            'check_value' => 'IS_WPCOM',
+            'check_constant_true' => true,
         )
     );
 
     foreach ( $compat_checks as $key => $value ) {
-        if ( ( $value['check_type'] == 'constant' && defined( $value['check_value'] ) )
-          || ( $value['check_type'] == 'function' && function_exists( $value['check_value'] ) )
-          || ( $value['check_type'] == 'class' && class_exists( $value['check_value'] ) ) ) {
-            include( PMPRO_DIR . '/includes/compatibility/' . $value['file'] ) ;
-        }
+		// Check for a constant and maybe check if the constant is true-ish.
+	    if (
+			'constant' === $value['check_type']
+			&& (
+				! defined( $value['check_value'] )
+				|| (
+					! isset( $value['check_constant_true'] )
+					&& constant( $value['check_value'] )
+				)
+			)
+	    ) {
+			return;
+	    }
+
+		// Check for a function.
+	    if ( 'function' === $value['check_type'] && ! function_exists( $value['check_value'] ) ) {
+			return;
+	    }
+
+		// Check for a class.
+	    if ( 'class' === $value['check_type'] && ! class_exists( $value['check_value'] ) ) {
+			return;
+	    }
+
+        include( PMPRO_DIR . '/includes/compatibility/' . $value['file'] ) ;
     }
 }
 add_action( 'plugins_loaded', 'pmpro_compatibility_checker' );

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -4,80 +4,99 @@
  * Check if certain plugins or themes are installed and activated
  * and if found dynamically load the relevant /includes/compatibility/ files.
  */
-function pmpro_compatibility_checker () {
-    $compat_checks = array(
-        array(
-            'file' => 'siteorigin.php',
-            'check_type' => 'constant',
-            'check_value' => 'SITEORIGIN_PANELS_VERSION',
-        ),
-        array(
-            'file' => 'elementor.php',
-            'check_type' => 'constant',
-            'check_value' => 'ELEMENTOR_VERSION'
-        ),
-        array(
-            'file' => 'beaver-builder.php',
-            'check_type' => 'constant',
-            'check_value' => 'FL_BUILDER_VERSION'
-        ),
-        array(
-            'file' => 'theme-my-login.php',
-            'check_type' => 'class',
-            'check_value' => 'Theme_My_Login'
-        ),
-		array(
-			'file' => 'woocommerce.php',
-			'check_type' => 'constant',
-			'check_value' => 'WC_PLUGIN_FILE'
-		),
-		array(
-			'file' => 'wp-engine.php',
-			'check_type' => 'function',
-			'check_value' => 'wpe_filter_site_url'
-		),
-        array(
-            'file' => 'divi.php',
-            'check_type' => 'constant',
-            'check_value' => 'ET_BUILDER_PLUGIN_DIR'
-        ),
-        array(
-            'file' => 'wp-com.php',
-            'check_type' => 'constant',
-            'check_value' => 'IS_WPCOM',
-            'check_constant_true' => true,
-        )
-    );
+function pmpro_compatibility_checker() {
+	$compat_checks = [
+		[
+			'file'        => 'siteorigin.php',
+			'check_type'  => 'constant',
+			'check_value' => 'SITEORIGIN_PANELS_VERSION',
+		],
+		[
+			'file'        => 'elementor.php',
+			'check_type'  => 'constant',
+			'check_value' => 'ELEMENTOR_VERSION',
+		],
+		[
+			'file'        => 'beaver-builder.php',
+			'check_type'  => 'constant',
+			'check_value' => 'FL_BUILDER_VERSION',
+		],
+		[
+			'file'        => 'theme-my-login.php',
+			'check_type'  => 'class',
+			'check_value' => 'Theme_My_Login',
+		],
+		[
+			'file'        => 'woocommerce.php',
+			'check_type'  => 'constant',
+			'check_value' => 'WC_PLUGIN_FILE',
+		],
+		[
+			'file'        => 'wp-engine.php',
+			'check_type'  => 'function',
+			'check_value' => 'wpe_filter_site_url',
+		],
+		[
+			'file'        => 'divi.php',
+			'check_type'  => 'constant',
+			'check_value' => 'ET_BUILDER_PLUGIN_DIR',
+		],
+		[
+			'file'                => 'wp-com.php',
+			'check_type'          => 'constant',
+			'check_value'         => 'IS_WPCOM',
+			'check_constant_true' => true,
+		],
+	];
 
-    foreach ( $compat_checks as $key => $value ) {
-		// Check for a constant and maybe check if the constant is true-ish.
-	    if (
-			'constant' === $value['check_type']
-			&& (
-				! defined( $value['check_value'] )
-				|| (
-					! isset( $value['check_constant_true'] )
-					&& constant( $value['check_value'] )
-				)
-			)
-	    ) {
+	foreach ( $compat_checks as $value ) {
+		if ( ! pmpro_compatibility_checker_is_requirement_met( $value ) ) {
 			return;
-	    }
-
-		// Check for a function.
-	    if ( 'function' === $value['check_type'] && ! function_exists( $value['check_value'] ) ) {
-			return;
-	    }
-
-		// Check for a class.
-	    if ( 'class' === $value['check_type'] && ! class_exists( $value['check_value'] ) ) {
-			return;
-	    }
+		}
 
         include( PMPRO_DIR . '/includes/compatibility/' . $value['file'] ) ;
     }
 }
 add_action( 'plugins_loaded', 'pmpro_compatibility_checker' );
+
+/**
+ * Check whether the requirement is met.
+ *
+ * @since TBD
+ *
+ * @param array $requirement The requirement config (check_type, check_value, check_constant_true).
+ *
+ * @return bool Whether the requirement is met.
+ */
+function pmpro_compatibility_checker_is_requirement_met( $requirement ) {
+	// Make sure we have the keys that we expect.
+	if ( ! isset( $requirement['check_type'], $requirement['check_value'] ) ) {
+		return false;
+	}
+
+	// Check for a constant and maybe check if the constant is true-ish.
+    if ( 'constant' === $requirement['check_type'] ) {
+		return (
+			defined( $requirement['check_value'] )
+			&& (
+				! isset( $requirement['check_constant_true'] )
+				|| constant( $requirement['check_value'] )
+			)
+		);
+    }
+
+	// Check for a function.
+    if ( 'function' === $requirement['check_type'] ) {
+		return function_exists( $requirement['check_value'] );
+    }
+
+	// Check for a class.
+    if ( 'class' === $requirement['check_type'] ) {
+		return class_exists( $requirement['check_value'] );
+    }
+
+	return false;
+}
 
 function pmpro_compatibility_checker_themes(){
 

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -79,7 +79,7 @@ function pmpro_compatibility_checker_is_requirement_met( $requirement ) {
 		return (
 			defined( $requirement['check_value'] )
 			&& (
-				! isset( $requirement['check_constant_true'] )
+				empty( $requirement['check_constant_true'] )
 				|| constant( $requirement['check_value'] )
 			)
 		);

--- a/includes/compatibility/wp-com.php
+++ b/includes/compatibility/wp-com.php
@@ -18,9 +18,8 @@ function pmpro_jetpack_sso_handle_login() {
 		return;
 	}
 
-	$login_page_id = (int) pmpro_getOption( 'login_page_id' );
 
-	if ( ! $login_page_id || ! is_page( $login_page_id ) ) {
+	if ( empty( $pmpro_pages['login'] ) || ! is_page( $pmpro_pages['login'] ) ) {
 		return;
 	}
 

--- a/includes/compatibility/wp-com.php
+++ b/includes/compatibility/wp-com.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * WordPress.com Compatibility.
+ * Supports version TBD.
+ *
+ * @since TBD
+ */
+
+ /**
+  * Support Jetpack SSO login on WordPress.com itself.
+  *
+  * @since TBD
+  */
+function pmpro_jetpack_sso_handle_login() {
+	global $pmpro_pages, $action;
+
+	if ( ! is_page() ) {
+		return;
+	}
+
+	$login_page_id = (int) pmpro_getOption( 'login_page_id' );
+
+	if ( ! $login_page_id || ! is_page( $login_page_id ) ) {
+		return;
+	}
+
+	$action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : 'login';
+
+	do_action( 'login_init' );
+}
+
+add_action( 'wp', 'pmpro_jetpack_sso_handle_login', 20 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure that WordPress.com Jetpack SSO continues to work as expected when using a custom login page in PMPro.

### How to test the changes in this Pull Request:

Prerequisite: PMPro site must have a Custom Login page set in PMPro.

1. Log into wordpress.com
2. Go to any dashboard for a site with PMPro
3. Click on Memberships menu or go to any submenu item
4. See the expected page, you should NOT be redirected only to be stopped at the login form to log in again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add compatibility with WordPress.com for the Jetpack Single Sign On auto-login feature when using a Custom Login page in Paid Memberships Pro