### PR TITLE
Added select all or none to the Require Membership metabox; now scrollls if 10+ levels.

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1,3 +1,11 @@
+/* Metaboxes on Editor */
+#poststuff #pmpro_page_meta.postbox .postbox-header {
+	border-bottom-width: 0;
+}
+#poststuff #pmpro_page_meta.postbox.closed .postbox-header {
+	border-bottom-width: 1px;
+}
+
 /* icon */
 #wp-admin-bar-paid-memberships-pro .ab-item .ab-icon:before {
 	font-family: "dashicons";

--- a/includes/metaboxes.php
+++ b/includes/metaboxes.php
@@ -7,8 +7,16 @@ function pmpro_page_meta() {
 	$membership_levels = pmpro_getAllLevels( true, true );
 	$membership_levels = pmpro_sort_levels_by_order( $membership_levels );
 	$page_levels = $wpdb->get_col( "SELECT membership_id FROM {$wpdb->pmpro_memberships_pages} WHERE page_id = '" . intval( $post->ID ) . "'" );
+
+	// Build the selectors for the #memberships list based on level count.
+	$pmpro_memberships_checklist_classes = array( 'list:category', 'categorychecklist', 'form-no-clear');
+	if ( count( $membership_levels ) > 9 ) {
+		$pmpro_memberships_checklist_classes[] = "pmpro_scrollable";
+	}
+	$pmpro_memberships_checklist_classes = implode( ' ', array_unique( $pmpro_memberships_checklist_classes ) );
 ?>
-    <ul id="membershipschecklist" class="list:category categorychecklist form-no-clear">
+    <p><?php esc_html_e( 'Select:', 'paid-memberships-pro' ); ?> <a id="pmpro-memberships-checklist-select-all" href="javascript:void(0);"><?php esc_html_e( 'All', 'paid-memberships-pro' ); ?></a> | <a id="pmpro-memberships-checklist-select-none" href="javascript:void(0);"><?php esc_html_e( 'None', 'paid-memberships-pro' ); ?></a></p>
+    <ul id="pmpro-memberships-checklist" class="<?php echo esc_attr( $pmpro_memberships_checklist_classes ); ?>">
     <input type="hidden" name="pmpro_noncename" id="pmpro_noncename" value="<?php echo esc_attr( wp_create_nonce( plugin_basename(__FILE__) ) )?>" />
 	<?php
 		$in_member_cat = false;
@@ -38,7 +46,16 @@ function pmpro_page_meta() {
 		<p class="pmpro_meta_notice">* <?php _e("This post is already protected for this level because it is within a category that requires membership.", 'paid-memberships-pro' );?></p>
 	<?php
 		}
-
+	?>
+	<script type="text/javascript">
+		jQuery('#pmpro-memberships-checklist-select-all').click(function(){
+			jQuery('#pmpro-memberships-checklist input').prop('checked', true);
+		});
+		jQuery('#pmpro-memberships-checklist-select-none').click(function(){
+			jQuery('#pmpro-memberships-checklist input').prop('checked', false);
+		});
+	</script>
+	<?php
 		do_action( 'pmpro_after_require_membership_metabox', $post );
 	?>
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added Select All | None to the Require Membership metabox. Jason recommended inline script/JS for this. Even if we “reuse” the logic, he felt it was better to be right there with the thing it is triggering.

Added a small CSS fix for when the Require Membership metabox is expanded so there is no top border on the list. We can consider improving the appearance of this metabox for the block editor to appear more like the other checkbox controls.

The list of checkboxes also now is in a fixed height scroll box if the count of levels is > 9. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves [1692](https://github.com/strangerstudios/paid-memberships-pro/issues/1692).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Improved usability of the Require Membership metabox for sites with a large number of levels.
 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
