### PR TITLE
Marking "trial ending" cron as deprecated

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -947,6 +947,8 @@
 		
 		function sendTrialEndingEmail( $user = NULL, $membership_id = NULL )
 		{
+			_deprecated_function( 'sendTrialEndingEmail', 'TBD' );
+
 			global $current_user, $wpdb;
 			if(!$user)
 				$user = $current_user;

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -220,10 +220,14 @@ function pmpro_cron_credit_card_expiring_warnings()
 	Commented out as of version 1.7.2 since this caused issues on some sites
 	and doesn't take into account the many "custom trial" solutions that are
 	in the wild (e.g. some trials are actually a delay of the subscription start date)
+
+	@deprecated TBD
 */
 //add_action("pmpro_cron_trial_ending_warnings", "pmpro_cron_trial_ending_warnings");
 function pmpro_cron_trial_ending_warnings()
 {
+	_deprecated_function( 'pmpro_cron_trial_ending_warnings', 'TBD' );
+
 	global $wpdb;
 
 	//clean up errors in the memberships_users table that could cause problems


### PR DESCRIPTION
The "trial ending" cron has been disabled since 2013. Marking it as deprecated now so that it can be removed in a future version.