### PR TITLE
Add option to remove duplicate levels after memberhsip level change.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1195,7 +1195,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 		/**
 		 * Allow filtering whether to remove duplicate "active" memberships by setting them to "changed".
 		 *
-		 * @since TBD
+		 * @since 2.6.6
 		 *
 		 * @param bool $remove_duplicate_memberships Whether to remove duplicate "active" memberships by setting them to "changed".
 		 */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1192,8 +1192,16 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 			return false;
 		}
 
-		// Remove duplicates of this level. Default to off for now.
-		if ( apply_filters( 'pmpro_remove_duplicate_membership_entries', false ) ) {
+		/**
+		 * Allow filtering whether to remove duplicate "active" memberships by setting them to "changed".
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $remove_duplicate_memberships Whether to remove duplicate "active" memberships by setting them to "changed".
+		 */
+		$remove_duplicate_memberships = apply_filters( 'pmpro_remove_duplicate_membership_entries', false );
+
+		if ( $remove_duplicate_memberships ) {
 			$wpdb->query(
 				$wpdb->prepare(
 					"

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1199,7 +1199,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 		 *
 		 * @param bool $remove_duplicate_memberships Whether to remove duplicate "active" memberships by setting them to "changed".
 		 */
-		$remove_duplicate_memberships = apply_filters( 'pmpro_remove_duplicate_membership_entries', false );
+		$remove_duplicate_memberships = apply_filters( 'pmpro_remove_duplicate_membership_entries', true );
 
 		if ( $remove_duplicate_memberships ) {
 			$wpdb->query(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added option to have old entries for a membership level deactivated when that level is changed to. This behavior is currently defaulted to off, but can be enabled using the `pmpro_remove_duplicate_membership_entries` filter. We may want to consider having this enabled be the default behavior.

This is useful in cases where users have multiple active memberships for a particular membership level. Typically, this should not happen, however there are edge cases (such as with WooCommerce Add On and potentially membership imports) where it could.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
