### PR TITLE
Expiration date invalid on Discount Code REST API Endpoint

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -612,7 +612,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 			$discount_code->code = $code;
 			$discount_code->starts = $starts;
-			$discount_code->ends = $expires;
+			$discount_code->expires = $expires;
 			$discount_code->uses = $uses;
 			$discount_code->levels = !empty( $levels_array ) ? $levels_array : $levels;
 			$discount_code->save();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We're currently referencing $discount_code->end when it should reference $discount_code->expires for the expiration date. 

### How to test the changes in this Pull Request:

Sample of existing POST request to create a discount code: 

![image](https://user-images.githubusercontent.com/8989542/145559784-2e7a1c8f-ce95-40f9-be2d-969a05611b1c.png)

After the changes have been made: 

![image](https://user-images.githubusercontent.com/8989542/145559848-f775fab4-e1e4-451e-8aac-7ebc78cabbae.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed a bug where the discount code expiration date wasn't being used in the REST API.
