### PR TITLE
Bug fix total amounts showing as 0 always.

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1275,13 +1275,11 @@
 			$this->certificateamount = "";
 
 			//calculate total
-			if(!empty($this->total))
+			if ( ! empty( $this->total ) ) {
 				$total = $this->total;
-			elseif ( ! isset( $this->total ) || $this->total === '' ) {
+			} else {
 				$total = (float)$amount + (float)$tax;
 				$this->total = $total;
-			} else {
-				$total = 0;
 			}
 			
 			//these fix some warnings/notices


### PR DESCRIPTION
* BUG FIX: Minor fix for v2.9 MemberOrder total calculations always set to 0 (even for paid orders). Thanks for the help @dparker1005 

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?