### PR TITLE
Fixing updating order timestamp from admin dashboard

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -316,7 +316,7 @@ if ( ! empty( $_REQUEST['save'] ) ) {
 		$hour   = intval( $_POST['ts_hour'] );
 		$minute = intval( $_POST['ts_minute'] );
 		$date = get_gmt_from_date( $year . '-' . $month . '-' . $day . ' ' . $hour . ':' . $minute . ':00' , 'U' );
-		$order->timestamp = strtotime( $date );
+		$order->timestamp = $date; // Passed 'U' to get_gmt_from_date() so that we get a Unix timesamp.
 	}
 
 	// affiliate stuff


### PR DESCRIPTION
Fixing issue where saving an order in admin would reset order date to current time.