### PR TITLE
Some MySQL setups require a primary key for each table. Going to doub…

### DIFF
--- a/includes/setup.sql
+++ b/includes/setup.sql
@@ -193,7 +193,7 @@ CREATE TABLE `wp_pmpro_memberships_categories` (
   `membership_id` int(11) unsigned NOT NULL,
   `category_id` int(11) unsigned NOT NULL,
   `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  UNIQUE KEY `membership_category` (`membership_id`,`category_id`),
+  PRIMARY KEY `membership_category` (`membership_id`,`category_id`),
   UNIQUE KEY `category_membership` (`category_id`,`membership_id`)
 );
 
@@ -207,7 +207,7 @@ CREATE TABLE `wp_pmpro_memberships_pages` (
   `membership_id` int(11) unsigned NOT NULL,
   `page_id` int(11) unsigned NOT NULL,
   `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  UNIQUE KEY `category_membership` (`page_id`,`membership_id`),
+  PRIMARY KEY `category_membership` (`page_id`,`membership_id`),
   UNIQUE KEY `membership_page` (`membership_id`,`page_id`)
 );
 

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -268,6 +268,15 @@ function pmpro_checkForUpgrades()
 		$pmpro_db_version = pmpro_upgrade_2_6();
 		pmpro_setOption( 'db_version', '2.6' );
 	}
+	
+	/**
+	 * Version 2.6.7
+	 * Running pmpro_db_delta to update KEY types in a couple tables.
+	 */
+	 if( $pmpro_db_version < 2.67 ) {
+ 		pmpro_db_delta(); 		
+ 		pmpro_setOption( 'db_version', '2.67' );
+ 	}
 }
 
 function pmpro_db_delta()
@@ -373,7 +382,7 @@ function pmpro_db_delta()
 		  `membership_id` int(11) unsigned NOT NULL,
 		  `category_id` bigint(20) unsigned NOT NULL,
 		  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-		  UNIQUE KEY `membership_category` (`membership_id`,`category_id`),
+		  PRIMARY KEY `membership_category` (`membership_id`,`category_id`),
 		  UNIQUE KEY `category_membership` (`category_id`,`membership_id`)
 		);
 	";
@@ -385,7 +394,7 @@ function pmpro_db_delta()
 		  `membership_id` int(11) unsigned NOT NULL,
 		  `page_id` bigint(20) unsigned NOT NULL,
 		  `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-		  UNIQUE KEY `category_membership` (`page_id`,`membership_id`),
+		  PRIMARY KEY `category_membership` (`page_id`,`membership_id`),
 		  UNIQUE KEY `membership_page` (`membership_id`,`page_id`)
 		);
 	";


### PR DESCRIPTION
A user was having bugs caused by these 2 tables not being created on their MySQL setup because the tables did not have primary keys.

So this PR sets the first unique key to a primary key. This table does not use "null" for any of the values in the columns, so this is okay.

I am double checking if we need the second unique key. I believe it's there for performance when querying by category, membership vs membership,category.