### PR TITLE
Format meta key names better.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4281,14 +4281,14 @@ function pmpro_maybe_send_wp_new_user_notification( $user_id, $level_id = null )
 }
 
 /**
- * Replace dashes and spaces with underscores.
+ * Replace all special characters with underscore, including spaces.
  * 
  * @since TBD
  * 
  * @param string $field_name The raw field name to be formatted.
  */
 function pmpro_format_field_name( $field_name ) {
-	$formatted_name = preg_replace( '/[\s-]+/', '_', $field_name );
+	$formatted_name = strtolower( preg_replace( '/[^A-Za-z0-9\-]/', '_', $field_name ) );
 	
 	/**
 	 * Filter the formatted/output field names.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4288,7 +4288,7 @@ function pmpro_maybe_send_wp_new_user_notification( $user_id, $level_id = null )
  * @param string $field_name The raw field name to be formatted.
  */
 function pmpro_format_field_name( $field_name ) {
-	$formatted_name = strtolower( preg_replace( '/[^A-Za-z0-9\-]+/', '_', $field_name ) );
+	$formatted_name = preg_replace( '/[^A-Za-z0-9\-]+/', '_', $field_name );
 	
 	/**
 	 * Filter the formatted/output field names.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4288,7 +4288,7 @@ function pmpro_maybe_send_wp_new_user_notification( $user_id, $level_id = null )
  * @param string $field_name The raw field name to be formatted.
  */
 function pmpro_format_field_name( $field_name ) {
-	$formatted_name = strtolower( preg_replace( '/[^A-Za-z0-9\-]/', '_', $field_name ) );
+	$formatted_name = strtolower( preg_replace( '/[^A-Za-z0-9\-]+/', '_', $field_name ) );
 	
 	/**
 	 * Filter the formatted/output field names.


### PR DESCRIPTION
Reworked the format meta key method to take all special characters and replace it with an underscore, as well as lowercase the field name. This should help prevent issues of naming, uppercase field keys.