### PR TITLE
Level name is required when creating a level

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -350,7 +350,7 @@
 
 				<tr>
 					<th scope="row" valign="top"><label for="name"><?php esc_html_e('Name', 'paid-memberships-pro' );?>:</label></th>
-					<td><input name="name" type="text" value="<?php echo esc_attr($level->name);?>" class="regular-text" required="required"/></td>
+					<td><input name="name" type="text" value="<?php echo esc_attr($level->name);?>" class="regular-text" required/></td>
 				</tr>
 
 				<tr>

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -350,7 +350,7 @@
 
 				<tr>
 					<th scope="row" valign="top"><label for="name"><?php esc_html_e('Name', 'paid-memberships-pro' );?>:</label></th>
-					<td><input name="name" type="text" value="<?php echo esc_attr($level->name);?>" class="regular-text" /></td>
+					<td><input name="name" type="text" value="<?php echo esc_attr($level->name);?>" class="regular-text" required="required"/></td>
 				</tr>
 
 				<tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The level name field has been set to required using the browser's default functionality. 

Resolves #2130 

### How to test the changes in this Pull Request:

1. Create a level
2. Leave the level name field empty
3. Try and save the level
4. A default browser tooltip will show when trying to save an empty field.

![image](https://user-images.githubusercontent.com/8989542/174986142-981cd7ea-455b-4adb-8c1e-bf3d77750472.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Creating a new level requires a level name before saving
