### PR TITLE
Enqueue admin assets for profile pages

### DIFF
--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -4,27 +4,27 @@
  */
 function pmpro_enqueue_scripts() {
     global $pmpro_pages;
-    
-    // Figure out which frontend.css file to load.    
+
+    // Figure out which frontend.css file to load.
     if( file_exists( get_stylesheet_directory() . "/paid-memberships-pro/css/frontend.css" ) ) {
-        $frontend_css = get_stylesheet_directory_uri() . "/paid-memberships-pro/css/frontend.css";        
+        $frontend_css = get_stylesheet_directory_uri() . "/paid-memberships-pro/css/frontend.css";
     } elseif( file_exists( get_template_directory() . "/paid-memberships-pro/frontend.css" ) ) {
-        $frontend_css = get_template_directory_uri() . "/paid-memberships-pro/frontend.css";        
+        $frontend_css = get_template_directory_uri() . "/paid-memberships-pro/frontend.css";
     } else {
-        $frontend_css = plugins_url( 'css/frontend.css',dirname(__FILE__) );        
+        $frontend_css = plugins_url( 'css/frontend.css',dirname(__FILE__) );
     }
     wp_enqueue_style( 'pmpro_frontend', $frontend_css, array(), PMPRO_VERSION, "screen" );
-    
+
     // Figure out which frontend-rlt.css file to load if applicable.
-    if( is_rtl() ) {        
+    if( is_rtl() ) {
         if( file_exists( get_stylesheet_directory() . "/paid-memberships-pro/css/frontend-rtl.css" ) ) {
             $frontend_css_rtl = get_stylesheet_directory_uri() . "/paid-memberships-pro/css/frontend-rtl.css";
         } elseif ( file_exists( get_template_directory() . "/paid-memberships-pro/css/frontend-rtl.css" ) ) {
             $frontend_css_rtl = get_template_directory_uri() . "/paid-memberships-pro/css/frontend-rtl.css";
         } else {
             $frontend_css_rtl = plugins_url('css/frontend-rtl.css',dirname(__FILE__) );
-        }        
-        wp_enqueue_style( 'pmpro_frontend_rtl', $frontend_css_rtl, array(), PMPRO_VERSION, "screen" ); 
+        }
+        wp_enqueue_style( 'pmpro_frontend_rtl', $frontend_css_rtl, array(), PMPRO_VERSION, "screen" );
     }
 
     // Print styles.
@@ -35,7 +35,7 @@ function pmpro_enqueue_scripts() {
     else
         $print_css = plugins_url('css/print.css',dirname(__FILE__) );
     wp_enqueue_style('pmpro_print', $print_css, array(), PMPRO_VERSION, "print");
-    
+
     // Checkout page JS
     if ( pmpro_is_checkout() ) {
         wp_register_script( 'pmpro_checkout',
@@ -51,8 +51,8 @@ function pmpro_enqueue_scripts() {
         ));
         wp_enqueue_script( 'pmpro_checkout' );
     }
-    
-    // Change Password page JS 
+
+    // Change Password page JS
 	$is_change_pass_page = ! empty( $pmpro_pages['member_profile_edit'] )
 							&& is_page( $pmpro_pages['member_profile_edit'] )
 							&& ! empty( $_REQUEST['view'] )
@@ -61,7 +61,7 @@ function pmpro_enqueue_scripts() {
 							&& is_page( $pmpro_pages['login'] )
 							&& ! empty( $_REQUEST['action'] )
 							&& $_REQUEST['action'] === 'rp';
-		
+
 	if ( $is_change_pass_page || $is_reset_pass_page ) {
         wp_register_script( 'pmpro_login',
                             plugins_url( 'js/pmpro-login.js', dirname(__FILE__) ),
@@ -69,11 +69,11 @@ function pmpro_enqueue_scripts() {
                             PMPRO_VERSION );
 
         /**
-         * Filter to allow weak passwords on the 
+         * Filter to allow weak passwords on the
          * change password and reset password forms.
          * At this time, this only disables the JS check on the frontend.
          * There is no backend check for weak passwords on those forms.
-         * 
+         *
          * @since 2.3.3
          *
          * @param bool $allow_weak_passwords    Whether to allow weak passwords.
@@ -84,7 +84,7 @@ function pmpro_enqueue_scripts() {
             'pmpro_login_page' => 'changepassword',
 			'strength_indicator_text' => __( 'Strength Indicator', 'paid-memberships-pro' ),
             'allow_weak_passwords' => $allow_weak_passwords ) );
-        wp_enqueue_script( 'pmpro_login' );	
+        wp_enqueue_script( 'pmpro_login' );
     }
 }
 add_action( 'wp_enqueue_scripts', 'pmpro_enqueue_scripts' );
@@ -93,6 +93,8 @@ add_action( 'wp_enqueue_scripts', 'pmpro_enqueue_scripts' );
  * Enqueue admin JavaScript and CSS
  */
 function pmpro_admin_enqueue_scripts() {
+	global $pagenow;
+
 	// Admin JS
 	wp_register_script( 'pmpro_admin', plugins_url( 'js/pmpro-admin.js', __DIR__ ), [
 		'jquery',
@@ -122,7 +124,7 @@ function pmpro_admin_enqueue_scripts() {
 	} else {
 		$admin_css = plugins_url( 'css/admin.css', __DIR__ );
 	}
-    
+
     // Figure out which admin-rtl.css to load if applicable.
     if ( file_exists( get_stylesheet_directory() . '/paid-memberships-pro/css/admin-rtl.css' ) ) {
 		$admin_css_rtl = get_stylesheet_directory_uri() . '/paid-memberships-pro/css/admin-rtl.css';
@@ -130,13 +132,16 @@ function pmpro_admin_enqueue_scripts() {
 		$admin_css_rtl = get_template_directory_uri() . '/paid-memberships-pro/css/admin-rtl.css';
 	} else {
 		$admin_css_rtl = plugins_url( 'css/admin-rtl.css', __DIR__ );
-	}        
+	}
 
 	wp_register_style( 'pmpro_admin', $admin_css, [], PMPRO_VERSION, 'screen' );
 	wp_register_style( 'pmpro_admin_rtl', $admin_css_rtl, [], PMPRO_VERSION, 'screen' );
 
-	// Only enqueue PMPro admin scripts on our own pages.
-	if ( ! isset( $_GET['page'] ) || 0 !== strpos( $_GET['page'], 'pmpro' ) ) {
+	$is_pmpro_page   = isset( $_GET['page'] ) && 0 === strpos( $_GET['page'], 'pmpro' );
+	$is_profile_page = ! empty( $pagenow ) && in_array( $pagenow, [ 'user-edit.php', 'profile.php' ], true );
+
+	// Only enqueue PMPro admin scripts on our own pages and on admin profile pages.
+	if ( ! $is_pmpro_page && ! $is_profile_page ) {
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves problems where the profile pages do not load our assets.

### How to test the changes in this Pull Request:

1. Load up profile.php or edit-user.php
2. See our admin.css

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed issue where admin assets were not loading on profile edit screen.