### PR TITLE
Avoiding a warning from IN() in the query. But we still want 0 results.

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -163,9 +163,15 @@
 				$search = " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
 			} elseif ( $search_key === 'discount' || $search_key === 'discount_code' || $search_key === 'dc' ) {
 				$user_ids = $wpdb->get_col( "SELECT dcu.user_id FROM $wpdb->pmpro_discount_codes_uses dcu LEFT JOIN $wpdb->pmpro_discount_codes dc ON dcu.code_id = dc.id WHERE dc.code = '" . esc_sql( $s ) . "'" );
+				if ( empty( $user_ids ) ) {
+					$user_ids = array(0);	// Avoid warning, but ensure 0 results.
+				}
 				$search = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 			} else {
 				$user_ids = $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '" . esc_sql( $search_key ) . "' AND meta_value lIKE '%" . esc_sql( $s ) . "%'" );
+				if ( empty( $user_ids ) ) {
+					$user_ids = array(0);	// Avoid warning, but ensure 0 results.
+				}
 				$search = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 			}
 		} else {

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -328,9 +328,15 @@ class PMPro_Members_List_Table extends WP_List_Table {
 					$search_query = " AND $key_column LIKE '%" . esc_sql( $s ) . "%' ";
 				} elseif ( $search_key === 'discount' || $search_key === 'discount_code' || $search_key === 'dc' ) {
 					$user_ids = $wpdb->get_col( "SELECT dcu.user_id FROM $wpdb->pmpro_discount_codes_uses dcu LEFT JOIN $wpdb->pmpro_discount_codes dc ON dcu.code_id = dc.id WHERE dc.code = '" . esc_sql( $s ) . "'" );
-					$search_query = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
+					if ( empty( $user_ids ) ) {
+						$user_ids = array(0);	// Avoid warning, but ensure 0 results.
+					}
+					$search_query = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";					
 				} else {
-					$user_ids = $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '" . esc_sql( $search_key ) . "' AND meta_value lIKE '%" . esc_sql( $s ) . "%'" );
+					$user_ids = $wpdb->get_col( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = '" . esc_sql( $search_key ) . "' AND meta_value LIKE '%" . esc_sql( $s ) . "%'" );
+					if ( empty( $user_ids ) ) {
+						$user_ids = array(0);	// Avoid warning, but ensure 0 results.
+					}
 					$search_query = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 				}
 			} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If you performed certain colon searches that had 0 results, a warning about a bad DB query would show up in your error log due to the `IN()` in the query. So we make sure there is something there for the query while still ensuring 0 results.

### How to test the changes in this Pull Request:

1. Perform a member's list search like `meta:notarealmetakeyorvalue`
2. There should be 0 results.
3. There should be no warning in the error log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed PHP warnings that happened when members list "colon" searches had 0 results.
