### PR TITLE
Make "discount code applied to your order" translations consistent

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -82,7 +82,12 @@ if ( empty( $default_gateway ) ) {
 
 				<div id="pmpro_level_cost">
 					<?php if($discount_code && pmpro_checkDiscountCode($discount_code)) { ?>
-						<?php printf(__('<p class="' . pmpro_get_element_class( 'pmpro_level_discount_applied' ) . '">The <strong>%s</strong> code has been applied to your order.</p>', 'paid-memberships-pro' ), $discount_code);?>
+						<?php echo wp_kses_post( sprintf(
+							'<p class="' . pmpro_get_element_class( 'pmpro_level_discount_applied' ) . '">' .
+							__( 'The <strong>%s</strong> code has been applied to your order.', 'paid-memberships-pro' ) .
+							'</p>',
+							$discount_code
+						) ); ?>
 					<?php } ?>
 					<?php echo wpautop(pmpro_getLevelCost($pmpro_level)); ?>
 					<?php echo wpautop(pmpro_getLevelExpiration($pmpro_level)); ?>

--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -90,7 +90,7 @@
 		$code_levels = apply_filters("pmpro_discount_code_level", $code_levels, $discount_code_id);
 	}
 
-	printf(__("The %s code has been applied to your order. ", 'paid-memberships-pro' ), $discount_code);
+	echo wp_kses_post( sprintf( __( 'The <strong>%s</strong> code has been applied to your order.', 'paid-memberships-pro' ), $discount_code ) );
 
 	$combined_level = null;
 	foreach ( $code_levels as $code_level ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There were 3 variations of "The <strong>%s</strong> code has been applied to your order."

1. One was exactly like this;
2. One was without the `<strong>` tag.
3. One was with a trailing space at the end.

Also applied kses where needed and removed extra html from the translation.

### How to test the changes in this Pull Request:

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Make "discount code applied to your order" translations consistent
