### PR TITLE
Autofill user ID value from query param

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -544,7 +544,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 						} else { 
 							$user_id = ! empty( $_REQUEST['user'] ) ? intval( $_REQUEST['user'] ) : $order->user_id;
 							?>
-							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( intval( $user_id ) ); ?>" size="10" />
+							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( $user_id ); ?>" size="10" />
 						<?php
 						}
 					?>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -541,6 +541,9 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					<?php
 						if ( in_array( 'user_id', $read_only_fields ) && $order_id > 0 ) {
 							echo esc_html( $order->user_id );
+						} else if( ! empty( $_REQUEST['user'] ) ) { ?>
+							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( intval( $_REQUEST['user'] ) ); ?>" size="10" />
+						<?php
 						} else { ?>
 							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( $order->user_id ); ?>" size="10" />
 						<?php

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -541,11 +541,10 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					<?php
 						if ( in_array( 'user_id', $read_only_fields ) && $order_id > 0 ) {
 							echo esc_html( $order->user_id );
-						} elseif ( ! empty( $_REQUEST['user'] ) ) { ?>
-							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( intval( $_REQUEST['user'] ) ); ?>" size="10" />
-						<?php
-						} else { ?>
-							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( $order->user_id ); ?>" size="10" />
+						} else { 
+							$user_id = ! empty( $_REQUEST['user'] ) ? intval( $_REQUEST['user'] ) : $order->user_id;
+							?>
+							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( intval( $user_id ) ); ?>" size="10" />
 						<?php
 						}
 					?>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -541,7 +541,7 @@ if ( function_exists( 'pmpro_add_email_order_modal' ) ) {
 					<?php
 						if ( in_array( 'user_id', $read_only_fields ) && $order_id > 0 ) {
 							echo esc_html( $order->user_id );
-						} else if( ! empty( $_REQUEST['user'] ) ) { ?>
+						} elseif ( ! empty( $_REQUEST['user'] ) ) { ?>
 							<input id="user_id" name="user_id" type="text" value="<?php echo esc_attr( intval( $_REQUEST['user'] ) ); ?>" size="10" />
 						<?php
 						} else { ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows you to add &user=XXX where XXX is a user ID which autofills in the user ID field

Resolves #2021 

### How to test the changes in this Pull Request:

1. Add wp-admin/admin.php?page=pmpro-orders&order=-1&user=1 to your URL
2. The User ID will auto fill in the user ID field

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Support to autofill user ID in new Order page from query parameter
