### PR TITLE
Showing update notices when update is available for PMPro

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1039,3 +1039,15 @@ button.pmpro_report_th_closed:before {
 		width: 0;
 	}
 }
+
+/* plugin update notice */
+.pmpro_plugin_update_notice {
+	background-color: #d54e21 !important;
+	padding: 10px !important;
+	color: #f9f9f9 !important;
+	margin-top: 10px !important;
+}
+
+.pmpro_plugin_update_notice + p:before {
+	display: none;
+}

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -188,7 +188,8 @@ if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-reports' ) {
  */
 function pmpro_maybe_show_upgrade_notices( $current_plugin_data, $update_data ) {
 	if ( isset( $update_data->upgrade_notice ) && strlen( trim( $update_data->upgrade_notice ) ) > 0 ) {
-		echo '<p class="pmpro_plugin_update_notice"><strong>' . esc_html( 'Important Upgrade Notice', 'paid-memberships-pro' ) . ':</strong> ' . strip_tags( $update_data->upgrade_notice ) . '</p>';
+		echo '<p class="pmpro_plugin_update_notice"><strong>' . esc_html( 'Important Upgrade Notice', 'paid-memberships-pro' ) . ':</strong> ' . esc_html( strip_tags( $update_data->upgrade_notice ) ) . '</p>';
+
 	}
 }
 $pmpro_path_from_plugins_dir_arr = explode( '/wp-content/plugins/', PMPRO_BASE_FILE );

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -154,3 +154,44 @@ function pmpro_show_notice_for_reports() {
 if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-reports' ) {
 	add_action( 'admin_notices', 'pmpro_show_notice_for_reports', 20 );
 }
+
+/**
+ * If there is an upgrade notice for updating PMPro to the latest version, show it.
+ *
+ * @since TBD
+ *
+ * @param array $current_plugin_data {
+ *     An array of plugin metadata.
+ *
+ *     @type string $name         The human-readable name of the plugin.
+ *     @type string $plugin_uri   Plugin URI.
+ *     @type string $version      Plugin version.
+ *     @type string $description  Plugin description.
+ *     @type string $author       Plugin author.
+ *     @type string $author_uri   Plugin author URI.
+ *     @type string $text_domain  Plugin text domain.
+ *     @type string $domain_path  Relative path to the plugin's .mo file(s).
+ *     @type bool   $network      Whether the plugin can only be activated network wide.
+ *     @type string $title        The human-readable title of the plugin.
+ *     @type string $author_name  Plugin author's name.
+ *     @type bool   $update       Whether there's an available update. Default null.
+ * }
+ * @param array $update_data {
+ *     An array of metadata about the available plugin update.
+ *
+ *     @type int    $id           Plugin ID.
+ *     @type string $slug         Plugin slug.
+ *     @type string $new_version  New plugin version.
+ *     @type string $url          Plugin URL.
+ *     @type string $package      Plugin update package URL.
+ * }
+ */
+function pmpro_maybe_show_upgrade_notices( $current_plugin_data, $update_data ) {
+	if ( isset( $update_data->upgrade_notice ) && strlen( trim( $update_data->upgrade_notice ) ) > 0 ) {
+		echo '<p class="pmpro_plugin_update_notice"><strong>' . esc_html( 'Important Upgrade Notice', 'paid-memberships-pro' ) . ':</strong> ' . esc_html( $update_data->upgrade_notice ) . '</p>';
+	}
+}
+$pmpro_path_from_plugins_dir_arr = explode( '/wp-content/plugins/', PMPRO_BASE_FILE );
+if ( ! empty( $pmpro_path_from_plugins_dir_arr ) ) {
+	add_action( 'in_plugin_update_message-' . end( $pmpro_path_from_plugins_dir_arr ), 'pmpro_maybe_show_upgrade_notices', 10, 2 );
+}

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -188,7 +188,7 @@ if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-reports' ) {
  */
 function pmpro_maybe_show_upgrade_notices( $current_plugin_data, $update_data ) {
 	if ( isset( $update_data->upgrade_notice ) && strlen( trim( $update_data->upgrade_notice ) ) > 0 ) {
-		echo '<p class="pmpro_plugin_update_notice"><strong>' . esc_html( 'Important Upgrade Notice', 'paid-memberships-pro' ) . ':</strong> ' . esc_html( $update_data->upgrade_notice ) . '</p>';
+		echo '<p class="pmpro_plugin_update_notice"><strong>' . esc_html( 'Important Upgrade Notice', 'paid-memberships-pro' ) . ':</strong> ' . strip_tags( $update_data->upgrade_notice ) . '</p>';
 	}
 }
 $pmpro_path_from_plugins_dir_arr = explode( '/wp-content/plugins/', PMPRO_BASE_FILE );


### PR DESCRIPTION
<img width="1306" alt="Screen Shot 2022-06-02 at 11 27 11 AM" src="https://user-images.githubusercontent.com/24977505/171666375-e9e6f8ea-8be8-40d8-ae36-1965823b8bad.png">

Useful for future PMPro updates where we want to warn users about breaking changes.

I have not been able to test this completely since this would require having an update for PMPro that includes an update notice; however, the code does work when setting PMPro to an old version and adding the following line of code at the top of the `pmpro_maybe_show_upgrade_notices()` function:
`$update_data->upgrade_notice = 'Your update notice...';`

Based off of this article: https://andidittrich.com/2015/05/howto-upgrade-notice-for-wordpress-plugins.html