### PR TITLE
PayPal Express IPN: set cancelled/error even when a membership has no user

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -249,6 +249,13 @@ if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_
 		$user = get_userdata( $last_subscription_order->user_id );
 
 		if ( empty( $user ) || empty( $user->ID ) ) {
+			//if the initial payment failed, cancel with status error instead of cancelled
+			if ( $initial_payment_status === "failed" ) {
+				$last_subscription_order->updateStatus('error');
+			} else {
+				$last_subscription_order->updateStatus('cancelled');
+			}
+
 			ipnlog( "ERROR: Could not cancel membership. No user attached to order #" . $last_subscription_order->id . " with subscription transaction id = " . $recurring_payment_id . "." );
 		} else {
 			/*

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -275,6 +275,8 @@ if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_
 
 				// The order should already be in status error
 				$last_subscription_order->updateStatus('error');
+
+				ipnlog( "Errored membership for user with id = " . $last_subscription_order->user_id . ". Subscription transaction id = " . $recurring_payment_id . "." );
 			} elseif ( $last_subscription_order->status === "cancelled" ) {
 				ipnlog( "We've already processed this cancellation. Probably originated from WP/PMPro. (Order #" . $last_subscription_order->id . ", Subscription Transaction ID #" . $recurring_payment_id . ")" );
 			} elseif ( ! pmpro_hasMembershipLevel( $last_subscription_order->membership_id, $user->ID ) ) {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Until now, when an order has no user (pretty common for errored subscriptions from PayPal Express even when the flows complete), we were not changing the order status. That's bad for reports and order's list readability.

### How to test the changes in this Pull Request:

1. Ask @mircobabini 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
