### PR TITLE
Avoid a warning in case of multiple levels passed in

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -544,10 +544,15 @@ function pmpro_getCancellations($period = null, $levels = 'all', $status = array
 	//make sure status is an array
 	if(!is_array($status))
 		$status = array($status);
-
+    
 	//check for a transient
 	$cache = get_transient( 'pmpro_report_memberships_cancellations' );
-	$hash = md5($period . $levels . implode(',', $status));
+	$hash = md5(
+		$period .
+		implode( ',', is_array( $levels ) ? $levels : array( $levels ) ) .
+		implode( ',', $status )
+	);
+
 	if( ! empty( $cache ) && ! empty( $cache[$hash] ) )
 		return $cache[$hash];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`Warning: Array to string conversion` in case of multiple levels passed in.

### How to test the changes in this Pull Request:

1. Create 2+ levels
2. Create a snippet with `pmpro_getCancellations('today',[1,2])`
3. Check the debug log for the warning

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
