### PR TITLE
BUG FIX: Fixed issues where pmprorh_sanitize was being called instead…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 = 2.9.2 - 2022-08-09 =
 * BUG FIX: Fixed issue where user fields set as "required" weren't being styled as required on the checkout page. #2180 (@ipokkel)
+* BUG FIX: Fixed issues where pmprorh_sanitize was being called instead of the new pmpro_sanitize, causing issues with date fields and others at checkout. #2182 
 
 = 2.9.1 - 2022-07-28 =
 * ENHANCEMENT: Enhanced doc blocks for some functions in includes/functions.php.

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -618,7 +618,7 @@ class PMPro_Field {
     {
         if ( isset( $this->sanitize ) && true === $this->sanitize ) {
 
-	        $value = pmprorh_sanitize( $value, $this );
+	        $value = pmpro_sanitize( $value, $this );
         }
 
     	$meta_key = str_replace("pmprorhprefix_", "", $name);

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -126,6 +126,13 @@ function pmpro_register_helper_deprecated() {
 			return pmpro_array_end( $array );
 		}
 	}
+	
+	// pmprorh_sanitize function
+	if ( ! function_exists( 'pmprorh_sanitize' ) ) {
+		function pmprorh_sanitize( $value, $field = null  ) {
+			return pmpro_sanitize( $value, $field );
+		}
+	}
 }
 add_action( 'plugins_loaded', 'pmpro_register_helper_deprecated', 20 );
 


### PR DESCRIPTION
… of the new pmpro_sanitize, causing issues with date fields and others at checkout. #2182

Also added pmprorh_sanitize as a deprecated function.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves 2182

### How to test the changes in this Pull Request:

1. Add a date field via user fields settings.
2. Don't have the separate Register Helper plugin active.
3. Checkout.
4. No more fatal error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issues where pmprorh_sanitize was being called instead of the new pmpro_sanitize, causing issues with date fields and others at checkout. #2182 
