### PR TITLE
Sending name to Stripe. Has been an option since April 2019.

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2024,6 +2024,7 @@ class PMProGateway_stripe extends PMProGateway {
 
 		// Build data to update customer with.
 		$customer_args = array(
+			'name'        => $name,
 			'email'       => $email,
 			'description' => $name . ' (' . $email . ')',
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since 2019, the Stripe API allows you to send a "name" field in addition to the email and description when creating a customer. 

### How to test the changes in this Pull Request:

1. Checkout with Stripe. Make sure a name is captured in the billing address or through the "add name to checkout add on"
2. Check the customer in Stripe. Edit the information on the customer page.
3. There should be a separate name field filled in with the user's name.

### Other information:

There was no change to how our Stripe class calculates the name. It look for first_name and last_name, and if not found, uses the user_login.

This change only fixes things for new checkouts for new users. Existing users/customers won't be updated. We have a separate issue to sync emails on user updates. We should perhaps sync names as well when we get to working on that.

https://github.com/strangerstudios/paid-memberships-pro/issues/1218

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Now sending "name" separate from the "description" when creating customers for Stripe checkouts.
