### PR TITLE
Adjusting email templates variables reference and other ui on email templates admin page

### DIFF
--- a/adminpages/emailtemplates.php
+++ b/adminpages/emailtemplates.php
@@ -17,8 +17,9 @@
 <form action="" method="post" enctype="multipart/form-data"> 
 	<?php wp_nonce_field('savesettings', 'pmpro_emailsettings_nonce');?>
 	
-	<h1 class="wp-heading-inline"><?php esc_html_e( 'Email Templates', 'paid-memberships-pro' ); ?></h1>
 	<hr class="wp-header-end">
+
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'Email Templates', 'paid-memberships-pro' ); ?></h1>
 
 	<p><?php esc_html_e( 'Select an email template from the dropdown below to customize the subject and body of emails sent through your membership site. You can also disable a specific email or send a test version through this admin page.', 'paid-memberships-pro' ); ?> <a href="https://www.paidmembershipspro.com/documentation/member-communications/list-of-pmpro-email-templates/" target="_blank"><?php esc_html_e( 'Click here for a description of each email sent to your members and admins at different stages of the member experience.', 'paid-memberships-pro'); ?></a></p>
 
@@ -111,90 +112,79 @@
 		<hr />
 
 		<div class="pmpro-email-templates-variable-reference">
-			<h1><?php esc_html_e( 'Variable Reference', 'paid-memberships-pro' ); ?></h1>
+			<h2><?php esc_html_e( 'Variable Reference', 'paid-memberships-pro' ); ?></h2>
 
 			<p><?php esc_html_e( 'Use the placeholder variables below to customize your member and admin emails with specific user or membership data.', 'paid-memberships-pro' ); ?></p>
-			<table class="form-table">
-				<tbody>
-				<tr>
-					<th scope="row"><?php esc_html_e('General Settings / Membership Info', 'paid-memberships-pro'); ?></th>
-					<td>
-						<table class="widefat striped">
-							<tbody>
-								<?php
-								$email_variables = [
-									'!!name!!'                  => __( 'Display Name (Profile/Edit User > Display name publicly as)', 'paid-memberships-pro' ),
-									'!!user_login!!'            => __( 'Username', 'paid-memberships-pro' ),
-									'!!sitename!!'              => __( 'Site Title', 'paid-memberships-pro' ),
-									'!!siteemail!!'             => __( 'Site Email Address (General Settings > Email OR Memberships > Settings > Email Settings)', 'paid-memberships-pro' ),
-									'!!membership_id!!'         => __( 'Membership Level ID', 'paid-memberships-pro' ),
-									'!!membership_level_name!!' => __( 'Membership Level Name', 'paid-memberships-pro' ),
-									'!!membership_change!!'     => __( 'Membership Level Change', 'paid-memberships-pro' ),
-									'!!membership_expiration!!' => __( 'Membership Level Expiration', 'paid-memberships-pro' ),
-									'!!startdate!!'             => __( 'Membership Start Date', 'paid-memberships-pro' ),
-									'!!enddate!!'               => __( 'Membership End Date', 'paid-memberships-pro' ),
-									'!!display_name!!'          => __( 'Display Name (Profile/Edit User > Display name publicly as)', 'paid-memberships-pro' ),
-									'!!user_email!!'            => __( 'User Email', 'paid-memberships-pro' ),
-									'!!login_url!!'            => __( 'Login URL', 'paid-memberships-pro' ),
-									'!!levels_url!!'           => __( 'Membership Levels Page URL', 'paid-memberships-pro' ),
-								];
-								
-								foreach ( $email_variables as $email_variable => $description ) {
-									?>
-										<tr>
-											<td><?php echo esc_html( $email_variable ); ?></td>
-											<td><?php echo esc_html( $description ); ?></td>
-										</tr>
-									<?php
-								}
-								?>
-							</tbody>
-						</table>
-					</td>
-				</tr>
-				<tr>
-					<th scope="row"><?php esc_html_e( 'Billing Information', 'paid-memberships-pro' ); ?></th>
-					<td>
-						<table class="widefat striped">
-							<tbody>
-								<?php
-								$email_variables = [
-									'!!billing_address!!' => __( 'Billing Info Complete Address', 'paid-memberships-pro' ),
-									'!!billing_name!!'    => __( 'Billing Info Name', 'paid-memberships-pro' ),
-									'!!billing_street!!'  => __( 'Billing Info Street Address', 'paid-memberships-pro' ),
-									'!!billing_city!!'    => __( 'Billing Info City', 'paid-memberships-pro' ),
-									'!!billing_state!!'   => __( 'Billing Info State', 'paid-memberships-pro' ),
-									'!!billing_zip!!'     => __( 'Billing Info ZIP Code', 'paid-memberships-pro' ),
-									'!!billing_country!!' => __( 'Billing Info Country', 'paid-memberships-pro' ),
-									'!!billing_phone!!'   => __( 'Billing Info Phone #', 'paid-memberships-pro' ),
-									'!!cardtype!!'        => __( 'Credit Card Type', 'paid-memberships-pro' ),
-									'!!accountnumber!!'   => __( 'Credit Card Number (last 4 digits)', 'paid-memberships-pro' ),
-									'!!expirationmonth!!' => __( 'Credit Card Expiration Month (mm format)', 'paid-memberships-pro' ),
-									'!!expirationyear!!'  => __( 'Credit Card Expiration Year (yyyy format)', 'paid-memberships-pro' ),
-									'!!membership_cost!!' => __( 'Membership Level Cost Text', 'paid-memberships-pro' ),
-									'!!instructions!!'    => __( 'Payment Instructions (used in Checkout - Email Template)', 'paid-memberships-pro' ),
-									'!!invoice_id!!'      => __( 'Invoice ID', 'paid-memberships-pro' ),
-									'!!invoice_total!!'   => __( 'Invoice Total', 'paid-memberships-pro' ),
-									'!!invoice_date!!'    => __( 'Invoice Date', 'paid-memberships-pro' ),
-									'!!invoice_url!!'    => __( 'Invoice Page URL', 'paid-memberships-pro' ),
-									'!!discount_code!!'   => __( 'Discount Code Applied', 'paid-memberships-pro' ),
-									'!!membership_level_confirmation_message!!' => __( 'Custom Level Confirmation Message', 'paid-memberships-pro' ),
-									
-								];
 
-								foreach ( $email_variables as $email_variable => $description ) {
-									?>
-										<tr>
-											<td><?php echo esc_html( $email_variable ); ?></td>
-											<td><?php echo esc_html( $description ); ?></td>
-										</tr>
-									<?php
-								}
-								?>
-							</tbody>
-						</table>
-					</td>
-				</tr>
+			<h3><?php esc_html_e('General Settings / Membership Info', 'paid-memberships-pro'); ?></h3>
+			<table class="widefat fixed striped">
+				<tbody>
+					<?php
+					$email_variables = [
+						'!!name!!'                  => __( 'Display Name (Profile/Edit User > Display name publicly as)', 'paid-memberships-pro' ),
+						'!!user_login!!'            => __( 'Username', 'paid-memberships-pro' ),
+						'!!sitename!!'              => __( 'Site Title', 'paid-memberships-pro' ),
+						'!!siteemail!!'             => __( 'Site Email Address (General Settings > Email OR Memberships > Settings > Email Settings)', 'paid-memberships-pro' ),
+						'!!membership_id!!'         => __( 'Membership Level ID', 'paid-memberships-pro' ),
+						'!!membership_level_name!!' => __( 'Membership Level Name', 'paid-memberships-pro' ),
+						'!!membership_change!!'     => __( 'Membership Level Change', 'paid-memberships-pro' ),
+						'!!membership_expiration!!' => __( 'Membership Level Expiration', 'paid-memberships-pro' ),
+						'!!startdate!!'             => __( 'Membership Start Date', 'paid-memberships-pro' ),
+						'!!enddate!!'               => __( 'Membership End Date', 'paid-memberships-pro' ),
+						'!!display_name!!'          => __( 'Display Name (Profile/Edit User > Display name publicly as)', 'paid-memberships-pro' ),
+						'!!user_email!!'            => __( 'User Email', 'paid-memberships-pro' ),
+						'!!login_url!!'            => __( 'Login URL', 'paid-memberships-pro' ),
+						'!!levels_url!!'           => __( 'Membership Levels Page URL', 'paid-memberships-pro' ),
+					];
+
+					foreach ( $email_variables as $email_variable => $description ) {
+						?>
+							<tr>
+								<th><code><?php echo esc_html( $email_variable ); ?></code></th>
+								<td><?php echo esc_html( $description ); ?></td>
+							</tr>
+						<?php
+					}
+					?>
+				</tbody>
+			</table>
+
+			<h3><?php esc_html_e( 'Billing Information', 'paid-memberships-pro' ); ?></h3>
+			<table class="widefat fixed striped">
+				<tbody>
+					<?php
+					$email_variables = [
+						'!!billing_address!!' => __( 'Billing Info Complete Address', 'paid-memberships-pro' ),
+						'!!billing_name!!'    => __( 'Billing Info Name', 'paid-memberships-pro' ),
+						'!!billing_street!!'  => __( 'Billing Info Street Address', 'paid-memberships-pro' ),
+						'!!billing_city!!'    => __( 'Billing Info City', 'paid-memberships-pro' ),
+						'!!billing_state!!'   => __( 'Billing Info State', 'paid-memberships-pro' ),
+						'!!billing_zip!!'     => __( 'Billing Info ZIP Code', 'paid-memberships-pro' ),
+						'!!billing_country!!' => __( 'Billing Info Country', 'paid-memberships-pro' ),
+						'!!billing_phone!!'   => __( 'Billing Info Phone #', 'paid-memberships-pro' ),
+						'!!cardtype!!'        => __( 'Credit Card Type', 'paid-memberships-pro' ),
+						'!!accountnumber!!'   => __( 'Credit Card Number (last 4 digits)', 'paid-memberships-pro' ),
+						'!!expirationmonth!!' => __( 'Credit Card Expiration Month (mm format)', 'paid-memberships-pro' ),
+						'!!expirationyear!!'  => __( 'Credit Card Expiration Year (yyyy format)', 'paid-memberships-pro' ),
+						'!!membership_cost!!' => __( 'Membership Level Cost Text', 'paid-memberships-pro' ),
+						'!!instructions!!'    => __( 'Payment Instructions (used in Checkout - Email Template)', 'paid-memberships-pro' ),
+						'!!invoice_id!!'      => __( 'Invoice ID', 'paid-memberships-pro' ),
+						'!!invoice_total!!'   => __( 'Invoice Total', 'paid-memberships-pro' ),
+						'!!invoice_date!!'    => __( 'Invoice Date', 'paid-memberships-pro' ),
+						'!!invoice_url!!'    => __( 'Invoice Page URL', 'paid-memberships-pro' ),
+						'!!discount_code!!'   => __( 'Discount Code Applied', 'paid-memberships-pro' ),
+						'!!membership_level_confirmation_message!!' => __( 'Custom Level Confirmation Message', 'paid-memberships-pro' ),
+					];
+
+					foreach ( $email_variables as $email_variable => $description ) {
+						?>
+							<tr>
+								<th><code><?php echo esc_html( $email_variable ); ?></code></th>
+								<td><?php echo esc_html( $description ); ?></td>
+							</tr>
+						<?php
+					}
+					?>
 				</tbody>
 			</table>
 		</div> <!-- end pmpro-email-templates-variable-reference -->

--- a/css/admin.css
+++ b/css/admin.css
@@ -385,11 +385,9 @@ tr.pmpro_settings_divider td {
 }
 
 /* admin pages */
-.pmpro_admin_section-email-templates-content .pmpro-email-templates-variable-reference .form-table td {
-	padding: 5px;
-}
-.pmpro_admin_section-email-templates-content .pmpro-email-templates-variable-reference .form-table .widefat {
-	margin-bottom: 20px;
+.pmpro_admin_section-email-templates-content .pmpro-email-templates-variable-reference table {
+	margin-bottom: 3em;
+	max-width: 900px;
 }
 
 /* messages */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adjusted the variables reference to use the <code> tag for each so they are easier to double click and copy.
Adjusted the tables where the variable references are listed to better use the full width of the page.
Moving the wp-header-end marker so the random messages appear before the title.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Improved the UI for email template variables reference on the Settings > Email Templates admin page.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
