### PR TITLE
Separating out these actions and checks to make the logic better. We …

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -136,24 +136,24 @@
 		);
 
 		// Was there an error inserting or updating?
-		if(empty($wpdb->last_error)) {		
+		if ( empty( $wpdb->last_error ) ) {		
 			$edit = false;
 			$msg = 1;
-			$msgt = __("Membership level added successfully.", 'paid-memberships-pro' );
+			$msgt = __( 'Membership level added successfully.', 'paid-memberships-pro' );
 		} else {
 			$msg = -1;
-			$msgt = __("Error adding membership level.", 'paid-memberships-pro' );
+			$msgt = __( 'Error adding membership level.', 'paid-memberships-pro' );
 		}
 
 		// Update saveid to insert id if this was a new level.
-		if($saveid < 1) {			
+		if ( $saveid < 1 ) {			
 			$saveid = $wpdb->insert_id;
 		}
 
 		// If we have a saveid, update categories.
 		if ( $saveid > 0 ) {
 			pmpro_updateMembershipCategories( $saveid, $ml_categories );
-			if( ! empty($wpdb->last_error)) {			
+			if ( ! empty( $wpdb->last_error ) ) {			
 				$msg = -2;
 				$msgt = __("Error updating membership level.", 'paid-memberships-pro' );
 			}

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -135,31 +135,25 @@
 			)
 		);
 
-		if($saveid < 1) {
-			//added a level
-			$saveid = $wpdb->insert_id;
-
-			pmpro_updateMembershipCategories( $saveid, $ml_categories );
-
-			if(empty($wpdb->last_error)) {
-				$saveid = $wpdb->insert_id;
-				pmpro_updateMembershipCategories( $saveid, $ml_categories );
-
-				$edit = false;
-				$msg = 1;
-				$msgt = __("Membership level added successfully.", 'paid-memberships-pro' );
-			} else {
-				$msg = -1;
-				$msgt = __("Error adding membership level.", 'paid-memberships-pro' );
-			}
+		// Was there an error inserting or updating?
+		if(empty($wpdb->last_error)) {		
+			$edit = false;
+			$msg = 1;
+			$msgt = __("Membership level added successfully.", 'paid-memberships-pro' );
 		} else {
-			pmpro_updateMembershipCategories( $saveid, $ml_categories );
+			$msg = -1;
+			$msgt = __("Error adding membership level.", 'paid-memberships-pro' );
+		}
 
-			if(empty($wpdb->last_error)) {
-				$edit = false;
-				$msg = 2;
-				$msgt = __("Membership level updated successfully.", 'paid-memberships-pro' );
-			} else {
+		// Update saveid to insert id if this was a new level.
+		if($saveid < 1) {			
+			$saveid = $wpdb->insert_id;
+		}
+
+		// If we have a saveid, update categories.
+		if ( $saveid > 0 ) {
+			pmpro_updateMembershipCategories( $saveid, $ml_categories );
+			if( ! empty($wpdb->last_error)) {			
 				$msg = -2;
 				$msgt = __("Error updating membership level.", 'paid-memberships-pro' );
 			}


### PR DESCRIPTION
…should update the saveid if we can. We should try to update categories if we can (even if the other update/insert didn't work). If there is any error with those DB queries, show the "error updating". Having an error doesn't mean the level wasn't partially updated, which we can't really try to do anyway.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The logic on saves here was odd. We were running the category update twice sometimes and the saveid and error messages could get confused here.

One issue that was happening is that add ons hooked into the pmpro_save_membership_level filter were getting a 0 for the level_id instead of the saveid here when using the "copy" function. This update fixes that issue and potentially others caused by the odd logic here.

### How to test the changes in this Pull Request:

1. Install some add ons like the subscription delay add on.
2. Create a new level and save it. Did all values save?
3. Copy a level, edit some things, and save it. Did all the values save?
4. Edit a level, edit some things, and save it. Did all the values save?

We could try to force DB errors to make sure this code still captures and processes those properly. DB errors are kind of rare as is and I'm pretty sure the code is accurate here.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issue where some level settings would not save on the first try when copying a level.
