### PR TITLE
BUG FIX/ENHANCEMENT: When saving user fields, now making sure that th…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 == Changelog ==
 = 2.9.2 - 2022-08-09 =
+* BUG FIX/ENHANCEMENT: When saving user fields, now making sure that the group name is not blank and unique. Blank or duplicate group names could cause other issues, e.g. with required fields or fields being shown multiple times at checkout. #2187 (@ideadude)
 * BUG FIX: Fixed issue where user fields set as "required" weren't being styled as required on the checkout page. #2180 (@ipokkel)
 
 = 2.9.1 - 2022-07-28 =

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -441,9 +441,25 @@ function pmpro_userfields_prep_click_events() {
 		window.onbeforeunload = null;
 
         let field_groups = [];
+        let group_names = [];
+        let default_group_name = 'More Information';
 
 		jQuery('.pmpro_userfield-group').each(function(index, value) {
             let group_name = jQuery(this).find('input[name=pmpro_userfields_group_name]').val();
+            
+            // Make sure name is not blank.
+            if ( group_name.length === 0 ) {
+                group_name = default_group_name;
+            }
+            // Make sure name is unique.
+            let count = 1;
+            while ( group_names.includes( group_name ) ) {
+                count++;
+                group_name = group_name.replace( /\(0-9*\)/, '' );
+                group_name = group_name + ' (' + String( count ) + ')';                
+            }
+            group_names.push( group_name );
+            
             let group_checkout = jQuery(this).find('select[name=pmpro_userfields_group_checkout]').val();
             let group_profile = jQuery(this).find('select[name=pmpro_userfields_group_profile]').val();
             let group_description = jQuery(this).find('textarea[name=pmpro_userfields_group_description]').val();


### PR DESCRIPTION
…e group name is not blank and unique. Blank or duplicate group names could cause other issues, e.g. with required fields or fields being shown multiple times at checkout. #2187 (@ideadude)

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves 2187

### How to test the changes in this Pull Request:

1. Create a new group for user fields. Leave the group name field blank.
2. Create another group. Leave the group name field blank or set to the same as another group.
3. Click the "save all settings" button.
4. The blank groups should default to a "More Information" label/name. Any duplicate group names should have a (2) or (3) etc appended to the name to make it unique.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX/ENHANCEMENT: When saving user fields, now making sure that the group name is not blank and unique. Blank or duplicate group names could cause other issues, e.g. with required fields or fields being shown multiple times at checkout. #2187 (@ideadude)
