### PR TITLE
Enhancement/decline throttling

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -38,6 +38,7 @@
 
 		// Checkout settings.
 		pmpro_setOption("tospage");
+		pmpro_setOption("spamprotection");
 		pmpro_setOption("recaptcha");
 		pmpro_setOption("recaptcha_version");
 		pmpro_setOption("recaptcha_publickey");
@@ -83,6 +84,7 @@
 
 	// Checkout settings.
 	$tospage = pmpro_getOption("tospage");
+	$spamprotection = pmpro_getOption("spamprotection");
 	$recaptcha = pmpro_getOption("recaptcha");
 	$recaptcha_version = pmpro_getOption("recaptcha_version");
 	$recaptcha_publickey = pmpro_getOption("recaptcha_publickey");
@@ -234,6 +236,19 @@
 						?>
 						<br />
 						<p class="description"><?php _e('If yes, create a WordPress page containing your TOS agreement and assign it using the dropdown above.', 'paid-memberships-pro' );?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row" valign="top">
+						<label for="spamprotection"><?php _e('Enable Spam Protection?', 'paid-memberships-pro' );?>:</label>
+					</th>
+					<td>
+						<select id="spamprotection" name="spamprotection">
+							<option value="0" <?php if(!$spamprotection) { ?>selected="selected"<?php } ?>><?php _e('No', 'paid-memberships-pro' );?></option>
+							<!-- For reference, removed the Yes - Free memberships only. option -->
+							<option value="2" <?php if( $spamprotection > 0 ) { ?>selected="selected"<?php } ?>><?php _e('Yes - Enable Spam Protection', 'paid-memberships-pro' );?></option>
+						</select>
+						<p class="description"><?php printf( __( 'Block IPs from checkout if there are more than %d failures within %d minutes.', 'paid-memberships-pro' ), PMPRO_SPAM_ACTION_NUM_LIMIT, round(PMPRO_SPAM_ACTION_TIME_LIMIT/60,2) );?></p>
 					</td>
 				</tr>
 				<tr>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3939,5 +3939,8 @@ function pmpro_get_ip() {
 		return false;
 	}
 	
+	// Sanitize the IP
+	$client_ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $client_ip );
+	
 	return $client_ip;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3874,3 +3874,70 @@ function pmpro_format_date_iso8601( $date ) {
 	$datetime = new DateTime( $date );
 	return $datetime->format( DateTime::ATOM );
 }
+
+/**
+ * Determines the user's actual IP address
+ *
+ * $_SERVER['REMOTE_ADDR'] cannot be used in all cases, such as when the user
+ * is making their request through a proxy, or when the web server is behind
+ * a proxy. In those cases, $_SERVER['REMOTE_ADDR'] is set to the proxy address rather
+ * than the user's actual address.
+ *
+ * Modified from WP_Community_Events::get_unsafe_client_ip() in core WP.
+ * Modified from https://stackoverflow.com/a/2031935/450127, MIT license.
+ * Modified from https://github.com/geertw/php-ip-anonymizer, MIT license.
+ *
+ * SECURITY WARNING: This function is _NOT_ intended to be used in
+ * circumstances where the authenticity of the IP address matters. This does
+ * _NOT_ guarantee that the returned address is valid or accurate, and it can
+ * be easily spoofed.
+ *
+ * @since 2.7
+ *
+ * @return string|false The ip address on success or false on failure.
+ */
+function pmpro_get_ip() {
+	$client_ip = false;
+
+	// In order of preference, with the best ones for this purpose first.
+	// Added some from JetPack's Jetpack_Protect_Module::get_headers()
+	$address_headers = array(
+		'GD_PHP_HANDLER',
+		'HTTP_AKAMAI_ORIGIN_HOP',
+		'HTTP_CF_CONNECTING_IP',
+		'HTTP_CLIENT_IP',
+		'HTTP_FASTLY_CLIENT_IP',
+		'HTTP_FORWARDED',
+		'HTTP_FORWARDED_FOR',
+		'HTTP_INCAP_CLIENT_IP',
+		'HTTP_TRUE_CLIENT_IP',
+		'HTTP_X_CLIENTIP',
+		'HTTP_X_CLUSTER_CLIENT_IP',
+		'HTTP_X_FORWARDED',
+		'HTTP_X_FORWARDED_FOR',
+		'HTTP_X_IP_TRAIL',
+		'HTTP_X_REAL_IP',
+		'HTTP_X_VARNISH',
+		'REMOTE_ADDR',			
+	);
+
+	foreach ( $address_headers as $header ) {
+		if ( array_key_exists( $header, $_SERVER ) ) {
+			/*
+			 * HTTP_X_FORWARDED_FOR can contain a chain of comma-separated
+			 * addresses. The first one is the original client. It can't be
+			 * trusted for authenticity, but we don't need to for this purpose.
+			 */
+			$address_chain = explode( ',', $_SERVER[ $header ] );
+			$client_ip     = trim( $address_chain[0] );
+
+			break;
+		}
+	}
+
+	if ( ! $client_ip ) {
+		return false;
+	}
+	
+	return $client_ip;
+}

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -121,7 +121,6 @@ function pmpro_track_spam_activity( $ip = null ) {
  *
  * @return bool True if the clearing of activity was successful, or false if IP could not be determined.
  */
- */
 function pmpro_clear_spam_activity( $ip = null ) {
     if ( empty( $ip ) ) {
         $ip = pmpro_get_ip();        
@@ -138,6 +137,18 @@ function pmpro_clear_spam_activity( $ip = null ) {
 
 	return true;
 }
+
+/**
+ * Track spam activity when checkouts or billing updates fail.
+ *
+ * @since 2.7
+ * @param MemberOrder $morder The order object used at checkout. We ignore it.
+ */
+function pmpro_track_failed_checkouts_for_spam( $morder ) {
+    pmpro_track_spam_activity();
+}
+add_action( 'pmpro_checkout_processing_failed', 'pmpro_track_failed_checkouts_for_spam' );
+add_action( 'pmpro_update_billing_failed', 'pmpro_track_failed_checkouts_for_spam' );
 
 /**
  * Disable checkout and billing update forms for spammers.

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -22,7 +22,7 @@ function pmpro_is_spammer() {
         $is_spammer = true;
     }
     
-    return apply_filters( 'pmpro_is_spammer', $is_spammer );
+    return apply_filters( 'pmpro_is_spammer', $is_spammer, $activity );
 }
 
 /**

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -150,6 +150,12 @@ function pmpro_clear_spam_activity( $ip = null ) {
  * @param MemberOrder $morder The order object used at checkout. We ignore it.
  */
 function pmpro_track_failed_checkouts_for_spam( $morder ) {
+	// Bail if Spam Protection is disabled.
+	$spamprotection = pmpro_getOption("spamprotection");	
+	if ( empty( $spamprotection ) ) {
+		return;
+	}
+	
 	pmpro_track_spam_activity();
 }
 add_action( 'pmpro_checkout_processing_failed', 'pmpro_track_failed_checkouts_for_spam' );
@@ -171,6 +177,12 @@ add_action( 'pmpro_update_billing_failed', 'pmpro_track_failed_checkouts_for_spa
  * @return array The list of required fields.
  */
 function pmpro_disable_checkout_for_spammers( $required_fields ) {
+	// Bail if Spam Protection is disabled.
+	$spamprotection = pmpro_getOption("spamprotection");	
+	if ( empty( $spamprotection ) ) {
+		return $required_fields;
+	}
+	
 	if ( pmpro_was_checkout_form_submitted() && pmpro_is_spammer() ) {
 		pmpro_setMessage( __( 'Suspicious activity detected. Try again in a few minutes.', 'paid-memberships-pro' ), 'pmpro_error' );
 	}

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -46,7 +46,9 @@ function pmpro_get_spam_activity( $ip = null ) {
     
     $transient_key = 'pmpro_spam_activity_' . $ip;
     $activity = get_transient( $transient_key );    
-    if ( empty( $activity ) ) { $activity = []; }
+	if ( empty( $activity ) || ! is_array( $activity ) ) {
+		$activity = [];
+	}
     
     // Remove old items.
 	$new_activity = [];

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -25,7 +25,15 @@ function pmpro_is_spammer() {
         $is_spammer = true;
     }
     
-    return apply_filters( 'pmpro_is_spammer', $is_spammer, $activity );
+	/**
+	 * Allow filtering whether the current visitor is a spammer.
+	 *
+	 * @since 2.7
+	 *
+	 * @param bool  $is_spammer Whether the current visitor is a spammer.
+	 * @param array $activity   The list of potential spam activity.
+	 */
+	return apply_filters( 'pmpro_is_spammer', $is_spammer, $activity );
 }
 
 /**

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -95,7 +95,7 @@ function pmpro_track_spam_activity( $ip = null ) {
     
     // Save to transient.
     $transient_key = 'pmpro_spam_activity_' . $ip;
-    set_transient( $transient_key, $activity );
+    set_transient( $transient_key, $activity, (int) PMPRO_SPAM_ACTION_TIME_LIMIT );
     
     return true;
 }

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -11,8 +11,11 @@ if ( ! defined( 'PMPRO_SPAM_ACTION_TIME_LIMIT' ) ) {
 }
 
 /**
- * Is the current visitor a spammer?
+ * Determine whether the current visitor a spammer.
+ *
  * @since 2.7
+ *
+ * @return bool Whether the current visitor a spammer.
  */
 function pmpro_is_spammer() {
     $is_spammer = false;

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -120,7 +120,9 @@ function pmpro_clear_spam_activity( $ip = null ) {
     
     $transient_key = 'pmpro_spam_activity_' . $ip;
     
-    delete_transient( $transient_key );
+	delete_transient( $transient_key );
+
+	return true;
 }
 
 /**

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -147,4 +147,4 @@ function pmpro_disable_checkout_for_spammers( $required_fields ) {
     
     return $required_fields;
 }
-add_filter( 'pmpro_required_billing_fields', 'pmpro_disable_checkout_for_spammers', 10, 1 );
+add_filter( 'pmpro_required_billing_fields', 'pmpro_disable_checkout_for_spammers' );

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Code related to spam detection and prevention.
+ */
+// Some values used below.
+if ( ! defined( 'PMPRO_SPAM_ACTION_NUM_LIMIT' ) ) {
+    define( 'PMPRO_SPAM_ACTION_NUM_LIMIT', 10 );
+}
+if ( ! defined( 'PMPRO_SPAM_ACTION_TIME_LIMIT' ) ) {
+    define( 'PMPRO_SPAM_ACTION_TIME_LIMIT', 900 );  // in seconds
+}
+
+/**
+ * Is the current visitor a spammer?
+ * @since 2.7
+ */
+function pmpro_is_spammer() {
+    $is_spammer = false;
+    
+    $activity = pmpro_get_spam_activity();
+    if ( count( $activity ) >= PMPRO_SPAM_ACTION_NUM_LIMIT ) {
+        $is_spammer = true;
+    }
+    
+    return apply_filters( 'pmpro_is_spammer', $is_spammer );
+}
+
+/**
+ * Get spam activity by IP.
+ * @since 2.7
+ * @param string $ip    The IP address to get activity for.
+ * @return array|False  The array of activity if successful, false if no IP. 
+ */
+function pmpro_get_spam_activity( $ip = null ) {
+    if ( empty( $ip ) ) {
+        $ip = pmpro_get_ip();        
+    }
+    
+    // If we can't determine the IP, let's bail.
+    if ( empty( $ip ) ) {
+        return false;
+    }
+    
+    $transient_key = 'pmpro_spam_activity_' . $ip;
+    $activity = get_transient( $transient_key );    
+    if ( empty( $activity ) ) { $activity = []; }
+    
+    // Remove old items.
+	$new_activity = [];
+	$now = current_time( 'timestamp', true ); // UTC
+    foreach( $activity as $item ) {
+		if ( $item > $now-( PMPRO_SPAM_ACTION_TIME_LIMIT ) ) {
+			$new_activity[] = $item;
+		}
+	}
+    
+    return $new_activity;    
+}
+
+/**
+ * Track spam activity.
+ * When we hit a certain number, the spam flag will trigger.
+ * For now we are only tracking credit card declines their timestamps.
+ * IP address isn't a perfect way to track this, but it's the best we have.
+ *
+ * @since 2.7
+ * @param string $ip    The IP address to track activity for.
+ * @return bool         True if successful. False if we couldn't determine the IP.
+ */
+function pmpro_track_spam_activity( $ip = null ) {
+    if ( empty( $ip ) ) {
+        $ip = pmpro_get_ip();        
+    }
+    
+    // If we can't determine the IP, let's bail.
+    if ( empty( $ip ) ) {
+        return false;
+    }
+        
+    $activity = pmpro_get_spam_activity( $ip );
+    $now = current_time( 'timestamp', true ); // UTC
+    array_unshift( $activity, $now );
+    
+    // If we have more than the limit, don't bother storing them.
+    if ( count( $activity ) > PMPRO_SPAM_ACTION_NUM_LIMIT ) {
+        rsort( $activity );
+        $activity = array_slice( $activity, 0, PMPRO_SPAM_ACTION_NUM_LIMIT );
+    }
+    
+    // Save to transient.
+    $transient_key = 'pmpro_spam_activity_' . $ip;
+    set_transient( $transient_key, $activity );
+    
+    return true;
+}
+
+/**
+ * Clears all stored spam activity for an IP address.
+ * Note that the pmpro_get_spam_activity function clears out old values
+ * automatically, and this should only be used to completely clear the activity.
+ *
+ * @since 2.7
+ * @param string $ip    The IP address to clear activity for.
+ * @return bool         True if successful. False if we couldn't determine the IP.
+ */
+function pmpro_clear_spam_activity( $ip = null ) {
+    if ( empty( $ip ) ) {
+        $ip = pmpro_get_ip();        
+    }
+    
+    // If we can't determine the IP, let's bail.
+    if ( empty( $ip ) ) {
+        return false;
+    }
+    
+    $transient_key = 'pmpro_spam_activity_' . $ip;
+    
+    delete_transient( $transient_key );
+}
+
+/**
+ * Disable checkout and billing update forms for spammers.
+ *
+ * We're using the pmpro_required_billing_fields filter because it is
+ * consistently used on the checkout and update billing pages.
+ * The pmpro_setMessage() function sets the $pmpro_msgt value to error,
+ * which stops the forms from working and shows the corresponding error.
+ * We return the $required_fields parameter to keep the filter working.
+ *
+ * @since 2.7
+ */
+function pmpro_disable_checkout_for_spammers( $required_fields ) {    
+    if ( pmpro_was_checkout_form_submitted() && pmpro_is_spammer() ) {
+        pmpro_setMessage( __( 'Suspicious activity detected. Try again in a few minutes.', 'paid-memberships-pro' ), 'pmpro_error' );        
+    }
+    
+    return $required_fields;
+}
+add_filter( 'pmpro_required_billing_fields', 'pmpro_disable_checkout_for_spammers', 10, 1 );

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -2,7 +2,7 @@
 /**
  * Code related to spam detection and prevention.
  */
-// Some values used below.
+// Constants. Define these in wp-config.php to override.
 if ( ! defined( 'PMPRO_SPAM_ACTION_NUM_LIMIT' ) ) {
     define( 'PMPRO_SPAM_ACTION_NUM_LIMIT', 10 );
 }

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -70,8 +70,10 @@ function pmpro_get_spam_activity( $ip = null ) {
  * IP address isn't a perfect way to track this, but it's the best we have.
  *
  * @since 2.7
- * @param string $ip    The IP address to track activity for.
- * @return bool         True if successful. False if we couldn't determine the IP.
+ *
+ * @param string|null $ip The IP address to track activity for, or leave as null to attempt to determine current IP address.
+ *
+ * @return bool True if the tracking of activity was successful, or false if IP could not be determined.
  */
 function pmpro_track_spam_activity( $ip = null ) {
     if ( empty( $ip ) ) {

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -40,8 +40,6 @@ function pmpro_is_spammer() {
  * Get the list of potential spam activity.
  *
  * @since 2.7
- * @param string $ip    The IP address to get activity for.
- * @return array|False  The array of activity if successful, false if no IP.
  *
  * @param string|null $ip The IP address to get activity for, or leave as null to attempt to determine current IP address.
  *

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -55,6 +55,7 @@ function pmpro_get_spam_activity( $ip = null ) {
 		return false;
 	}
 
+	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $ip );
 	$transient_key = 'pmpro_spam_activity_' . $ip;
 	$activity = get_transient( $transient_key );
 	if ( empty( $activity ) || ! is_array( $activity ) ) {
@@ -107,6 +108,7 @@ function pmpro_track_spam_activity( $ip = null ) {
 	}
 
 	// Save to transient.
+	$ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $ip );
 	$transient_key = 'pmpro_spam_activity_' . $ip;
 	set_transient( $transient_key, $activity, (int) PMPRO_SPAM_ACTION_TIME_LIMIT );
 

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -133,6 +133,10 @@ function pmpro_clear_spam_activity( $ip = null ) {
  * We return the $required_fields parameter to keep the filter working.
  *
  * @since 2.7
+ *
+ * @param array $required_fields The list of required fields.
+ *
+ * @return array The list of required fields.
  */
 function pmpro_disable_checkout_for_spammers( $required_fields ) {    
     if ( pmpro_was_checkout_form_submitted() && pmpro_is_spammer() ) {

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -4,10 +4,10 @@
  */
 // Constants. Define these in wp-config.php to override.
 if ( ! defined( 'PMPRO_SPAM_ACTION_NUM_LIMIT' ) ) {
-    define( 'PMPRO_SPAM_ACTION_NUM_LIMIT', 10 );
+	define( 'PMPRO_SPAM_ACTION_NUM_LIMIT', 10 );
 }
 if ( ! defined( 'PMPRO_SPAM_ACTION_TIME_LIMIT' ) ) {
-    define( 'PMPRO_SPAM_ACTION_TIME_LIMIT', 900 );  // in seconds
+	define( 'PMPRO_SPAM_ACTION_TIME_LIMIT', 900 );  // in seconds
 }
 
 /**
@@ -18,13 +18,13 @@ if ( ! defined( 'PMPRO_SPAM_ACTION_TIME_LIMIT' ) ) {
  * @return bool Whether the current visitor a spammer.
  */
 function pmpro_is_spammer() {
-    $is_spammer = false;
-    
-    $activity = pmpro_get_spam_activity();
-    if ( count( $activity ) >= PMPRO_SPAM_ACTION_NUM_LIMIT ) {
-        $is_spammer = true;
-    }
-    
+	$is_spammer = false;
+
+	$activity = pmpro_get_spam_activity();
+	if ( count( $activity ) >= PMPRO_SPAM_ACTION_NUM_LIMIT ) {
+		$is_spammer = true;
+	}
+
 	/**
 	 * Allow filtering whether the current visitor is a spammer.
 	 *
@@ -40,35 +40,35 @@ function pmpro_is_spammer() {
  * Get spam activity by IP.
  * @since 2.7
  * @param string $ip    The IP address to get activity for.
- * @return array|False  The array of activity if successful, false if no IP. 
+ * @return array|False  The array of activity if successful, false if no IP.
  */
 function pmpro_get_spam_activity( $ip = null ) {
-    if ( empty( $ip ) ) {
-        $ip = pmpro_get_ip();        
-    }
-    
-    // If we can't determine the IP, let's bail.
-    if ( empty( $ip ) ) {
-        return false;
-    }
-    
-    $transient_key = 'pmpro_spam_activity_' . $ip;
-    $activity = get_transient( $transient_key );    
+	if ( empty( $ip ) ) {
+		$ip = pmpro_get_ip();
+	}
+
+	// If we can't determine the IP, let's bail.
+	if ( empty( $ip ) ) {
+		return false;
+	}
+
+	$transient_key = 'pmpro_spam_activity_' . $ip;
+	$activity = get_transient( $transient_key );
 	if ( empty( $activity ) || ! is_array( $activity ) ) {
 		$activity = [];
 	}
-    
-    // Remove old items.
+
+	// Remove old items.
 	$new_activity = [];
 	$now = current_time( 'timestamp', true ); // UTC
-    foreach( $activity as $item ) {
+	foreach( $activity as $item ) {
 		// Determine whether this item is recent enough to include.
 		if ( $item > $now-( PMPRO_SPAM_ACTION_TIME_LIMIT ) ) {
 			$new_activity[] = $item;
 		}
 	}
-    
-    return $new_activity;    
+
+	return $new_activity;
 }
 
 /**
@@ -84,30 +84,30 @@ function pmpro_get_spam_activity( $ip = null ) {
  * @return bool True if the tracking of activity was successful, or false if IP could not be determined.
  */
 function pmpro_track_spam_activity( $ip = null ) {
-    if ( empty( $ip ) ) {
-        $ip = pmpro_get_ip();        
-    }
-    
-    // If we can't determine the IP, let's bail.
-    if ( empty( $ip ) ) {
-        return false;
-    }
-        
-    $activity = pmpro_get_spam_activity( $ip );
-    $now = current_time( 'timestamp', true ); // UTC
-    array_unshift( $activity, $now );
-    
-    // If we have more than the limit, don't bother storing them.
-    if ( count( $activity ) > PMPRO_SPAM_ACTION_NUM_LIMIT ) {
-        rsort( $activity );
-        $activity = array_slice( $activity, 0, PMPRO_SPAM_ACTION_NUM_LIMIT );
-    }
-    
-    // Save to transient.
-    $transient_key = 'pmpro_spam_activity_' . $ip;
-    set_transient( $transient_key, $activity, (int) PMPRO_SPAM_ACTION_TIME_LIMIT );
-    
-    return true;
+	if ( empty( $ip ) ) {
+		$ip = pmpro_get_ip();
+	}
+
+	// If we can't determine the IP, let's bail.
+	if ( empty( $ip ) ) {
+		return false;
+	}
+
+	$activity = pmpro_get_spam_activity( $ip );
+	$now = current_time( 'timestamp', true ); // UTC
+	array_unshift( $activity, $now );
+
+	// If we have more than the limit, don't bother storing them.
+	if ( count( $activity ) > PMPRO_SPAM_ACTION_NUM_LIMIT ) {
+		rsort( $activity );
+		$activity = array_slice( $activity, 0, PMPRO_SPAM_ACTION_NUM_LIMIT );
+	}
+
+	// Save to transient.
+	$transient_key = 'pmpro_spam_activity_' . $ip;
+	set_transient( $transient_key, $activity, (int) PMPRO_SPAM_ACTION_TIME_LIMIT );
+
+	return true;
 }
 
 /**
@@ -122,17 +122,17 @@ function pmpro_track_spam_activity( $ip = null ) {
  * @return bool True if the clearing of activity was successful, or false if IP could not be determined.
  */
 function pmpro_clear_spam_activity( $ip = null ) {
-    if ( empty( $ip ) ) {
-        $ip = pmpro_get_ip();        
-    }
-    
-    // If we can't determine the IP, let's bail.
-    if ( empty( $ip ) ) {
-        return false;
-    }
-    
-    $transient_key = 'pmpro_spam_activity_' . $ip;
-    
+	if ( empty( $ip ) ) {
+		$ip = pmpro_get_ip();
+	}
+
+	// If we can't determine the IP, let's bail.
+	if ( empty( $ip ) ) {
+		return false;
+	}
+
+	$transient_key = 'pmpro_spam_activity_' . $ip;
+
 	delete_transient( $transient_key );
 
 	return true;
@@ -145,7 +145,7 @@ function pmpro_clear_spam_activity( $ip = null ) {
  * @param MemberOrder $morder The order object used at checkout. We ignore it.
  */
 function pmpro_track_failed_checkouts_for_spam( $morder ) {
-    pmpro_track_spam_activity();
+	pmpro_track_spam_activity();
 }
 add_action( 'pmpro_checkout_processing_failed', 'pmpro_track_failed_checkouts_for_spam' );
 add_action( 'pmpro_update_billing_failed', 'pmpro_track_failed_checkouts_for_spam' );
@@ -165,11 +165,11 @@ add_action( 'pmpro_update_billing_failed', 'pmpro_track_failed_checkouts_for_spa
  *
  * @return array The list of required fields.
  */
-function pmpro_disable_checkout_for_spammers( $required_fields ) {    
-    if ( pmpro_was_checkout_form_submitted() && pmpro_is_spammer() ) {
-        pmpro_setMessage( __( 'Suspicious activity detected. Try again in a few minutes.', 'paid-memberships-pro' ), 'pmpro_error' );        
-    }
-    
-    return $required_fields;
+function pmpro_disable_checkout_for_spammers( $required_fields ) {
+	if ( pmpro_was_checkout_form_submitted() && pmpro_is_spammer() ) {
+		pmpro_setMessage( __( 'Suspicious activity detected. Try again in a few minutes.', 'paid-memberships-pro' ), 'pmpro_error' );
+	}
+
+	return $required_fields;
 }
 add_filter( 'pmpro_required_billing_fields', 'pmpro_disable_checkout_for_spammers' );

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -106,8 +106,11 @@ function pmpro_track_spam_activity( $ip = null ) {
  * automatically, and this should only be used to completely clear the activity.
  *
  * @since 2.7
- * @param string $ip    The IP address to clear activity for.
- * @return bool         True if successful. False if we couldn't determine the IP.
+ *
+ * @param string|null $ip The IP address to clear activity for, or leave as null to attempt to determine current IP address.
+ *
+ * @return bool True if the clearing of activity was successful, or false if IP could not be determined.
+ */
  */
 function pmpro_clear_spam_activity( $ip = null ) {
     if ( empty( $ip ) ) {

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -54,6 +54,7 @@ function pmpro_get_spam_activity( $ip = null ) {
 	$new_activity = [];
 	$now = current_time( 'timestamp', true ); // UTC
     foreach( $activity as $item ) {
+		// Determine whether this item is recent enough to include.
 		if ( $item > $now-( PMPRO_SPAM_ACTION_TIME_LIMIT ) ) {
 			$new_activity[] = $item;
 		}

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -74,7 +74,8 @@ require_once( PMPRO_DIR . '/includes/cleanup.php' );                // clean thi
 require_once( PMPRO_DIR . '/includes/login.php' );                  // code to redirect away from login/register page
 require_once( PMPRO_DIR . '/includes/capabilities.php' );           // manage PMPro capabilities for roles
 require_once( PMPRO_DIR . '/includes/privacy.php' );                // code to aid with user data privacy, e.g. GDPR compliance
-require_once( PMPRO_DIR . '/includes/pointers.php' );
+require_once( PMPRO_DIR . '/includes/pointers.php' );				// popover help pointers
+require_once( PMPRO_DIR . '/includes/spam.php' );					// code to combat spam of various kinds
 
 require_once( PMPRO_DIR . '/includes/xmlrpc.php' );                 // xmlrpc methods
 require_once( PMPRO_DIR . '/includes/rest-api.php' );               // rest API endpoints

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -276,8 +276,13 @@ if ($submit) {
 			
 			do_action( 'pmpro_after_update_billing', $current_user->ID, $morder );
         } else {
-			// Track as spam activity to prevent too many CC attempts.
-			pmpro_track_spam_activity();
+			/**
+			 * Allow running code when the update fails.
+			 *
+			 * @since 2.7
+			 * @param MemberOrder $morder The order for the sub being updated.
+			 */
+			do_action( 'pmpro_update_billing_failed', $morder );
 			
 			// Make sure we have an error message.
 			$pmpro_msg = $morder->error;

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -276,7 +276,11 @@ if ($submit) {
 			
 			do_action( 'pmpro_after_update_billing', $current_user->ID, $morder );
         } else {
-            $pmpro_msg = $morder->error;
+			// Track as spam activity to prevent too many CC attempts.
+			pmpro_track_spam_activity();
+			
+			// Make sure we have an error message.
+			$pmpro_msg = $morder->error;
 
             if (!$pmpro_msg)
                 $pmpro_msg = __("Error updating billing information.", 'paid-memberships-pro' );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -457,17 +457,17 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 						 * @param MemberOrder $morder The order object used at checkout.
 						 */
 						do_action( 'pmpro_checkout_processing_failed', $morder );
-						
+
 						// Make sure we have an error message.
 						$pmpro_msg = !empty( $morder->error ) ? $morder->error : null;
 						if ( empty( $pmpro_msg ) ) {
 							$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", 'paid-memberships-pro' );
-						}						
+						}
 						if ( ! empty( $morder->error_type ) ) {
 							$pmpro_msgt = $morder->error_type;
 						} else {
 							$pmpro_msgt = "pmpro_error";
-						}						
+						}
 					}
 
 				} else // !$pmpro_requirebilling
@@ -635,7 +635,7 @@ if ( ! empty( $pmpro_confirmed ) ) {
 		} else {
 			$code_check = pmpro_checkDiscountCode( $discount_code, $pmpro_level->id, true );
 		}
-		
+
 		if ( $code_check[0] == false ) {
 			//error
 			$pmpro_msg  = $code_check[1];
@@ -647,8 +647,8 @@ if ( ! empty( $pmpro_confirmed ) ) {
 			//all okay
 			$use_discount_code = true;
 		}
-		
-		//update membership_user table.		
+
+		//update membership_user table.
 		if ( ! empty( $discount_code ) && ! empty( $use_discount_code ) ) {
 			$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
 		} else {
@@ -705,7 +705,7 @@ if ( ! empty( $pmpro_confirmed ) ) {
 				}
 
 				$wpdb->query( "INSERT INTO $wpdb->pmpro_discount_codes_uses (code_id, user_id, order_id, timestamp) VALUES('" . $discount_code_id . "', '" . $user_id . "', '" . intval( $code_order_id ) . "', '" . current_time( "mysql" ) . "')" );
-				
+
 				do_action( 'pmpro_discount_code_used', $discount_code_id, $user_id, $code_order_id );
 			}
 
@@ -788,7 +788,7 @@ if ( ! empty( $pmpro_confirmed ) ) {
 			do_action( "pmpro_after_checkout", $user_id, $morder );    //added $morder param in v2.0
 
 			$sendemails = apply_filters( "pmpro_send_checkout_emails", true);
-	
+
 			if($sendemails) { // Send the emails only if the flag is set to true
 
 				//setup some values for the emails

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -450,11 +450,14 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 						$pmpro_msgt      = "pmpro_success";
 						$pmpro_confirmed = true;
 					} else {
+						// Track as spam activity to prevent too many CC attempts.
+						pmpro_track_spam_activity();
+						
+						// Make sure we have an error message.
 						$pmpro_msg = !empty( $morder->error ) ? $morder->error : null;
 						if ( empty( $pmpro_msg ) ) {
 							$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", 'paid-memberships-pro' );
-						}
-						
+						}						
 						if ( ! empty( $morder->error_type ) ) {
 							$pmpro_msgt = $morder->error_type;
 						} else {

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -450,8 +450,13 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 						$pmpro_msgt      = "pmpro_success";
 						$pmpro_confirmed = true;
 					} else {
-						// Track as spam activity to prevent too many CC attempts.
-						pmpro_track_spam_activity();
+						/**
+						 * Allow running code when processing fails.
+						 *
+						 * @since 2.7
+						 * @param MemberOrder $morder The order object used at checkout.
+						 */
+						do_action( 'pmpro_checkout_processing_failed', $morder );
 						
 						// Make sure we have an error message.
 						$pmpro_msg = !empty( $morder->error ) ? $morder->error : null;


### PR DESCRIPTION
Spammers are testing credit cards on our checkout pages. Adding reCAPTCHA to the page helps. Using gateway tools like Stripe's RADAR helps. But still, this activity puts load on the site, incurs charges, and potentially can get your gateway to cancel your account.

This PR adds a new file includes/spam.php with some a new system to help combat that.

The checkout and billing preheaders will now make a call to pmpro_track_spam_activity() whenever they fail in error. If there are more than 10 failed charges, authorizations, subscriptions, or billing updates from the same IP address within a 15 minute period, then the pmpro_required_billing_fields hook is used to set up an error to stop checkouts/updates from happening. This will prevent the spammer from continued spam testing.

There is a hook pmpro_is_spammer passing params $is_spammer and $activity, which can be used to override whether or not the spam preventive measures will happen.

The $activity value is an array of timestamps of when the spam activity occurred. It does not log the type of activity. We could set that up now or in the future.

You can adjust the spam activity limit and time limit by adding these constants to your wp-config.php

`
define( 'PMPRO_SPAM_ACTION_NUM_LIMIT', 10 );    // tracked activity within the timeframe
define( 'PMPRO_SPAM_ACTION_TIME_LIMIT', 900 );  // in seconds
`

The activity is stored in transients tied to the IP address. We want to keep the data footprint small.

Some open questions:
* Do we want to specifically exclude admins from the spam checking?
* Do we want to make this feature a setting on the Payment Settings page or should we always enable it?
* Do we want to do something more drastic if pmpro_is_spammer()? We could filter the shortcodes to hide the forms all together, redirect those users to a specific page, or serve them an invalid HTTP status.
* Are there false positives, DDOS possibilities, or other issues with this system?
* Are there better default values for the activity and time limit? Should they be settings.
* Do we want the lockout period to be separate from the tracking period? Both are 15m now.