### PR TITLE
Move the Tos input inside the label to support multiline i18n

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -473,7 +473,10 @@ if ( empty( $default_gateway ) ) {
 						$tos = "";
 					}
 				?>
-				<input type="checkbox" name="tos" value="1" id="tos" <?php checked( 1, $tos ); ?> /> <label class="<?php echo pmpro_get_element_class( 'pmpro_label-inline pmpro_clickable', 'tos' ); ?>" for="tos"><?php printf(__('I agree to the %s', 'paid-memberships-pro' ), $tospage->post_title);?></label>
+				<label class="<?php echo pmpro_get_element_class( 'pmpro_label-inline pmpro_clickable', 'tos' ); ?>" for="tos">
+                    <input type="checkbox" name="tos" value="1" id="tos" <?php checked( 1, $tos ); ?> />
+                    <?php printf(__('I agree to the %s', 'paid-memberships-pro' ), $tospage->post_title);?>
+                </label>
 			</div> <!-- end pmpro_checkout-fields -->
 		</div> <!-- end pmpro_tos_fields -->
 		<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When you have an extra long translation for the label "I agree to the %", the whole text goes on a new line, leaving the checkbox alone. This is because the input is not inside the label.

This PR moves the input inside the label.
![Screenshot 2022-03-16 at 06 58 40](https://user-images.githubusercontent.com/636911/158527494-ab53ed72-50d4-4dbe-837f-6fead2acee80.png)

If you also want to keep all the lines indented, it's super easy with some css (not part of this PR):
```css
input[name=tos] {
    margin-right: 10px;
}

label[for=tos] {
    display: block;
    padding-left: 24px;
    text-indent: -24px;
}
```
![Screenshot 2022-03-16 at 07 12 50](https://user-images.githubusercontent.com/636911/158527790-1458c7cb-dfe1-4837-99f7-445d8ea93b7e.png)
This is a bit tricky and you probably need to play with margin/padding values to make it pixel perfect on your theme.

### How to test the changes in this Pull Request:

1. Activate the TOS option in settings
2. Change language and use any i18n solution to translate the label to something loooong

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->