### PR TITLE
Duplicate Refund Processes

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -1125,7 +1125,7 @@
 				global $current_user;
 
 				// translators: %1$s is the Transaction ID. %2$s is the user display name that initiated the refund.
-				$morder->notes = trim( $morder->notes . ' ' . sprintf( __('Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );
+				$morder->notes = trim( $morder->notes . ' ' . sprintf( __('Admin: Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );
 
 				$user = get_user_by( 'id', $morder->user_id );
 				//send an email to the member
@@ -1134,13 +1134,13 @@
 
 				//send an email to the admin
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedAdminEmail( $current_user, $morder->membership_id );
+				$myemail->sendRefundedAdminEmail( $user, $morder->membership_id );
 
 			} else {
 				//The refund failed, so lets return the gateway message
 				
 				// translators: %1$s is the Transaction ID. %1$s is the Gateway Error
-				$morder->notes = trim( $morder->notes .' '. sprintf( __( 'There was a problem processing a refund for transaction ID %1$s. Gateway Error: %2$s.', 'paid-memberships-pro' ), $transaction_id, $httpParsedResponseAr['L_LONGMESSAGE0'] ) );
+				$morder->notes = trim( $morder->notes .' '. sprintf( __( 'Admin: There was a problem processing a refund for transaction ID %1$s. Gateway Error: %2$s.', 'paid-memberships-pro' ), $transaction_id, $httpParsedResponseAr['L_LONGMESSAGE0'] ) );
 			}
 
 			$morder->SaveOrder();

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3231,7 +3231,7 @@ class PMProGateway_stripe extends PMProGateway {
 			'invoice.payment_action_required',
 			'customer.subscription.deleted',
 			'charge.failed',
-      'charge.refunded',
+      		'charge.refunded',
 		);
 
 		if ( self::using_stripe_checkout() ) {
@@ -4771,7 +4771,7 @@ class PMProGateway_stripe extends PMProGateway {
 			
 				global $current_user;
 
-				$order->notes = trim( $order->notes.' '.sprintf( __('Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );	
+				$order->notes = trim( $order->notes.' '.sprintf( __('Admin: Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );	
 
 				$user = get_user_by( 'id', $order->user_id );
 				//send an email to the member
@@ -4780,16 +4780,17 @@ class PMProGateway_stripe extends PMProGateway {
 
 				//send an email to the admin
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedAdminEmail( $current_user, $order->membership_id );				
+				$myemail->sendRefundedAdminEmail( $user, $order->membership_id );
+
 			} else {
-				$order->notes = trim( $order->notes . ' ' . __('An error occured while attempting to process this refund.', 'paid-memberships-pro' ) );
+				$order->notes = trim( $order->notes . ' ' . __('Admin: An error occured while attempting to process this refund.', 'paid-memberships-pro' ) );
 
 			}
 
 		} catch ( \Throwable $e ) {			
-			$order->notes = trim( $order->notes . ' ' . __( 'There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );	
+			$order->notes = trim( $order->notes . ' ' . __( 'Admin: There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );	
 		} catch ( \Exception $e ) {
-			$order->notes = trim( $order->notes . ' ' . __( 'There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );
+			$order->notes = trim( $order->notes . ' ' . __( 'Admin: There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );
 		}		
 
 		$order->saveOrder();

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -419,12 +419,17 @@ if ( strtolower( $payment_status ) === 'refunded' ) {
 			
 			$success = true;
 
+			if( $morder->status == 'refunded' ) {
+				//Refunded already, don't do this again
+				return true;
+			}
+
 			$morder->status = 'refunded';
 
 			// translators: %1$s is the date. %2$s is the transaction ID.
-			$morder->notes = trim( $morder->notes .' '. sprintf( __('Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+			$morder->notes = trim( $morder->notes .' '. sprintf( __('IPN: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 
-			ipnlog( printf( __('Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+			ipnlog( printf( __('IPN: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 
 			$user = get_user_by( 'email', $morder->Email );
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -431,16 +431,21 @@
 
 			//We've got the right order	
 			if( !empty( $morder->id ) ) { 
+
+				if( $morder->status == 'refunded' ) {
+					//Refunded already, don't do this again
+					pmpro_stripeWebhookExit();
+				}
 					
 				$morder->status = 'refunded';
 
 				// translators: %1$s is the date of the refund. %2$s is the transaction ID.
 				
-				$logstr .= sprintf( __('Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id );	
+				$logstr .= sprintf( __('Webhook: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id );	
 				//Add to order notes. 
 				
 				// translators: %1$s is the date of the refund. %2$s is the transaction ID.
-				$morder->notes = trim( $morder->notes . ' ' . sprintf( __('Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+				$morder->notes = trim( $morder->notes . ' ' . sprintf( __('Webhook: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 
 				$morder->SaveOrder();
 
@@ -455,6 +460,7 @@
 				$myemail->sendRefundedAdminEmail( $user, $morder->membership_id );
 
 				pmpro_stripeWebhookExit();
+				}
 
 			} else {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- We check if an order has been refunded already so that the webook doesn't process or try and mark it as refunded again
- Correct user object sent through in admin refunded email 
- Order notes show if the order note comes from the admin dashboard or a webhook
- 
### How to test the changes in this Pull Request:

1. Refund from the orders page
2. The same refund shouldn't be processed a second time from the webhook

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry


