### PR TITLE
Fix deprecation notice "required parameter follows optional parameter"

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1762,7 +1762,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @param array $values Current settings.
 	 * @param string $gateway currently being shown.
 	 */
-	private function show_connect_payment_option_fields( $livemode = true, $values, $gateway ) {
+	private function show_connect_payment_option_fields( $livemode, $values, $gateway ) {
 		$gateway_environment = $this->gateway_environment;
 
 		$stripe_legacy_key      = $values['stripe_publishablekey'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1920.

### How to test the changes in this Pull Request:

As reported into the issue, this function declaration sends two deprecation notices to the output. Then, he gets the "headers already sent" which is just a consequence of the errors displayed. This is gonna fix the issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix deprecation notice "required parameter follows optional parameter"