### PR TITLE
Sales Report: push Revenue label right and align vertical

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -759,7 +759,9 @@ h2.nav-tab-wrapper {
 #pmpro_report_sales .wp-list-table tfoot td {
 	font-size: 1.1rem;
 	font-weight: bold;
+    vertical-align: middle;
 }
+#pmpro_report_sales .wp-list-table thead th:last-child,
 #pmpro_report_sales .wp-list-table tbody td:last-child,
 #pmpro_report_sales .wp-list-table tfoot td:last-child {
 	text-align: right;

--- a/css/admin.css
+++ b/css/admin.css
@@ -759,7 +759,7 @@ h2.nav-tab-wrapper {
 #pmpro_report_sales .wp-list-table tfoot td {
 	font-size: 1.1rem;
 	font-weight: bold;
-    vertical-align: middle;
+	vertical-align: middle;
 }
 #pmpro_report_sales .wp-list-table thead th:last-child,
 #pmpro_report_sales .wp-list-table tbody td:last-child,

--- a/css/admin.css
+++ b/css/admin.css
@@ -759,7 +759,7 @@ h2.nav-tab-wrapper {
 #pmpro_report_sales .wp-list-table tfoot td {
 	font-size: 1.1rem;
 	font-weight: bold;
-	vertical-align: middle;
+	vertical-align: top;
 }
 #pmpro_report_sales .wp-list-table thead th:last-child,
 #pmpro_report_sales .wp-list-table tbody td:last-child,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:
![Screenshot 2022-05-09 at 21 24 05](https://user-images.githubusercontent.com/636911/167485748-b707d4a6-a386-42d8-9494-028831ed3e56.png)

This is the "Sales" report. Not looking good because with i18n (italian in that case) some rows height is double.
This PR aims to:
- right align "Revenue" label in table head
- vertical align table values

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
