### PR TITLE
Add membership_id to REST API response for recent orders.

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -876,6 +876,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 					`u`.`ID` AS `user_id`,
 					`u`.`user_email`,
 					`u`.`user_nicename`,
+					`o`.`membership_id`,
 					`o`.`billing_name`,
 					`o`.`billing_street`,
 					`o`.`billing_city`,


### PR DESCRIPTION
* ENHANCEMENT: Add 'membership_id' to recent_orders REST API route.

This adds the membership ID specifically for Zapier integration.