### PR TITLE
Update to force Site Health to report on all levels, including hidden.

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -115,7 +115,6 @@ class PMPro_Site_Health {
 	 */
 	public function get_levels() {
 		$membership_levels = pmpro_getAllLevels( true, true );
-		d( $membership_levels );
 
 		if ( ! $membership_levels ) {
 			return __( 'No Levels Found', 'paid-memberships-pro' );

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -114,7 +114,8 @@ class PMPro_Site_Health {
 	 * @return string The level information.
 	 */
 	public function get_levels() {
-		$membership_levels = pmpro_getAllLevels( true );
+		$membership_levels = pmpro_getAllLevels( true, true );
+		d( $membership_levels );
 
 		if ( ! $membership_levels ) {
 			return __( 'No Levels Found', 'paid-memberships-pro' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The levels information we add to the Site Health screen wasn't including hidden levels. This update to add a second 'true' parameter for the pmpro_getAllLevels function that calls levels fixes this.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUG FIX: Now including all levels (public and hidden) in the Paid Memberships Pro section of Site Health information. 

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
