### PR TITLE
IPN: Logs the "ERROR" message only if needed. Otherwise just log a meaningful message

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -274,11 +274,11 @@ if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_
 			//if the initial payment failed, cancel with status error instead of cancelled
 			if ( $initial_payment_status === "failed" ) {
 				$last_subscription_order->updateStatus('error');
+				ipnlog( "Errored membership without user. Subscription transaction id = " . $recurring_payment_id . "." );
 			} else {
 				$last_subscription_order->updateStatus('cancelled');
+				ipnlog( "ERROR: Could not cancel membership. No user attached to order #" . $last_subscription_order->id . " with subscription transaction id = " . $recurring_payment_id . "." );
 			}
-
-			ipnlog( "ERROR: Could not cancel membership. No user attached to order #" . $last_subscription_order->id . " with subscription transaction id = " . $recurring_payment_id . "." );
 		} else {
 			/*
 				We want to make sure this is a cancel originating from PayPal and not one already handled by PMPro.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Was investigating these messages in my logs:

> ERROR: Could not cancel membership. No user attached to order #...

Then noticed it was not handling a cancellation; instead it was logging an error creating a subscription profile.

We can have this more meaningful error in that case (since we are not creating the user if the initial subscription fails for a guest, it's intended to receive an ipn request for an initial failure without an user associated).
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
