### PR TITLE
Update minimum PHP version in readme.txt so that it's exposed to WordPress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: strangerstudios, kimannwall, andrewza, dlparker1005, paidmembershi
 Tags: memberships, members, subscriptions, ecommerce, user registration, member, membership, e-commerce, paypal, stripe, braintree, authorize.net, payflow, restrict access, restrict content, directory
 Requires at least: 5.2
 Tested up to: 5.8.1
+Requires PHP: 5.6
 Stable tag: 2.6.3
 
 Get Paid with Paid Memberships Pro: The most complete member management and membership subscriptions plugin for your WordPress site.


### PR DESCRIPTION
Just a simple PR to set the required PHP version in readme.txt so that WordPress.org and plugin installs/updates can be aware of the version requirement.