### PR TITLE
Allow MemberOrder to create PMPro_Subscription without user having level

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1159,12 +1159,6 @@
 				return false;
 			}
 
-			// Make sure that the user has the membership level for this order.
-			if ( ! pmpro_hasMembershipLevel( $this->membership_id, $this->user_id ) ) {
-				// The user doesn't have the membership level for this order, so we shouldn't track the subscription.
-				return false;
-			}
-
 			$get_subscription_args = array(
 				'subscription_transaction_id' => $this->subscription_transaction_id,
 				'gateway'                     => $this->gateway,


### PR DESCRIPTION
Example use-case: Orders are imported onto a site but the user does not currently have the membership level associated with the imported order. In this case, we still want to track the subscription if it may be active at the gateway.