### PR TITLE
Now sending all level data to Wisdom

### DIFF
--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -267,6 +267,7 @@ class PMPro_Wisdom_Integration {
 
 		// Levels info.
 		$levels_info = $this->get_levels_info();
+		$stats['plugin_options_fields']['pmpro_level_count']    = $levels_info['pmpro_level_count'];
 		$stats['plugin_options_fields']['pmpro_level_setups']   = $levels_info['pmpro_level_setups'];
 		$stats['plugin_options_fields']['pmpro_has_free_level'] = $levels_info['pmpro_has_free_level'];
 		$stats['plugin_options_fields']['pmpro_has_paid_level'] = $levels_info['pmpro_has_paid_level'];
@@ -393,9 +394,16 @@ class PMPro_Wisdom_Integration {
 			'pmpro_level_setups'   => array(),
 			'pmpro_has_free_level' => 'no',
 			'pmpro_has_paid_level' => 'yes',
+			'pmpro_level_count'    => 0,
 		);
 
+		// Get the levels.
 		$levels = pmpro_getAllLevels( true );
+
+		// Update the level count.
+		$stats['pmpro_level_count'] = count( $levels );
+
+		// Loop through the levels.
 		foreach ( $levels as $level_id => $level_data ) {
 			// Remove sensitive info.
 			unset( $level_data->name );

--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -266,7 +266,10 @@ class PMPro_Wisdom_Integration {
 		$stats['plugin_options_fields'] = array_merge( $stats['plugin_options_fields'], $this->get_gateway_info() );
 
 		// Levels info.
-		$stats['plugin_options_fields'] = array_merge( $stats['plugin_options_fields'], $this->get_levels_info() );
+		$levels_info = $this->get_levels_info();
+		$stats['plugin_options_fields']['pmpro_level_setups']   = $levels_info['pmpro_level_setups'];
+		$stats['plugin_options_fields']['pmpro_has_free_level'] = $levels_info['pmpro_has_free_level'];
+		$stats['plugin_options_fields']['pmpro_has_paid_level'] = $levels_info['pmpro_has_paid_level'];
 
 		// Members info.
 		$stats['plugin_options_fields']['pmpro_members_count']           = pmpro_getSignups( 'all time' );
@@ -312,7 +315,6 @@ class PMPro_Wisdom_Integration {
 
 			$stats['plugin_options_fields'][ $option ] = $value;
 		}
-
 		return $stats;
 	}
 
@@ -385,68 +387,46 @@ class PMPro_Wisdom_Integration {
 	 * @return array The level information for all levels to track.
 	 */
 	public function get_levels_info() {
-		$stats = [];
+		global $wpdb;
+
+		$stats = array(
+			'pmpro_level_setups'   => array(),
+			'pmpro_has_free_level' => 'no',
+			'pmpro_has_paid_level' => 'yes',
+		);
 
 		$levels = pmpro_getAllLevels( true );
+		foreach ( $levels as $level_id => $level_data ) {
+			// Remove sensitive info.
+			unset( $level_data->name );
+			unset( $level_data->description );
+			unset( $level_data->confirmation );
 
-		$stats['pmpro_levels_count'] = count( $levels );
+			// Add Set Expiration Date/Subscription Delay info.
+			$level_data->set_expiration_date = get_option( 'pmprosed_' . $level_id , '' );
+			$level_data->subscription_delay  = get_option( 'pmpro_subscription_delay_' . $level_id , '' );
 
-		$range_groups = [
-			'0'  => [
-				'range' => [ 0, 0 ],
-				'count' => 0,
-			],
-			'0.01_to_10'  => [
-				'range' => [ 0.01, 10 ],
-				'count' => 0,
-			],
-			'10.01_to_30' => [
-				'range' => [ 10.01, 30 ],
-				'count' => 0,
-			],
-			'30.01_to_100' => [
-				'range' => [ 30.01, 100 ],
-				'count' => 0,
-			],
-			'100.01_to_300' => [
-				'range' => [ 100.01, 300 ],
-				'count' => 0,
-			],
-			'300.01_to_1000' => [
-				'range' => [ 300.01, 1000 ],
-				'count' => 0,
-			],
-			'1000.01_to_9999' => [
-				'range' => [ 1000.01, 9999 ],
-				'count' => 0,
-			],
-		];
+			// Add if a category is set.
+			$categories = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT category_id
+					FROM $wpdb->pmpro_memberships_categories
+					WHERE membership_id = %d",
+					$level_id
+				)
+			);
+			$level_data->has_categories = ! empty( $categories ) ? 'yes' : 'no';
 
-		$billing_amount_prices = wp_list_pluck( $levels, 'billing_amount' );
-		$billing_amount_prices = array_unique( $billing_amount_prices );
+			// Add level info.
+			$stats['pmpro_level_setups'][ $level_id ] = $level_data;
 
-		foreach ( $billing_amount_prices as $billing_amount_price ) {
-			foreach ( $range_groups as $key => $group ) {
-				// Zero price range handling.
-				if ( 0 === $group['range'][0] && 0 === $group['range'][1] && 0 === $billing_amount_price ) {
-					$range_groups[ $key ]['count'] ++;
-
-					break;
-				}
-
-				// Check if price is within the range group constraints.
-				if ( $group['range'][0] <= $billing_amount_price && $billing_amount_price <= $group['range'][1] ) {
-					$range_groups[ $key ]['count'] ++;
-
-					break;
-				}
+			// Update whether or not we have a free/paid level yet.
+			if ( pmpro_isLevelFree( $level_data ) ) {
+				$stats['pmpro_has_free_level'] = 'yes';
+			} else {
+				$stats['pmpro_has_paid_level'] = 'yes';
 			}
 		}
-
-		foreach ( $range_groups as $key => $group ) {
-			$stats['pmpro_levels_price_ranges_' . $key ] = $group['count'];
-		}
-
 		return $stats;
 	}
 

--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -393,7 +393,7 @@ class PMPro_Wisdom_Integration {
 		$stats = array(
 			'pmpro_level_setups'   => array(),
 			'pmpro_has_free_level' => 'no',
-			'pmpro_has_paid_level' => 'yes',
+			'pmpro_has_paid_level' => 'no',
 			'pmpro_level_count'    => 0,
 		);
 


### PR DESCRIPTION
Now sending all level data to Wisdom. 

It is important to note that the `$stats['plugin_options_fields']['pmpro_level_setups']` data may be very large as it contains the settings for all membership levels. Not sure if this will cause issues for sites with many levels.