### PR TITLE
Escaping output and email content in our webhook handlers.

### DIFF
--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -58,7 +58,7 @@
 		else
 			$log_email = get_option("admin_email");
 			
-		wp_mail($log_email, "Authorize.net Silent Post From " . get_option("blogname"), nl2br($logstr));
+		wp_mail( $log_email, "Authorize.net Silent Post From " . get_option( "blogname" ), nl2br( esc_html( $logstr ) ) );
 	}	
 
 	// If it is an ARB transaction, do something with it

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -598,7 +598,7 @@ function pmpro_braintreeWebhookExit() {
 				$log_email = get_option( "admin_email" );
 			}
 			
-			wp_mail( $log_email, get_option( "blogname" ) . " Braintree Webhook Log", nl2br( $debuglog ) );
+			wp_mail( $log_email, get_option( "blogname" ) . " Braintree Webhook Log", nl2br( esc_html( $debuglog ) ) );
 		}
 	}
 	

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -369,7 +369,7 @@ function pmpro_ipnExit() {
 	if ( $logstr ) {
 		$logstr = "Logged On: " . date_i18n( "m/d/Y H:i:s" ) . "\n" . $logstr . "\n-------------\n";
 
-		echo $logstr;
+		echo esc_html( $logstr );
 
 		//log or dont log? log in file or email?
 		//- dont log if constant is undefined or defined but false
@@ -387,10 +387,10 @@ function pmpro_ipnExit() {
 				fclose( $loghandle );
 			} elseif ( is_email( PMPRO_IPN_DEBUG ) ) {
 				//email to specified address
-				wp_mail( PMPRO_IPN_DEBUG, get_option( "blogname" ) . " IPN Log", nl2br( $logstr ) );							
+				wp_mail( PMPRO_IPN_DEBUG, get_option( "blogname" ) . " IPN Log", nl2br( esc_html( $logstr ) ) );							
 			} else {
 				//email to admin
-				wp_mail( get_option( "admin_email" ), get_option( "blogname" ) . " IPN Log", nl2br( $logstr ) );							
+				wp_mail( get_option( "admin_email" ), get_option( "blogname" ) . " IPN Log", nl2br( esc_html( $logstr ) ) );							
 			}
 		}
 	}
@@ -573,7 +573,7 @@ function pmpro_ipnChangeMembershipLevel( $txn_id, &$morder ) {
 
 	global $pmpro_error;
 	if ( ! empty( $pmpro_error ) ) {
-		echo $pmpro_error;
+		echo esc_html( $pmpro_error );
 		ipnlog( $pmpro_error );
 	}
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -558,7 +558,7 @@
 		{
 			$logstr = "Logged On: " . date_i18n("m/d/Y H:i:s") . "\n" . $logstr . "\n-------------\n";
 
-			echo $logstr;
+			echo esc_html( $logstr );
 
 			//log in file or email?
 			if(defined('PMPRO_STRIPE_WEBHOOK_DEBUG') && PMPRO_STRIPE_WEBHOOK_DEBUG === "log")
@@ -576,7 +576,7 @@
 				else
 					$log_email = get_option("admin_email");
 
-				wp_mail($log_email, get_option("blogname") . " Stripe Webhook Log", nl2br($logstr));
+				wp_mail( $log_email, get_option( "blogname" ) . " Stripe Webhook Log", nl2br( esc_html( $logstr ) ) );
 			}
 		}
 

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -195,7 +195,7 @@
 	function pmpro_twocheckoutExit($redirect = false)
 	{
 		global $logstr;
-		//echo $logstr;
+		//echo esc_html( $logstr );
 
 		$logstr = var_export($_REQUEST, true) . "Logged On: " . date_i18n("m/d/Y H:i:s") . "\n" . $logstr . "\n-------------\n";
 
@@ -215,7 +215,7 @@
 			else
 				$log_email = get_option("admin_email");
 
-			wp_mail($log_email, get_option("blogname") . " 2Checkout INS Log", nl2br($logstr));
+			wp_mail( $log_email, get_option( "blogname" ) . " 2Checkout INS Log", nl2br( esc_html( $logstr ) ) );
 		}
 
 		if(!empty($redirect))
@@ -330,7 +330,7 @@
 		global $pmpro_error;
 		if(!empty($pmpro_error))
 		{
-			echo $pmpro_error;
+			echo esc_html( $pmpro_error );
 			inslog($pmpro_error);
 		}
 


### PR DESCRIPTION
As reported by Victor Garcia, our webhook handlers were not properly escaping content that was output to the browser or emailed to the admin when the webhook debug log options were being used.

While tricky to do, motivated actors could generate post requests to the webhook handlers that would output HTML or JavaScript to the webhook handler URL to either spoof content on your site or further attack the site through cross site scripting.

This PR escapes all output and email content in the webhook handlers.