### PR TITLE
Stored values of gateways displayed in Site Health

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -187,14 +187,17 @@ class PMPro_Site_Health {
 
 			if ( $legacy ) {
 				$gateway_text .= ' (' . __( 'Legacy Keys', 'paid-memberships-pro' ) . ')';
+				return $gateway_text . ' [' . $gateway . ':legacy-keys]';
 			}
 
 			if ( $connect ) {
 				$gateway_text .= ' (' . __( 'Stripe Connect', 'paid-memberships-pro' ) . ')';
+				return $gateway_text . ' [' . $gateway . ':stripe-connect]';
 			}
+
 		}
 
-		return $gateway_text;
+		return $gateway_text . ' [' . $gateway . ']';
 	}
 
 	/**
@@ -217,7 +220,7 @@ class PMPro_Site_Health {
 			return sprintf( __( '%s (environment not registered)', 'paid-memberships-pro' ), $environment );
 		}
 
-		return $environments[ $environment ];
+		return $environments[ $environment ] . ' [' . $environment . ']';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Displays an untranslated string for the gateway type and environment in the Site Health info

Relates to #1988

### How to test the changes in this Pull Request:

1. Go to Tools > Site Health > Paid Memberships Pro
2. The Payment Gateway & Gateway Environment strings have been adjusted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Untranslated gateway identifiers added to Site Health info
