### PR TITLE
Add filter for BrainTree transactions to allow additional data to be passed to BrainTree.

### DIFF
--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -613,8 +613,8 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 			{
 				$braintree_sale_array = apply_filters( 'pmpro_braintree_transaction_sale_array', array(
 					'amount' => $amount,
-				    'customerId' => $this->customer->id
-					) 
+					'customerId' => $this->customer->id
+					)
 				);
 
 				$response = Braintree_Transaction::sale( $braintree_sale_array );

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -611,10 +611,13 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 			//charge
 			try
 			{
-				$response = Braintree_Transaction::sale(array(
-				  'amount' => $amount,
-				  'customerId' => $this->customer->id
-				));
+				$braintree_sale_array = apply_filters( 'pmpro_braintree_transaction_sale_array', array(
+					'amount' => $amount,
+				    'customerId' => $this->customer->id
+					) 
+				);
+
+				$response = Braintree_Transaction::sale( $braintree_sale_array );
 			}
 			catch (Exception $e)
 			{


### PR DESCRIPTION
Added filter 'pmpro_braintree_transaction_sale_array' to allow adding or adjusting of the sale transaction method.

This allows developer's to add their merchant_account_id and other custom fields etc.

See related docs: https://developer.paypal.com/braintree/docs/reference/request/transaction/sale#specify-merchant-account-id


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
