### PR TITLE
Now creating user before payment at checkout

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3662,7 +3662,7 @@ function pmpro_show_discount_code() {
 	global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_levels, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user, $pmpro_requirebilling, $tospage, $username, $password, $password2, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear, $pmpro_states, $recaptcha, $recaptcha_privatekey, $CVV;
 
 	$morder                   = new MemberOrder();
-	$morder->user_id		  = $current_user->ID;
+	$morder->user_id          = $current_user->ID;
 	$morder->membership_id    = $pmpro_level->id;
 	$morder->membership_name  = $pmpro_level->name;
 	$morder->discount_code    = $discount_code;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3662,6 +3662,7 @@ function pmpro_show_discount_code() {
 	global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_levels, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user, $pmpro_requirebilling, $tospage, $username, $password, $password2, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear, $pmpro_states, $recaptcha, $recaptcha_privatekey, $CVV;
 
 	$morder                   = new MemberOrder();
+	$morder->user_id		  = $current_user->ID;
 	$morder->membership_id    = $pmpro_level->id;
 	$morder->membership_name  = $pmpro_level->name;
 	$morder->discount_code    = $discount_code;

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -441,7 +441,8 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 
 				//first name
 				if ( ! empty( $_REQUEST['first_name'] ) ) {
-					$first_name = $_REQUEST['first_name'];
+					$first_name = sanitize_text_field( $_REQUEST['first_name'] );
+
 				} else {
 					$first_name = $bfirstname;
 				}

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -448,7 +448,8 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 				}
 				//last name
 				if ( ! empty( $_REQUEST['last_name'] ) ) {
-					$last_name = $_REQUEST['last_name'];
+					$last_name = sanitize_text_field( $_REQUEST['last_name'] );
+
 				} else {
 					$last_name = $blastname;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
PMPro currently waits until after a payment is successful to create a WP user, but this can result in checkout issues that are often plugin conflicts that are difficult to debug (see [troubleshooting article here](https://www.paidmembershipspro.com/troubleshooting-guide-users-not-created-at-checkout/)). Furthermore, not having a WP user set up causes orders to be created in `token` status without an associated user when an offsite gateway, which can be confusing to customers.

Instead, this PR moves the user creation step to before the payment collection step to avoid these kinds of issues entirely.

Main downside is that some websites don't want to have users created unless they have actually paid, so we need to decide if it is more important to keep things as-is for those users or to avoid checkout issues for others.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
