### PR TITLE
Added function pmpro_send_200_http_response()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3791,7 +3791,7 @@ add_filter( 'wp_kses_allowed_html', 'pmpro_kses_allowed_html', 10, 2 );
  *
  * Works with Apache and Nginx.
  *
- * Copied from https://stackoverflow.com/a/42245266
+ * Based on code from https://stackoverflow.com/a/42245266
  *
  * @since TBD.
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3796,6 +3796,13 @@ add_filter( 'wp_kses_allowed_html', 'pmpro_kses_allowed_html', 10, 2 );
  * @since TBD.
  */
 function pmpro_send_200_http_response() {
+	/**
+	 * Allow filtering whether to send an early 200 HTTP response.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $send_early_response Whether to send an early 200 HTTP response.
+	 */
 	if ( ! apply_filters( 'pmpro_send_200_http_response', true ) ) {
 		return;
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3807,11 +3807,8 @@ function pmpro_send_200_http_response() {
 		return;
 	}
 
-	// Check if fastcgi_finish_request is callable.
+	// Ngnix compatibility: Check if fastcgi_finish_request is callable.
 	if ( is_callable( 'fastcgi_finish_request' ) ) {
-		/*
-		 * This works in Nginx but the next approach not
-		 */
 		session_write_close();
 		fastcgi_finish_request();
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3801,7 +3801,7 @@ function pmpro_send_200_http_response() {
 	}
 
 	// Check if fastcgi_finish_request is callable.
-	if (is_callable('fastcgi_finish_request')) {
+	if ( is_callable( 'fastcgi_finish_request' ) ) {
 		/*
 		 * This works in Nginx but the next approach not
 		 */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3793,7 +3793,7 @@ add_filter( 'wp_kses_allowed_html', 'pmpro_kses_allowed_html', 10, 2 );
  *
  * Based on code from https://stackoverflow.com/a/42245266
  *
- * @since TBD.
+ * @since TBD
  */
 function pmpro_send_200_http_response() {
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3814,11 +3814,11 @@ function pmpro_send_200_http_response() {
 	ignore_user_abort(true);
 
 	ob_start();
-	$serverProtocole = filter_input(INPUT_SERVER, 'SERVER_PROTOCOL', FILTER_SANITIZE_STRING);
-	header($serverProtocole.' 200 OK');
-	header('Content-Encoding: none');
-	header('Content-Length: '.ob_get_length());
-	header('Connection: close');
+	$server_protocol = filter_input( INPUT_SERVER, 'SERVER_PROTOCOL', FILTER_SANITIZE_STRING );
+	header( $server_protocol . ' 200 OK' );
+	header( 'Content-Encoding: none' );
+	header( 'Content-Length: ' . ob_get_length() );
+	header( 'Connection: close' );
 
 	ob_end_flush();
 	ob_flush();

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -86,6 +86,9 @@
 	//real event?
 	if(!empty($pmpro_stripe_event->id))
 	{
+		// Send a 200 HTTP response to Stripe to avoid timeout.
+		pmpro_send_200_http_response();
+
 		// Log that we have successfully received a webhook from Stripe.
 		update_option( 'pmpro_stripe_last_webhook_received_' . ( $livemode ? 'live' : 'sandbox' ), date( 'Y-m-d H:i:s' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added function pmpro_send_200_http_response(). Useful to avoid issues like timeouts from gateways during webhook/IPN handlers. Works with Apache and Nginx.

The following code will disable this functionality:
`add_filter( 'pmpro_send_200_http_response', '__return_false' );`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
