### PR TITLE
Now tracking library conflicts and displaying in site health

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -100,7 +100,11 @@ class PMPro_Site_Health {
 				'pmpro-pages' => [
 					'label' => __( 'Membership Pages', 'paid-memberships-pro' ),
 					'value' => self::get_pmpro_pages(),
-				]
+				],
+				'pmpro-library-conflicts' => [
+					'label' => __( 'Library Conflicts', 'paid-memberships-pro' ),
+					'value' => self::get_library_conflicts(),
+				],
 			],
 		];
 
@@ -473,6 +477,37 @@ class PMPro_Site_Health {
 	}
 
 	/**
+	 * Get library conflicts.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|string[] The member page information
+	 */
+	function get_library_conflicts() {
+		// Get the current list of library conflicts.
+		$library_conflicts = get_option( 'pmpro_library_conflicts' );
+
+		// If there are no library conflicts, return a message.
+		if ( empty( $library_conflicts ) ) {
+			return __( 'No library conflicts detected.', 'paid-memberships-pro' );
+		}
+
+		// Format data to be displayed in site health.
+		$return_arr = array();
+
+		// Loop through all libraries that have conflicts.
+		foreach ( $library_conflicts as $library_name => $conflicting_plugins ) {
+			$conflict_strings = array();
+			// Loop through all plugins that have conflicts with this library.
+			foreach ( $conflicting_plugins as $conflicting_plugin_path => $conflicting_plugin_data ) {
+				$conflict_strings[] = 'v' . $conflicting_plugin_data['version'] . ' (' . $conflicting_plugin_data['timestamp'] . ')' . ' - ' . $conflicting_plugin_path;
+			}
+			$return_arr[ $library_name ] = implode( ' | ', $conflict_strings );
+		}
+		return $return_arr;
+	}
+
+	/**
 	 * Get the constants site health information.
 	 *
 	 * @since 2.6.4
@@ -544,5 +579,4 @@ class PMPro_Site_Health {
 
 		return $constants_formatted;
 	}
-
 }

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -109,8 +109,15 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 		function loadBraintreeLibrary()
 		{
 			//load Braintree library if it hasn't been loaded already (usually by another plugin using Braintree)
-			if(!class_exists("\Braintree"))
+			if ( ! class_exists( "\Braintree" ) ) {
 				require_once( PMPRO_DIR . "/includes/lib/Braintree/lib/Braintree.php");
+			} else {
+				// Another plugin may have loaded the Braintree library already.
+				// Let's log the current Braintree Library info so that we know
+				// where to look if we need to troubleshoot library conflicts.
+				$previously_loaded_class = new \ReflectionClass( '\Braintree' );
+				pmpro_track_library_conflict( 'braintree', $previously_loaded_class->getFileName(), Braintree\Version::get() );
+			}
 		}
 
 		/**

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -78,6 +78,12 @@ class PMProGateway_stripe extends PMProGateway {
 		//load Stripe library if it hasn't been loaded already (usually by another plugin using Stripe)
 		if ( ! class_exists( "Stripe\Stripe" ) ) {
 			require_once( PMPRO_DIR . "/includes/lib/Stripe/init.php" );
+		} else {
+			// Another plugin may have loaded the Stripe library already.
+			// Let's log the current Stripe Library info so that we know
+			// where to look if we need to troubleshoot library conflicts.
+			$previously_loaded_class = new \ReflectionClass( 'Stripe\Stripe' );
+			pmpro_track_library_conflict( 'stripe', $previously_loaded_class->getFileName(), Stripe\Stripe::VERSION );
 		}
 	}
 

--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -9,8 +9,15 @@
 	{
 		function __construct($gateway = NULL)
 		{
-			if(!class_exists("Twocheckout"))
-				require_once(dirname(__FILE__) . "/../../includes/lib/Twocheckout/Twocheckout.php");
+			if ( ! class_exists( "Twocheckout" ) ) {
+				require_once( dirname(__FILE__) . "/../../includes/lib/Twocheckout/Twocheckout.php" );
+			} else {
+				// Another plugin may have loaded the 2Checkout library already.
+				// Let's log the current 2Checkout Library info so that we know
+				// where to look if we need to troubleshoot library conflicts.
+				$previously_loaded_class = new \ReflectionClass( 'Twocheckout' );
+				pmpro_track_library_conflict( 'twocheckout', $previously_loaded_class->getFileName(), Twocheckout::VERSION );
+			}
 
 			//set API connection vars
 			Twocheckout::sellerId(pmpro_getOption('twocheckout_accountnumber'));

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -114,3 +114,34 @@ function pmpro_compatibility_checker_themes(){
 
 }
 add_action( 'after_setup_theme', 'pmpro_compatibility_checker_themes' );
+
+/**
+ * Keep track of plugins that load libraries before PMPro loads its version.
+ *
+ * @param string $name    The name of the library.
+ * @param string $path    The path of the loaded library.
+ * @param string $version The version of the loaded library.
+ *
+ * @since TBD
+ */
+function pmpro_track_library_conflict( $name, $path, $version ) {
+	// Get the current list of library conflicts.
+	$library_conflicts = get_option( 'pmpro_library_conflicts', array() );
+
+	// Make sure we have an entry for this library.
+	if ( ! isset( $library_conflicts[ $name ] ) ) {
+		$library_conflicts[ $name ] = array();
+	}
+
+	// Make sure we have an entry for this path.
+	if ( ! isset( $library_conflicts[ $name ][ $path ] ) ) {
+		$library_conflicts[ $name ][ $path ] = array();
+	}
+
+	// Update the library conflict information.
+	$library_conflicts[ $name ][ $path ]['version']   = $version;
+	$library_conflicts[ $name ][ $path ]['timestamp'] = current_time( 'Y-m-d H:i:s' );
+
+	// Save changes.
+	update_option( 'pmpro_library_conflicts', $library_conflicts );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We want to give our support team a way to see if other plugins are loading outdated versions of libraries and provide affected customers with a solution for resolving these kinds of conflicts. This PR adds code to record the path and version of plugins that load libraries before PMPro loads ours and add this information to the Site Health tool. Having this information should make it easier to debug plugin conflicts with PMPro.


<img width="658" alt="Screen Shot 2022-04-11 at 1 03 01 PM" src="https://user-images.githubusercontent.com/24977505/162793126-88c475c2-26ca-4888-bef0-b73503c47800.png">
Screenshot shows example of sample plugin loading a different version of the Stripe library than PMPro (simple-stripe-subscriptions) and demonstrates how conflicts can be shown for multiple libraries.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

ENHANCEMENT: Now tracking plugins that could potentially be loading conflicting libraries.