### PR TITLE
Changing cancel_at_gateway() to also mark subscription as cancelled

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1115,9 +1115,6 @@ class PMPro_Subscription {
 	/**
 	 * Cancels the subscription at the payment gateway.
 	 *
-	 * IPNs/Webhooks should then trigger the cancellation of the subscription in the
-	 * database.
-	 *
 	 * Legacy: Falls back on calling the gateway's cancel() method if the gateway does not
 	 * support cancelling PMPro_Subscription objects specifically.
 	 *
@@ -1153,8 +1150,6 @@ class PMPro_Subscription {
 		}
 
 		// If the cancellation failed, send an email to the admin.
-		// We will also mark the subscription as cancelled in the database since
-		// no IPN/webhooks will be sent by the gateway.
 		if ( ! $cancelled ) {
 			// Notify the admin.
 			$user                      = get_userdata( $this->user_id );
@@ -1170,10 +1165,11 @@ class PMPro_Subscription {
 			$pmproemail->data['body'] .= '<hr />' . "\n";
 			$pmproemail->data['body'] .= '<p>' . esc_html__( 'Edit User', 'paid-memberships-pro' ) . ': ' . esc_url( add_query_arg( 'user_id', $this->user_id, self_admin_url( 'user-edit.php' ) ) ) . '</p>';
 			$pmproemail->sendEmail( get_bloginfo( 'admin_email' ) );
-
-			// Mark the subscription as cancelled in the database.
-			$this->mark_as_cancelled();
 		}
+
+		// Mark the subscription as cancelled in the database.
+		$this->mark_as_cancelled();
+
 		return $cancelled;
 	}
 


### PR DESCRIPTION
We split up the PMPro_Subscription `cancel()` methods into two functions:
1. `cancel_at_gateway()`
2. `mark_as_cancelled()`

The goal of this change was to separate out these actions so that you can call one independently of the other. It also had the "clever" perk that if you cancelled the subscription  at the gateway, you didn't need to mark the subscription as cancelled in the database since the IPN/webhook handler would do that work for you.

While testing this behavior, I ran into a conflict with PMPro CONPD where if you check out for a subscription with Stripe and then cancel it, CONPD would give the user's membership back to them and then the Stripe webhook handler would remove the returned membership.

After some thought, it seems right to get rid of the cleverness. `mark_as_cancelled()` still makes sense as a function, but having it always be called at the end of the `cancel_at_gateway()` function is closer to the beavior currently in PMPro and is safer in cases where webhooks may not always be working. 

Intuitively, there is also never a case where you successfully cancel a subscription at the gateway but don't want to mark it as cancelled on the site. This would defeat the purpose of the subs table.