### PR TITLE
Now removing the application fee for all premium license types (inclu…

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3509,7 +3509,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 */
 	public static function get_application_fee_percentage() {
 		pmpro_method_should_be_private( '2.7.0' );
-		$application_fee_percentage = pmpro_license_isValid( null, 'plus' ) ? 0 : 1;
+		$application_fee_percentage = pmpro_license_isValid( null, pmpro_license_get_premium_types() ) ? 0 : 1;
 		$application_fee_percentage = apply_filters( 'pmpro_set_application_fee_percentage', $application_fee_percentage );
 		return round( floatval( $application_fee_percentage ), 2 );
 	}


### PR DESCRIPTION
…dign standard and builder)

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The 2.7.4 update connects to a new v2 of the PMPro license server, which can return license types of "standard" or "builder" in addition to "plus". This code fixes an issue where only plus licenses were removing the Stripe application fee of 1%.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issue where Stripe application fees were still charged for PMPro Standard and PMPro Builder license holders. From now on, payments and subscriptions will not include the fee.
