### PR TITLE
Now checking if actually on a checkout form before preventing default

### DIFF
--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -68,6 +68,11 @@ jQuery( document ).ready( function( $ ) {
 		pmpro_require_billing = pmproStripe.pmpro_require_billing;
 	}
 	$( '.pmpro_form' ).submit( function( event ) {
+		// If there is no "level" input, then this is not a checkout form. Return.
+		if ( $( 'input[name="level"]' ).length === 0 ) {
+			return;
+		}
+
 		var name, address;
 
 		// Prevent the form from submitting with the default action.


### PR DESCRIPTION
If pmpro-stripe.js is loaded on a page with a non-checkout PMPro form, it would prevent submit buttons from working. This could often be the case when using this code recipe which sets up a checkout form on every page:
https://www.paidmembershipspro.com/process-membership-checkout-in-a-modal-or-popover-window/

This change tries to minimize this issue by only preventing default if a checkout form was submitted. The criteria for checking this is currently if there is a "level" input in the form, but we can revise this later if necessary if there are additional cases where issues come up.