### PR TITLE
BUG FIX: Now showing the new level templates even if you click on the…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 = 2.9.2 - 2022-08-09 =
 * BUG FIX: Fixed issue where user fields set as "required" weren't being styled as required on the checkout page. #2180 (@ipokkel)
+* BUG FIX: Now showing the new level templates even if you click on the link in the dashboard or on a fresh install's levels page. #2181 (@kimwhite)
 
 = 2.9.1 - 2022-07-28 =
 * ENHANCEMENT: Enhanced doc blocks for some functions in includes/functions.php.

--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -110,7 +110,7 @@ function pmpro_dashboard_welcome_callback() { ?>
     			<?php if ( current_user_can( 'pmpro_membershiplevels' ) ) { ?>
     				<li>
     					<?php if ( empty( $pmpro_level_ready ) ) { ?>
-    						<a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels&edit=-1' ) );?>"><i class="dashicons dashicons-admin-users"></i> <?php esc_html_e( 'Create a Membership Level', 'paid-memberships-pro' ); ?></a>
+    						<a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels&showpopup=1' ) );?>"><i class="dashicons dashicons-admin-users"></i> <?php esc_html_e( 'Create a Membership Level', 'paid-memberships-pro' ); ?></a>
     					<?php } else { ?>
     						<a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) );?>"><i class="dashicons dashicons-admin-users"></i> <?php esc_html_e( 'View Membership Levels', 'paid-memberships-pro' ); ?></a>
     					<?php } ?>

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1035,7 +1035,7 @@
 		<?php if( empty( $s ) && count( $reordered_levels ) === 0 ) { ?>
 			<div class="pmpro-new-install">
 				<h2><?php esc_html_e( 'No Membership Levels Found', 'paid-memberships-pro' ); ?></h2>
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels&edit=-1' ) ); ?>" class="button-primary"><?php esc_html_e( 'Create a Membership Level', 'paid-memberships-pro' ); ?></a>
+				<a href="javascript:addLevel();" class="button-primary"><?php esc_html_e( 'Create a Membership Level', 'paid-memberships-pro' ); ?></a>
 				<a href="https://www.paidmembershipspro.com/documentation/initial-plugin-setup/step-1-add-new-membership-level/?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=documentation&utm_content=step-1-add-new-membership-level" target="_blank" rel="nofollow noopener" class="button"><?php esc_html_e( 'Video: Membership Levels', 'paid-memberships-pro' ); ?></a>
 			</div> <!-- end pmpro-new-install -->
 		<?php } else { ?>
@@ -1278,10 +1278,11 @@
 			jQuery('.pmproPopupCloseButton').click(function() {
 				jQuery('.pmpro-popup-overlay').hide();
 			});
+			<?php if( ! empty( $_REQUEST['showpopup'] ) ) { ?>addLevel();<?php } ?>
 		} );
 		function addLevel() {
 			jQuery('.pmpro-popup-overlay').show();
-		}
+		}		
 	</script>
 	<div id="pmpro-popup" class="pmpro-popup-overlay">
 		<span class="pmpro-popup-helper"></span>


### PR DESCRIPTION
… link in the dashboard or on a fresh install's levels page. #2181 (@kimwhite)

The Create New Level link that shows when there are no levels, now calls the addLevel() JS function, which will show the template options.

Also, if you pass "showpopup" as a URL parameter to the Settings > Levels page, it will show the popup on load. We use this param in the Create New Level link shown on the dashboard now.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves 2181.

### How to test the changes in this Pull Request:

1. Install PMPro fressh with no levels.
2. Click the Create New Level link from the dashboard or the Memberships > Settings page.
3. The new level template popover should show up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Now showing the new level templates even if you click on the link in the dashboard or on a fresh install's levels page. #2181 (@kimwhite)
