### PR TITLE
Remove a trailing comma which can cause issues

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1711,13 +1711,14 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 's' => $order->subscription_transaction_id ), admin_url( 'admin.php' ) ) ); ?>" title="<?php esc_attr_e( 'View all orders for this subscription', 'paid-memberships-pro' ); ?>" class="pmpro_order-renewal"><?php esc_html_e( 'Renewal', 'paid-memberships-pro' ); ?></a>
 						<?php } ?>
 					</td>
-					<td class="column-date">
+					<td class="
+						   ">
 						<?php
 							 echo esc_html( sprintf(
 								// translators: %1$s is the date and %2$s is the time.
 								__( '%1$s at %2$s', 'paid-memberships-pro' ),
 								esc_html( date_i18n( get_option( 'date_format' ), $order->getTimestamp() ) ),
-								esc_html( date_i18n( get_option( 'time_format' ), $order->getTimestamp() ) ),
+								esc_html( date_i18n( get_option( 'time_format' ), $order->getTimestamp() ) )
 							) ); ?>
 					</td>
 					<?php if ( ! empty( $pmpro_discount_codes ) ) { ?>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1497,7 +1497,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 								'id'	 => sprintf(
 									// translators: %s is the Order ID.
 									__( 'ID: %s', 'paid-memberships-pro' ),
-									esc_attr( $order->id ),
+									esc_attr( $order->id )
 								),
 								'edit'   => sprintf(
 									'<a title="%1$s" href="%2$s">%3$s</a>',

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1711,8 +1711,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 							<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 's' => $order->subscription_transaction_id ), admin_url( 'admin.php' ) ) ); ?>" title="<?php esc_attr_e( 'View all orders for this subscription', 'paid-memberships-pro' ); ?>" class="pmpro_order-renewal"><?php esc_html_e( 'Renewal', 'paid-memberships-pro' ); ?></a>
 						<?php } ?>
 					</td>
-					<td class="
-						   ">
+					<td class="column-date">
 						<?php
 							 echo esc_html( sprintf(
 								// translators: %1$s is the date and %2$s is the time.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Trailing commas in functions call are valid since PHP 7.3. We are 5.6+ compatible, then we should avoid it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
