### PR TITLE
Added MMPU compatibility for some crons

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -958,7 +958,7 @@
 			if ( empty( $membership_id ) ) {
 				$membership_level = pmpro_getMembershipLevelForUser($user->ID);
 			} else {
-				$membership_level = pmpro_getMembershipLevelForUser($user->ID, $membership_id);
+				$membership_level = pmpro_getSpecificMembershipLevelForUser($user->ID, $membership_id);
 			}
 
 						
@@ -1021,7 +1021,7 @@
 			if ( empty( $membership_id ) ) {
 				$membership_level = pmpro_getMembershipLevelForUser($user->ID);
 			} else {
-				$membership_level = pmpro_getMembershipLevelForUser($user->ID, $membership_id);
+				$membership_level = pmpro_getSpecificMembershipLevelForUser($user->ID, $membership_id);
 			}
 						
 			$this->email = $user->user_email;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added MMPU compatibility for membership expiration and expiration warning crons.

Also considered updating the credit card expiration warning and trial ending crons, but CC expiration really needs subscriptions table to be done nicely and the trial ending cron hasn't been running since 2013 and should maybe be deprecated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
