### PR TITLE
Improved error message when create_subscription_for_customer_from_order() fails

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1456,8 +1456,8 @@ class PMProGateway_stripe extends PMProGateway {
 			if ( pmpro_isLevelRecurring( $order->membership_level ) ) {
 				$subscription = $this->create_subscription_for_customer_from_order( $customer->id, $order );
 				if ( empty( $subscription ) ) {
-					// There was an issue creating the subscription.
-					$order->error      = __( 'Error creating subscription for customer.', 'paid-memberships-pro' );
+					// There was an issue creating the subscription. Order will have error message.
+					$order->error      = __( 'Error creating subscription for customer.', 'paid-memberships-pro' ) . ' ' . $order->error;
 					$order->shorterror = $order->error;
 					return false;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Improved error message when `create_subscription_for_customer_from_order()` fails in Stripe class.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This change is made in an effort to help customers debug issues that may occur when subscription creation fails.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* BUG FIX/ENHANCEMENT: Improved error messages when creating subscriptions with Stripe.
