### PR TITLE
Fixing warning when page_msg is empty; Removing unused output of message on single edit

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -171,7 +171,7 @@
 			$msgt .= ' <strong class="red">' . sprintf( __( 'WARNING: A level was set with both a recurring billing amount and an expiration date. You only need to set one of these unless you really want this membership to expire after a specific time period. For more information, <a target="_blank" rel="nofollow noopener" href="%s">see our post here</a>.', 'paid-memberships-pro' ), 'https://www.paidmembershipspro.com/important-notes-on-recurring-billing-and-expiration-dates-for-membership-levels/?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=blog&utm_content=important-notes-on-recurring-billing-and-expiration-dates-for-membership-levels' ) . '</strong>';
 
 			// turn success to errors
-			if( $page_msg > 0 ) {
+			if ( ! empty( $page_msg ) && $page_msg > 0 ) {
 				$page_msg = 0 - $page_msg;
 			}
 		}
@@ -1104,15 +1104,6 @@
 		<?php if(empty($_REQUEST['s']) && count($reordered_levels) > 1) { ?>
 		    <p><?php esc_html_e('Drag and drop membership levels to reorder them on the Levels page.', 'paid-memberships-pro' ); ?></p>
 	    <?php } ?>
-
-		<?php
-			// Show the settings page message.
-			if ( ! empty( $page_msg ) ) { ?>
-				<div class="inline notice notice-large <?php echo $page_msg > 0 ? 'notice-success' : 'notice-error'; ?>">
-					<p><?php echo $page_msgt; ?></p>
-				</div>
-			<?php }
-		?>
 
 	    <?php
 	    	//going to capture the output of this table so we can filter it


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This update clears a warning when $page_msg is empty.

I also removed the output of the unique message on single edit for membership level. The idea was that we'd show page-specific messages separate of general plugin status/settings alerts. This needs more thought and development.
