### PR TITLE
Fixing line breaks that created a space between the order field edit label and colon.

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -481,8 +481,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 				</td>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="billing_street"><?php esc_html_e( 'Billing Street', 'paid-memberships-pro' ); ?>
-						:</label></th>
+				<th scope="row" valign="top"><label for="billing_street"><?php esc_html_e( 'Billing Street', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'billing_street', $read_only_fields ) && $order_id > 0 ) {
@@ -507,8 +506,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 									<?php } ?>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="billing_state"><?php esc_html_e( 'Billing State', 'paid-memberships-pro' ); ?>
-						:</label></th>
+				<th scope="row" valign="top"><label for="billing_state"><?php esc_html_e( 'Billing State', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'billing_state', $read_only_fields ) && $order_id > 0 ) {
@@ -520,8 +518,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 									<?php } ?>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="billing_zip"><?php esc_html_e( 'Billing Postal Code', 'paid-memberships-pro' ); ?>
-						:</label></th>
+				<th scope="row" valign="top"><label for="billing_zip"><?php esc_html_e( 'Billing Postal Code', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'billing_zip', $read_only_fields ) && $order_id > 0 ) {
@@ -533,8 +530,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 									<?php } ?>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="billing_country"><?php esc_html_e( 'Billing Country', 'paid-memberships-pro' ); ?>
-						:</label></th>
+				<th scope="row" valign="top"><label for="billing_country"><?php esc_html_e( 'Billing Country', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'billing_country', $read_only_fields ) && $order_id > 0 ) {
@@ -547,8 +543,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 				</td>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="billing_phone"><?php esc_html_e( 'Billing Phone', 'paid-memberships-pro' ); ?>
-						:</label></th>
+				<th scope="row" valign="top"><label for="billing_phone"><?php esc_html_e( 'Billing Phone', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'billing_phone', $read_only_fields ) && $order_id > 0 ) {
@@ -676,7 +671,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 				</td>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="cardtype"><?php esc_html_e( 'Card Type', 'paid-memberships-pro' ); ?></label></th>
+				<th scope="row" valign="top"><label for="cardtype"><?php esc_html_e( 'Card Type', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'cardtype', $read_only_fields ) && $order_id > 0 ) {
@@ -690,8 +685,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 				</td>
 			</tr>
 			<tr>
-				<th scope="row" valign="top"><label for="accountnumber"><?php esc_html_e( 'Account Number', 'paid-memberships-pro' ); ?>
-						:</label></th>
+				<th scope="row" valign="top"><label for="accountnumber"><?php esc_html_e( 'Account Number', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'accountnumber', $read_only_fields ) && $order_id > 0 ) {
@@ -729,8 +723,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					</td>
 				</tr>
 				<tr>
-					<th scope="row" valign="top"><label for="expirationyear"><?php esc_html_e( 'Expiration Year', 'paid-memberships-pro' ); ?>
-				:</label></th>
+					<th scope="row" valign="top"><label for="expirationyear"><?php esc_html_e( 'Expiration Year', 'paid-memberships-pro' ); ?>:</label></th>
 					<td>
 						<input id="expirationyear" name="expirationyear" type="text" size="10"
 				   value="<?php echo esc_attr( $order->expirationyear ); ?>"/>
@@ -816,8 +809,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 			</tr>
 			<tr>
 				<th scope="row" valign="top"><label
-						for="subscription_transaction_id"><?php esc_html_e( 'Subscription Transaction ID', 'paid-memberships-pro' ); ?>
-						:</label></th>
+						for="subscription_transaction_id"><?php esc_html_e( 'Subscription Transaction ID', 'paid-memberships-pro' ); ?>:</label></th>
 				<td>
 					<?php
 					if ( in_array( 'subscription_transaction_id', $read_only_fields ) && $order_id > 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Edit Order screen has labels for each field row. Probably someone ran a linter that pushed the " :</label>" to a new line, creating a "space" in the view between the text of the label and the colon.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
