### PR TITLE
Remove a trailing comma, not supported in PHP 5.6

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -833,7 +833,7 @@
 										'id'	 => sprintf(
 											// translators: %s is the Order ID.
 											__( 'ID: %s', 'paid-memberships-pro' ),
-											esc_attr( $code->id ),
+											esc_attr( $code->id )
 										),
 										'edit'   => sprintf(
 											'<a title="%1$s" href="%2$s">%3$s</a>',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove another trailing comma. Last one.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

