### PR TITLE
Enhancement/colon search

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -37,20 +37,20 @@
 	//get users (search input field)
 	$search_key = false;
 	if( isset( $_REQUEST['s'] ) ) {
-		$s = sanitize_text_field( trim( $_REQUEST['s'] ) );		
+		$s = sanitize_text_field( trim( $_REQUEST['s'] ) );
 	} else {
 		$s = '';
 	}
-	
+
 	// If there's a colon in the search, let's split it out.
-	if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
+	if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {
 		$parts = explode( ':', $s );
 		$search_key = $parts[0];
 		$s = $parts[1];
 	}
-	
+
 	// Treat * as wild cards.
-	$s = str_replace( '*', '%', $s );	
+	$s = str_replace( '*', '%', $s );
 
 	// requested a level id
 	if(isset($_REQUEST['l']))
@@ -154,7 +154,7 @@
 		SELECT
 			DISTINCT u.ID
 		FROM $wpdb->users u ";
-		
+
 	if ( $s ) {
 		if ( ! empty( $search_key ) ) {
 			// If there's a colon in the search string, make the search smarter.
@@ -171,11 +171,11 @@
 		} else {
 			// Default search checks a few fields.
 			$sqlQuery .= "LEFT JOIN {$wpdb->usermeta} um ON u.ID = um.user_id ";
-			$search = " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";			
+			$search = " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";
 		}
 	} else {
 		$search = '';
-	}		
+	}
 
 	$sqlQuery .= "LEFT JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id ";
 	$sqlQuery .= "LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id ";
@@ -193,7 +193,7 @@
 
 	// looking for a specific user
 	if ( ! empty( $s ) ) {
-		$sqlQuery .= $search;		
+		$sqlQuery .= $search;
 	}
 
 	// if ($former_members)
@@ -324,7 +324,7 @@
 
 		//increment starting position
 		$i_start += $max_users_per_loop;
-		
+
 		//escape the % for LIKE comparison with $wpdb
 		if(!empty($search))
 			$search = str_replace('%', '%%', $search);

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -37,17 +37,20 @@
 	//get users (search input field)
 	$search_key = false;
 	if( isset( $_REQUEST['s'] ) ) {
-		$s = sanitize_text_field( trim( $_REQUEST['s'] ) );
-		
-		// If there's a colon in the search, let's split it out.
-		if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
-			$parts = explode( ':', $s );
-			$search_key = $parts[0];
-			$s = $parts[1];
-		}
+		$s = sanitize_text_field( trim( $_REQUEST['s'] ) );		
 	} else {
 		$s = '';
-	}	
+	}
+	
+	// If there's a colon in the search, let's split it out.
+	if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
+		$parts = explode( ':', $s );
+		$search_key = $parts[0];
+		$s = $parts[1];
+	}
+	
+	// Treat * as wild cards.
+	$s = str_replace( '*', '%', $s );	
 
 	// requested a level id
 	if(isset($_REQUEST['l']))

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -45,8 +45,8 @@
 	// If there's a colon in the search, let's split it out.
 	if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {
 		$parts = explode( ':', $s );
-		$search_key = $parts[0];
-		$s = $parts[1];
+		$search_key = array_shift( $parts );
+		$s = implode( ':', $parts );
 	}
 
 	// Treat * as wild cards.

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -158,7 +158,7 @@
 	if ( $s ) {
 		if ( ! empty( $search_key ) ) {
 			// If there's a colon in the search string, make the search smarter.
-			if( in_array( $search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ) ) ) {
+			if( in_array( $search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ), true ) ) {
 				$key_column = 'u.user_' . esc_sql( $search_key );
 				$search = " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
 			} elseif ( $search_key === 'discount' || $search_key === 'discount_code' || $search_key === 'dc' ) {

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -253,14 +253,14 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			$l = false;
 		}
 		
-		$colon_search_key = false;
+		$search_key = false;
 		if( isset( $_REQUEST['s'] ) ) {
 			$s = sanitize_text_field( trim( $_REQUEST['s'] ) );
 			
 			// If there's a colon in the search, let's split it out.
 			if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
 				$parts = explode( ':', $s );
-				$colon_search_key = $parts[0];
+				$search_key = $parts[0];
 				$s = $parts[1];
 			}
 		} else {
@@ -328,16 +328,16 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		$sqlQuery .= ' WHERE mu.membership_id > 0 ';
 		
 		if ( ! empty( $s ) ) {
-			if ( ! empty( $colon_search_key ) ) {
+			if ( ! empty( $search_key ) ) {
 				// If there's a colon in the search string, make the search smarter.
-				if( in_array( $colon_search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ) ) ) {
-					$key_column = 'u.user_' . esc_sql( $colon_search_key );
+				if( in_array( $search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ) ) ) {
+					$key_column = 'u.user_' . esc_sql( $search_key );
 					$sqlQuery .= " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
-				} elseif ( $colon_search_key == 'discount' || $colon_search_key == 'discount_code' || $colon_search_key = 'dc' ) {
+				} elseif ( $search_key == 'discount' || $search_key == 'discount_code' || $search_key = 'dc' ) {
 					$user_ids = $wpdb->get_col( "SELECT dcu.user_id FROM $wpdb->pmpro_discount_codes_uses dcu LEFT JOIN $wpdb->pmpro_discount_codes dc ON dcu.code_id = dc.id WHERE dc.code = '" . esc_sql( $s ) . "'" );
 					$sqlQuery .= " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 				} else {
-					$user_ids = $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '" . esc_sql( $colon_search_key ) . "' AND meta_value lIKE '%" . esc_sql( $s ) . "%'" );
+					$user_ids = $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '" . esc_sql( $search_key ) . "' AND meta_value lIKE '%" . esc_sql( $s ) . "%'" );
 					$sqlQuery .= " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 				}
 			} else {

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -255,17 +255,20 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		
 		$search_key = false;
 		if( isset( $_REQUEST['s'] ) ) {
-			$s = sanitize_text_field( trim( $_REQUEST['s'] ) );
-			
-			// If there's a colon in the search, let's split it out.
-			if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
-				$parts = explode( ':', $s );
-				$search_key = $parts[0];
-				$s = $parts[1];
-			}
+			$s = sanitize_text_field( trim( $_REQUEST['s'] ) );			
 		} else {
 			$s = '';
 		}
+		
+		// If there's a colon in the search, let's split it out.
+		if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
+			$parts = explode( ':', $s );
+			$search_key = $parts[0];
+			$s = $parts[1];
+		}
+		
+		// Treat * as wild cards.
+		$s = str_replace( '*', '%', $s );
 
 		// some vars for ordering
 		if(isset($_REQUEST['orderby'])) {

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -333,7 +333,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				if( in_array( $search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ) ) ) {
 					$key_column = 'u.user_' . esc_sql( $search_key );
 					$sqlQuery .= " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
-				} elseif ( $search_key == 'discount' || $search_key == 'discount_code' || $search_key = 'dc' ) {
+				} elseif ( $search_key === 'discount' || $search_key === 'discount_code' || $search_key === 'dc' ) {
 					$user_ids = $wpdb->get_col( "SELECT dcu.user_id FROM $wpdb->pmpro_discount_codes_uses dcu LEFT JOIN $wpdb->pmpro_discount_codes dc ON dcu.code_id = dc.id WHERE dc.code = '" . esc_sql( $s ) . "'" );
 					$sqlQuery .= " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 				} else {
@@ -343,7 +343,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			} else {
 				// Default search checks a few fields.
 				$sqlQuery .= " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";
-			}			
+			}
 		}
 
 		if ( 'oldmembers' === $l ) {

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -252,11 +252,21 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		} else {
 			$l = false;
 		}
-		if(isset($_REQUEST['s']))
-			$s = sanitize_text_field(trim($_REQUEST['s']));
-		else
-			$s = "";
 		
+		$colon_search_key = false;
+		if( isset( $_REQUEST['s'] ) ) {
+			$s = sanitize_text_field( trim( $_REQUEST['s'] ) );
+			
+			// If there's a colon in the search, let's split it out.
+			if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
+				$parts = explode( ':', $s );
+				$colon_search_key = $parts[0];
+				$s = $parts[1];
+			}
+		} else {
+			$s = '';
+		}
+
 		// some vars for ordering
 		if(isset($_REQUEST['orderby'])) {
 			$orderby = $this->sanitize_orderby( $_REQUEST['orderby'] );
@@ -318,7 +328,22 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		$sqlQuery .= ' WHERE mu.membership_id > 0 ';
 		
 		if ( ! empty( $s ) ) {
-			$sqlQuery .= " AND (u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%') ";
+			if ( ! empty( $colon_search_key ) ) {
+				// If there's a colon in the search string, make the search smarter.
+				if( in_array( $colon_search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ) ) ) {
+					$key_column = 'u.user_' . esc_sql( $colon_search_key );
+					$sqlQuery .= " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
+				} elseif ( $colon_search_key == 'discount' || $colon_search_key == 'discount_code' || $colon_search_key = 'dc' ) {
+					$user_ids = $wpdb->get_col( "SELECT dcu.user_id FROM $wpdb->pmpro_discount_codes_uses dcu LEFT JOIN $wpdb->pmpro_discount_codes dc ON dcu.code_id = dc.id WHERE dc.code = '" . esc_sql( $s ) . "'" );
+					$sqlQuery .= " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
+				} else {
+					$user_ids = $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '" . esc_sql( $colon_search_key ) . "' AND meta_value lIKE '%" . esc_sql( $s ) . "%'" );
+					$sqlQuery .= " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
+				}
+			} else {
+				// Default search checks a few fields.
+				$sqlQuery .= " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";
+			}			
 		}
 
 		if ( 'oldmembers' === $l ) {

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -252,21 +252,21 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		} else {
 			$l = false;
 		}
-		
+
 		$search_key = false;
 		if( isset( $_REQUEST['s'] ) ) {
-			$s = sanitize_text_field( trim( $_REQUEST['s'] ) );			
+			$s = sanitize_text_field( trim( $_REQUEST['s'] ) );
 		} else {
 			$s = '';
 		}
-		
+
 		// If there's a colon in the search, let's split it out.
-		if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {				
+		if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {
 			$parts = explode( ':', $s );
 			$search_key = $parts[0];
 			$s = $parts[1];
 		}
-		
+
 		// Treat * as wild cards.
 		$s = str_replace( '*', '%', $s );
 
@@ -287,13 +287,13 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				$order = 'DESC';
 			}
 		}
-		
-		// some vars for pagination	
+
+		// some vars for pagination
 		if(isset($_REQUEST['paged']))
 			$pn = intval($_REQUEST['paged']);
 		else
 			$pn = 1;
-		
+
 		$limit = $this->get_items_per_page( 'users_per_page' );
 
 		$end = $pn * $limit;
@@ -310,8 +310,8 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				UNIX_TIMESTAMP(CONVERT_TZ(max(mu.enddate), '+00:00', @@global.time_zone)) as enddate, m.name as membership
 				";
 		}
-			
-		$sqlQuery .= 
+
+		$sqlQuery .=
 			"	
 			FROM $wpdb->users u 
 			LEFT JOIN $wpdb->pmpro_memberships_users mu
@@ -319,7 +319,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			LEFT JOIN $wpdb->pmpro_membership_levels m
 			ON mu.membership_id = m.id
 			";
-			
+
 		if ( !empty( $s ) ) {
 			if ( ! empty( $search_key ) ) {
 				// If there's a colon in the search string, make the search smarter.
@@ -337,16 +337,16 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				// Default search checks a few fields.
 				$sqlQuery .= " LEFT JOIN $wpdb->usermeta um ON u.ID = um.user_id ";
 				$search_query = " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";
-			}			
+			}
 		}
 
 		if ( 'oldmembers' === $l || 'expired' === $l || 'cancelled' === $l ) {
 				$sqlQuery .= " LEFT JOIN $wpdb->pmpro_memberships_users mu2 ON u.ID = mu2.user_id AND mu2.status = 'active' ";
 		}
-		
+
 		$sqlQuery .= ' WHERE mu.membership_id > 0 ';
-		
-		if ( ! empty( $s ) ) {			
+
+		if ( ! empty( $s ) ) {
 			$sqlQuery .= $search_query;
 		}
 
@@ -361,26 +361,26 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		} else {
 			$sqlQuery .= " AND mu.status = 'active' ";
 		}
-		
+
 		if ( ! $count ) {
 			$sqlQuery .= ' GROUP BY u.ID ';
-			
+
 			$sqlQuery .= " ORDER BY $orderby $order ";
-			
+
 			$sqlQuery .= " LIMIT $start, $limit ";
 		}
 
 		$sqlQuery = apply_filters("pmpro_members_list_sql", $sqlQuery);
-		
+
 		if( $count ) {
 			$sql_table_data = $wpdb->get_var( $sqlQuery );
 		} else {
 			$sql_table_data = $wpdb->get_results( $sqlQuery, ARRAY_A );
 		}
-		
+
 		return $sql_table_data;
 	}
-	
+
 	/**
 	 * Sanitize the orderby value.
 	 * Only allow fields we want to order by.
@@ -402,15 +402,15 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			'startdate' 		=> 'mu.startdate',
 			'enddate' 			=> 'mu.enddate',
 		);
-		
+
 		$allowed_orderbys = apply_filters('pmpro_memberslist_allowed_orderbys', $allowed_orderbys );
-		
+
 	 	if ( ! empty( $allowed_orderbys[$orderby] ) ) {
 			$orderby = $allowed_orderbys[$orderby];
 		} else {
 			$orderby = false;
 		}
-		
+
 		return $orderby;
 	}
 

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -263,8 +263,8 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		// If there's a colon in the search, let's split it out.
 		if( ! empty( $s ) && strpos( $s, ':' ) !== false ) {
 			$parts = explode( ':', $s );
-			$search_key = $parts[0];
-			$s = $parts[1];
+		$search_key = array_shift( $parts );
+		$s = implode( ':', $parts );
 		}
 
 		// Treat * as wild cards.

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -323,7 +323,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		if ( !empty( $s ) ) {
 			if ( ! empty( $search_key ) ) {
 				// If there's a colon in the search string, make the search smarter.
-				if( in_array( $search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ) ) ) {
+				if( in_array( $search_key, array( 'login', 'nicename', 'email', 'url', 'display_name' ), true ) ) {
 					$key_column = 'u.user_' . esc_sql( $search_key );
 					$search_query = " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
 				} elseif ( $search_key === 'discount' || $search_key === 'discount_code' || $search_key === 'dc' ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The default members list search runs the query against the user_login, user_email, display_name and THE ENTIRE USER META TABLE.

On sites with lots of users and/or user meta fields, these queries and searches can get slow.

This update checks for ":" in the search query and if found, it will split the query up and query against a specific user table column or user meta field. This speeds up the query A LOT.

This also allows you to search against specific user meta fields, which helps for search terms that might show up in multiple, but unrelated meta fields.

So for example `pmpro_bstate:pa` would return all members with the billing state of "pa". A search for `email:email@domain.com` would return just the user with that specific email.

This PR also swaps * for % in the search query.

User meta that might have * or : in them will break now. We don't allow for escaping these characters in the query. We could do that by swapping out ** and %% or \* and \% and then swapping them back in. I don't think that's needed. These characters aren't allowed in user names or email addresses and so shouldn't come up that often.

It would be nice in a future update to somehow share this hidden feature with users. We could e.g. detect a slow query or a query for an email address and share some text to perform the colon search.

### How to test the changes in this Pull Request:

1. Search the members list for things like `email:email@domain.com`, `first_name:Jason`, or `meta_key:meta_value`/etc.
2. Make sure the results match.
3. Export the results to CSV and make sure they also match.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: You can now search the members list on specific user table columns or user meta fields by using a colon in your search term. These queries are faster than the default queries. The format is `meta_key:meta_value` (no backticks). You can also use login, nicename, email, url, or display_name as the meta_key and the users table will be searched against the related column.
