### PR TITLE
Add .htaccess checks to Site Health

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -61,33 +61,41 @@ class PMPro_Site_Health {
 			'label'       => 'Paid Memberships Pro',
 			'description' => __( 'This debug information for your Paid Memberships Pro installation can assist you in getting support.', 'paid-memberships-pro' ),
 			'fields'      => [
-				'pmpro-cron-jobs'         => [
-					'label' => __( 'Cron Job Status', 'paid-membership-levels' ),
+				'pmpro-cron-jobs'            => [
+					'label' => __( 'Cron Job Status', 'paid-memberships-pro' ),
 					'value' => self::get_cron_jobs(),
 				],
-				'pmpro-gateway'           => [
-					'label' => __( 'Payment Gateway', 'paid-membership-levels' ),
+				'pmpro-gateway'              => [
+					'label' => __( 'Payment Gateway', 'paid-memberships-pro' ),
 					'value' => self::get_gateway(),
 				],
-				'pmpro-gateway-env'       => [
-					'label' => __( 'Payment Gateway Environment', 'paid-membership-levels' ),
+				'pmpro-gateway-env'          => [
+					'label' => __( 'Payment Gateway Environment', 'paid-memberships-pro' ),
 					'value' => self::get_gateway_env(),
 				],
-				'pmpro-orders'            => [
-					'label' => __( 'Orders', 'paid-membership-levels' ),
+				'pmpro-orders'               => [
+					'label' => __( 'Orders', 'paid-memberships-pro' ),
 					'value' => self::get_orders(),
 				],
-				'pmpro-discount-codes'    => [
-					'label' => __( 'Discount Codes', 'paid-membership-levels' ),
+				'pmpro-discount-codes'       => [
+					'label' => __( 'Discount Codes', 'paid-memberships-pro' ),
 					'value' => self::get_discount_codes(),
 				],
-				'pmpro-membership-levels' => [
-					'label' => __( 'Membership Levels', 'paid-membership-levels' ),
+				'pmpro-membership-levels'    => [
+					'label' => __( 'Membership Levels', 'paid-memberships-pro' ),
 					'value' => self::get_levels(),
 				],
-				'pmpro-custom-templates'  => [
-					'label' => __( 'Custom Templates', 'paid-membership-levels' ),
+				'pmpro-custom-templates'     => [
+					'label' => __( 'Custom Templates', 'paid-memberships-pro' ),
 					'value' => self::get_custom_templates(),
+				],
+				'pmpro-getfile-usage'        => [
+					'label' => __( 'getfile.php Usage', 'paid-memberships-pro' ),
+					'value' => self::get_getfile_usage(),
+				],
+				'pmpro-htaccess-cache-usage' => [
+					'label' => __( '.htaccess Cache Usage', 'paid-memberships-pro' ),
+					'value' => self::get_htaccess_cache_usage(),
 				],
 			],
 		];
@@ -308,6 +316,76 @@ class PMPro_Site_Health {
 		}
 
 		return implode( " | \n", $cron_information );
+	}
+
+	/**
+	 * Get the .htaccess services/getfile.php usage information.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The .htaccess services/getfile.php usage information.
+	 */
+	public function get_getfile_usage() {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		/**
+		 * @var $wp_filesystem WP_Filesystem_Base
+		 */
+		global $wp_filesystem;
+
+		WP_Filesystem();
+
+		if ( ! $wp_filesystem ) {
+			return __( 'Unable to verify', 'paid-memberships-pro' );
+		}
+
+		if ( ! $wp_filesystem->exists( ABSPATH . '/.htaccess' ) ) {
+			return __( 'Off - No .htaccess file', 'paid-memberships-pro' );
+		}
+
+		$htaccess_contents = $wp_filesystem->get_contents( ABSPATH . '/.htaccess' );
+
+		if ( false === strpos( $htaccess_contents, '/services/getfile.php' ) ) {
+			return __( 'Off', 'paid-memberships-pro' );
+		}
+
+		return __( 'On - .htaccess contains services/getfile.php usage', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the .htaccess cache usage information.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The .htaccess cache usage information.
+	 */
+	public function get_htaccess_cache_usage() {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		/**
+		 * @var $wp_filesystem WP_Filesystem_Base
+		 */
+		global $wp_filesystem;
+
+		WP_Filesystem();
+
+		if ( ! $wp_filesystem ) {
+			return __( 'Unable to verify', 'paid-memberships-pro' );
+		}
+
+		if ( ! $wp_filesystem->exists( ABSPATH . '/.htaccess' ) ) {
+			return __( 'Off - No .htaccess file', 'paid-memberships-pro' );
+		}
+
+		$htaccess_contents = $wp_filesystem->get_contents( ABSPATH . '/.htaccess' );
+
+		if ( false !== strpos( $htaccess_contents, 'ExpiresByType text/html' ) ) {
+			return __( 'On - Browser cache enabled for HTML (ExpiresByType text/html), this may interfere with Content Restriction after Login. Remove that line from your .htaccess to resolve this problem.', 'paid-memberships-pro' );
+		} elseif ( false !== strpos( $htaccess_contents, 'ExpiresDefault' ) ) {
+			return __( 'On - Browser cache enabled for HTML (ExpiresDefault), this may interfere with Content Restriction after Login. Remove that line from your .htaccess to resolve this problem.', 'paid-memberships-pro' );
+		}
+
+		return __( 'Off', 'paid-memberships-pro' );
 	}
 
 }

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -358,6 +358,14 @@ class PMPro_Site_Health {
 	 * @return string The .htaccess services/getfile.php usage information.
 	 */
 	public function get_getfile_usage() {
+		if ( ! defined( 'PMPRO_GETFILE_ENABLED' ) ) {
+			return __( 'PMPRO_GETFILE_ENABLED is not set', 'paid-memberships-pro' );
+		}
+
+		if ( ! PMPRO_GETFILE_ENABLED ) {
+			return __( 'PMPRO_GETFILE_ENABLED is off', 'paid-memberships-pro' );
+		}
+
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
 		/**
@@ -368,7 +376,7 @@ class PMPro_Site_Health {
 		WP_Filesystem();
 
 		if ( ! $wp_filesystem ) {
-			return __( 'Unable to verify', 'paid-memberships-pro' );
+			return __( 'Unable to access .htaccess file', 'paid-memberships-pro' );
 		}
 
 		if ( ! $wp_filesystem->exists( ABSPATH . '/.htaccess' ) ) {
@@ -402,7 +410,7 @@ class PMPro_Site_Health {
 		WP_Filesystem();
 
 		if ( ! $wp_filesystem ) {
-			return __( 'Unable to verify', 'paid-memberships-pro' );
+			return __( 'Unable to access .htaccess file', 'paid-memberships-pro' );
 		}
 
 		if ( ! $wp_filesystem->exists( ABSPATH . '/.htaccess' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* Adds .htaccess checks to Site Health for getfile.php and presence of Expires cache rules
* Also improves Custom Templates check in Site Health to show path as well as support checking parent vs child theme

### How to test the changes in this Pull Request:

1. Add getfile.php rule(s) to your .htaccess (see below)
2. Add Expires cache rules (see below)
3. Go to Tools > Site Health and look at the Paid Memberships Pro section
4. See the usage detection as expected (with presence of or absence of the rules)

![Screen Shot 2021-10-22 at 12 31 44 PM](https://user-images.githubusercontent.com/709662/138500080-78423b42-db3f-47f7-8c7e-dc4360c45527.png)

#### Example getfile.php rule

```
# Normal getfile.php handler
RewriteRule ^wp-content/uploads/(.*)$ /wp-content/plugins/paid-memberships-pro/services/getfile.php [L]

# Custom getfile.php handler
RewriteRule ^wp-content/test/(.*)$ /wp-content/plugins/paid-memberships-pro/services/getfile.php [L]
```

#### Example Expires cache rules

```
<IfModule mod_expires.c>
ExpiresActive On
ExpiresByType image/jpg "access plus 1 year"
ExpiresByType image/jpeg "access plus 1 year"
ExpiresByType image/gif "access plus 1 year"
ExpiresByType image/png "access plus 1 year"
ExpiresByType text/css "access plus 1 month"
ExpiresByType application/pdf "access plus 1 month"
ExpiresByType text/javascript "access plus 1 month"
ExpiresByType text/html "access plus 2 hours"
ExpiresByType image/x-icon "access plus 1 year"
ExpiresDefault "access plus 6 hours"
</IfModule>
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Now showing more information for Site Health when we detect that .htaccess contains certain rules that may help Support understand your PMPro configuration.

> Added Site Health usage information for parent/child themes when using custom template overrides.