### PR TITLE
Fix for "PHP Notice: Undefined variable: morder" when ! $order_id

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -274,7 +274,7 @@ if ($submit) {
             $pmpro_msg = sprintf(__('Information updated. <a href="%s">&laquo; back to my account</a>', 'paid-memberships-pro' ), pmpro_url("account"));
             $pmpro_msgt = "pmpro_success";
 			
-			do_action( 'pmpro_after_update_billing', $current_user->ID, $morder );
+			do_action( 'pmpro_after_update_billing', $current_user->ID, !empty( $morder ) ? $morder : null );
         } else {
 			/**
 			 * Allow running code when the update fails.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we don't have an $order_id, we are forcing $worked = true: https://github.com/strangerstudios/paid-memberships-pro/blob/dev/preheaders/billing.php#L265

We still don't have an order though, then this line was triggering a Notice:
`PHP Notice:  Undefined variable: morder in /wp-content/plugins/paid-memberships-pro/preheaders/billing.php on line 277`

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
