### PR TITLE
If we don't find a payment method for some reason, log it, but let's …

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -179,7 +179,6 @@
 						$logstr .= "Could not find payment method for invoice " . $invoice->id . ".";
 						$payment_method = null;
 					}
-					$payment_method = null;
 					// Update payment method and billing address on order.
 					pmpro_stripe_webhook_populate_order_from_payment( $morder, $payment_method );				
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -261,7 +261,6 @@
 					// If we didn't get a payment method, check the charge.
 					$payment_method = $payment_intent->charges->data[0]->payment_method_details;
 				}
-				$payment_method = $payment_intent->charges->data[0]->payment_method_details;		        
 				if ( empty( $payment_method ) ) {		       	
 					$logstr .= "Could not find payment method for invoice " . $invoice->id;					
 				}


### PR DESCRIPTION
There were recent bugs where our Stripe webhook handler wasn't creating orders if it couldn't locate the related payment method from the Stripe invoice/intent/etc.

There have been other PRs to do a better job of finding the payment method, but there may still be cases where orders are created without them.

Since we're just getting the payment method to log some meta data, including billing address, to the order, we can still create an order with the amount and other information.

I considered copying some of the address data from the old orders, but probably better to leave it blank in this edge case.