### PR TITLE
Filtering data used in emails to avoid URLs that would be made clicka…

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -595,3 +595,39 @@ function pmpro_email_templates_get_template_body($template) {
 
 	return $body;
 }
+
+/**
+ * Make sure none of the template vars used in our default emails
+ * look like URLs that make_clickable will convert.
+ * This could be a vector of attack by agents spamming the checkout page.
+ */
+function pmpro_sanitize_email_data( $data ) {	
+	$keys_to_sanitize = array(
+		'name',
+		'display_name',
+		'user_login',
+		'billing_name',
+		'billing_street',
+		'billing_city',
+		'billing_state',
+		'billing_zip',
+		'billing_country',
+		'billing_phone',
+		'cardtype',
+		'account_number',
+		'expirationmonth',
+		'expirationyear',
+		'billing_address'
+	);
+	
+	foreach( $keys_to_sanitize as $key ) {
+		if ( isset( $data[$key] ) ) {
+			$data[$key] = str_replace( 'www.', 'www ', $data[$key] );
+			$data[$key] = str_replace( 'ftp.', 'ftp ', $data[$key] );
+			$data[$key] = str_replace( '://', ': ', $data[$key] );
+		}
+	}
+	
+	return $data;
+}
+add_filter( 'pmpro_email_data', 'pmpro_sanitize_email_data' );


### PR DESCRIPTION
…ble.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The emails that PMPro sends out are passed through the `make_clickable()` function, which turns URL-looking things into clickable a tags. This is good for the login URL and other URLs we want in the email, but it also means that user submitted data, like the display name, or billing address, could be interpreted as a URL and sent to someone's email address as a clickable URL.

So, in effect, this allows someone to send arbitrary clickable URLs to anyone's email address via a PMPro checkout page.

There were a couple of fixes that were considered, and one included in this PR that we are ready to push out now.

We considered filtering fields like the username, first and last name fields to make sure that URL-looking things aren't submitted. The new user form in the WP dashboard and user-related functions don't do any similar filter now. So we didn't at this time want to add these kinds of new restrictions to the user_login or name fields. For example, even when run through the `sanitize_user()` function, a user_login like 'www.yourdomain.com' is still allowed.

We considered removing the make_clickable calls in the emails. We didn't want to remove the functionality this adds, and also many other plugins and WP setups do similar make_clickable calls on things that are emailed. So even if we removed our own calls to make_clickable, quite a few sites would still make these URLs clickable.

What we ended up doing for now is filtering the $data array that is part of the PMProEmail class. These are the values that are swapped into the email templates, e.g. when a !!billing_address!! tag is found. We built an array of the default values that are included in these emails which could be user submitted, and run them through a couple filters to swap things out to make these URLs unclickable. You may still find something like yoursite.com?maliciouspayload=xyz in the emails sent, but they at least are not clickable links in folks email clients. They will have to copy/paste them themselves.

We should consider ways to also filter fields that are added via the user fields settings. Some of these fields might actually be URLs (admins should be wary clicking on user submitted URLs), and some data programatically added by custom code could be URLs that sites will want made clickable. But others should be sanitized.

Another thing to consider is validating email addresses before sending any other emails, including emails with user submitted data. That kind of update would require quite a bit more effort, but is something we are considering for both the pmpro-email-confirmation add on and also for the core PMPro plugin, at least as an option of some sort. We will continue to design that out.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set up a paid level on your site.
2. Checkout for that level as a new user and enter something like "www.yoursite.com" or "https://yoursite.com" as your name, billing address, etc.
3. The confirmation email sent by default should NOT have clickable links in them for the URLs you entered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Filtering the data array used in emails to make sure none of the default template vars are made "clickable", which could be a vector of attack by agents spamming the checkout page. (Thanks, Tayyab Sial)
