### PR TITLE
Stripe products separate environments

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2203,8 +2203,6 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Get the Stripe product ID for a given membership level.
 	 *
-	 * TODO: Separate products for live and sandbox mode.
-	 *
 	 * @since TBD
 	 *
 	 * @param PMPro_Membership_Leve|int $level to get product ID for.
@@ -2242,8 +2240,6 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * WARNING: Will overwrite old Stripe product set for level if
 	 * there is already one set.
-	 *
-	 * TODO: Separate products for live and sandbox mode.
 	 *
 	 * @since TBD
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

Saves Stripe Product IDs for live mode and sandbox mode separately so that swapping between gateway environments does not cause issues.