### PR TITLE
Fixing some calls to pmpro_check_field_for_level()

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -454,7 +454,7 @@ function pmpro_registration_checks_for_user_fields( $okay ) {
                     continue;
                 }
                 
-                if ( ! pmpro_check_field_for_level( $field, "profile", $user_id ) ) {
+                if ( ! pmpro_check_field_for_level( $field ) ) {
                     continue;
                 }
 
@@ -550,7 +550,7 @@ function pmpro_paypalexpress_session_vars_for_user_fields() {
                     continue;
                 }
                 
-                if ( ! pmpro_check_field_for_level( $field, "profile", $user_id ) ) {
+                if ( ! pmpro_check_field_for_level( $field ) ) {
                     continue;
                 }
 


### PR DESCRIPTION
Fixing undefined $user_id in lines `pmpro_check_field_for_level( $field, "profile", $user_id )`