### PR TITLE
Add new action pmpro_before_commit_express_checkout

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -601,7 +601,7 @@
 				/**
 				 * Allow performing actions just before sending the user to the gateway to complete the payment.
 				 *
-				 * @since TBD
+				 * @since 2.6.5
 				 *
 				 * @param MemberOrder $order The new order with status = token.
 				 */

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -598,6 +598,15 @@
 				//update order
 				$order->saveOrder();
 
+				/**
+				 * Allow performing actions just before sending the user to the gateway to complete the payment.
+				 *
+				 * @since TBD
+				 *
+				 * @param MemberOrder $order The new order with status = token.
+				 */
+				do_action( 'pmpro_before_commit_express_checkout', $order );
+
 				//redirect to paypal
 				$paypal_url = "https://www.paypal.com/webscr?cmd=_express-checkout&useraction=commit&token=" . $this->httpParsedResponseAr['TOKEN'];
 				$environment = pmpro_getOption("gateway_environment");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This one allows performing actions on order status = token, just before sending the user to the gateway to complete the payment.

Expecially useful to save pmpro_signup_username / pmpro_signup_password / pmpro_signup_email into order metas, to be used when trying to recover checkout failure if the browser session is lost, as reported #1338.

To be combined with this snippet: https://gist.github.com/mircobabini/bf9b65010124e4ab1e04c0c634681364

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->