### PR TITLE
Fix "Unused local variable 'name_parts'"

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -1026,8 +1026,8 @@ function pmpro_stripe_webhook_populate_order_from_payment( $order, $payment_meth
 	$order->billing->phone = empty( $payment_method->billing_details->phone ) ? '' : $payment_method->billing_details->phone;
 
 	$name_parts = empty( $payment_method->billing_details->name ) ? [] : pnp_split_full_name( $payment_method->billing_details->name );
-	$order->FirstName = empty( $nameparts['fname'] ) ? '' : $nameparts['fname'];
-	$order->LastName = empty( $nameparts['lname'] ) ? '' : $nameparts['lname'];
+	$order->FirstName = empty( $name_parts['fname'] ) ? '' : $name_parts['fname'];
+	$order->LastName = empty( $name_parts['lname'] ) ? '' : $name_parts['lname'];
 	$order->Email = $wpdb->get_var("SELECT user_email FROM $wpdb->users WHERE ID = '" . esc_sql( $order->user_id ) . "' LIMIT 1");
 	$order->Address1 = $order->billing->street;
 	$order->City = $order->billing->city;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Found an unused variable, fixed it.

### How to test the changes in this Pull Request:

1. Create a stripe order
2. Trigger a webhook on it in order to run the func `pmpro_stripe_webhook_populate_order_from_payment`
3. Now check the order details (first/last name)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
