### PR TITLE
Optimize subs table indexing

### DIFF
--- a/includes/setup.sql
+++ b/includes/setup.sql
@@ -269,7 +269,7 @@ CREATE TABLE `wp_pmpro_subscriptions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `subscription_link` (`subscription_transaction_id`, `gateway_environment`, `gateway`),
   KEY `user_id` (`user_id`),
-  KEY `next_payment_date` (`next_payment_date`),
+  KEY `next_payment_date` (`next_payment_date`)
 );
 
 -- --------------------------------------------------------

--- a/includes/setup.sql
+++ b/includes/setup.sql
@@ -269,15 +269,6 @@ CREATE TABLE `wp_pmpro_subscriptions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `subscription_link` (`subscription_transaction_id`, `gateway_environment`, `gateway`),
   KEY `user_id` (`user_id`),
-  KEY `membership_level_id` (`membership_level_id`),
-  KEY `gateway` (`gateway`),
-  KEY `gateway_environment` (`gateway_environment`),
-  KEY `subscription_transaction_id` (`subscription_transaction_id`),
-  KEY `status` (`status`),
-  KEY `startdate` (`startdate`),
-  KEY `enddate` (`enddate`),
-  KEY `next_payment_date` (`next_payment_date`),
-  KEY `modified` (`modified`)
 );
 
 -- --------------------------------------------------------

--- a/includes/setup.sql
+++ b/includes/setup.sql
@@ -269,6 +269,7 @@ CREATE TABLE `wp_pmpro_subscriptions` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `subscription_link` (`subscription_transaction_id`, `gateway_environment`, `gateway`),
   KEY `user_id` (`user_id`),
+  KEY `next_payment_date` (`next_payment_date`),
 );
 
 -- --------------------------------------------------------

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -548,15 +548,6 @@ function pmpro_db_delta()
 			PRIMARY KEY (`id`),
 			UNIQUE KEY `subscription_link` (`subscription_transaction_id`, `gateway_environment`, `gateway`),
 			KEY `user_id` (`user_id`),
-			KEY `membership_level_id` (`membership_level_id`),
-			KEY `gateway` (`gateway`),
-			KEY `gateway_environment` (`gateway_environment`),
-			KEY `subscription_transaction_id` (`subscription_transaction_id`),
-			KEY `status` (`status`),
-			KEY `startdate` (`startdate`),
-			KEY `enddate` (`enddate`),
-			KEY `next_payment_date` (`next_payment_date`),
-			KEY `modified` (`modified`)
 		);
 	";
 	dbDelta($sqlQuery);

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -548,6 +548,7 @@ function pmpro_db_delta()
 			PRIMARY KEY (`id`),
 			UNIQUE KEY `subscription_link` (`subscription_transaction_id`, `gateway_environment`, `gateway`),
 			KEY `user_id` (`user_id`),
+			KEY `next_payment_date` (`next_payment_date`),
 		);
 	";
 	dbDelta($sqlQuery);

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -548,7 +548,7 @@ function pmpro_db_delta()
 			PRIMARY KEY (`id`),
 			UNIQUE KEY `subscription_link` (`subscription_transaction_id`, `gateway_environment`, `gateway`),
 			KEY `user_id` (`user_id`),
-			KEY `next_payment_date` (`next_payment_date`),
+			KEY `next_payment_date` (`next_payment_date`)
 		);
 	";
 	dbDelta($sqlQuery);


### PR DESCRIPTION
The vast majority of subs table queries will be when we have the subscription transaction ID, gateway, and gateway_environment, when we are looking for subscriptions for a particular user, or when we are trying to find subscriptions with upcoming next payment dates.

For any query including subscription transaction ID, gateway, and gateway_environment, there will only ever be one subscription that fits those meaning that indexing is a huge help.

Since SQL only benefits from the index that narrows down the search to the fewest number of results, in any query that includes a user ID, indexing by user ID should return a very small number of subscriptions. I doubt that indexing any other value in this table could do better when a user ID is present.

Searching for subscriptions with upcoming "next payment dates" may also be a common operation for use cases such as sending renewal notification emails, so indexing that column makes sense for those kinds of workflows.

None of the other columns seem like something that we would want to search without also looking for a user ID, so indexing them seems pointless except for niche use-cases.