### PR TITLE
Add Constant Info to Site Health

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -476,6 +476,16 @@ class PMPro_Site_Health {
 			$constants = array_merge( $constants, $gateway_specific_constants[ $gateway ] );
 		}
 
+		/**
+		 * Allow filtering the supported Site Health constants by other add ons.
+		 *
+		 * @since TBD
+		 *
+		 * @param array  $constants The list of constants to show in Site Health.
+		 * @param string $gateway   The current payment gateway.
+		 */
+		$constants = apply_filters( 'pmpro_site_health_constants', $constants, $gateway );
+
 		// Get and format constant information.
 		$constants_formatted = [];
 

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -100,6 +100,9 @@ class PMPro_Site_Health {
 			],
 		];
 
+		// Automatically add information about constants set.
+		$info['pmpro']['fields'] = array_merge( $info['pmpro']['fields'], self::get_constants() );
+
 		return $info;
 	}
 
@@ -426,6 +429,69 @@ class PMPro_Site_Health {
 		}
 
 		return __( 'Off', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the constants site health information.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The constants site health information.
+	 */
+	public function get_constants() {
+		$constants = [
+			'PMPRO_CRON_LIMIT'                => __( 'Cron Limit', 'paid-memberships-pro' ),
+			'PMPRO_DEFAULT_LEVEL'             => __( 'Default Membership Level', 'paid-memberships-pro' ),
+			'PMPRO_USE_SESSIONS'              => __( 'Use Sessions', 'paid-memberships-pro' ),
+		];
+
+		$gateway_specific_constants = [
+			'authorizenet' => [
+				'PMPRO_AUTHNET_SILENT_POST_DEBUG' => __( 'Authorize.net Silent Post Debug Mode', 'paid-memberships-pro' ),
+			],
+			'braintree' => [
+				'PMPRO_BRAINTREE_WEBHOOK_DEBUG'   => __( 'Braintree Webhook Debug Mode', 'paid-memberships-pro' ),
+			],
+			'paypal' => [
+				'PMPRO_IPN_DEBUG'                 => __( 'PayPal IPN Debug Mode', 'paid-memberships-pro' ),
+			],
+			'paypalexpress' => [
+				'PMPRO_IPN_DEBUG'                 => __( 'PayPal IPN Debug Mode', 'paid-memberships-pro' ),
+			],
+			'paypalstandard' => [
+				'PMPRO_IPN_DEBUG'                 => __( 'PayPal IPN Debug Mode', 'paid-memberships-pro' ),
+			],
+			'stripe' => [
+				'PMPRO_STRIPE_WEBHOOK_DELAY'      => __( 'Stripe Webhook Delay', 'paid-memberships-pro' ),
+				'PMPRO_STRIPE_WEBHOOK_DEBUG'      => __( 'Stripe Webhook Debug Mode', 'paid-memberships-pro' ),
+			],
+			'twocheckout' => [
+				'PMPRO_INS_DEBUG'                 => __( '2Checkout INS Debug Mode', 'paid-memberships-pro' ),
+			],
+		];
+
+		$gateway = pmpro_getOption( 'gateway' );
+
+		if ( $gateway && isset( $gateway_specific_constants[ $gateway ] ) ) {
+			$constants = array_merge( $constants, $gateway_specific_constants[ $gateway ] );
+		}
+
+		// Get and format constant information.
+		$constants_formatted = [];
+
+		foreach ( $constants as $constant => $label ) {
+			// Only get site health info for constants that are set.
+			if ( ! defined( $constant ) ) {
+				continue;
+			}
+
+			$constants_formatted[ 'pmpro-constants-' . $constant ] = [
+				'label' => $label . ' (' . $constant . ')',
+				'value' => var_export( constant( $constant ), true ),
+			];
+		}
+
+		return $constants_formatted;
 	}
 
 }


### PR DESCRIPTION
This addition to Site Health follows #1827 and is set up to just make it easy to merge both without conflicts. 

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Add helpful information about certain PMPro constants and their values if they are manually set

### How to test the changes in this Pull Request:

1. Set `PMPRO_DEFAULT_LEVEL` or any of the supported constants
2. Look in Tools > Site Health > Info > Paid Memberships Pro
3. See constant shows up now and includes the value it's set to

#### Example constant

`define( 'PMPRO_DEFAULT_LEVEL', 123 );`

#### Example info copy/paste output

```
pmpro-constants-PMPRO_CRON_LIMIT: 'testing'
pmpro-constants-PMPRO_DEFAULT_LEVEL: 'testing'
pmpro-constants-PMPRO_USE_SESSIONS: false
pmpro-constants-PMPRO_STRIPE_WEBHOOK_DELAY: 'testing'
pmpro-constants-PMPRO_STRIPE_WEBHOOK_DEBUG: 'testing'
```

#### Example info shown on screen

<img width="340" alt="Screen Shot 2021-10-28 at 4 15 19 PM" src="https://user-images.githubusercontent.com/709662/139336744-018620bf-133d-4d56-b3a1-01337aa138a5.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add helpful information about certain PMPro constants and their values if they are manually set