### PR TITLE
The property of the email object we want to set is ->email.

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -284,7 +284,7 @@ function pmpro_email_templates_send_test() {
 
 	//setup test email
 	$test_email = new PMProEmail();
-	$test_email->to = sanitize_email( $_REQUEST['email'] );
+	$test_email->email = sanitize_email( $_REQUEST['email'] );
 	$test_email->template = sanitize_text_field( str_replace('email_', '', $_REQUEST['template']) );
 
 	//add filter to change recipient


### PR DESCRIPTION
We are filtering the `$email->email` value later in its own callback, so it doesn't really matter, but it's possible other stuff hooked in is looking for the email.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Activate PMPro
2. Go to Settings -> Email Templates
3. Choose an email template.
4. Change the test email address to something you'll notice.
5. Send the test email.

You will get the email. It will have been sent to the to address you set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Fixed test email setup to set the $email->email property properly.