### PR TITLE
NIT: @param for pmpro_getLevel() is incorrect

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2208,7 +2208,7 @@ function pmpro_getSpecificMembershipLevelForUser( $user_id, $level_id ) {
 /**
  * pmpro_getLevel() returns the level object for a level
  *
- * @param $level may be the level id or name
+ * @param int|string|object $level may be the level id or name
  *
  * @return false|object
  * Return values:


### PR DESCRIPTION
Current PHPDoc block for pmpro_getLevel() causes various code quality tools to trigger warnings/errors that are sufficiently annoying.

### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Simple fix to the @param portion of the (somewhat incomplete) documentation of pmpro_getLevel() function 

### How to test the changes in this Pull Request:

N/A

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

Tests do not cover code standards so do not apply.

### Changelog entry

BUG FIX: pmpro_getLevel() documentation nit that fixes a sufficiently annoying problem resulting inIDE errors and code standard tests failing
