### PR TITLE
Added unset magic method for MemberOrder

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -376,6 +376,21 @@
 			return property_exists( $this, $property ) || isset( $this->other_properties[ $property ] );
 	
 		}
+
+		/**
+		 * Unset Magic Method.
+		 *
+		 * @since TBD
+		 * 
+		 * @param string $property The property we want to unset.
+		 */
+		public function __unset( $property ) {
+			if ( property_exists( $this, $property ) ) {
+				unset( $this->{$property} );
+			} else {
+				unset( $this->other_properties[ $property ] );
+			}
+		}
 		
 		/**
 		 * Get a specific order by ID, code, or an array of arguments


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-mxmberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added unset magic method for MemberOrder. Resolves fatal error at checkout with PMPro Zapier.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
