### PR TITLE
is_renewal() fix for cache and better support recurring memberships

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -141,6 +141,9 @@
 				$this->notes = $dbobj->notes;
 				$this->checkout_id = $dbobj->checkout_id;
 
+				//reset caches
+				$this->is_renewal = null;
+				
 				//reset the gateway
 				if(empty($this->nogateway))
 					$this->setGateway();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Recurring orders must have their logic.**
We should query the FIRST order for a certain subscription_transaction_id and then check if the order id is the same (not renewal) or not (renewal). Otherwise it will say "renewal" even for new orders. I know that the note says "renewal means from a user who has a previous paid order" but it's completely misleading.

**This can cause cache issues: https://github.com/strangerstudios/paid-memberships-pro/blob/dev/classes/class.memberorder.php#L224-L227**
We don't usually recycle MemberOrder instances but it's possible that some dev does.
So the value can be already set but for a different order; we should at least unset that value at the end of `getMemberOrderByID` . [It was introduced here](https://github.com/strangerstudios/paid-memberships-pro/commit/dc2d6c45c7ecc51c978a96752c6dee7cd6453bc9). (edited)

➕ The [current is_renewal implementation](https://github.com/strangerstudios/paid-memberships-pro/blob/dev/classes/class.memberorder.php#L236-L245) does not consider the membership_id, which is something to reconsider imo (removed [here](https://github.com/strangerstudios/paid-memberships-pro/commit/b141126d1d663c27e64cc064d5f290d3d9fc44c9)).

Since you might have completely different memberships (one to show videos, one to view pictures, one to get support) and you can't say "renewal" if it's not for the same membership type. Or, at least, it's not so obvious. He is a returning customer for sure, but not always a real renewal.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
