### PR TITLE
Using a 100 limit here to avoid issues if there are > 10 prices with …

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2308,6 +2308,7 @@ class PMProGateway_stripe extends PMProGateway {
 			'product'  => $product_id,
 			'type'     => $is_recurring ? 'recurring' : 'one_time',
 			'currency' => strtolower( $pmpro_currency ),
+			'limit' => 100,
 		);
 		if ( $is_recurring ) {
 			$price_search_args['recurring'] = array( 'interval' => $cycle_period );


### PR DESCRIPTION
…the same cycle period. This would e.g. if the donations add on was being used or otherwise there were lots of changes in pricing on the site through discount codes or whatever.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The default limit for prices returned from a prices search with the Stripe API is 10. If a product had more than 10 prices with the same billing period (e.g. if the donations add on were being used, there have been > 10 discount codes with different prices, or just the price changed a lot) then this search might not find an existing price and continue to create new prices.

This update just kicks the can down the road for the issue, but it's much less likely for a single level/product to have > 100 prices vs 10.

A solution to account for > 100 prices could check the "has_more" parameter of the search results and do another API prices search setting starting_with parameter to page through the results.

Related Stripe docs here: https://stripe.com/docs/api/prices/list

### How to test the changes in this Pull Request:

1. Set up the Stripe testing gateway.
2. Create a recurring level.
3. Checkout with the recurring level.
4. Check in Stripe that a product/price was created. Repeat checkouts to make sure they are being reused.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX/ENHANCEMENT: Increased search limit to make sure we reuse Stripe "prices" when members check out for recurring plans with Stripe.
