### PR TITLE
Includes Member Pages in Site Health Information

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -97,6 +97,10 @@ class PMPro_Site_Health {
 					'label' => __( '.htaccess Cache Usage', 'paid-memberships-pro' ),
 					'value' => self::get_htaccess_cache_usage(),
 				],
+				'pmpro-pages' => [
+					'label' => __( 'Membership Pages', 'paid-memberships-pro' ),
+					'value' => self::get_pmpro_pages(),
+				]
 			],
 		];
 
@@ -351,6 +355,43 @@ class PMPro_Site_Health {
 		}
 
 		return implode( " | \n", $cron_information );
+	}
+
+	/**
+	 * Get the assigned Member pages and their URL's
+	 *
+	 * @since TBA
+	 *
+	 * @return string The member page information
+	 */
+	public function get_pmpro_pages() {
+
+		global $pmpro_pages;
+
+		$page_information = array();
+		
+		if( !empty( $pmpro_pages ) ){
+
+			foreach( $pmpro_pages as $key => $val ){
+
+				$permalink = get_the_permalink( (int)$val );
+
+				if( empty( $permalink ) ){
+					$page_information[$key] = 'Not Set'; //Not translating this
+				} else {
+					$page_information[$key] = $permalink;
+				}
+
+			}
+
+		} else {
+
+			return __( 'No Membership Pages Found', 'paid-memberships-pro' );
+
+		}
+
+		return $page_information;
+
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Includes member page URL's in the Site Health information

![image](https://user-images.githubusercontent.com/8989542/149135785-e4aa7ef3-39f7-4407-88ce-a2903e227196.png)


### How to test the changes in this Pull Request:

1. Navigate to the Site Health Information page
2. Scroll down to the Paid Memberships Pro section
3. The 'Membership Pages' section has now been added

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Membership pages included in Site Health Information
