### PR TITLE
Fixing update function for PayPal Website Payments

### DIFF
--- a/classes/gateways/class.pmprogateway_paypal.php
+++ b/classes/gateways/class.pmprogateway_paypal.php
@@ -633,7 +633,7 @@
 		{
 			//paypal profile stuff
 			$nvpStr = "";
-			$nvpStr .= "&PROFILEID=" . $order->subscription_transaction_id;
+			$nvpStr .= "&PROFILEID=" .  urlencode( $order->subscription_transaction_id );
 
 			//credit card fields
 			if($order->cardtype == "American Express")
@@ -643,26 +643,26 @@
 
 			//credit card fields
 			if($cardtype)
-				$nvpStr .= "&CREDITCARDTYPE=" . $cardtype . "&ACCT=" . $order->accountnumber . "&EXPDATE=" . $order->ExpirationDate . "&CVV2=" . $order->CVV2;
+				$nvpStr .= "&CREDITCARDTYPE=" .  urlencode( $cardtype ) . "&ACCT=" .  urlencode( $order->accountnumber ) . "&EXPDATE=" .  urlencode( $order->ExpirationDate ) . "&CVV2=" .  urlencode( $order->CVV2 );
 
 			//Maestro/Solo card fields. (Who uses these?) :)
 			if($order->StartDate)
-				$nvpStr .= "&STARTDATE=" . $order->StartDate . "&ISSUENUMBER=" . $order->IssueNumber;
+				$nvpStr .= "&STARTDATE=" .  urlencode( $order->StartDate ) . "&ISSUENUMBER=" .  urlencode( $order->IssueNumber );
 
 				// Name and email info
 				if ( $order->FirstName && $order->LastName && $order->Email ) {
-					$nvpStr .= "&EMAIL=" . $order->Email . "&FIRSTNAME=" . $order->FirstName . "&LASTNAME=" . $order->LastName;
+					$nvpStr .= "&EMAIL=" .  urlencode( $order->Email ) . "&FIRSTNAME=" .  urlencode( $order->FirstName ) . "&LASTNAME=" .  urlencode( $order->LastName );
 				}
 
 				//billing address, etc
 				if($order->Address1)
 				{
-					$nvpStr .= "&STREET=" . $order->Address1;
+					$nvpStr .= "&STREET=" . urlencode( $order->Address1 );
 
 					if($order->Address2)
-						$nvpStr .= "&STREET2=" . $order->Address2;
+						$nvpStr .= "&STREET2=" . urlencode( $order->Address2 );
 
-					$nvpStr .= "&CITY=" . $order->billing->city . "&STATE=" . $order->billing->state . "&COUNTRYCODE=" . $order->billing->country . "&ZIP=" . $order->billing->zip . "&SHIPTOPHONENUM=" . $order->billing->phone;
+					$nvpStr .= "&CITY=" . urlencode( $order->billing->city ) . "&STATE=" . urlencode( $order->billing->state ) . "&COUNTRYCODE=" . urlencode( $order->billing->country )  . "&ZIP=" . urlencode( $order->billing->zip ) . "&SHIPTOPHONENUM=" . urlencode( $order->billing->phone );
 				}
 
 			$this->httpParsedResponseAr = $this->PPHttpPost('UpdateRecurringPaymentsProfile', $nvpStr);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Remove the `SHIPTOPHONENUM` parameter so that the update does not error out when we don't pass the rest of the user's shipping information
2. URL encode parameters that are passed in the update method


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
