### PR TITLE
Fix login redirect issue for trashed pages.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -113,7 +113,7 @@ function pmpro_login_url_filter( $login_url='', $redirect='' ) {
 
 	// Check for a PMPro Login page.
 	$login_page_id = pmpro_getOption( 'login_page_id' );
-	if ( ! empty ( $login_page_id ) ) {
+	if ( ! empty ( $login_page_id ) && 'publish' === get_post_status( $login_page_id ) ) {
 		$login_page_permalink = get_permalink( $login_page_id );
 		// If the page or permalink is unavailable, don't override the url here.
 		if ( $login_page_permalink ) {


### PR DESCRIPTION
*BUG FIX: Fixes an issue to only redirect to the set PMPro login page if the page is published.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves: https://github.com/strangerstudios/paid-memberships-pro/issues/2068.

### How to test the changes in this Pull Request:

1. Delete the Log In page from the pages list. (Or even unpublish it).
2. Logout.
3. Try to login via the default wp-admin (should redirect to default wp-login.php)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

