### PR TITLE
BUG FIX: Fix fatal error for older PHP sites when visiting the page settings in admin dashboard.

### DIFF
--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -29,7 +29,7 @@ $post_types = apply_filters( 'pmpro_admin_pagesetting_post_type_array', array( '
 
 // For backward compatibility we extract the first element from the array
 if ( is_array( $post_types ) ) {
-        $post_type = reset( $post_types );
+    $post_type = reset( $post_types );
 } else {
     $post_type = $post_types;
 }

--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -28,13 +28,8 @@ $extra_pages = apply_filters('pmpro_extra_page_settings', array());
 $post_types = apply_filters( 'pmpro_admin_pagesetting_post_type_array', array( 'page' ) );
 
 // For backward compatibility we extract the first element from the array
-// For backward compatibility we extract the first element from the array
 if ( is_array( $post_types ) ) {
-    if ( function_exists( 'array_key_first' ) ) {
-        $post_type = $post_types[ array_key_first( $post_types ) ];
-    } else {
-        $post_type = $post_types[0];
-    }
+        $post_type = reset( $post_types );
 } else {
     $post_type = $post_types;
 }

--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -28,8 +28,16 @@ $extra_pages = apply_filters('pmpro_extra_page_settings', array());
 $post_types = apply_filters( 'pmpro_admin_pagesetting_post_type_array', array( 'page' ) );
 
 // For backward compatibility we extract the first element from the array
-$post_type = is_array( $post_types ) ? $post_types[ array_key_first( $post_types ) ] : $post_types;
-
+// For backward compatibility we extract the first element from the array
+if ( is_array( $post_types ) ) {
+    if ( function_exists( 'array_key_first' ) ) {
+        $post_type = $post_types[ array_key_first( $post_types ) ];
+    } else {
+        $post_type = $post_types[0];
+    }
+} else {
+    $post_type = $post_types;
+}
 /**
  * Set post type to use for PMPro pages in the page settings dropdown.
  *


### PR DESCRIPTION
BUG FIX: Fixed fatal error on sites older than PHP 7.3 when trying to use the admin pages settings. Updating previous PR to be simpler and use reset method instead.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX: Fixed fatal error on sites older than PHP 7.3 when trying to use the admin pages settings.