### PR TITLE
Adjusting the default color of text in the TOS at checkout for better contrast and accessibility

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -342,7 +342,7 @@ span.pmpro_price_part_sub:before {
 #pmpro_license {
 	background: #FFF;
 	border: 1px solid #CCC;
-	color: #666;
+	color: #333;
 	height: 200px;
 	margin: 3px;
 	overflow: auto;


### PR DESCRIPTION
Small adjustment to set the TOS at checkout font color to a darker grey/almost black. We discussed this and agreed that instead of inherit font color from page, set the bg color of that block to white and dark text.