### PR TITLE
We need to load admin.css on all admin pages.

### DIFF
--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -133,12 +133,7 @@ function pmpro_admin_enqueue_scripts() {
 	}        
 
 	wp_register_style( 'pmpro_admin', $admin_css, [], PMPRO_VERSION, 'screen' );
-	wp_register_style( 'pmpro_admin_rtl', $admin_css_rtl, [], PMPRO_VERSION, 'screen' );
-
-	// Only enqueue PMPro admin scripts on our own pages.
-	if ( ! isset( $_GET['page'] ) || 0 !== strpos( $_GET['page'], 'pmpro' ) ) {
-		return;
-	}
+	wp_register_style( 'pmpro_admin_rtl', $admin_css_rtl, [], PMPRO_VERSION, 'screen' );	
 
 	wp_enqueue_script( 'pmpro_admin' );
 	wp_enqueue_style( 'pmpro_admin' );


### PR DESCRIPTION
In a previous update we added a check to only load admin.css on "PMPro admin pages". This caused an issue because we also need to load that CSS on the edit user/profile page. In reality, we potentially will use the styles in admin.css on any number of admin pages. I'd rather our design team only have to manage the one admin.css file for all admin styles.

If there are conflicts from loading these styles on an admin page, we should update our CSS code to better target it instead of unloading the CSS.

One minor issue that is still present is that the dashicon we add to the Memberships menu in the admin bar is not showing up when viewed from a frontend page. We can fix this later by inserting that specific CSS into the admin bar code via filter.