### PR TITLE
BUG FIX: PayFast gateway not saving TOS

### DIFF
--- a/includes/privacy.php
+++ b/includes/privacy.php
@@ -495,6 +495,7 @@ function pmpro_after_checkout_update_consent( $user_id, $order ) {
 add_action( 'pmpro_after_checkout', 'pmpro_after_checkout_update_consent', 10, 2 );
 add_action( 'pmpro_before_send_to_paypal_standard', 'pmpro_after_checkout_update_consent', 10, 2);
 add_action( 'pmpro_before_send_to_twocheckout', 'pmpro_after_checkout_update_consent', 10, 2);
+add_action( 'pmpro_before_send_to_payfast', 'pmpro_after_checkout_update_consent', 10, 2 );
 
 /**
  * Convert a consent entry into a English sentence.


### PR DESCRIPTION
BUG FIX: Fixed issue where PayFast gateway was not saving TOS log during checkout.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?