### PR TITLE
Add level metas for site health info

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -128,8 +128,10 @@ class PMPro_Site_Health {
 			return __( 'No Levels Found', 'paid-memberships-pro' );
 		}
 
-		foreach ( $membership_levels as $membership_level ) {
+		foreach ( $membership_levels as &$membership_level ) {
 			$membership_level->meta = get_pmpro_membership_level_meta( $membership_level->id );
+
+			$membership_level = apply_filters( 'pmpro_site_health_info_membership_level', $membership_level );
 		}
 
 		return wp_json_encode( $membership_levels, JSON_PRETTY_PRINT );

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -128,6 +128,10 @@ class PMPro_Site_Health {
 			return __( 'No Levels Found', 'paid-memberships-pro' );
 		}
 
+		foreach ( $membership_levels as $membership_level ) {
+			$membership_level->meta = get_pmpro_membership_level_meta( $membership_level->id );
+		}
+
 		return wp_json_encode( $membership_levels, JSON_PRETTY_PRINT );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you want to know exactly how the levels are configured, the levels metas are needed.
It's also useful to gather informations from the addons, but this should be delegated to them.

Example:
```php
function pmprosd_site_health_info_membership_level( $membership_level ) {
	$membership_level->subscription_delay = get_option( 'pmpro_subscription_delay_' . $membership_level->id, '' );

	return $membership_level;
}

add_filter( 'pmpro_site_health_info_membership_level', 'pmprosd_site_health_info_membership_level' );
```

**Btw, if we could use level metas in subscription delay addon, to avoid the need of the code above.**
