### PR TITLE
Crons: fix array key for interval

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -48,8 +48,8 @@ function pmpro_get_crons() {
 			$cron['timestamp'] = current_time( 'timestamp' );
 		}
 
-		if ( empty( $cron['recurrence'] ) ) {
-			$cron['recurrence'] = 'hourly';
+		if ( empty( $cron['interval'] ) ) {
+			$cron['interval'] = 'hourly';
 		}
 
 		if ( empty( $cron['args'] ) ) {
@@ -71,7 +71,7 @@ function pmpro_maybe_schedule_crons() {
 	$crons = pmpro_get_crons();
 
 	foreach ( $crons as $hook => $cron ) {
-		pmpro_maybe_schedule_event( $cron['timestamp'], $cron['recurrence'], $hook, $cron['args'] );
+		pmpro_maybe_schedule_event( $cron['timestamp'], $cron['interval'], $hook, $cron['args'] );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since 2.8 the activity report has been sent hourly instead of weekly because of a mismatch in array keys (using `recurrence` instead of `interval`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
