### PR TITLE
Add level_id parameter

### DIFF
--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -105,7 +105,14 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 
 										$pmpro_member_action_links['cancel'] = sprintf( '<a id="pmpro_actionlink-cancel" href="%s">%s</a>', esc_url( add_query_arg( 'levelstocancel', $level->id, pmpro_url( 'cancel' ) ) ), esc_html__( 'Cancel', 'paid-memberships-pro' ) );
 
-										$pmpro_member_action_links = apply_filters( 'pmpro_member_action_links', $pmpro_member_action_links );
+										/**
+										 * Filter the member action links.
+										 *
+										 * @param array $pmpro_member_action_links Member action links.
+										 * @param int   $level->id The ID of the membership level.
+										 * @return array $pmpro_member_action_links Member action links.
+										 */
+										$pmpro_member_action_links = apply_filters( 'pmpro_member_action_links', $pmpro_member_action_links, $level->id );
 
 										$allowed_html = array(
 											'a' => array (


### PR DESCRIPTION
Add additional level ID parameter to pmpro_member_action_links filter.
This may be helpful to set custom action links per membership level of the user if the user has multiple levels.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add additional level ID parameter to pmpro_member_action_links filter.

### How to test the changes in this Pull Request:

1. Create a function with $pmpro_member_action_links and $level_id as arguments
2. Create a conditional change if the $level_id matches X to one of the action links
3. Hook function into `pmpro_member_action_links` filter
4. Visit the Membership Account page to view results

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement: Add additional level ID parameter to pmpro_member_action_links filter to allow customization of member action links per membership level of the user.