### PR TITLE
Fix/membership renewal considers month to always be 30 days

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -40,9 +40,9 @@ function pmpro_checkout_level_extend_memberships( $level ) {
 				$expiration_day = $expiration_date->format('d');
 				$expiration_month = strtotime('+1 month', $expiration_date->format('n'));
 				if ($expiration_day > cal_days_in_month($expiration_month)) {
-					$additional_month = strtotime('Y-m-t', strtotime("+1 month", $expiration_date));
+					$additional_month = strtotime('Y-m-t', strtotime("+1 month", $expiration_date)) - $todays_date;
 				} else {
-					$additional_month = strtotime('Y-m-d', strtotime("+1 month", $expiration_date));
+					$additional_month = (strtotime('Y-m-d', strtotime("+1 month", $expiration_date))) - $todays_date;
 				}
 				$total_days = $days_left + $level->expiration_number * $additional_month;
 			} elseif ( $level->expiration_period == 'Year' ) {

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -38,13 +38,13 @@ function pmpro_checkout_level_extend_memberships( $level ) {
 				$total_days = $days_left + $level->expiration_number * 7;
 			} elseif ( $level->expiration_period == 'Month' ) {
 				$expiration_day = $expiration_date->format('d');
-				$expiration_month = strtotime('+1 month', $expiration_date->format('n'));
+				$expiration_month = strtotime("+{$level->expiration_number} month", $expiration_date->format('n'));
 				if ($expiration_day > cal_days_in_month($expiration_month)) {
-					$additional_month = strtotime('Y-m-t', strtotime("+1 month", $expiration_date)) - $todays_date;
+					$additional_time = strtotime('Y-m-t', strtotime("+{$level->expiration_number} month", $expiration_date)) - $todays_date;
 				} else {
-					$additional_month = (strtotime('Y-m-d', strtotime("+1 month", $expiration_date))) - $todays_date;
+					$additional_time = (strtotime('Y-m-d', strtotime("+{$level->expiration_number}", $expiration_date))) - $todays_date;
 				}
-				$total_days = $days_left + $level->expiration_number * $additional_month;
+				$total_days = $days_left + $additional_time;
 			} elseif ( $level->expiration_period == 'Year' ) {
 				$total_days = $days_left + $level->expiration_number * 365;
 			}

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -37,7 +37,14 @@ function pmpro_checkout_level_extend_memberships( $level ) {
 			} elseif ( $level->expiration_period == 'Week' ) {
 				$total_days = $days_left + $level->expiration_number * 7;
 			} elseif ( $level->expiration_period == 'Month' ) {
-				$total_days = $days_left + $level->expiration_number * 30;
+				$expiration_day = $expiration_date->format('d');
+				$expiration_month = strtotime('+1 month', $expiration_date->format('n'));
+				if ($expiration_day > cal_days_in_month($expiration_month)) {
+					$additional_month = strtotime('Y-m-t', strtotime("+1 month", $expiration_date));
+				} else {
+					$additional_month = strtotime('Y-m-d', strtotime("+1 month", $expiration_date));
+				}
+				$total_days = $days_left + $level->expiration_number * $additional_month;
 			} elseif ( $level->expiration_period == 'Year' ) {
 				$total_days = $days_left + $level->expiration_number * 365;
 			}


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves Membership renewal considers month to always be 30 days

Utilizes strtotime(+1 month) function, checks if days of expiration date is greater than the last day of the following month. If the last day of the following month is greater than the expiration date's day, then precedes as normal. Otherwise, the new expiration day is set to the last day of the next month, this date is than subtracted from todays date to produce the number of days in the extension

### How to test the changes in this Pull Request:
Attempt to extend a membership by one month

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.


#1617 