### PR TITLE
Beginning to remove the term "Plus" from the core plugin and use more general language about plans.

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -12,8 +12,8 @@ We don't offer technical support on GitHub so we recommend using the following:
 **Reading our documentation**
 Usage docs can be found here: https://www.paidmembershipspro.com/documentation/
 
-**Technical support for premium extensions or if you're a Paid Memberships Pro Plus member**
-Submit a ticket on our helpdesk by visiting https://www.paidmembershipspro.com/new-topic/ (Please note that an [active membership](https://www.paidmembershipspro.com/pricing) is required for paid support.)
+**Technical support for premium extensions or if you're an active paid member**
+Submit a ticket on our helpdesk by visiting https://www.paidmembershipspro.com/new-topic/ (Please note that an [active paid membership](https://www.paidmembershipspro.com/pricing) is required for paid support.)
 
 **General usage and development questions**
 - WordPress.org Forums: https://wordpress.org/support/plugin/paid-memberships-pro

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ For more information please visit [the Paid Memberships Pro website](https://www
 
 Paid Memberships Pro is distributed under the GPLv2 license. This means, among other things, that you may use the software on any site free of charge.
 
-An annual support license is recommended for websites running Paid Memberships Pro. This support license includes access to our technical support team in the Member Support Area, as well as one-click installation and updates for over 70 feature-enhancing Add Ons. Plus membership is backed by a 30-day, no questions asked, refund guarantee.
+An annual support license is recommended for websites running Paid Memberships Pro. Support licenses include access to our technical support team in the Member Support Area, as well as one-click installation and updates for feature-enhancing Add Ons based on your level. All of our paid  memberships are backed by a 30-day, no questions asked, refund guarantee.
 
-[Purchase a Plus Membership »](https://www.paidmembershipspro.com/membership-checkout/?level=20)
+[View Plans and Pricing »](https://www.paidmembershipspro.com/pricing/)
 
 ## Installation ##
 For detailed installation steps, visit the [documentation on installing the plugin](https://www.paidmembershipspro.com/documentation/download/) and the [initial plugin setup instructions](https://www.paidmembershipspro.com/documentation/initial-plugin-setup/).
@@ -45,5 +45,5 @@ There are various **ways to help the development** of Paid Memberships Pro:
 Here are some ways for **non-developers to contribute** to Paid Memberships Pro:
 
 1. Translate Paid Memberships Pro into your own [language](https://www.paidmembershipspro.com/paid-memberships-pro-in-your-language/).
-2. [Purchase a plus membership](https://paidmembershipspro.com/pricing) to help fund ongoing development and bug fixes.
+2. [Purchase a paid membership](https://paidmembershipspro.com/pricing) to help fund ongoing development and bug fixes.
 3. Leave an honest review for [Paid Memberships Pro](https://wordpress.org/support/plugin/paid-memberships-pro/reviews/#new-post).

--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -182,11 +182,11 @@ function pmpro_dashboard_welcome_callback() { ?>
     		<?php } ?>
 
     		<?php if ( ! pmpro_license_isValid() ) { ?>
-    			<p><?php esc_html_e( 'An annual support license is recommended for websites running Paid Memberships Pro.', 'paid-memberships-pro' ); ?><br /><a href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=pmpro-dashboard&utm_campaign=pricing&utm_content=upgrade" target="_blank"><?php esc_html_e( 'View Pricing &raquo;' , 'paid-memberships-pro' ); ?></a></p>
-    			<p><a href="https://www.paidmembershipspro.com/membership-checkout/?level=20&utm_source=plugin&utm_medium=pmpro-dashboard&utm_campaign=plus-checkout&utm_content=upgrade" target="_blank" class="button button-action button-hero"><?php esc_attr_e( 'Upgrade', 'paid-memberships-pro' ); ?></a>
+				<p><?php esc_html_e( 'An annual support license is recommended for websites running Paid Memberships Pro.', 'paid-memberships-pro' ); ?></p>
+				<p><a href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=pmpro-dashboard&utm_campaign=pricing&utm_content=upgrade" target="_blank" class="button button-primary button-hero"><?php esc_attr_e( 'View Plans and Pricing', 'paid-memberships-pro' ); ?></a>
     		<?php } ?>
-    		<hr />
-    		<p><?php echo wp_kses_post( sprintf( __( 'Paid Memberships Pro and our add ons are distributed under the <a target="_blank" href="%s">GPLv2 license</a>. This means, among other things, that you may use the software on this site or any other site free of charge.', 'paid-memberships-pro' ), 'http://www.gnu.org/licenses/gpl-2.0.html' ) ); ?></p>
+			<hr />
+			<p><?php echo wp_kses_post( sprintf( __( 'Paid Memberships Pro and our Add Ons are distributed under the <a target="_blank" href="%s">GPLv2 license</a>. This means, among other things, that you may use the software on this site or any other site free of charge.', 'paid-memberships-pro' ), 'http://www.gnu.org/licenses/gpl-2.0.html' ) ); ?></p>
     	</div> <!-- end pmpro-dashboard-welcome-column -->
     	<div class="pmpro-dashboard-welcome-column">
     		<h3><?php esc_html_e( 'Get Involved', 'paid-memberships-pro' ); ?></h3>

--- a/adminpages/license.php
+++ b/adminpages/license.php
@@ -59,8 +59,7 @@ if ( defined( 'PMPRO_DIR' ) ) {
 
 			<p>
 				<?php if ( ! pmpro_license_isValid() ) { ?>
-					<a class="button button-primary button-hero" href="https://www.paidmembershipspro.com/membership-checkout/?level=20&utm_source=plugin&utm_medium=pmpro-license&utm_campaign=plus-checkout&utm_content=buy-plus" target="_blank"><?php echo esc_html( 'Buy Plus License', 'paid-memberships-pro' ); ?></a>
-					<a class="button button-hero" href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=pmpro-license&utm_campaign=pricing&utm_content=view-license-options" target="_blank"><?php echo esc_html( 'View Support License Options', 'paid-memberships-pro' ); ?></a>
+					<a class="button button-primary button-hero" href="https://www.paidmembershipspro.com/pricing/?utm_source=plugin&utm_medium=pmpro-license&utm_campaign=pricing&utm_content=view-plans-pricing" target="_blank"><?php echo esc_html( 'View Plans and Pricing', 'paid-memberships-pro' ); ?></a>
 				<?php } else { ?>
 					<a class="button button-primary button-hero" href="https://www.paidmembershipspro.com/login/?redirect_to=%2Fmembership-account%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dmembership-account%26utm_content%3Dview-account" target="_blank"><?php echo esc_html( 'Manage My Account', 'paid-memberships-pro' ); ?></a>
 					<a class="button button-hero" href="https://www.paidmembershipspro.com/login/?redirect_to=%2Fnew-topic%2F%3Futm_source%3Dplugin%26utm_medium%3Dpmpro-license%26utm_campaign%3Dsupport%26utm_content%3Dnew-support-ticket" target="_blank"><?php echo esc_html( 'Open Support Ticket', 'paid-memberships-pro' ); ?></a>
@@ -88,7 +87,7 @@ if ( defined( 'PMPRO_DIR' ) ) {
 			?>
 
 			<?php
-				echo '<p>' . wp_kses( __( '<strong>Paid Memberships Pro offers plans for automatic updates of Add Ons and premium support.</strong> These plans include a Plus license key which we recommend for all public websites running Paid Memberships Pro. A Plus license key allows you to automatically install new Add Ons and update  active Add Ons when a new security, bug fix, or feature enhancement is released.' ), $allowed_pmpro_license_strings_html ) . '</p>';
+				echo '<p>' . wp_kses( __( '<strong>Paid Memberships Pro offers plans for automatic updates of Add Ons and premium support.</strong> These plans include a license key which we recommend for all public websites running Paid Memberships Pro. A license key allows you to automatically install Add Ons included in your plan and update active Add Ons included in your plan when a new security, bug fix, or feature enhancement is released.' ), $allowed_pmpro_license_strings_html ) . '</p>';
 			?>
 
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We offer a few paid plans, and the language throughout the core plugin only references "Plus". There is more work to do here, but these are a few places that needed to be updated to speak about plans in general vs. specifically Plus.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Enhancement: Generalized language about support license / membership options throughout the admin.
 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
