### PR TITLE
Support PayPal Standard subscr_failed txt

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -224,7 +224,7 @@ if ( $txn_type == "recurring_payment" ) {
 	pmpro_ipnExit();
 }
 
-if ( $txn_type == "recurring_payment_skipped" ) {
+if ( $txn_type == 'recurring_payment_skipped' || $txn_type == 'subcr_failed' ) {
 	$last_subscription_order = new MemberOrder();
 	if ( $last_subscription_order->getLastMemberOrderBySubscriptionTransactionID( $subscr_id ) ) {
 		// the payment failed


### PR DESCRIPTION
* ENHANCEMENT: Support PayPal Standard txn_type of 'subscr_failed' for failed subs.