### PR TITLE
Fixed issue where trial period days can be calculated incorrectly for Stripe subscriptions

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2388,7 +2388,6 @@ class PMProGateway_stripe extends PMProGateway {
 
 		// For free trials, multiply the trial period for each additional free period.
 		if ( ! empty( $order->TrialBillingCycles ) && $order->TrialAmount == 0 ) {
-			$trialOccurrences = (int) $order->TrialBillingCycles;
 			$trial_period_days = $trial_period_days * ( $order->TrialBillingCycles + 1 );
 		}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2377,15 +2377,14 @@ class PMProGateway_stripe extends PMProGateway {
 	private function calculate_trial_period_days( $order ) {
 		// Use a trial period to set the first recurring payment date.
 		if ( $order->BillingPeriod == "Year" ) {
-			$days_in_billing_period = $order->BillingFrequency * 365;    //annual
+			$trial_period_days = $order->BillingFrequency * 365;    //annual
 		} elseif ( $order->BillingPeriod == "Day" ) {
-			$days_in_billing_period = $order->BillingFrequency * 1;        //daily
+			$trial_period_days = $order->BillingFrequency * 1;        //daily
 		} elseif ( $order->BillingPeriod == "Week" ) {
-			$days_in_billing_period = $order->BillingFrequency * 7;        //weekly
+			$trial_period_days = $order->BillingFrequency * 7;        //weekly
 		} else {
-			$days_in_billing_period = $order->BillingFrequency * 30;    //assume monthly
+			$trial_period_days = $order->BillingFrequency * 30;    //assume monthly
 		}
-		$trial_period_days = $order->BillingFrequency * $days_in_billing_period;
 
 		// For free trials, multiply the trial period for each additional free period.
 		if ( ! empty( $order->TrialBillingCycles ) && $order->TrialAmount == 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed issue where trial period days can be calculated incorrectly for Stripe subscriptions. Specifically, cases when the billing frequency was not 1 could cause initial subscription trials to have incorrect lengths in Stripe.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
- BUG FIX: Resolved issue where subscriptions could have incorrect trial lengths in Stripe.
