### PR TITLE
update rest-api.php

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -784,7 +784,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			$limit = apply_filters( 'pmpro_trigger_recent_orders_limit', $orders_limit );
+			$limit = apply_filters( 'pmpro_rest_api_recent_orders_limit', $orders_limit );
 
 			global $wpdb;
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -777,8 +777,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		public function pmpro_rest_api_recent_orders( $request ) {
 			$params = $request->get_params();
 			
-			if ( isset($params['limit']) && is_int($params['limit']) ) {
-				$orders_limit = $params['limit'];
+			if ( isset($params['limit']) ) {
+				$orders_limit = intval( $params['limit'] );
 			} else {
 				$orders_limit = 1;
 			}

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -720,8 +720,14 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		public function pmpro_rest_api_recent_memberships( $request ) {
 			$params = $request->get_params();
 
+			if ( isset($params['limit']) && is_int($params['limit']) ) {
+				$members_limit = $params['limit'];
+			} else {
+				$members_limit = 1;
+			}
+
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			$limit = apply_filters( 'pmpro_trigger_recent_members_limit', 1 );
+			$limit = apply_filters( 'pmpro_trigger_recent_members_limit', $members_limit );
 
 			// Grab the useful information.
 			global $wpdb;
@@ -770,9 +776,15 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 */
 		public function pmpro_rest_api_recent_orders( $request ) {
 			$params = $request->get_params();
+			
+			if ( isset($params['limit']) && is_int($params['limit']) ) {
+				$orders_limit = $params['limit'];
+			} else {
+				$orders_limit = 1;
+			}
 
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			$limit = apply_filters( 'pmpro_trigger_recent_orders_limit', 1 );
+			$limit = apply_filters( 'pmpro_trigger_recent_orders_limit', $orders_limit );
 
 			global $wpdb;
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -784,7 +784,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			$limit = apply_filters( 'pmpro_rest_api_recent_orders_limit', $orders_limit );
+			$limit = apply_filters( 'pmpro_trigger_recent_orders_limit', $orders_limit );
 
 			global $wpdb;
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -721,7 +721,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$params = $request->get_params();
 
 			if ( isset($params['limit']) && is_int($params['limit']) ) {
-				$members_limit = $params['limit'];
+				$members_limit = intval( $params['limit'] );
 			} else {
 				$members_limit = 1;
 			}

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -720,7 +720,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		public function pmpro_rest_api_recent_memberships( $request ) {
 			$params = $request->get_params();
 
-			if ( isset($params['limit']) && is_int($params['limit']) ) {
+			if ( isset($params['limit']) ) {
 				$members_limit = intval( $params['limit'] );
 			} else {
 				$members_limit = 1;

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -727,7 +727,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			$limit = apply_filters( 'pmpro_rest_api_recent_memberships_limit', $members_limit );
+			$limit = apply_filters( 'pmpro_trigger_recent_members_limit', $members_limit );
 
 			// Grab the useful information.
 			global $wpdb;

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -727,7 +727,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			$limit = apply_filters( 'pmpro_trigger_recent_members_limit', $members_limit );
+			$limit = apply_filters( 'pmpro_rest_api_recent_memberships_limit', $members_limit );
 
 			// Grab the useful information.
 			global $wpdb;


### PR DESCRIPTION
added optional limit GET value in the rest api to output more recent orders and recent members

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Changes in REST API methods: /pmpro/v1/recent_orders and /pmpro/v1/recent_memberships
It adds the possibility to set a GET parameter - **limit**, to have more than 1 recent order or recent member.
It is useful when synchronising with an accounting system

### How to test the changes in this Pull Request:

1. Call the /pmpro/v1/recent_orders method adding a GET parameter limit=5. it should output 5 last orders
2. When the limit is incorrect or missing, only one last order will be received

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

New optional "limit" parameter in /pmpro/v1/recent_orders and /pmpro/v1/recent_memberships methonds. 