### PR TITLE
Set height to auto for SelectControl in our block elements

### DIFF
--- a/css/blocks.editor.css
+++ b/css/blocks.editor.css
@@ -24,6 +24,9 @@
 .pmpro-block-element .components-base-control {
 	margin-bottom: 16px;
 }
+.pmpro-block-element .components-base-control .components-select-control {
+	height: auto;
+}
 .pmpro-block-element .components-base-control .components-base-control__label {
 	display: block;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves problem with SelectControl height in WordPress 5.9 FSE for our blocks.

### How to test the changes in this Pull Request:

1. Load up WP 5.9 (beta/rc/final)
2. Install a block theme or use Twenty Twenty-Two
3. Open up Site Editor
4. Add PMPro Checkout Button block to any template
5. Open block and see SelectControl for Membership Level is normal height

### Before fix

![Screen Recording 2022-01-14 at 07 49 22 PM](https://user-images.githubusercontent.com/709662/149604495-cc74311f-9911-413b-b38e-4643fc731034.gif)

### After fix

![Screen Shot 2022-01-14 at 7 48 22 PM](https://user-images.githubusercontent.com/709662/149604504-dd7fd259-8822-4f3e-8521-ab4cf6995765.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed visual issue with WordPress 5.9 in the new Site Editor (FSE) where the height of certain select fields in PMPro blocks appeared extra tall
