### PR TITLE
Direct include avoid Call to undefined function pmpro_doing_webhook()

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -16,9 +16,6 @@
 	global $logstr;
 	$logstr = "";
 
-	// Sets the PMPRO_DOING_WEBHOOK constant and fires the pmpro_doing_webhook action.
-	pmpro_doing_webhook( 'stripe', true );
-
 	//you can define a different # of seconds (define PMPRO_STRIPE_WEBHOOK_DELAY in your wp-config.php) if you need this webhook to delay more or less
 	if(!defined('PMPRO_STRIPE_WEBHOOK_DELAY'))
 		define('PMPRO_STRIPE_WEBHOOK_DELAY', 2);
@@ -33,6 +30,9 @@
 	if(!class_exists("Stripe\Stripe")) {
 		require_once( PMPRO_DIR . "/includes/lib/Stripe/init.php" );
 	}
+
+	// Sets the PMPRO_DOING_WEBHOOK constant and fires the pmpro_doing_webhook action.
+	pmpro_doing_webhook( 'stripe', true );
 
 	// retrieve the request's body and parse it as JSON
 	if(empty($_REQUEST['event_id']))


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

That pmpro_doing_webhook() called before wp bootstrap causes error 500.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
