### PR TITLE
move email header/footer where they should be

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -87,24 +87,6 @@
 			elseif(!empty($this->data) && !empty($this->data['body']))
 				$this->body = $this->data['body'];																						//data passed in
 
-
-			// Get template header.
-			if( pmpro_getOption( 'email_header_disabled' ) != 'true' ) {
-				$email_header = pmpro_email_templates_get_template_body('header');
-			} else {
-				$email_header = '';
-			}
-
-			// Get template footer
-			if( pmpro_getOption( 'email_footer_disabled' ) != 'true' ) {
-				$email_footer = pmpro_email_templates_get_template_body('footer');
-			} else {
-				$email_footer = '';
-			}
-
-			// Add header and footer to email body.
-			$this->body = $email_header . $this->body . $email_footer;
-
 			//if data is a string, assume we mean to replace !!body!! with it
 			if(is_string($this->data))
 				$this->data = array("body"=>$data);											

--- a/includes/email.php
+++ b/includes/email.php
@@ -301,7 +301,7 @@ function pmpro_email_templates_send_test() {
 	$test_user->membership_level = array_pop( $all_levels );
 
 	//add notice to email body
-	add_filter('pmpro_email_body', 'pmpro_email_templates_test_body', 10, 2);
+	add_filter('pmpro_email_body', 'pmpro_email_templates_test_body', 100000, 2);
 
 	//force the template
 	add_filter('pmpro_email_filter', 'pmpro_email_templates_test_template', 5, 1);

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -259,3 +259,23 @@ function pmpro_ignore_checkout_order_when_cancelling_old_orders( $order_ids ) {
 	return $order_ids;
 }
 add_filter( 'pmpro_other_order_ids_to_cancel', 'pmpro_ignore_checkout_order_when_cancelling_old_orders' );
+
+function pmpro_email_add_header_footer( $body, $temail ){
+	// Get template header.
+	if( pmpro_getOption( 'email_header_disabled' ) != 'true' ) {
+		$email_header = pmpro_email_templates_get_template_body('header');
+	} else {
+		$email_header = '';
+	}
+
+	// Get template footer
+	if( pmpro_getOption( 'email_footer_disabled' ) != 'true' ) {
+		$email_footer = pmpro_email_templates_get_template_body('footer');
+	} else {
+		$email_footer = '';
+	}
+
+	// Add header and footer to email body.
+	return $email_header . $body . $email_footer;
+}
+add_filter( 'pmpro_email_body', 'pmpro_email_add_header_footer', 99999, 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves the appended contents to be placed before the footer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
