### PR TITLE
PR2 - Don't cancel subscriptions when deleting a level

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1142,7 +1142,7 @@
 						$delete_text = esc_html(
 							sprintf(
 								// translators: %s is the Level Name.
-								__( 'Are you sure you want to delete membership level %s? All subscriptions will be cancelled.', 'paid-memberships-pro' ),
+								__( 'Are you sure you want to delete membership level %s? Any subscriptions or third-party connections with a members account will remain active.', 'paid-memberships-pro' ),
 								$level->name
 							)
 						);

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1142,7 +1142,7 @@
 						$delete_text = esc_html(
 							sprintf(
 								// translators: %s is the Level Name.
-								__( 'Are you sure you want to delete membership level %s? Any subscriptions or third-party connections with a members account will remain active.', 'paid-memberships-pro' ),
+								__( 'Are you sure you want to delete membership level %s? Any gateway subscriptions or third-party connections with a member's account will remain active.', 'paid-memberships-pro' ),
 								$level->name
 							)
 						);

--- a/classes/class-pmpro-levels.php
+++ b/classes/class-pmpro-levels.php
@@ -202,7 +202,7 @@ class PMPro_Membership_Level{
         global $wpdb;
         $r1 = false; // Remove level.
         $r2 = false; // Remove categories from level.
-        $r3 = true; // Remove users from level.
+        $r3 = false; // Remove users from level.
 
         if ( $wpdb->delete( $wpdb->pmpro_membership_levels, array('id' => $this->id), array('%d') ) ) {
             $r1 = true;
@@ -212,38 +212,16 @@ class PMPro_Membership_Level{
             $r2 = true;
         }
 
-        // Try to remove users from the level too
-        $user_ids = $wpdb->get_col( $wpdb->prepare( "
-				SELECT user_id FROM $wpdb->pmpro_memberships_users
-				WHERE membership_id = %d
-				AND status = 'active'",
-			 	$this->id
-            ) );
-            
-
-			foreach($user_ids as $user_id) {
-				//change there membership level to none. that will handle the cancel
-				if(pmpro_changeMembershipLevel(0, $user_id)) {
-					//okay
-				} else {
-					//couldn't delete the subscription
-					//we should probably notify the admin
-					$pmproemail = new PMProEmail();
-					$pmproemail->data = array("body"=>"<p>" . sprintf(__("There was an error canceling the subscription for user with ID=%d. You will want to check your payment gateway to see if their subscription is still active.", 'paid-memberships-pro' ), $user_id) . "</p>");
-					$last_order = $wpdb->get_row( $wpdb->prepare( "
-						SELECT * FROM $wpdb->pmpro_membership_orders
-						WHERE user_id = %d
-						ORDER BY timestamp DESC LIMIT 1",
-						$user_id
-					) );
-					if($last_order)
-						$pmproemail->data["body"] .= "<p>" . __("Last Invoice", 'paid-memberships-pro' ) . ":<br />" . nl2br(var_export($last_order, true)) . "</p>";
-                    $pmproemail->sendEmail(get_bloginfo("admin_email"));
-                    
-                    $r3 = false; // Set it to false if it couldn't delete the subscription.
-				}
-            }
+        //Delete the memberships associated with this level - we're not cancelling them though
+        $deleted_membership_users = $wpdb->delete(
+            $wpdb->pmpro_memberships_users,
+            array( 'membership_id' => $this->id ),
+            array( '%d' )
+        );
         
+        if( $deleted_membership_users > 0 ) {
+            $r3 = true;
+        }
             
         if ( $r1 == true && $r2 == true && $r3 == true ) {
             return true;

--- a/classes/class-pmpro-levels.php
+++ b/classes/class-pmpro-levels.php
@@ -219,7 +219,7 @@ class PMPro_Membership_Level{
             array( '%d' )
         );
         
-        if( $deleted_membership_users > 0 ) {
+        if( $deleted_membership_users !== false ) {
             $r3 = true;
         }
             


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We no longer cancel all of the subscriptions associated with a membership level upon deleting it. Instead, members should be canceled first before deleting the level. Language around this has also been adjusted.

### How to test the changes in this Pull Request:

1. Have a member with an active membership level and subscription
2. Delete the level from Memberships > Settings > Level
3. Their subscription should still remain active in the gateway

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

We no longer cancel subscriptions when deleting a membership level.
