### PR TITLE
Display Login Page post state to avoid accidental deletion

### DIFF
--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -354,6 +354,10 @@ function pmpro_display_post_states( $post_states, $post ) {
 		$post_states['pmpro_levels_page'] = __( 'Membership Levels Page', 'paid-memberships-pro' );
 	}
 
+	if ( intval( $pmpro_pages['login'] ) === $post->ID ) {
+		$post_states['pmpro_login_page'] = __( 'Paid Memberships Pro Login Page', 'paid-memberships-pro' );
+	}
+
 	if ( intval( $pmpro_pages['member_profile_edit'] ) === $post->ID ) {
 		$post_states['pmpro_member_profile_edit_page'] = __( 'Member Profile Edit Page', 'paid-memberships-pro' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Related to #2068 which happened because of an accidental deletion of the login page on a site (seemed unused).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
