### PR TITLE
Fix timestamp is_renewal()

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -232,6 +232,9 @@
 				return $this->is_renewal;
 			}
 			
+			if ( empty( $this->timestamp ) ) {
+				$this->timestamp = time();
+			}
 			// Check the DB.
 			$sqlQuery = "SELECT `id`
 						 FROM $wpdb->pmpro_membership_orders


### PR DESCRIPTION
* BUG FIX: Minor fix for cases where the timestamp of the is_renewal method is empty. (i.e. calling is_renewal in the pmpro_added_order hook)