### PR TITLE
Wrapping sections of the level cost on checkout page so that it can be styled with CSS

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -64,7 +64,7 @@ if ( empty( $default_gateway ) ) {
 				<?php if(count($pmpro_levels) > 1) { ?><span class="<?php echo pmpro_get_element_class( 'pmpro_checkout-h3-msg' ); ?>"><a href="<?php echo esc_url( pmpro_url( "levels" ) ); ?>"><?php esc_html_e('change', 'paid-memberships-pro' );?></a></span><?php } ?>
 			</h3>
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_checkout-fields' ); ?>">
-				<p>
+				<p class="<?php echo pmpro_get_element_class( 'pmpro_level_name_text' );?>">
 					<?php printf(__('You have selected the <strong>%s</strong> membership level.', 'paid-memberships-pro' ), $pmpro_level->name);?>
 				</p>
 
@@ -76,17 +76,37 @@ if ( empty( $default_gateway ) ) {
 					 * @param object $pmpro_level The PMPro Level object.
 					 */
 					$level_description = apply_filters('pmpro_level_description', $pmpro_level->description, $pmpro_level);
-					if(!empty($level_description))
-						echo $level_description;
+					if ( ! empty( $level_description ) ) { ?>
+						<div class="<?php echo pmpro_get_element_class( 'pmpro_level_description_text' );?>">
+							<?php echo $level_description; ?>
+						</div>
+						<?php
+					}
 				?>
 
 				<div id="pmpro_level_cost">
 					<?php if($discount_code && pmpro_checkDiscountCode($discount_code)) { ?>
 						<?php printf(__('<p class="' . pmpro_get_element_class( 'pmpro_level_discount_applied' ) . '">The <strong>%s</strong> code has been applied to your order.</p>', 'paid-memberships-pro' ), $discount_code);?>
 					<?php } ?>
-					<?php echo wpautop(pmpro_getLevelCost($pmpro_level)); ?>
-					<?php echo wpautop(pmpro_getLevelExpiration($pmpro_level)); ?>
-				</div>
+
+					<?php
+						$level_cost_text = pmpro_getLevelCost( $pmpro_level );
+						if ( ! empty( $level_cost_text ) ) { ?>
+							<div class="<?php echo pmpro_get_element_class( 'pmpro_level_cost_text' );?>">
+								<?php echo wpautop( $level_cost_text ); ?>
+							</div>
+						<?php }
+					?>
+
+					<?php
+						$level_expiration_text = pmpro_getLevelExpiration( $pmpro_level );
+						if ( ! empty( $level_expiration_text ) ) { ?>
+							<div class="<?php echo pmpro_get_element_class( 'pmpro_level_expiration_text' );?>">
+								<?php echo wpautop( $level_expiration_text ); ?>
+							</div>
+						<?php }
+					?>
+				</div> <!-- end #pmpro_level_cost -->
 
 				<?php do_action("pmpro_checkout_after_level_cost"); ?>
 

--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -135,21 +135,34 @@
 			<?php
 			$html = [];
 
-			$html[] = wp_kses_post( sprintf( __( 'The <strong>%s</strong> code has been applied to your order.', 'paid-memberships-pro' ), $discount_code ) );
+			$html[] = '<p class="' . pmpro_get_element_class( 'pmpro_level_discount_applied' ) . '">' . wp_kses_post( sprintf( __( 'The <strong>%s</strong> code has been applied to your order.', 'paid-memberships-pro' ), $discount_code ) ) . '</div>';
 
 			if ( count( $code_levels ) <= 1 ) {
 				$code_level = empty( $code_levels ) ? null : $code_levels[0];
 
-				$html[] = pmpro_getLevelCost( $code_level );
-				$html[] = pmpro_getLevelExpiration( $code_level );
+				$level_cost_text = pmpro_getLevelCost( $code_level );
+				if ( ! empty( $level_cost_text ) ) {
+					$html[] = '<div class="' . pmpro_get_element_class( 'pmpro_level_cost_text' ) . '">' . wpautop( $level_cost_text ) . '</div>';
+				}
+
+				$level_expiration_text = pmpro_getLevelExpiration( $code_level );
+				if ( ! empty( $level_expiration_text ) ) {
+					$html[] = '<div class="' . pmpro_get_element_class( 'pmpro_level_expiration_text' ) . '">' . wpautop( $level_expiration_text ) . '</div>';
+				}
 			} else {
-				$html[] = pmpro_getLevelsCost( $code_levels );
-				$html[] = pmpro_getLevelsExpiration( $code_levels );
+				$levels_cost_text = pmpro_getLevelsCost( $code_levels );
+				if ( ! empty( $levels_cost_text ) ) {
+					$html[] = '<div class="' . pmpro_get_element_class( 'pmpro_level_cost_text' ) . '">' . wpautop( $levels_cost_text ) . '</div>';
+				}
+
+				$levels_expiration_text = pmpro_getLevelsExpiration( $code_levels );
+				if ( ! empty( $levels_expiration_text ) ) {
+					$html[] = '<div class="' . pmpro_get_element_class( 'pmpro_level_expiration_text' ) . '">' . wpautop( $levels_expiration_text ) . '</div>';
+				}
 			}
 
 			$html = array_filter( $html );
 			$html = implode( "\n\n", $html );
-			$html = wpautop( $html );
 			?>
 				jQuery('#pmpro_level_cost').html( <?php echo wp_json_encode( wp_kses_post( $html ) ); ?> );
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The level information we output on the checkout page as several sections including description, price, expiration, and discount code.  These were difficult to target with CSS because they don't have unique selectors that break apart the price from expiration, etc.

This PR wraps each price component on the checkout page in a div so CSS can style these sections independently.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Improved frontend level cost details output on the checkout page with classes for better design control.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
