### PR TITLE
Fix/error when activating Register Helper

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -59,11 +59,8 @@ add_action( 'init', 'pmpro_admin_init_redirect_old_menu_items' );
  * Old Register Helper functions and classes.
  */
 function pmpro_register_helper_deprecated() {
-	// Activated plugins run after plugins_loaded. Bail to be safe.
-	// IMPORTANT NOTE: This works when activating RH,
-	// but fails if you have RH custom code and activate a different plugin.
-	// We need to keep RH from ever being activated.
-	if ( pmpro_activating_plugin() ) {
+	// Activated plugins run after plugins_loaded. Bail to be safe.	
+	if ( pmpro_activating_plugin( 'pmpro-register-helper/pmpro-register-helper.php' ) ) {
 		return;
 	}
 	

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -59,6 +59,14 @@ add_action( 'init', 'pmpro_admin_init_redirect_old_menu_items' );
  * Old Register Helper functions and classes.
  */
 function pmpro_register_helper_deprecated() {
+	// Activated plugins run after plugins_loaded. Bail to be safe.
+	// IMPORTANT NOTE: This works when activating RH,
+	// but fails if you have RH custom code and activate a different plugin.
+	// We need to keep RH from ever being activated.
+	if ( pmpro_activating_plugin() ) {
+		return;
+	}
+	
 	// PMProRH_Field class
 	if ( ! class_exists( 'PMProRH_Field' ) ) {
 		class PMProRH_Field extends PMPro_Field {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4302,3 +4302,40 @@ function pmpro_format_field_name( $field_name ) {
 
 	return $formatted_name;
 }
+
+/**
+ * Are we activating a plugin?
+ * @since 2.9.1
+ * @param string $plugin A specific plugin to check for (optional).
+ * @return bool True if we are activating a plugin, otherwise false.
+ */
+function pmpro_activating_plugin( $plugin = null ) {
+	if ( ! is_admin() ) {
+		return false;
+	}
+	
+	if ( empty( $_REQUEST['action'] ) ) {
+		return false;	
+	}
+	
+	if ( $_REQUEST['action'] !== 'activate'
+		&& $_REQUEST['action'] !== 'activate-selected' ) {
+		return false;
+	}
+	
+	// Not checking for a specific plugin, and activating something.
+	if ( empty( $plugin ) ) {
+		return true;
+	}
+	
+	// Check if the specified plugin isn't one being activated.
+	if ( ! empty( $_REQUEST['plugin'] ) && $_REQUEST['plugin'] !== $plugin ) {
+		return false;
+	}
+	if ( ! empty( $_REQUEST['checked'] ) && ! in_array( $plugin, (array)$_REQUEST['checked'] ) ) {
+		return false;
+	}
+	
+	// Must be activating the $plugin specified.
+	return true;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The pmpro_register_helper_deprecated() function in includes/deprecated.php is creating some functions and classes that don't exist when the old Register Helper plugin is deactivated. This will make sure that sites using old custom code and gists that use the old RH names of things continue to work.

However, when activating Register Helper, PMPro puts the functions in place, but then RH throw an error when trying to define those functions on activation.

This update adds a new function pmpro_activating_plugin() which can be used to tell if a specific plugin (or any plugin) is being activated. So when activating RH, we don't create the functions to swap.

We should consider an update to RH to avoid creating these functions when the core PMPro ones exist. But also, people shouldn't be using Register Helper anymore. We just don't want it to blow up a site on activation.

To allow folks to delete RH for good, we need to create a new plugin to support the restrict by email domain/username features in RH. Everything else can be done by another plugin (core PMPro, sign up short code, directory, and fields).

### How to test the changes in this Pull Request:

1. Activate PMPro.
2. Deactivate Register Helper.
3. Activate Register Helper.

There should be no error. Also test activating and deactivating different combinations of PMPro, RH, and other plugins.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed fatal error that occurred when activating the Register Helper add on.
