### PR TITLE
Fix PHP 8 fatal error in `services/authnet-silent-post.php`.

### DIFF
--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -104,6 +104,7 @@
 				$morder->Zip = $fields['x_zip'];
 				$morder->PhoneNumber = $fields['x_phone'];
 
+				$morder->billing = new stdClass();
 				$morder->billing->name = $fields['x_first_name'] . " " . $fields['x_last_name'];
 				$morder->billing->street = $fields['x_address'];
 				$morder->billing->city = $fields['x_city'];


### PR DESCRIPTION
The error that this fixes:

```
Uncaught Error: Attempt to assign property "name" on null in /EXAMPLE_SITE/public_html/wp-content/plugins/paid-memberships-pro/services/authnet-silent-post.php:107
```

From the PHP 8 ["Backward Incompatible Changes" page](https://www.php.net/manual/en/migration80.incompatible.php):
> A number of warnings have been converted into Error exceptions:
> - Attempting to write to a property of a non-object. Previously this implicitly created an stdClass object for null, false and empty strings.
>
> [...]

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a fatal error that occurs in PHP 8 when the code in `paid-memberships-pro/services/authnet-silent-post.php` runs. Similar fixes were made in other spots in #1808, but this one was overlooked.

### How to test the changes in this Pull Request:

I'm not really sure how to test it. I just noticed the issue occurring on a site I work on, so I decided to patch it. As mentioned in the prior section, the fix is similar to previous fixes in other parts of the code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed PHP 8 fatal error in `services/authnet-silent-post.php`.
