### PR TITLE
Update notice removed, deprecated notice added for Better Login Reports

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -69,6 +69,10 @@ function pmpro_check_for_deprecated_add_ons() {
 		'pmpro-email-templates-addon' => array(
 			'file' => 'pmpro-email-templates.php',
 			'label' => 'Email Templates'
+		),
+		'pmpro-better-logins-report' => array(
+			'file' => 'pmpro-better-logins-report.php',
+			'label' => 'Better Logins Report'
 		)
 	);
 	

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -133,24 +133,3 @@ function pmpro_updates_notice_complete() {
 </div>
 <?php
 }
-
-/**
- * Show a notice if Better Logins Report Add On activated with version 2.0
- * This Add On has been merged into PMPro Core from 2.0
- * @since 2.0
- */
-function pmpro_show_notice_for_reports() {
-
-	if( ! function_exists( 'pmproblr_fixOptions' ) || ! current_user_can( 'activate_plugins' ) ) {
-		return;
-	}
-
-	?>
-    <div class="notice notice-warning">
-        <p><?php echo sprintf( __( 'You currently have the Better Login Reports Add On activated. This functionality has now been merged into Paid Memberships Pro. %s', 'paid-memberships-pro' ), "<br/><a href='". esc_url( admin_url( '/plugins.php?s=better%20logins%20report%20add%20on&plugin_status=inactive&pmpro-deactivate-reports=true' ) ) . "'>" . __( 'Please deactivate and remove this plugin.', 'paid-memberships-pro' ) . "</a>" ); ?></p>
-    </div>
-    <?php
-}
-if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-reports' ) {
-	add_action( 'admin_notices', 'pmpro_show_notice_for_reports', 20 );
-}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update notice for Better Logins Report Add On has been removed. Added to the deprecated notice list.

Resolves #1961 

### How to test the changes in this Pull Request:

1. Install the archived version of Better Logins Report Add On
2. The new deprecated notice will show up on the admin dashboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Better Login Reports Add On deprecated notice adjusted
