### PR TITLE
Splitting cancel method of PMPro_Subscription

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1113,13 +1113,14 @@ class PMPro_Subscription {
 	}
 
 	/**
-	 * Cancels this subscription in PMPro and at the payment gateway.
+	 * Cancels the subscription at the payment gateway.
+	 *
+	 * IPNs/Webhooks should then trigger the cancellation of the subscription in the
+	 * database.
 	 *
 	 * @since TBD
-	 *
-	 * @return bool True if the subscription was canceled successfully in the payment gateway.
 	 */
-	public function cancel() {
+	public function cancel_at_gateway() {
 		// Prevent infinite loops when calling gateway's cancel() method and passing an order.
 		static $cancelled_subscription_ids = [];
 		if ( 'cancelled' !== $this->status && in_array( $this->id, $cancelled_subscription_ids, true ) ) {
@@ -1149,6 +1150,8 @@ class PMPro_Subscription {
 		}
 
 		// If the cancellation failed, send an email to the admin.
+		// We will also mark the subscription as cancelled in the database since
+		// no IPN/webhooks will be sent by the gateway.
 		if ( ! $result ) {
 			// Notify the admin.
 			$user                      = get_userdata( $this->user_id );
@@ -1164,17 +1167,34 @@ class PMPro_Subscription {
 			$pmproemail->data['body'] .= '<hr />' . "\n";
 			$pmproemail->data['body'] .= '<p>' . esc_html__( 'Edit User', 'paid-memberships-pro' ) . ': ' . esc_url( add_query_arg( 'user_id', $this->user_id, self_admin_url( 'user-edit.php' ) ) ) . '</p>';
 			$pmproemail->sendEmail( get_bloginfo( 'admin_email' ) );
-    }
-    
+
+			// Mark the subscription as cancelled in the database.
+			$this->mark_as_cancelled();
+		}
+		return $result;
+	}
+
+	/**
+	 * Marks the subscription as cancelled in the database. Also marks
+	 * incomplete orders for this subscription as error.
+	 *
+	 * @since TBD
+	 */
+	public function mark_as_cancelled() {
+		// Mark subscription as cancelled.
 		$this->status  = 'cancelled';
 		if ( empty( $this->enddate ) ) {
 			// Only set enddate if we don't have one yet.
-    		$this->enddate = gmdate( 'Y-m-d H:i:s' );
+			$this->enddate = gmdate( 'Y-m-d H:i:s' );
 		}
 		$this->update();
 		$this->save();
 
-		return $result;
+		// Mark incomplete orders as error.
+		$incomplete_orders = $this->get_orders( array( 'status' => array( 'token', 'pending', 'review' ) ) );
+		foreach ( $incomplete_orders as $order ) {
+			$last_subscription_order->updateStatus( 'error' );
+		}
 	}
 
 	/**

--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1122,6 +1122,8 @@ class PMPro_Subscription {
 	 * support cancelling PMPro_Subscription objects specifically.
 	 *
 	 * @since TBD
+	 *
+	 * @return bool True if the subscription was canceled successfully in the payment gateway.
 	 */
 	public function cancel_at_gateway() {
 		// Legacy: Prevent infinite loops when calling gateway's cancel() method and passing an order.

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -965,7 +965,7 @@
 			if ( ! empty( $this->subscription_transaction_id ) ) {
 				$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $this->subscription_transaction_id, $this->gateway, $this->gateway_environment );
 				if ( ! empty( $subscription ) ) {
-					return $subscription->cancel();
+					return $subscription->cancel_at_gateway();
 				}
 			}
 				


### PR DESCRIPTION
Right now, we just have a cancel() method in the PMPro_Subscription class, but there’s really two cases when you would want to call that function:
1. When you would like to cancel the subscription at the gateway
2. When you would like to mark the subscription as cancelled in PMPro

This PR separates these two cases into separate methods in an effort to make the code more intuitive