### PR TITLE
Fixing issue where billing address not added to Stripe customer

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2035,7 +2035,7 @@ class PMProGateway_stripe extends PMProGateway {
 			! empty( $order->billing->street ) &&
 			! empty( $order->billing->city ) &&
 			! empty( $order->billing->state ) &&
-			! empty( $order->billing->postal_code ) &&
+			! empty( $order->billing->zip ) &&
 			! empty( $order->billing->country ) 
 		) {
 			// We collected a billing address at checkout.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing issue where billing address may not added to Stripe customer. We weren't adding the billing address at all pre-2.7, so nothing was working then but broken here. New functionality just wasn't firing.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
- BUG FIX/ENHANCEMENT: Billing address is now being added to Stripe Customers.
