### PR TITLE
Better escape custom HTML attributes in field rendering and add new hook to customize them before render

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -753,16 +753,43 @@ class PMPro_Field
 		return $r;
 	}
 
+	/**
+	 * Get the HTML attributes for this field.
+	 *
+	 * Note: Attribute names and values are escaped for output.
+	 *
+	 * @return string The HTML attributes for this field.
+	 */
 	function getHTMLAttributes() {
-		$astring = "";
-		if(!empty($this->html_attributes)) {
-			foreach($this->html_attributes as $name => $value)
-				$astring .= "{$name}=\"{$value}\"";
+		$html = '';
+
+		/**
+		 * Allow filtering the HTML attributes before escaping.
+		 *
+		 * @since TBD
+		 *
+		 * @param array       $html_attributes The list of HTML attributes.
+		 * @param PMPro_Field $field           The field object.
+		 */
+		$this->html_attributes = apply_filters( 'pmpro_field_custom_html_attributes', $this->html_attributes, $this );
+
+		if ( ! empty( $this->html_attributes ) ) {
+			foreach ( $this->html_attributes as $name => $value ) {
+				// Note: In the future, WP may introduce esc_attr_name(), but for now we'll do it ourselves.
+				$attribute_name = wp_check_invalid_utf8( $name );
+				$attribute_name = preg_replace( '/[^a-zA-Z0-9\-_\[\]]+/', '-', $attribute_name );
+
+				$html .= sprintf(
+					' %1$s="%2$s"',
+					$attribute_name,
+					esc_attr( $value )
+				);
+			}
 		}
 
-		return $astring;
-	}	
-	
+		return $html;
+	}
+
 	function getDependenciesJS()
 	{
 		global $pmprorh_registration_fields;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves problems when attribute names and values are output but not escaped.

### How to test the changes in this Pull Request:

1. Add any custom field and define 'html_attributes' with an array of unescaped values.
2. See they are properly escaped on output

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Better escape custom HTML attributes in field rendering

> Add new filter `pmpro_field_custom_html_attributes` to customize the HTML attributes used for fields before render