### PR TITLE
Current screen name gets partially translated

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -118,7 +118,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 
 		// Shortcut for editing columns in default memberslist location.
 		$current_screen = get_current_screen();
-		if ( ! empty( $current_screen ) && 'memberships_page_pmpro-memberslist' === $current_screen->id ) {
+		if ( ! empty( $current_screen ) && strpos( $current_screen->id, "pmpro-memberslist" ) !== false ) {
 			$columns = apply_filters( 'pmpro_manage_memberslist_columns', $columns );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `members_page-pmpro-memberslist` page name seems to get partially transport. 

This means that the screen name becomes `membresia_page_pmpro-memberslist` when changing to Spanish. 

As a band-aid, we're checking for the last part of the screen name now. 

Relates to #1876 

### How to test the changes in this Pull Request:

1. Steps on how to recreate this can be found in #1876 
2. Add the code recipe https://www.paidmembershipspro.com/add-custom-column-members-list-users-admin-pages/
3. Change site language to anything except English
4. The column will disappear after changing languages

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes around the `pmpro_manage_memberslist_columns` filter to accommodate sites that aren't in English
