### PR TITLE
Avoid line breaks in "powered by" html comment

### DIFF
--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -548,9 +548,10 @@ add_action( 'wp_ajax_pmpro_hide_notice', 'pmpro_hide_notice' );
 /**
  * Show Powered by Paid Memberships Pro comment (only visible in source) in the footer.
  */
-function pmpro_link() { ?>
-Memberships powered by Paid Memberships Pro v<?php echo PMPRO_VERSION; ?>.
-<?php }
+function pmpro_link() {
+	?>Memberships powered by Paid Memberships Pro v<?php echo PMPRO_VERSION; ?>.<?php
+}
+
 function pmpro_footer_link() {
 	if ( ! pmpro_getOption( 'hide_footer_link' ) ) { ?>
 		<!-- <?php echo pmpro_link()?> -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Remove that line break at the end of our "powered by" html comment.
```
<!-- Memberships powered by Paid Memberships Pro v2.5.10.2.
  -->
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

