### PR TITLE
WPCS on cleanup.php file

### DIFF
--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -50,7 +50,7 @@ add_action( 'delete_user_form', 'pmpro_delete_user_form_notice', 10, 2 );
 // deleting a category? remove any level associations
 function pmpro_delete_category( $cat_id = null ) {
 	global $wpdb;
-	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_categories WHERE category_id = '" . $cat_id . "'";
+	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_categories WHERE category_id = '" . esc_sql( $cat_id ) . "'";
 	$wpdb->query( $sqlQuery );
 }
 add_action( 'delete_category', 'pmpro_delete_category' );
@@ -58,7 +58,7 @@ add_action( 'delete_category', 'pmpro_delete_category' );
 // deleting a post? remove any level associations
 function pmpro_delete_post( $post_id = null ) {
 	global $wpdb;
-	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '" . $post_id . "'";
+	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '" . esc_sql( $post_id ) . "'";
 	$wpdb->query( $sqlQuery );
 }
 add_action( 'delete_post', 'pmpro_delete_post' );

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -50,7 +50,10 @@ add_action( 'delete_user_form', 'pmpro_delete_user_form_notice', 10, 2 );
 // deleting a category? remove any level associations
 function pmpro_delete_category( $cat_id = null ) {
 	global $wpdb;
-	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_categories WHERE category_id = '" . esc_sql( $cat_id ) . "'";
+	$sqlQuery = $wpdb->prepare(
+		"DELETE FROM $wpdb->pmpro_memberships_categories WHERE category_id = '%d'",
+		$cat_id
+	);
 	$wpdb->query( $sqlQuery );
 }
 add_action( 'delete_category', 'pmpro_delete_category' );
@@ -58,7 +61,10 @@ add_action( 'delete_category', 'pmpro_delete_category' );
 // deleting a post? remove any level associations
 function pmpro_delete_post( $post_id = null ) {
 	global $wpdb;
-	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '" . esc_sql( $post_id ) . "'";
+	$sqlQuery = $wpdb->prepare(
+		"DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '%d'",
+		$post_id
+	);
 	$wpdb->query( $sqlQuery );
 }
 add_action( 'delete_post', 'pmpro_delete_post' );

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -64,7 +64,7 @@ function pmpro_delete_post( $post_id = null ) {
 	$wpdb->delete( 
 		$wpdb->pmpro_memberships_pages, 
 		array( 'page_id' => $post_id ), 
-		'%d' 
+		array( '%d' )
 	);
 }
 add_action( 'delete_post', 'pmpro_delete_post' );

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -50,21 +50,21 @@ add_action( 'delete_user_form', 'pmpro_delete_user_form_notice', 10, 2 );
 // deleting a category? remove any level associations
 function pmpro_delete_category( $cat_id = null ) {
 	global $wpdb;
-	$sqlQuery = $wpdb->prepare(
-		"DELETE FROM $wpdb->pmpro_memberships_categories WHERE category_id = '%d'",
-		$cat_id
+	$wpdb->delete(
+		$wpdb->pmpro_memberships_categories,
+		array( 'category_id' => $cat_id ),
+		'%d'
 	);
-	$wpdb->query( $sqlQuery );
 }
 add_action( 'delete_category', 'pmpro_delete_category' );
 
 // deleting a post? remove any level associations
 function pmpro_delete_post( $post_id = null ) {
 	global $wpdb;
-	$sqlQuery = $wpdb->prepare(
-		"DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '%d'",
-		$post_id
+	$wpdb->delete( 
+		$wpdb->pmpro_memberships_pages, 
+		array( 'page_id' => $post_id ), 
+		'%d' 
 	);
-	$wpdb->query( $sqlQuery );
 }
 add_action( 'delete_post', 'pmpro_delete_post' );

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -2,24 +2,19 @@
 /*
 	Clean things up when deletes happen, etc. (This stuff needs a better home.)
 */
-//deleting a user? remove their account info.
-function pmpro_delete_user($user_id = NULL)
-{
-	global $wpdb;
+// deleting a user? remove their account info.
+function pmpro_delete_user( $user_id = null ) {
 
-	//changing their membership level to 0 will cancel any subscription and remove their membership level entry
-	//we don't remove the orders because it would affect reporting
-	if(pmpro_changeMembershipLevel(0, $user_id))
-	{
-		//okay
-	}
-	else
-	{
-		//okay, guessing they didn't have a level
+	// changing their membership level to 0 will cancel any subscription and remove their membership level entry
+	// we don't remove the orders because it would affect reporting
+	if ( pmpro_changeMembershipLevel( 0, $user_id ) ) {
+		// okay
+	} else {
+		// okay, guessing they didn't have a level
 	}
 }
-add_action('delete_user', 'pmpro_delete_user');
-add_action('wpmu_delete_user', 'pmpro_delete_user');
+add_action( 'delete_user', 'pmpro_delete_user' );
+add_action( 'wpmu_delete_user', 'pmpro_delete_user' );
 
 /**
  * Show a notice on the Delete User form so admin knows that membership and subscriptions will be cancelled.
@@ -39,32 +34,31 @@ function pmpro_delete_user_form_notice( $current_user, $userids ) {
 	// Show a notice if users for deletion have an an active membership level.
 	if ( ! empty( $userids_have_levels ) ) { ?>
 		<div class="notice notice-error inline">
-			<?php if ( count( $userids ) > 1 ) {
+			<?php
+			if ( count( $userids ) > 1 ) {
 				_e( '<p><strong>Warning:</strong> One or more users for deletion have an active membership level. Deleting a user will also cancel their membership and recurring subscription.</p>', 'paid-memberships-pro' );
 			} else {
 				_e( '<p><strong>Warning:</strong> This user has an active membership level. Deleting a user will also cancel their membership and recurring subscription.</p>', 'paid-memberships-pro' );
 			}
-		?>
+			?>
 		</div>
-	<?php
+		<?php
 	}
 }
 add_action( 'delete_user_form', 'pmpro_delete_user_form_notice', 10, 2 );
 
-//deleting a category? remove any level associations
-function pmpro_delete_category($cat_id = NULL)
-{
+// deleting a category? remove any level associations
+function pmpro_delete_category( $cat_id = null ) {
 	global $wpdb;
 	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_categories WHERE category_id = '" . $cat_id . "'";
-	$wpdb->query($sqlQuery);
+	$wpdb->query( $sqlQuery );
 }
-add_action('delete_category', 'pmpro_delete_category');
+add_action( 'delete_category', 'pmpro_delete_category' );
 
-//deleting a post? remove any level associations
-function pmpro_delete_post($post_id = NULL)
-{
+// deleting a post? remove any level associations
+function pmpro_delete_post( $post_id = null ) {
 	global $wpdb;
 	$sqlQuery = "DELETE FROM $wpdb->pmpro_memberships_pages WHERE page_id = '" . $post_id . "'";
-	$wpdb->query($sqlQuery);
+	$wpdb->query( $sqlQuery );
 }
-add_action('delete_post', 'pmpro_delete_post');
+add_action( 'delete_post', 'pmpro_delete_post' );


### PR DESCRIPTION
* Added WordPress Coding Standards to cleanup.php

* Removed a stray `global $wpdb` in the pmpro_delete_user function

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?