### PR TITLE
including recaptcha on the billing page. updated submit button to wor…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.6.7 - 2022-01-06 =
+* SECURITY: Updated escaping in the pmpro_getLevelAtCheckout and pmpro_checkDiscountCode functions as extra precaution against SQL injections. (Thanks, WPScan)
+
 = 2.6.6 - 2021-11-18 =
 * SECURITY: Updated escaping on the discount codes page in the dashboard to prevent XSS attacks. #1867 (Thanks, Erwan from WPScan)
 * BUG FIX/ENHANCEMENT: Added code to remove duplicate active rows in the pmpro_memberships_users table after level change. This might have happened e.g. if users were purchasing a level via the WooCommerce Add On multiple times. #1860 (@dlparker1005)

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -238,12 +238,12 @@
 			?>
 			<span id="pmpro_paypalexpress_checkout" <?php if(($gateway != "paypalexpress" && $gateway != "paypalstandard") || !$pmpro_requirebilling) { ?>style="display: none;"<?php } ?>>
 				<input type="hidden" name="submit-checkout" value="1" />
-				<input type="image" value="<?php _e('Check Out with PayPal', 'paid-memberships-pro' );?> &raquo;" src="<?php echo apply_filters("pmpro_paypal_button_image", "https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-medium.png");?>" />
+				<input type="image" id="pmpro_btn-submit-paypalstandard" class="<?php echo pmpro_get_element_class( 'pmpro_btn-submit-checkout' ); ?>" value="<?php _e('Check Out with PayPal', 'paid-memberships-pro' );?> &raquo;" src="<?php echo apply_filters("pmpro_paypal_button_image", "https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-medium.png");?>" />
 			</span>
 
 			<span id="pmpro_submit_span" <?php if(($gateway == "paypalexpress" || $gateway == "paypalstandard") && $pmpro_requirebilling) { ?>style="display: none;"<?php } ?>>
 				<input type="hidden" name="submit-checkout" value="1" />
-				<input type="submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ); ?>" value="<?php if($pmpro_requirebilling) { _e('Submit and Check Out', 'paid-memberships-pro' ); } else { _e('Submit and Confirm', 'paid-memberships-pro' );}?> &raquo;" />
+				<input type="submit" id="pmpro_btn-submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ); ?>" value="<?php if($pmpro_requirebilling) { _e('Submit and Check Out', 'paid-memberships-pro' ); } else { _e('Submit and Confirm', 'paid-memberships-pro' );}?> &raquo;" />				
 			</span>
 			<?php
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2356,12 +2356,7 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 
 	// what level are they purchasing? (discount code passed)
 	if ( ! empty( $level_id ) && ! empty( $discount_code ) ) {
-		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
-
-		var_dump( $wpdb );
-		echo "<hr />";
-		var_dump( $wpdb->error );
-		echo "<hr />";
+		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );		
 
 		// check code
 		global $pmpro_checkout_level_ids; // Set by MMPU.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -110,7 +110,7 @@ function pmpro_get_slug( $post_id ) {
 	$post_id = intval( $post_id );
 
 	if ( ! $pmpro_slugs[ $post_id ] ) {
-		$pmpro_slugs[ $post_id ] = $wpdb->get_var( "SELECT post_name FROM $wpdb->posts WHERE ID = '" . $post_id . "' LIMIT 1" );
+		$pmpro_slugs[ $post_id ] = $wpdb->get_var( "SELECT post_name FROM $wpdb->posts WHERE ID = '" . esc_sql( $post_id ) . "' LIMIT 1" );
 	}
 
 	return $pmpro_slugs[ $post_id ];
@@ -1079,7 +1079,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	if ( $old_levels && $pmpro_deactivate_old_levels ) {
 		foreach ( $old_levels as $old_level ) {
 
-			$sql = "UPDATE $wpdb->pmpro_memberships_users SET `status`='$old_level_status', `enddate`='" . current_time( 'mysql' ) . "' WHERE `id`=" . $old_level->subscription_id;
+			$sql = "UPDATE $wpdb->pmpro_memberships_users SET `status`='$old_level_status', `enddate`='" . esc_sql( current_time( 'mysql' ) ) . "' WHERE `id`=" . esc_sql( $old_level->subscription_id );
 
 			if ( ! $wpdb->query( $sql ) ) {
 				$pmpro_error = __( 'Error interacting with database', 'paid-memberships-pro' ) . ': ' . ( $wpdb->last_error ? $wpdb->last_error : 'unavailable' );
@@ -1093,7 +1093,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	if ( ! empty( $cancel_level ) ) {
 		$pmpro_cancel_previous_subscriptions = true;    // don't filter cause we're doing just the one
 
-		$other_order_ids = $wpdb->get_col( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . $user_id . "' AND status = 'success' AND membership_id = '" . esc_sql( $cancel_level ) . "' ORDER BY id DESC LIMIT 1" );
+		$other_order_ids = $wpdb->get_col( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE user_id = '" . esc_sql( $user_id ) . "' AND status = 'success' AND membership_id = '" . esc_sql( $cancel_level ) . "' ORDER BY id DESC LIMIT 1" );
 	} else {
 		$pmpro_cancel_previous_subscriptions = true;
 		if ( isset( $_REQUEST['cancel_membership'] ) && $_REQUEST['cancel_membership'] == false ) {
@@ -1104,7 +1104,7 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 		$other_order_ids = $wpdb->get_col(
 			"SELECT id, IF(subscription_transaction_id = '', CONCAT('UNIQUE_SUB_ID_', id), subscription_transaction_id) as unique_sub_id
 											FROM $wpdb->pmpro_membership_orders
-											WHERE user_id = '" . $user_id . "'
+											WHERE user_id = '" . esc_sql( $user_id ) . "'
 												AND status = 'success'
 											GROUP BY unique_sub_id
 											ORDER BY id DESC"
@@ -1409,7 +1409,7 @@ function pmpro_getMembershipCategories( $level_id ) {
 	$categories = $wpdb->get_col(
 		"SELECT c.category_id
 										FROM {$wpdb->pmpro_memberships_categories} AS c
-										WHERE c.membership_id = '" . $level_id . "'"
+										WHERE c.membership_id = '" . esc_sql( $level_id ) . "'"
 	);
 
 	return $categories;
@@ -1788,7 +1788,7 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 	// have we run out of uses?
 	if ( ! $error ) {
 		if ( $dbcode->uses > 0 ) {
-			$used = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . $dbcode->id . "'" );
+			$used = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $dbcode->id ) . "'" );
 			if ( $used >= $dbcode->uses ) {
 				$error = __( 'This discount code is no longer valid.', 'paid-memberships-pro' );
 			}
@@ -1806,7 +1806,7 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 			} else {
 				$level_id = intval( $level_id );
 			}
-			$code_level = $wpdb->get_row( "SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id WHERE cl.code_id = '" . $dbcode->id . "' AND cl.level_id IN (" . $level_id . ") LIMIT 1" );
+			$code_level = $wpdb->get_row( "SELECT l.id, cl.*, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id WHERE cl.code_id = '" . esc_sql( $dbcode->id ) . "' AND cl.level_id IN (" . esc_sql( $level_id ) . ") LIMIT 1" );
 
 			if ( empty( $code_level ) ) {
 				$error = __( 'This discount code does not apply to this membership level.', 'paid-memberships-pro' );
@@ -2205,7 +2205,7 @@ function pmpro_getLevel( $level ) {
 			return $pmpro_levels[ $level_id ];
 		} else {
 			global $wpdb;
-			$pmpro_levels[ $level_id ] = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . $level_id . "' LIMIT 1" );
+			$pmpro_levels[ $level_id ] = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . esc_sql( $level_id ) . "' LIMIT 1" );
 		}
 	} else {
 		global $wpdb;
@@ -2356,7 +2356,12 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 
 	// what level are they purchasing? (discount code passed)
 	if ( ! empty( $level_id ) && ! empty( $discount_code ) ) {
-		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . $discount_code . "' LIMIT 1" );
+		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
+
+		var_dump( $wpdb );
+		echo "<hr />";
+		var_dump( $wpdb->error );
+		echo "<hr />";
 
 		// check code
 		global $pmpro_checkout_level_ids; // Set by MMPU.
@@ -2366,12 +2371,12 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 			$code_check = pmpro_checkDiscountCode( $discount_code, $level_id, true );
 		}
 		if ( $code_check[0] != false ) {
-			$sqlQuery    = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups, l.confirmation FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.code = '" . $discount_code . "' AND cl.level_id = '" . $level_id . "' LIMIT 1";
+			$sqlQuery    = "SELECT l.id, cl.*, l.name, l.description, l.allow_signups, l.confirmation FROM $wpdb->pmpro_discount_codes_levels cl LEFT JOIN $wpdb->pmpro_membership_levels l ON cl.level_id = l.id LEFT JOIN $wpdb->pmpro_discount_codes dc ON dc.id = cl.code_id WHERE dc.code = '" . esc_sql( $discount_code ) . "' AND cl.level_id = '" . esc_sql( $level_id ) . "' LIMIT 1";
 			$pmpro_level = $wpdb->get_row( $sqlQuery );
 
 			// if the discount code doesn't adjust the level, let's just get the straight level
 			if ( empty( $pmpro_level ) ) {
-				$pmpro_level = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . $level_id . "' LIMIT 1" );
+				$pmpro_level = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_membership_levels WHERE id = '" . esc_sql( $level_id ) . "' LIMIT 1" );
 			}
 
 			// filter adjustments to the level
@@ -2532,7 +2537,7 @@ if ( ! function_exists( 'pmpro_getMemberStartdate' ) ) {
 			if ( ! empty( $level_id ) ) {
 				$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND membership_id IN(" . esc_sql( $level_id ) . ") AND user_id = '" . $user_id . "' ORDER BY id LIMIT 1";
 			} else {
-				$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND user_id = '" . $user_id . "' ORDER BY id LIMIT 1";
+				$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND user_id = '" . esc_sql( $user_id ) . "' ORDER BY id LIMIT 1";
 			}
 
 			$startdate = apply_filters( 'pmpro_member_startdate', $wpdb->get_var( $sqlQuery ), $user_id, $level_id );

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -17,7 +17,7 @@ function pmpro_init_recaptcha() {
 		return;
 	}
 	
-	//check for validation	
+	//check for validation
 	$recaptcha_validated = pmpro_get_session_var( 'pmpro_recaptcha_validated' );	
 	if ( ! empty( $recaptcha_validated ) ) {
 	    $recaptcha = false;

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -18,7 +18,7 @@ function pmpro_init_recaptcha() {
 	}
 	
 	//check for validation
-	$recaptcha_validated = pmpro_get_session_var( 'pmpro_recaptcha_validated' );	
+	$recaptcha_validated = pmpro_get_session_var( 'pmpro_recaptcha_validated' );
 	if ( ! empty( $recaptcha_validated ) ) {
 	    $recaptcha = false;
     }

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -5,14 +5,15 @@
  */
 function pmpro_init_recaptcha() {
 	//don't load if setting is off
-	global $recaptcha, $recaptcha_validated;
+	global $recaptcha, $recaptcha_validated, $pmpro_pages;
 	$recaptcha = pmpro_getOption( 'recaptcha' );
 	if ( empty( $recaptcha ) ) {
 		return;
 	}
 	
-	//don't load unless we're on the checkout page
-	if ( ! pmpro_is_checkout() ) {
+	//don't load unless we're on the checkout or billing page
+	$is_billing = ! empty( $pmpro_pages['billing'] ) && is_page( $pmpro_pages['billing'] );
+	if ( ! pmpro_is_checkout() && ! $is_billing ) {
 		return;
 	}
 	

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -17,8 +17,8 @@ function pmpro_init_recaptcha() {
 		return;
 	}
 	
-	//check for validation
-	$recaptcha_validated = pmpro_get_session_var( 'pmpro_recaptcha_validated' );
+	//check for validation	
+	$recaptcha_validated = pmpro_get_session_var( 'pmpro_recaptcha_validated' );	
 	if ( ! empty( $recaptcha_validated ) ) {
 	    $recaptcha = false;
     }
@@ -190,7 +190,7 @@ function pmpro_wp_ajax_validate_recaptcha() {
 	
 	$reCaptcha = new pmpro_ReCaptcha( $recaptcha_privatekey );
 	$resp      = $reCaptcha->verifyResponse( $_SERVER['REMOTE_ADDR'], $_REQUEST['g-recaptcha-response'] );
-
+	
 	if ( $resp->success ) {
 	    pmpro_set_session_var( 'pmpro_recaptcha_validated', true );
 		echo "1";
@@ -207,3 +207,4 @@ function pmpro_after_checkout_reset_recaptcha() {
     pmpro_unset_session_var( 'pmpro_recaptcha_validated' );
 }
 add_action( 'pmpro_after_checkout', 'pmpro_after_checkout_reset_recaptcha' );
+add_action( 'pmpro_after_update_billing', 'pmpro_after_checkout_reset_recaptcha' );

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -190,7 +190,6 @@ function pmpro_wp_ajax_validate_recaptcha() {
 	
 	$reCaptcha = new pmpro_ReCaptcha( $recaptcha_privatekey );
 	$resp      = $reCaptcha->verifyResponse( $_SERVER['REMOTE_ADDR'], $_REQUEST['g-recaptcha-response'] );
-	
 	if ( $resp->success ) {
 	    pmpro_set_session_var( 'pmpro_recaptcha_validated', true );
 		echo "1";

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -417,12 +417,21 @@
 			}
 			?>
 
+			<div class="<?php echo pmpro_get_element_class( 'pmpro_checkout-field pmpro_captcha', 'pmpro_captcha' ); ?>">
+			<?php
+				global $recaptcha, $recaptcha_publickey;				
+				if ( $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) {
+					echo pmpro_recaptcha_get_html($recaptcha_publickey, NULL, true);
+				}
+			?>
+			</div> <!-- end pmpro_captcha -->
+
 			<?php do_action("pmpro_billing_before_submit_button"); ?>
 
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_submit' ); ?>">
 				<hr />
 				<input type="hidden" name="update-billing" value="1" />
-				<input type="submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit' ); ?>" value="<?php _e('Update', 'paid-memberships-pro' );?>" />
+				<input type="submit" id="pmpro_btn-submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ); ?>" value="<?php _e('Update', 'paid-memberships-pro' );?>" />
 				<input type="button" name="cancel" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-cancel', 'pmpro_btn-cancel' ); ?>" value="<?php _e('Cancel', 'paid-memberships-pro' );?>" onclick="location.href='<?php echo pmpro_url("account")?>';" />
 			</div>
 		</form>

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -431,7 +431,8 @@
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_submit' ); ?>">
 				<hr />
 				<input type="hidden" name="update-billing" value="1" />
-				<input type="submit" id="pmpro_btn-submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ); ?>" value="<?php _e('Update', 'paid-memberships-pro' );?>" />
+				<input type="submit" id="pmpro_btn-submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ); ?>" value="<?php esc_attr_e('Update', 'paid-memberships-pro' );?>" />
+
 				<input type="button" name="cancel" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-cancel', 'pmpro_btn-cancel' ); ?>" value="<?php _e('Cancel', 'paid-memberships-pro' );?>" onclick="location.href='<?php echo pmpro_url("account")?>';" />
 			</div>
 		</form>

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -3,7 +3,7 @@
  * Plugin Name: Paid Memberships Pro
  * Plugin URI: https://www.paidmembershipspro.com
  * Description: The most complete member management and membership subscriptions plugin for WordPress.
- * Version: 2.6.6
+ * Version: 2.6.7
  * Author: Stranger Studios
  * Author URI: https://www.strangerstudios.com
  * Text Domain: paid-memberships-pro
@@ -16,7 +16,7 @@
  */
 
 // version constant
-define( 'PMPRO_VERSION', '2.6.6' );
+define( 'PMPRO_VERSION', '2.6.7' );
 define( 'PMPRO_USER_AGENT', 'Paid Memberships Pro v' . PMPRO_VERSION . '; ' . site_url() );
 define( 'PMPRO_MIN_PHP_VERSION', '5.6' );
 

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -158,6 +158,39 @@ if ($submit) {
         }
     }
 	
+	// Check reCAPTCHA if needed.
+	global $recaptcha, $recaptcha_validated;
+	if (  $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) {
+		global $recaptcha_privatekey;
+		if ( isset( $_POST["recaptcha_challenge_field"] ) ) {
+			//using older recaptcha lib
+			$resp = recaptcha_check_answer( $recaptcha_privatekey,
+				$_SERVER["REMOTE_ADDR"],
+				$_POST["recaptcha_challenge_field"],
+				$_POST["recaptcha_response_field"] );
+
+			$recaptcha_valid  = $resp->is_valid;
+			$recaptcha_errors = $resp->error;
+		} else {
+			//using newer recaptcha lib
+			// NOTE: In practice, we don't execute this code because
+			// we use AJAX to send the data back to the server and set the
+			// pmpro_recaptcha_validated session variable, which is checked
+			// earlier. We should remove/refactor this code.
+			$reCaptcha = new pmpro_ReCaptcha( $recaptcha_privatekey );
+			$resp      = $reCaptcha->verifyResponse( $_SERVER["REMOTE_ADDR"], $_POST["g-recaptcha-response"] );
+
+			$recaptcha_valid  = $resp->success;
+			$recaptcha_errors = $resp->errorCodes;
+		}
+		if ( ! $recaptcha_valid ) {
+			$pmpro_msg  = sprintf( __( "reCAPTCHA failed. (%s) Please try again.", 'paid-memberships-pro' ), $recaptcha_errors );
+			$pmpro_msgt = "pmpro_error";
+		} else {			
+			pmpro_set_session_var( 'pmpro_recaptcha_validated', true );
+		}
+	}
+	
     if (!empty($missing_billing_field)) {
         $pmpro_msg = __("Please complete all required fields.", 'paid-memberships-pro' );
         $pmpro_msgt = "pmpro_error";
@@ -167,7 +200,9 @@ if ($submit) {
     } elseif (!is_email($bemail)) {
         $pmpro_msg = __("The email address entered is in an invalid format. Please try again.", 'paid-memberships-pro' );
         $pmpro_msgt = "pmpro_error";
-    } else {
+    } elseif ( $pmpro_msgt == 'pmpro_error' ) {
+		// Something else threw an error, maybe reCAPTCHA.		
+	} else {
         //all good. update billing info.
         $pmpro_msg = __("All good!", 'paid-memberships-pro' );
 
@@ -238,6 +273,8 @@ if ($submit) {
             //message
             $pmpro_msg = sprintf(__('Information updated. <a href="%s">&laquo; back to my account</a>', 'paid-memberships-pro' ), pmpro_url("account"));
             $pmpro_msgt = "pmpro_success";
+			
+			do_action( 'pmpro_after_update_billing', $current_user->ID, $morder );
         } else {
             $pmpro_msg = $morder->error;
 

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -408,6 +408,10 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 					$recaptcha_errors = $resp->error;
 				} else {
 					//using newer recaptcha lib
+					// NOTE: In practice, we don't execute this code because
+					// we use AJAX to send the data back to the server and set the
+					// pmpro_recaptcha_validated session variable, which is checked
+					// earlier. We should remove/refactor this code.
 					$reCaptcha = new pmpro_ReCaptcha( $recaptcha_privatekey );
 					$resp      = $reCaptcha->verifyResponse( $_SERVER["REMOTE_ADDR"], $_POST["g-recaptcha-response"] );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: memberships, members, subscriptions, ecommerce, user registration, member,
 Requires at least: 5.2
 Tested up to: 5.8.1
 Requires PHP: 5.6
-Stable tag: 2.6.6
+Stable tag: 2.6.7
 
 Get Paid with Paid Memberships Pro: The most complete member management and membership subscriptions plugin for your WordPress site.
 
@@ -156,6 +156,9 @@ Not sure? You can find out by doing a bit a research.
 9. Membership Account page, display all sections or show specific sections using shortcode attributes.
 
 == Changelog ==
+= 2.6.7 - 2022-01-06 =
+* SECURITY: Updated escaping in the pmpro_getLevelAtCheckout and pmpro_checkDiscountCode functions as extra precaution against SQL injections. (Thanks, WPScan)
+
 = 2.6.6 - 2021-11-18 =
 * SECURITY: Updated escaping on the discount codes page in the dashboard to prevent XSS attacks. #1867 (Thanks, Erwan from WPScan)
 * BUG FIX/ENHANCEMENT: Added code to remove duplicate active rows in the pmpro_memberships_users table after level change. This might have happened e.g. if users were purchasing a level via the WooCommerce Add On multiple times. #1860 (@dlparker1005)


### PR DESCRIPTION
…k with recaptcha JS.

Folks are now spamming the update billing page to test credit cards. So we want to use recaptcha on that page.

This update loads the recaptcha code on the update billing page and includes the recaptcha code into the form.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Set up recaptcha v2 or v3 on the advanced settings page
2. Checkout for a recurring membership with a gateway like Stripe, Braintree or Authorize.net
3. Go to the account page. Click to update billing.
4. The recaptcha should show up and be required to complete the form. Note that the v3 recaptcha automatically checks things without required input most of the time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
