### PR TITLE
Add filters to change gateway ipn/webhook logfile

### DIFF
--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -49,7 +49,8 @@
 	if(defined('PMPRO_AUTHNET_SILENT_POST_DEBUG') && PMPRO_AUTHNET_SILENT_POST_DEBUG === "log")
 	{
 		//file
-		$loghandle = fopen(dirname(__FILE__) . "/../logs/authnet-silent-post.txt", "a+");
+		$logfile = apply_filters( 'pmpro_authnet_silent_post_logfile', dirname( __FILE__ ) . "/../logs/authnet-silent-post.txt" );
+		$loghandle = fopen( $logfile, "a+" );
 		fwrite($loghandle, $logstr);
 		fclose($loghandle);
 	} elseif(defined('PMPRO_AUTHNET_SILENT_POST_DEBUG') && false !== PMPRO_AUTHNET_SILENT_POST_DEBUG) {

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -586,7 +586,8 @@ function pmpro_braintreeWebhookExit() {
 		//log in file or email?
 		if ( defined( 'PMPRO_BRAINTREE_WEBHOOK_DEBUG' ) && PMPRO_BRAINTREE_WEBHOOK_DEBUG === "log" ) {
 			//file
-			$loghandle = fopen( dirname( __FILE__ ) . "/../logs/braintree-webhook.txt", "a+" );
+			$logfile = apply_filters( 'pmpro_braintree_webhook_logfile', dirname( __FILE__ ) . "/../logs/braintree-webhook.txt" );
+			$loghandle = fopen( $logfile, "a+" );
 			fwrite( $loghandle, $debuglog );
 			fclose( $loghandle );
 		} else if ( defined( 'PMPRO_BRAINTREE_WEBHOOK_DEBUG' ) ) {

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -570,9 +570,10 @@
 			if(defined('PMPRO_STRIPE_WEBHOOK_DEBUG') && PMPRO_STRIPE_WEBHOOK_DEBUG === "log")
 			{
 				//file
-				$loghandle = fopen(dirname(__FILE__) . "/../logs/stripe-webhook.txt", "a+");
-				fwrite($loghandle, $logstr);
-				fclose($loghandle);
+				$logfile = apply_filters( 'pmpro_stripe_webhook_logfile', dirname( __FILE__ ) . "/../logs/stripe-webhook.txt" );
+				$loghandle = fopen( logfile, "a+" );
+				fwrite( $loghandle, $logstr );
+				fclose( $loghandle );
 			}
 			elseif(defined('PMPRO_STRIPE_WEBHOOK_DEBUG') && false !== PMPRO_STRIPE_WEBHOOK_DEBUG )
 			{

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -571,7 +571,7 @@
 			{
 				//file
 				$logfile = apply_filters( 'pmpro_stripe_webhook_logfile', dirname( __FILE__ ) . "/../logs/stripe-webhook.txt" );
-				$loghandle = fopen( logfile, "a+" );
+				$loghandle = fopen( $logfile, "a+" );
 				fwrite( $loghandle, $logstr );
 				fclose( $loghandle );
 			}

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -205,7 +205,8 @@
 		if(defined('PMPRO_INS_DEBUG') && PMPRO_INS_DEBUG === "log")
 		{
 			//file
-			$loghandle = fopen(dirname(__FILE__) . "/../logs/ipn.txt", "a+");
+			$logfile = apply_filters( 'pmpro_twocheckout_ins_logfile', dirname( __FILE__ ) . "/../logs/ipn.txt" );
+			$loghandle = fopen( $logfile, "a+" );
 			fwrite($loghandle, $logstr);
 			fclose($loghandle);
 		}


### PR DESCRIPTION
I want to keep the history, can't log into pmpro plugin folder.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I want to keep the history of the log files, it must be saved out of the plugin folder.

We did something similar with the filter pmpro_ipn_logfile on paypal 2 years ago.
We may also do the same refactoring on the log if/else structure in case. https://github.com/strangerstudios/paid-memberships-pro/commit/4ead1200536e64f3dd567a380813aa409a8823cc

### New filters:
`pmpro_stripe_webhook_logfile`
`pmpro_twocheckout_ins_logfile`
`pmpro_braintree_webhook_logfile`
`pmpro_authnet_silent_post_logfile`

We also have `pmpro_ipn_logfile` since May 2020.

### Usage example:

```php
add_filter( 'pmpro_ipn_logfile', function ( $filepath ) {
	$today = date( 'Ymd' );

	@mkdir( WP_CONTENT_DIR . '/logs', 0755, true );
	$filepath = WP_CONTENT_DIR . "/logs/debug-paypal-ipn-$today.log";

	return $filepath;
} );

add_filter( 'pmpro_stripe_webhook_logfile', function ( $filepath ) {
	$today = date( 'Ymd' );

	@mkdir( WP_CONTENT_DIR . '/logs', 0755, true );
	$filepath = WP_CONTENT_DIR . "/logs/debug-stripe-webhook-$today.log";

	return $filepath;
} );
```

### How to test the changes in this Pull Request:

1. Apply the patch
2. Add the example snippet
3. Trigger some Stripe events
4. Check the log files by date  into wp-content/logs/ 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
