### PR TITLE
CSS in admin accessibility; Fixing a warning for a deleted level

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -491,6 +491,7 @@ tr.pmpro_settings_divider td {
 .pmpro_admin .pmpro_message {
 	background: #FFF;
 	border-left: 4px solid #FFF;
+	color: #3c434a;
 	margin-right: 15px;
 	padding: 15px;
 }
@@ -710,6 +711,9 @@ p.pmpro_meta_notice {
 }
 .memberships_page_pmpro-license .pmpro_icon {
 	margin-top: 20px;
+}
+.memberships_page_pmpro-license .about-wrap .about-text {
+	color: #3c434a;
 }
 
 /* misc */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1949,7 +1949,9 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 		$level_names = array();
 		foreach ( $level_ids as $key => $id ) {
 			$level_obj = pmpro_getLevel( $id );
-			$level_names[] = $level_obj->name;
+			if ( ! empty( $level_obj ) ) {
+				$level_names[] = $level_obj->name;
+			}
 		}
 	}
 


### PR DESCRIPTION
Small CSS tweak for admin to make sure our pmpro_message class elements ( when they otherwise don't have a contextual color set ) are dark nearly black text for accessibility.

Fixed a warning in the membership required messages replacements function when looking for a deleted level's Name.