### PR TITLE
Removing redundant settings of $current_user->membership_level

### DIFF
--- a/preheaders/account.php
+++ b/preheaders/account.php
@@ -10,11 +10,6 @@ if ( ! is_user_logged_in() ) {
 	}
 }
 
-// Make sure the membership level is set for the user.
-if( $current_user->ID ) {
-    $current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );
-}
-
 // Process the msg param.
 if ( isset($_REQUEST['msg'] ) ) {
     if ( $_REQUEST['msg'] == 1 ) {

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -7,9 +7,6 @@ if ( ! is_user_logged_in() ) {
 	$billing_url = pmpro_url( 'billing' );
     wp_redirect( add_query_arg( 'redirect_to', urlencode( $billing_url ), pmpro_login_url() ) );
     exit;
-} else {
-    // Get the current user's membership level. 
-    $current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );
 }
 
 //need to be secure?

--- a/preheaders/cancel.php
+++ b/preheaders/cancel.php
@@ -25,8 +25,6 @@
 		wp_redirect( add_query_arg( 'redirect_to', urlencode( $redirect ), pmpro_login_url() ) );
 		exit;
 	} else {
-		// Get the membership level for the current user.
-		$current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID) ;
 		// If user has no membership level, redirect to levels page.
 		if ( ! isset( $current_user->membership_level->ID ) ) {
 			wp_redirect( pmpro_url( 'levels' ) );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -4,11 +4,6 @@ global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pm
 // we are on the checkout page
 add_filter( 'pmpro_is_checkout', '__return_true' );
 
-//make sure we know current user's membership level
-if ( $current_user->ID ) {
-	$current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );
-}
-
 //this var stores fields with errors so we can make them red on the frontend
 $pmpro_error_fields = array();
 

--- a/preheaders/confirmation.php
+++ b/preheaders/confirmation.php
@@ -13,11 +13,6 @@ if ( ! is_user_logged_in() ) {
 	exit;
 }
 
-// Get the membership level for the current user.
-if ( $current_user->ID ) {
-	$current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
-}
-
 // Get the most recent invoice for the current user.
 $pmpro_invoice = new MemberOrder();
 $pmpro_invoice->getLastMemberOrder( $current_user->ID, apply_filters( 'pmpro_confirmation_order_status', array( 'success', 'pending', 'token' ) ) );

--- a/preheaders/invoice.php
+++ b/preheaders/invoice.php
@@ -2,10 +2,6 @@
 
 global $current_user, $pmpro_invoice;
 
-if ( $current_user->ID ) {
-	$current_user->membership_level = pmpro_getMembershipLevelForUser( $current_user->ID );
-}
-
 //get invoice from DB
 if ( ! empty( $_REQUEST['invoice'] ) ) {
 	$invoice_code = sanitize_text_field( $_REQUEST['invoice'] );

--- a/preheaders/levels.php
+++ b/preheaders/levels.php
@@ -2,9 +2,6 @@
 
 global $current_user;
 
-if($current_user->ID)
-    $current_user->membership_level = pmpro_getMembershipLevelForUser($current_user->ID);
-
 //is there a default level to redirect to?
 if (defined("PMPRO_DEFAULT_LEVEL"))
     $default_level = intval(PMPRO_DEFAULT_LEVEL);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In July 2014, this code was added to every preheader to allow PMPro pages to retrieve a user's membership level using the global `$current_user->membership_level`:
https://github.com/strangerstudios/paid-memberships-pro/commit/11f0fa711d07ff88cce1499ea7e36a0cef9d6326

In August 2014, this process was abstracted to instead set `$current_user->membership_level` on every page load:
https://github.com/strangerstudios/paid-memberships-pro/commit/b33c0fdaa303d6ae28de82c3a21385a04a03b1e3

Since that property is now set on every page load, it should no longer be necessary to set it in preheaders.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
