### PR TITLE
Ensure $old_order is an existing order on getOldOrderFromInvoiceEvent()

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -244,54 +244,63 @@
 		elseif($pmpro_stripe_event->type == "invoice.payment_action_required") {
 			// TODO: Test subs with SCA.
 			$old_order = getOldOrderFromInvoiceEvent($pmpro_stripe_event);
-			$user_id = $old_order->user_id;
-			$user = get_userdata($user_id);
-			
-			// Prep order for emails.
-			$morder = new MemberOrder();
-			$morder->user_id = $user_id;
-			$morder->billing = new stdClass();
-			$morder->billing->name = $old_order->billing->name;
-			$morder->billing->street = $old_order->billing->street;
-			$morder->billing->city = $old_order->billing->city;
-			$morder->billing->state = $old_order->billing->state;
-			$morder->billing->zip = $old_order->billing->zip;
-			$morder->billing->country = $old_order->billing->country;
-			$morder->billing->phone = $old_order->billing->phone;
 
-			//get CC info that is on file
-			$morder->cardtype = get_user_meta($user_id, "pmpro_CardType", true);
-			$morder->accountnumber = hideCardNumber(get_user_meta($user_id, "pmpro_AccountNumber", true), false);
-			$morder->expirationmonth = get_user_meta($user_id, "pmpro_ExpirationMonth", true);
-			$morder->expirationyear = get_user_meta($user_id, "pmpro_ExpirationYear", true);
-			
-			// Add invoice link to the order.
-			$morder->invoice_url = $pmpro_stripe_event->data->object->hosted_invoice_url;
-			
-			// Email the user and ask them to authenticate their payment.
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendPaymentActionRequiredEmail($user, $morder);
+			if( ! empty( $old_order ) && ! empty( $old_order->id ) ) {
+				$user_id = $old_order->user_id;
+				$user = get_userdata($user_id);
 
-			// Email admin so they are aware.
-			// TODO: Remove?
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendPaymentActionRequiredAdminEmail($user, $morder);
+				// Prep order for emails.
+				$morder = new MemberOrder();
+				$morder->user_id = $user_id;
+				$morder->billing = new stdClass();
+				$morder->billing->name = $old_order->billing->name;
+				$morder->billing->street = $old_order->billing->street;
+				$morder->billing->city = $old_order->billing->city;
+				$morder->billing->state = $old_order->billing->state;
+				$morder->billing->zip = $old_order->billing->zip;
+				$morder->billing->country = $old_order->billing->country;
+				$morder->billing->phone = $old_order->billing->phone;
 
-			$logstr .= "Subscription payment for order ID #" . $old_order->id . " requires customer authentication. Sent email to the member and site admin.";
-			pmpro_stripeWebhookExit();
-			
-			
-		} elseif($pmpro_stripe_event->type == "charge.failed")
+				//get CC info that is on file
+				$morder->cardtype = get_user_meta($user_id, "pmpro_CardType", true);
+				$morder->accountnumber = hideCardNumber(get_user_meta($user_id, "pmpro_AccountNumber", true), false);
+				$morder->expirationmonth = get_user_meta($user_id, "pmpro_ExpirationMonth", true);
+				$morder->expirationyear = get_user_meta($user_id, "pmpro_ExpirationYear", true);
+
+				// Add invoice link to the order.
+				$morder->invoice_url = $pmpro_stripe_event->data->object->hosted_invoice_url;
+
+				// Email the user and ask them to authenticate their payment.
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendPaymentActionRequiredEmail($user, $morder);
+
+				// Email admin so they are aware.
+				// TODO: Remove?
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendPaymentActionRequiredAdminEmail($user, $morder);
+
+				$logstr .= "Subscription payment for order ID #" . $old_order->id . " requires customer authentication. Sent email to the member and site admin.";
+				pmpro_stripeWebhookExit();
+			}
+			else
+			{
+				$logstr .= "Could not find the related subscription for event with ID #" . $pmpro_stripe_event->id . ".";
+				if(!empty($pmpro_stripe_event->data->object->customer))
+					$logstr .= " Customer ID #" . $pmpro_stripe_event->data->object->customer . ".";
+				pmpro_stripeWebhookExit();
+			}
+		}
+		elseif($pmpro_stripe_event->type == "charge.failed")
 		{
 			//last order for this subscription
 			$old_order = getOldOrderFromInvoiceEvent($pmpro_stripe_event);
 
-			$user_id = $old_order->user_id;
-			$user = get_userdata($user_id);
-
-			if(!empty($old_order->id))
+			if( ! empty( $old_order ) && ! empty( $old_order->id ) )
 			{
 				do_action("pmpro_subscription_payment_failed", $old_order);
+
+				$user_id = $old_order->user_id;
+				$user = get_userdata($user_id);
 
 				//prep this order for the failure emails
 				$morder = new MemberOrder();
@@ -337,7 +346,7 @@
 			//for one of our users? if they still have a membership for the same level, cancel it
 			$old_order = getOldOrderFromInvoiceEvent($pmpro_stripe_event);
 
-			if(!empty($old_order)) {
+			if( ! empty( $old_order ) && ! empty( $old_order->id ) ) {
 				$user_id = $old_order->user_id;
 				$user = get_userdata($user_id);
 								


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1850.
And makes `$old_order` checks consistent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
