### PR TITLE
BUG FIX/ENHANCEMENT: Now correctly deprecating the pmprorh_section_he…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 == Changelog ==
 = 2.9.2 - 2022-08-09 =
+* BUG FIX/ENHANCEMENT: Now correctly deprecating the pmprorh_section_header() function. We accidentally had it reversed and throwing a warning when using the new pmpro_default_field_group_label() function. (@kimcoleman)
 * BUG FIX: Fixed issue where user fields set as "required" weren't being styled as required on the checkout page. #2180 (@ipokkel)
 
 = 2.9.1 - 2022-07-28 =

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -11,9 +11,10 @@
 function pmpro_init_check_for_deprecated_filters() {
 	global $wp_filter;
 	
+	// NOTE: Array is mapped new filter => old filter.
 	$pmpro_map_deprecated_filters = array(
-		'pmpro_getfile_extension_blocklist'    => 'pmpro_getfile_extension_blacklist',
-		'pmprorh_section_header'			   => 'pmpro_default_field_group_label',
+		'pmpro_getfile_extension_blocklist' => 'pmpro_getfile_extension_blacklist',
+		'pmpro_default_field_group_label'   => 'pmprorh_section_header',
 	);
 	
 	foreach ( $pmpro_map_deprecated_filters as $new => $old ) {


### PR DESCRIPTION
…ader() function. We accidentally had it reversed and throwing a warning when using the new pmpro_default_field_group_label() function. (@kimcoleman)


### Changelog entry

> BUG FIX/ENHANCEMENT: Now correctly deprecating the pmprorh_section_header() function. We accidentally had it reversed and throwing a warning when using the new pmpro_default_field_group_label() function. (@kimcoleman)
