### PR TITLE
Use wp_strip_all_tags to remove contents of script/style tags

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -341,7 +341,7 @@ function pmpro_membership_content_filter( $content, $skipcheck = false ) {
 				//auto generated excerpt. pulled from wp_trim_excerpt
 				$content = strip_shortcodes( $content );
 				$content = str_replace(']]>', ']]&gt;', $content);
-				$content = strip_tags($content);
+				$content = wp_strip_all_tags( $content );
 				$excerpt_length = apply_filters('excerpt_length', 55);
 				$words = preg_split("/[\n\r\t ]+/", $content, $excerpt_length + 1, PREG_SPLIT_NO_EMPTY);
 				if ( count($words) > $excerpt_length ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves issues with creating excerpts from Elementor Pro content when that post/page is protected.

### How to test the changes in this Pull Request:

I've had trouble reproducing this issue but was able to test the fix against a working example from Kim here https://clean.pixeltalk.xyz/2021/06/14/community-blend/ (note: with the fix, it no longer shows style output)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Ensure styles are removed from excerpts generated for protected content