### PR TITLE
Fixing variable name

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -973,7 +973,7 @@ function pmpro_stripe_webhook_populate_order_from_payment( $order, $payment_meth
 	}
 
 	// Add billing address information.
-	$morder->billing = new stdClass();
+	$order->billing = new stdClass();
 	$order->billing->name = empty( $payment_method->billing_details->name ) ? '' : $payment_method->billing_details->name;
 	$order->billing->street = empty( $payment_method->billing_details->address->line1 ) ? '' : $payment_method->billing_details->address->line1;
 	$order->billing->city = empty( $payment_method->billing_details->address->city ) ? '' : $payment_method->billing_details->address->city;


### PR DESCRIPTION
Fixing PHP Fatal error:  Uncaught Error: Attempt to assign property "billing" on null in .../wp-content/plugins/paid-memberships-pro/services/stripe-webhook.php:976