### PR TITLE
Wrapping the no_access message in a divi selector so it doesn't full wrap

### DIFF
--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -91,3 +91,15 @@ class PMProDivi{
 	}
 }
 new PMProDivi();
+
+/**
+ * Filter the element classess added to the no_access messages for improved appearance in Divi.
+ *
+ */
+function divi_pmpro_element_class( $class, $element ) {
+	if ( in_array( 'pmpro_content_message', $class ) ) {
+		$class[] = 'et_pb_row';
+	}
+	return $class;
+}
+add_action( 'pmpro_element_class', 'divi_pmpro_element_class', 10, 2 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When you protect a post using the Require Membership box with Divi, it has a fairly decent appearance. That same page protection on a single page, though, have no wrapping container and span the full width of the page with no padding or margins.

This PR update the CSS classes added to the no_access message for Divi to make it look better without too much formatting,

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Protect a page at the page level with Divi using the Require Membership metabox
2. View on the frontend as a non-member
3. With this css selector added to the content message it should look decent in the page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Improved appearance of no_access messages with Divi builder.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
