### PR TITLE
Testing PHP Sessions in Site Health

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -81,6 +81,10 @@ class PMPro_Site_Health {
 					'label' => __( 'Discount Codes', 'paid-memberships-pro' ),
 					'value' => self::get_discount_codes(),
 				],
+				'pmpro-sessions'       => [
+					'label' => __( 'PHP Sessions', 'paid-memberships-pro' ),
+					'value' => self::test_sessions(),
+				],
 				'pmpro-membership-levels'    => [
 					'label' => __( 'Membership Levels', 'paid-memberships-pro' ),
 					'value' => self::get_levels(),
@@ -225,6 +229,35 @@ class PMPro_Site_Health {
 		}
 
 		return $environments[ $environment ] . ' [' . $environment . ']';
+	}
+
+	/**
+	 * Tests if PHP sessions are enabled
+	 *
+	 * @since TBD
+	 *
+	 * @return string The PHP Session data.
+	 */
+	public function test_sessions() {
+
+		$session_data = array();
+
+		$php_session_status = session_status();
+
+		if( $php_session_status ) {
+			$session_data['Session Satus'] = __( 'Active', 'paid-memberships-pro' );
+		} else {
+			$session_data['Session Satus'] = __( 'Inactive', 'paid-memberships-pro' );
+		}
+
+		if( defined( 'PANTHEON_SESSIONS_VERSION' ) ) {
+			$session_data['WP Native Sessions Plugin'] = __( 'Active', 'paid-memberships-pro' );
+		} else {
+			$session_data['WP Native Sessions Plugin'] = __( 'Not Found', 'paid-memberships-pro' );
+		}
+
+		return $session_data;
+
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We now test to see if Sessions are available and return this data in Site Health

Resolves #2117 

### How to test the changes in this Pull Request:

1. Navigate to Tools -> Site Health -> Paid Memberships Pro
2. Session data is present 

![image](https://user-images.githubusercontent.com/8989542/174983852-fd858b8a-7dfd-4b3f-903c-779070ecc3e1.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

We now test PHP sessions in our Site Health data.
