### PR TITLE
Subs table IPN/webhook race condition

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1130,6 +1130,9 @@ class PMPro_Subscription {
 		}
 		$cancelled_subscription_ids[] = $this->id;
 
+		// Mark the subscription as cancelled in the database.
+		$this->mark_as_cancelled();
+
 		// Cancel the subscription in the gateway.
 		$cancelled = false;
 		$gateway_object = $this->get_gateway_object();
@@ -1166,9 +1169,6 @@ class PMPro_Subscription {
 			$pmproemail->data['body'] .= '<p>' . esc_html__( 'Edit User', 'paid-memberships-pro' ) . ': ' . esc_url( add_query_arg( 'user_id', $this->user_id, self_admin_url( 'user-edit.php' ) ) ) . '</p>';
 			$pmproemail->sendEmail( get_bloginfo( 'admin_email' ) );
 		}
-
-		// Mark the subscription as cancelled in the database.
-		$this->mark_as_cancelled();
 
 		return $cancelled;
 	}

--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1130,8 +1130,11 @@ class PMPro_Subscription {
 		}
 		$cancelled_subscription_ids[] = $this->id;
 
-		// Mark the subscription as cancelled in the database.
-		$this->mark_as_cancelled();
+		// Mark the subscription as cancelled in the database without
+		// syncing with the payment gateway. We want this subscription
+		// to be cancelled in the database when the IPN/webhook hits
+		// so that the user's membership is not cancelled.
+		$this->mark_as_cancelled( false );
 
 		// Cancel the subscription in the gateway.
 		$cancelled = false;
@@ -1170,6 +1173,9 @@ class PMPro_Subscription {
 			$pmproemail->sendEmail( get_bloginfo( 'admin_email' ) );
 		}
 
+		$this->update();
+		$this->save();
+
 		return $cancelled;
 	}
 
@@ -1178,11 +1184,15 @@ class PMPro_Subscription {
 	 * incomplete orders for this subscription as error.
 	 *
 	 * @since TBD
+	 *
+	 * @param bool $update Whether to update the subscription from the gateway.
 	 */
-	public function mark_as_cancelled() {
+	public function mark_as_cancelled( $update = true ) {
 		// Mark subscription as cancelled.
 		$this->status  = 'cancelled';
-		$this->update();
+		if ( $update ) {
+			$this->update();
+		}
 		$this->save();
 
 		// Mark incomplete orders as error.

--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1134,7 +1134,7 @@ class PMPro_Subscription {
 		// syncing with the payment gateway. We want this subscription
 		// to be cancelled in the database when the IPN/webhook hits
 		// so that the user's membership is not cancelled.
-		$this->mark_as_cancelled( false );
+		$this->mark_as_cancelled( false ); // False so that we don't sync with the gateway.
 
 		// Cancel the subscription in the gateway.
 		$cancelled = false;

--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1130,10 +1130,11 @@ class PMPro_Subscription {
 		}
 		$cancelled_subscription_ids[] = $this->id;
 
-		// Mark the subscription as cancelled in the database without
-		// syncing with the payment gateway. We want this subscription
-		// to be cancelled in the database when the IPN/webhook hits
-		// so that the user's membership is not cancelled.
+		/** Mark the subscription as cancelled in the database without
+		 * syncing with the payment gateway. We want this subscription
+		 * to be cancelled in the database when the IPN/webhook hits
+		 * so that the user's membership is not cancelled.
+		 */
 		$this->mark_as_cancelled( false ); // False so that we don't sync with the gateway.
 
 		// Cancel the subscription in the gateway.


### PR DESCRIPTION
In the original code, PMPro only marks a subscription as cancelled in the database after actually cancelling the sub in the gateway. This causes a race condition between the PMPro_Subscription's `mark_as_cancelled()` method and the IPN/webhook message that is sent from the payment gateway. If the IPN/webhook is processed before the `mark_as_cancelled()` finishes running, then users may have their membership level removed when it shouldn't be.

This PR removes this race condition by marking the subscription as canclled in the database before reaching out to the gateway, causing IPN/webhook handlers to not process those cancellations.

Since originally the subscription was always marked as cancelled in the PMPro_Subscription `cancel_at_gateway()` method regardless of what happened during the cancellation itself, marking the subscriptions early shouldn't be any different than waht is currently happening.