### PR TITLE
Refactored IPN/webhook handlers for subscription cancelled messages

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -10,21 +10,31 @@
  */
 function pmpro_init_check_for_deprecated_filters() {
 	global $wp_filter;
-	
+
+	// Deprecated filter name => new filter name (or null if there is no alternative).
 	$pmpro_map_deprecated_filters = array(
-		'pmpro_getfile_extension_blocklist'    => 'pmpro_getfile_extension_blacklist',
+		'pmpro_getfile_extension_blacklist' => 'pmpro_getfile_extension_blocklist',
+		'pmpro_stripe_subscription_deleted' => null,
+		'pmpro_subscription_cancelled'      => null,
 	);
 	
-	foreach ( $pmpro_map_deprecated_filters as $new => $old ) {
+	foreach ( $pmpro_map_deprecated_filters as $old => $new ) {
 		if ( has_filter( $old ) ) {
-			/* translators: 1: the old hook name, 2: the new or replacement hook name */
-			trigger_error( sprintf( esc_html__( 'The %1$s hook has been deprecated in Paid Memberships Pro. Please use the %2$s hook instead.', 'paid-memberships-pro' ), $old, $new ) );
-			
-			// Add filters back using the new tag.
-			foreach( $wp_filter[$old]->callbacks as $priority => $callbacks ) {
-				foreach( $callbacks as $callback ) {
-					add_filter( $new, $callback['function'], $priority, $callback['accepted_args'] ); 
+			if ( ! empty( $new ) ) {
+				// We have an alternative filter. Let's show an error message and forward to that new filter.
+				/* translators: 1: the old hook name, 2: the new or replacement hook name */
+				trigger_error( sprintf( esc_html__( 'The %1$s hook has been deprecated in Paid Memberships Pro. Please use the %2$s hook instead.', 'paid-memberships-pro' ), $old, $new ) );
+				
+				// Add filters back using the new tag.
+				foreach( $wp_filter[$old]->callbacks as $priority => $callbacks ) {
+					foreach( $callbacks as $callback ) {
+						add_filter( $new, $callback['function'], $priority, $callback['accepted_args'] ); 
+					}
 				}
+			} else {
+				// We don't have an alternative filter. Let's just show an error message.
+				/* translators: 1: the old hook name */
+				trigger_error( sprintf( esc_html__( 'The %1$s hook has been deprecated in Paid Memberships Pro and may not be available in future versions.', 'paid-memberships-pro' ), $old ) );
 			}
 		}
 	}

--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -33,7 +33,9 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 	if ( 'stripe' === $gateway ) {
 		/**
 		 * Action for when a subscription is cancelled at a payment gateway.
-		 * Legacy filter brought over from Stripe. May soon be deprecated.
+		 * Legacy filter brought over from Stripe.
+		 *
+		 * @deprecated 3.0
 		 *
 		 * @param int $user_id The ID of the user associated with the subscription.
 		 */
@@ -49,19 +51,6 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 	$subscription->set( 'status', 'cancelled' );
 	$subscription->save();
 
-	// Legacy Stripe code to avoid cancelling membership in some cases.
-	if ( 'stripe' === $gateway ) {
-		// Array of Stripe.com subscription IDs and the timestamp when they were configured as 'preservable'.
-		$preserve = get_user_meta( $user_id, 'pmpro_stripe_dont_cancel', true );
-
-		// If the $subscription_transaction_id is in the list, remove it and bail on cancelling membership.
-		if ( is_array( $preserve ) && in_array( $subscription_transaction_id, array_keys( $preserve ) ) ) {
-			unset( $preserve[ $subscription_transaction_id ] );
-			update_user_meta( $user_id, 'pmpro_stripe_dont_cancel', $preserve );
-			return 'Stripe subscription ' . $subscription_transaction_id . ' has been flagged as preservable. Not removing membership.';			
-		}
-	}
-
 	// Check to see if the user has the membership level associated with this subscription.
 	if ( ! pmpro_hasMembershipLevel( $subscription->get_membership_level_id(), $user->ID ) ) {
 		return 'The user no longer has the membership level associated with this subscription. No membership cancellation is needed. ( Subscription Transaction ID #' . $recurring_payment_id . ')';
@@ -73,7 +62,9 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 		if ( ! empty( $newest_order ) ) {
 			/**
 			 * Action for when a subscription is cancelled at a payment gateway.
-			 * Legacy filter brought over from Braintree. May soon be deprecated.
+			 * Legacy filter brought over from Braintree.
+			 *
+			 * @deprecated 3.0
 			 *
 			 * @param int $user_id The ID of the user associated with the subscription.
 			 */

--- a/includes/gateway_request_handlers.php
+++ b/includes/gateway_request_handlers.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Handle IPN/webhook requests from gateways
+ * notifying site of subscription cancellation.
+ *
+ * @since TBD
+ *
+ * @param string $subscription_transaction_id The subscription transaction ID.
+ * @param string $gateway The gateway that sent the request.
+ * @param string $gateway_environment 'live' or 'sandbox'.
+ *
+ * @return string Entry to add to IPN/webhook log.
+ */
+function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transaction_id, $gateway, $gateway_environment ) {
+	// Find subscription.
+	$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $subscription_transaction_id, 'paypal_express', $gateway_environment );
+	if ( empty( $subscription ) ) {
+		// The subscription does not exist on this site. Bail.
+		return 'ERROR: Could not find this subscription to cancel (subscription_transaction_id=' . $subscription_transaction_id . ').';
+	}
+
+	// Get the user associated with the subscription.
+	$user = get_userdata( $subscription->get_user_id() );
+	if ( empty( $user ) ) {
+		// The user for this subscription does not exist. Let's just set the subscription status to cancelled.
+		$subscription->set( 'status', 'cancelled' );
+		$subscription->save();
+		return 'ERROR: Could not cancel membership. No user attached to subscription #' . $subscription->get_id() . ' with subscription transaction id = ' . $recurring_payment_id . '.';
+	}
+
+	// Legacy Stripe code to add action on subscription cancellation.
+	if ( 'stripe' === $gateway ) {
+		/**
+		 * Action for when a subscription is cancelled at a payment gateway.
+		 * Legacy filter brought over from Stripe. May soon be deprecated.
+		 *
+		 * @param int $user_id The ID of the user associated with the subscription.
+		 */
+		do_action( 'pmpro_stripe_subscription_deleted', $user->ID );
+	}
+
+	// Check if we have already cancelled the subscription in PMPro.
+	if ( 'cancelled' === $subscription->status ) {
+		return 'We have already processed this cancellation. Probably originated from WP/PMPro. ( Subscription Transaction ID #' . $recurring_payment_id . ')';
+	}
+
+	// Mark the PMPro_Subscription as cancelled.
+	$subscription->set( 'status', 'cancelled' );
+	$subscription->save();
+
+	// Legacy Stripe code to avoid cancelling membership in some cases.
+	if ( 'stripe' === $gateway ) {
+		// Array of Stripe.com subscription IDs and the timestamp when they were configured as 'preservable'.
+		$preserve = get_user_meta( $user_id, 'pmpro_stripe_dont_cancel', true );
+
+		// If the $subscription_transaction_id is in the list, remove it and bail on cancelling membership.
+		if ( is_array( $preserve ) && in_array( $subscription_transaction_id, array_keys( $preserve ) ) ) {
+			unset( $preserve[ $subscription_transaction_id ] );
+			update_user_meta( $user_id, 'pmpro_stripe_dont_cancel', $preserve );
+			return 'Stripe subscription ' . $subscription_transaction_id . ' has been flagged as preservable. Not removing membership.';			
+		}
+	}
+
+	// Check to see if the user has the membership level associated with this subscription.
+	if ( ! pmpro_hasMembershipLevel( $subscription->get_membership_level_id(), $user->ID ) ) {
+		return 'The user no longer has the membership level associated with this subscription. No membership cancellation is needed. ( Subscription Transaction ID #' . $recurring_payment_id . ')';
+	}
+
+	// Legacy Braintree code to add action on subscription cancellation.
+	if ( 'braintree' === $gateway ) {
+		$newest_order = $this->get_orders( array( 'limit' => 1 ) );
+		if ( ! empty( $newest_order ) ) {
+			/**
+			 * Action for when a subscription is cancelled at a payment gateway.
+			 * Legacy filter brought over from Braintree. May soon be deprecated.
+			 *
+			 * @param int $user_id The ID of the user associated with the subscription.
+			 */
+			do_action( "pmpro_subscription_cancelled", current( $newest_order ) );
+		}
+	}
+
+	// Cancel the membership.
+	pmpro_cancelMembershipLevel( $subscription->get_membership_level_id(), $user->ID, 'cancelled' );
+
+	// Send an email to the member.
+	$myemail = new PMProEmail();
+	$myemail->sendCancelEmail( $user, $subscription->get_membership_level_id() );
+
+	// Send an email to the admin.
+	$myemail = new PMProEmail();
+	$myemail->sendCancelAdminEmail( $user, $subscription->get_membership_level_id() );
+
+	return 'Cancelled membership for user with id = ' . $user->ID . '. Subscription transaction id = ' . $recurring_payment_id . '.';
+}

--- a/includes/gateway_request_handlers.php
+++ b/includes/gateway_request_handlers.php
@@ -14,7 +14,7 @@
  */
 function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transaction_id, $gateway, $gateway_environment ) {
 	// Find subscription.
-	$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $subscription_transaction_id, 'paypal_express', $gateway_environment );
+	$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $subscription_transaction_id, $gateway, $gateway_environment );
 	if ( empty( $subscription ) ) {
 		// The subscription does not exist on this site. Bail.
 		return 'ERROR: Could not find this subscription to cancel (subscription_transaction_id=' . $subscription_transaction_id . ').';

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -82,6 +82,7 @@ require_once( PMPRO_DIR . '/includes/spam.php' );					// code to combat spam of 
 require_once( PMPRO_DIR . '/includes/xmlrpc.php' );                 // xmlrpc methods
 require_once( PMPRO_DIR . '/includes/rest-api.php' );               // rest API endpoints
 require_once( PMPRO_DIR . '/includes/widgets.php' );                // widgets for PMPro
+require_once( PMPRO_DIR . '/includes/gateway_request_handlers.php' ); // gateway request handlers
 
 require_once( PMPRO_DIR . '/classes/class-pmpro-site-health.php' ); // Site Health information.
 

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -82,7 +82,7 @@ require_once( PMPRO_DIR . '/includes/spam.php' );					// code to combat spam of 
 require_once( PMPRO_DIR . '/includes/xmlrpc.php' );                 // xmlrpc methods
 require_once( PMPRO_DIR . '/includes/rest-api.php' );               // rest API endpoints
 require_once( PMPRO_DIR . '/includes/widgets.php' );                // widgets for PMPro
-require_once( PMPRO_DIR . '/includes/gateway_request_handlers.php' ); // gateway request handlers
+require_once( PMPRO_DIR . '/includes/gateway-request-handlers.php' ); // gateway request handlers
 
 require_once( PMPRO_DIR . '/classes/class-pmpro-site-health.php' ); // Site Health information.
 

--- a/services/braintree-webhook.php
+++ b/services/braintree-webhook.php
@@ -435,73 +435,14 @@ if ( $webhookNotification->kind === Braintree_WebhookNotification::SUBSCRIPTION_
 
 //subscription cancelled (they used one l canceled)
 if ( $webhookNotification->kind === Braintree_WebhookNotification::SUBSCRIPTION_CANCELED ) {
-	
-	$logstr[] = "The Braintree gateway cancelled the subscription plan";
-	
-	//need a subscription id
+	$logstr[] = 'The Braintree gateway cancelled the subscription plan';
+
+	// Need a subscription id.
 	if ( empty( $webhookNotification->subscription->id ) ) {
-		$logstr[] = "No subscription ID.";
+		$logstr[] = 'No subscription ID.';
 		pmpro_braintreeWebhookExit();
 	}
-	
-	//figure out which order to attach to
-	$old_order = new \MemberOrder();
-	$old_order->getLastMemberOrderBySubscriptionTransactionID( $webhookNotification->subscription->id );
-	
-	if ( empty( $old_order ) ) {
-		$logstr[] = "Couldn't find old order for failed payment with subscription id={$webhookNotification->subscription->id}";
-		pmpro_braintreeWebhookExit();
-	}
-	
-	/**
-	 * @since v1.9.5+ - BUG FIX: Don't process previously handled subscription cancellation
-	 */
-	$subscription  = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $old_order->subscription_transaction_id, $old_order->gateway, $old_order->gateway_environment );
-	if ( $old_order->status == "cancelled" || ( ! empty( $subscription ) && $subscription->status == 'cancelled') ) {
-		$logstr[] = "Order for subscription id {$webhookNotification->subscription->id} is cancelled already";
-		pmpro_braintreeWebhookExit();
-	}
-	
-	$user_id                = $old_order->user_id;
-	$user                   = get_userdata( $user_id );
-	$user->membership_level = pmpro_getMembershipLevelForUser( $user_id,true );
-	
-	/**
-	 * @since 1.9.5 - BUG FIX: Erroneously triggering warning email
-	 *                Happens when a user cancels their membership (and Braintree) sends a webhook notifying us
-	 *                of the fact that the user cancelled their subscription plan (SUBSCRIPTION_CANCELED event).
-	 */
-	if ( empty( $user->membership_level ) ) {
-		
-		$logstr[] = "Membership for user (ID: {$user_id}) is cancelled already. Probably a duplicate webhook notification. Exiting!";
-		pmpro_braintreeWebhookExit();
-	}
-	
-	// Trigger subscription cancelled action
-	do_action( "pmpro_subscription_cancelled", $old_order );
-	
-	$transaction = isset( $webhookNotification->transactions ) && is_array( $webhookNotification->transactions ) ?
-		$webhookNotification->transactions[0] :
-		null;
-	
-	if ( empty( $transaction ) || ! isset( $transaction->billing_details ) ) {
-		// Get billing address info from either old order or billing meta
-		$old_order->billing = pmpro_braintreeAddressInfo( $user_id, $old_order );
-	}
-	
-	// Cancel the related membership.
-	pmpro_cancelMembershipLevel( $old_order->membership_id, $old_order->user_id, 'cancelled' );
-	
-	$logstr[] = "Cancelled membership for user with id = {$old_order->user_id}. Subscription transaction id = {$old_order->subscription_transaction_id}.\n";
-	
-	// Send an email to the member.
-	$myemail = new PMProEmail();
-	$myemail->sendCancelEmail( $user, $old_order->membership_id );
-	
-	// Send an email to the admin.
-	$myemail = new PMProEmail();
-	$myemail->sendCancelAdminEmail( $user, $old_order->membership_id );
-	
+	$logstr[] = pmpro_handle_subscription_cancellation_at_gateway( $webhookNotification->subscription->id, 'braintree', pmpro_getOption( 'gateway_environment' ) );
 	pmpro_braintreeWebhookExit();
 }
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -325,85 +325,8 @@
 		}
 		elseif($pmpro_stripe_event->type == "customer.subscription.deleted")
 		{
-			//for one of our users? if they still have a membership for the same level, cancel it
-			$old_order = getOldOrderFromInvoiceEvent($pmpro_stripe_event);
-
-			if( ! empty( $old_order ) && ! empty( $old_order->id ) ) {
-				$user_id = $old_order->user_id;
-				$user = get_userdata($user_id);
-								
-				/**
-				 * Array of Stripe.com subscription IDs and the timestamp when they were configured as 'preservable'
-				 */
-				$preserve = get_user_meta( $user_id, 'pmpro_stripe_dont_cancel', true );
-				
-				// Asume we should cancel the membership
-				$cancel_membership = true;
-				
-				// Grab the subscription ID from the webhook
-				if ( !empty( $pmpro_stripe_event->data->object ) && 'subscription' == $pmpro_stripe_event->data->object->object ) {
-					
-					$subscr = $pmpro_stripe_event->data->object;
-					
-					// Check if there's a sub ID to look at (from the webhook)
-					// If it's in the list of preservable subscription IDs, don't delete it
-					if ( is_array( $preserve ) && in_array( $subscr->id, array_keys( $preserve ) ) ) {
-						
-						$logstr       .= "Stripe subscription ({$subscr->id}) has been flagged during Subscription Update (in user profile). Will NOT cancel the membership for {$user->display_name} ({$user->user_email})!\n";
-						$cancel_membership = false;
-						
-					}
-				}
-				
-				if(!empty($user->ID) && true === $cancel_membership ) {
-					do_action( "pmpro_stripe_subscription_deleted", $user->ID );
-
-					$subscription  = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $old_order->subscription_transaction_id, $old_order->gateway, $old_order->gateway_environment );
-
-					if ( $old_order->status == "cancelled" || ( ! empty( $subscription ) && $subscription->status == 'cancelled') ) {
-						$logstr .= "We've already processed this cancellation. Probably originated from WP/PMPro. (Order #{$old_order->id}, Subscription Transaction ID #{$old_order->subscription_transaction_id})\n";
-					} else if ( ! pmpro_hasMembershipLevel( $old_order->membership_id, $user->ID ) ) {
-						$logstr .= "This user has a different level than the one associated with this order. Their membership was probably changed by an admin or through an upgrade/downgrade. (Order #{$old_order->id}, Subscription Transaction ID #{$old_order->subscription_transaction_id})\n";
-					} else {
-						//if the initial payment failed, cancel with status error instead of cancelled					
-						pmpro_cancelMembershipLevel( $old_order->membership_id, $old_order->user_id, 'cancelled' );
-						
-						$logstr .= "Cancelled membership for user with id = {$old_order->user_id}. Subscription transaction id = {$old_order->subscription_transaction_id}.\n";
-						
-						//send an email to the member
-						$myemail = new PMProEmail();
-						$myemail->sendCancelEmail( $user, $old_order->membership_id );
-						
-						//send an email to the admin
-						$myemail = new PMProEmail();
-						$myemail->sendCancelAdminEmail( $user, $old_order->membership_id );
-					}
-					
-					// Try to delete the usermeta entry as it's (probably) stale
-					if ( isset( $preserve[$old_order->subscription_transaction_id])) {
-						unset( $preserve[$old_order->subscription_transaction_id]);
-						update_user_meta( $user_id, 'pmpro_stripe_dont_cancel', $preserve );
-					}
-					
-					$logstr .= "Subscription deleted for user ID #" . $user->ID . ". Event ID #" . $pmpro_stripe_event->id . ".";
-					pmpro_stripeWebhookExit();
-				} else {
-					$logstr .= "Stripe tells us they deleted the subscription, but for some reason we must ignore it. ";
-					
-					if ( false === $cancel_membership ) {
-						$logstr .= "The subscription has been flagged as one to not delete the user membership for.\n ";
-					} else {
-						$logstr .= "Perhaps we could not find a user here for that subscription. ";
-					}
-					
-					$logstr .= "Could also be a subscription managed by a different app or plugin. Event ID # {$pmpro_stripe_event->id}.";
-					pmpro_stripeWebhookExit();
-				}
-				
-			} else {
-				$logstr .= "Stripe tells us a subscription is deleted, but we could not find the order for that subscription. Could be a subscription managed by a different app or plugin. Event ID #" . $pmpro_stripe_event->id . ".";
-				pmpro_stripeWebhookExit();
-			}
+			$logstr .= pmpro_handle_subscription_cancellation_at_gateway( $pmpro_stripe_event->data->object->id, 'stripe', $livemode ? 'live' : 'sandbox' );
+			pmpro_stripeWebhookExit();
 		}
 		elseif( $pmpro_stripe_event->type == "charge.refunded" )
 		{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, all of our IPN/webhook handlers were coded in vacuums causing a lot of similar code across the platform. This change is the first step in making these IPN/webhook handlers more modular so that they are easier to develop and update in the future.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
