### PR TITLE
Autoload ->Gateway when needed

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -6,9 +6,6 @@
 		 */
 		function __construct($id = NULL)
 		{
-			//set up the gateway
-			$this->setGateway(pmpro_getOption("gateway"));
-
 			//get data if an id was passed
 			if($id)
 			{
@@ -19,6 +16,25 @@
 			}
 			else
 				return $this->getEmptyMemberOrder();	//blank constructor
+		}
+
+		public function __get( $name )
+		{
+			if( 'Gateway' === $name ){
+				// we are here only if ->Gateway is NOT set
+				$this->setGateway( $this->gateway ? $this->gateway : '' );
+
+				return $this->Gateway;
+			}
+
+			$trace = debug_backtrace();
+			trigger_error(
+				'Undefined property via __get(): ' . $name .
+				' in ' . $trace[0]['file'] .
+				' on line ' . $trace[0]['line']
+			);
+
+			return null;
 		}
 
 		/**
@@ -142,8 +158,11 @@
 				$this->checkout_id = $dbobj->checkout_id;
 
 				//reset the gateway
-				if(empty($this->nogateway))
+				if( empty( $this->nogateway ) ) {
 					$this->setGateway();
+				} else {
+					unset( $this->Gateway );
+				}
 
 				return $this->id;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We had an issue discussed on slack; because of `setGateway` loaded to default gateway on `MemberOrder::__construct()`, we found a case in which the `->Gateway` instance does not reflect the `->gateway` type.

Code to reproduce:
```php
// I have Stripe as active Gateway, + PPE Addon
$order            = new MemberOrder();
$order->nogateway = true;
$order->getMemberOrderByCode( 'E9A0ED3C5F' ); // PPE order
// $order->setGateway( $order->gateway );

echo $order->gateway; // paypalexpress !!!!
echo get_class( $order->Gateway ); // PMProGateway_stripe !!!!
```

### How to test the changes in this Pull Request:

1. Add the code above somewhere using a PPE order (with stripe as default gateway)
2. Check the dumps
3. Apply the patchs and re-check the dumps

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
