### PR TITLE
Recaptcha free levels

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -244,7 +244,7 @@
 						<select id="recaptcha" name="recaptcha" onchange="pmpro_updateRecaptchaTRs();">
 							<option value="0" <?php if(!$recaptcha) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
 							<!-- For reference, removed the Yes - Free memberships only. option -->
-							<option value="2" <?php if($recaptcha == 2) { ?>selected="selected"<?php } ?>><?php _e('Yes - All memberships.', 'paid-memberships-pro' );?></option>
+							<option value="2" <?php if( $recaptcha > 0 ) { ?>selected="selected"<?php } ?>><?php _e('Yes - All memberships.', 'paid-memberships-pro' );?></option>
 						</select>
 						<p class="description"><?php _e('A free reCAPTCHA key is required.', 'paid-memberships-pro' );?> <a href="https://www.google.com/recaptcha/admin/create"><?php _e('Click here to signup for reCAPTCHA', 'paid-memberships-pro' );?></a>.</p>
 					</td>

--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -243,7 +243,7 @@
 					<td>
 						<select id="recaptcha" name="recaptcha" onchange="pmpro_updateRecaptchaTRs();">
 							<option value="0" <?php if(!$recaptcha) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
-							<option value="1" <?php if($recaptcha == 1) { ?>selected="selected"<?php } ?>><?php _e('Yes - Free memberships only.', 'paid-memberships-pro' );?></option>
+							<!-- For reference, removed the Yes - Free memberships only. option -->
 							<option value="2" <?php if($recaptcha == 2) { ?>selected="selected"<?php } ?>><?php _e('Yes - All memberships.', 'paid-memberships-pro' );?></option>
 						</select>
 						<p class="description"><?php _e('A free reCAPTCHA key is required.', 'paid-memberships-pro' );?> <a href="https://www.google.com/recaptcha/admin/create"><?php _e('Click here to signup for reCAPTCHA', 'paid-memberships-pro' );?></a>.</p>

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -485,7 +485,7 @@ if ( empty( $default_gateway ) ) {
 	<div class="<?php echo pmpro_get_element_class( 'pmpro_checkout-field pmpro_captcha', 'pmpro_captcha' ); ?>">
 	<?php
 		global $recaptcha, $recaptcha_publickey;
-		if ( $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) {
+		if ( $recaptcha == 2 || $recaptcha == 1 ) {
 			echo pmpro_recaptcha_get_html($recaptcha_publickey, NULL, true);
 		}
 	?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Based on the issue #1840, its better to remove the option of having reCAPTCHA for free levels only. You should be able to have it on for all, or off completely. This reduces other possible edge cases such as a paid level that becomes free after a discount code. 

Relates to #1840 

### How to test the changes in this Pull Request:

1. If you had previously set reCAPTCHA to only show for Free Levels, it will now show for all members
2. The dropdown option in the Advanced Setting defaults to Yes - All Membership Levels if the option of Free Levels was previously selected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Removed the option of displaying reCAPTCHA for free membership levels.
