### PR TITLE
Fixes fatal error when activating Register Helper

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -115,7 +115,7 @@ function pmpro_register_helper_deprecated() {
 		}
 	}
 }
-add_action( 'plugins_loaded', 'pmpro_register_helper_deprecated', 20 );
+add_action( 'wp', 'pmpro_register_helper_deprecated', 20 );
 
 // Check if installed, deactivate it and show a notice now.
 function pmpro_check_for_deprecated_add_ons() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Runs the deprecated functions for Register Helper later (changes it from plugins_loaded to wp)

### How to test the changes in this Pull Request:

1. Activate PMPro
2. Try and activate Register Helper
3. No fatal errors should occur on activation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes a fatal error when activating Register Helper after PMPro
