### PR TITLE
Small fix to ensure that form input fields aren't insanely tiny/short.

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -148,6 +148,7 @@ form.pmpro_form select,
 #loginform input[type=password] {
 	display: inline-block;
 	max-width: 90%;
+	min-height: 1.5rem;
 }
 form.pmpro_form .pmpro_checkout-field-bcity_state_zip .input,
 form.pmpro_form .pmpro_checkout-field-bcity_state_zip select {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Form input fields on the newest WP theme Twenty Twenty-Two were very vertically short. This adjustment sets a min height for all of our form fields equal to 1.5x the base font size for the stylesheet/agent. This is a failsafe to make sure that form inputs aren't too small.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Setting a min-height for input fields of 1.5em (1.5 x base font size) for usability.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
