### PR TITLE
Fix license activation/deactivation routines

### DIFF
--- a/includes/license.php
+++ b/includes/license.php
@@ -86,16 +86,14 @@ function pmpro_license_isValid($key = NULL, $type = NULL, $force = false) {
 	Activation/Deactivation. Check keys once a month.
 */
 //activation
-function pmpro_license_activation() {
-	pmpro_maybe_schedule_event(current_time('timestamp'), 'monthly', 'pmpro_license_check_key');
-}
-register_activation_hook(__FILE__, 'pmpro_activation');
+add_action( 'pmpro_activation', function () {
+	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'monthly', 'pmpro_license_check_key' );
+} );
 
 //deactivation
-function pmpro_license_deactivation() {
-	wp_clear_scheduled_hook('pmpro_license_check_key');
-}
-register_deactivation_hook(__FILE__, 'pmpro_deactivation');
+add_action( 'pmpro_deactivation', function () {
+	wp_clear_scheduled_hook( 'pmpro_license_check_key' );
+} );
 
 /**
  * Check a key against the PMPro license server.

--- a/includes/updates/upgrade_TBD.php
+++ b/includes/updates/upgrade_TBD.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Upgrade to TBD
+ * 
+ */
+function pmpro_upgrade_TBD() {
+	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'monthly', 'pmpro_license_check_key' );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The license cron job `pmpro_license_check_key` were never registered.
Now it is, when pmpro is activated.

### How to test the changes in this Pull Request:

1. Install pmpro
2. Use WP Control to see that the cron is missing
3. Apply the patch, deactivate and reactivate pmpro
4. Now the cron is in place
5. ➕ we should add an update routing to register it for everybody on update.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix license activation/deactivation routines