### PR TITLE
Updating the email for refund and refund admin

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -1130,11 +1130,11 @@
 				$user = get_user_by( 'id', $morder->user_id );
 				//send an email to the member
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedEmail( $user );
+				$myemail->sendRefundedEmail( $user, $morder );
 
 				//send an email to the admin
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedAdminEmail( $user, $morder->membership_id );
+				$myemail->sendRefundedAdminEmail( $user, $morder );
 
 			} else {
 				//The refund failed, so lets return the gateway message

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -4793,11 +4793,11 @@ class PMProGateway_stripe extends PMProGateway {
 				$user = get_user_by( 'id', $order->user_id );
 				//send an email to the member
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedEmail( $user );
+				$myemail->sendRefundedEmail( $user, $order );
 
 				//send an email to the admin
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedAdminEmail( $user, $order->membership_id );
+				$myemail->sendRefundedAdminEmail( $user, $order );
 
 			} else {
 				$order->notes = trim( $order->notes . ' ' . __('Admin: An error occured while attempting to process this refund.', 'paid-memberships-pro' ) );

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -499,28 +499,35 @@ $pmpro_email_templates_defaults = array(
 		'help_text' => __( 'This email is sent to the member when the trial portion of their membership level is approaching, at an interval based on the term of the trial.', 'paid-memberships-pro' )
 	),
 	'refund'                   => array(
-		'subject'     => __( "Your membership at !!sitename!! has been REFUNDED", 'paid-memberships-pro' ),
+		'subject'     => __( 'Your invoice for order #!!invoice_id!! at !!sitename!! has been REFUNDED', 'paid-memberships-pro' ),
 		'description' => __('Refund', 'paid-memberships-pro'),
-		'body' => __( '<p>Your membership at !!sitename!! has been refunded.</p>
+		'body' => __( '<p>Your invoice for order #!!invoice_id!! at !!sitename!! has been refunded.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
+<p>
+	Invoice #!!invoice_id!! on !!invoice_date!!<br />
+	Total Refunded: !!invoice_total!!
+</p>
+
+<p>Log in to your membership account here: !!login_url!!</p>
+<p>To view an online version of this invoice, click here: !!invoice_url!!</p>
 
 <p>If you did not request this refund and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ),
-		'help_text' => __( 'The site administrator can manually refund a user\'s membership through the WordPress admin. This email is sent to the member as confirmation of a refunded membership.', 'paid-memberships-pro' )
+		'help_text' => __( 'This email is sent to the member as confirmation of a refunded payment. The email is sent after your membership site receives notification of a successful payment refund through your gateway.', 'paid-memberships-pro' )
 	),
 	'refund_admin'             => array(
-		'subject'     => __( "Membership for !!user_login!! at !!sitename!! has been REFUNDED", 'paid-memberships-pro' ),
+		'subject'     => __( 'Invoice for order #!!invoice_id!! at !!sitename!! has been REFUNDED', 'paid-memberships-pro' ),
 		'description' => __('Refund (admin)', 'paid-memberships-pro'),
-		'body' => __( '<p>The membership for !!user_login!! at !!sitename!! has been refunded.</p>
+		'body' => __( '<p>The invoice for order #!!invoice_id!! at !!sitename!! has been refunded.</p>
 
 <p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Start Date: !!startdate!!</p>
-<p>End Date: !!enddate!!</p>
+<p>
+	Invoice #!!invoice_id!! on !!invoice_date!!<br />
+	Total Refunded: !!invoice_total!!
+</p>
 
 <p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ),
-		'help_text' => __( 'The site administrator can manually refund a user\'s membership through the WordPress admin. This email is sent to the site administrator as confirmation of a refunded membership.', 'paid-memberships-pro' )
+		'help_text' => __( 'This email is sent to the admin as confirmation of a refunded payment. The email is sent after your membership site receives notification of a successful payment refund through your gateway.', 'paid-memberships-pro' )
 	),
 );
 

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -435,11 +435,11 @@ if ( strtolower( $payment_status ) === 'refunded' ) {
 
 			//send an email to the member
 			$myemail = new PMProEmail();
-			$myemail->sendRefundedEmail( $user );
+			$myemail->sendRefundedEmail( $user, $morder );
 
 			//send an email to the admin
 			$myemail = new PMProEmail();
-			$myemail->sendRefundedAdminEmail( $user, $morder->membership_id );
+			$myemail->sendRefundedAdminEmail( $user, $morder );
 
 			$morder->SaveOrder();
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -439,11 +439,11 @@
 
 				//send an email to the member
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedEmail( $user );
+				$myemail->sendRefundedEmail( $user, $morder );
 
 				//send an email to the admin
 				$myemail = new PMProEmail();
-				$myemail->sendRefundedAdminEmail( $user, $morder->membership_id );
+				$myemail->sendRefundedAdminEmail( $user, $morder );
 
 				pmpro_stripeWebhookExit();
 			} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR rewrites the default email content for the Refund and Refund (admin) email templates. I also adjusted the methods to include the order object so that we can show populate order-related template variables in the emails.

I removed the old level ID information. Refunds are exclusively about the invoice/order data and don't affect membership level for the invoice's user.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
