### PR TITLE
Now creating new Stripe product if saved ID doesn't exist

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2691,7 +2691,7 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		// Return the product ID.
-		return empty( $stripe_product_id ) ? null : $stripe_product_id;
+		return ! empty( $stripe_product_id ) ? $stripe_product_id : null;
 	}
 
 	/**


### PR DESCRIPTION
There are a couple cases in support where users switch Stripe accounts and are then seeing the error `No such product: prod_......` at checkout. This fixes that issue by checking that a product exists before attempting to create a charge for it and, if the product does not exist, creating a new one.