### PR TITLE
Checkout checkboxes: avoid line breaks in case of very long labels

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -125,7 +125,7 @@ form.pmpro_form #pmpro_payment_information_fields .pmpro_checkout-fields label {
 }
 form.pmpro_form .pmpro_checkout-field-checkbox label {
 	cursor: pointer;
-	display: inline-block;
+	display: inline;
 	width: auto;
 }
 form.pmpro_form .pmpro_checkout-field-checkbox_grouped ul {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Very long checkbox label:
![Screenshot 2022-08-29 at 16 06 30](https://user-images.githubusercontent.com/636911/187223362-b994628e-39d0-437e-b2af-f313296d5bd6.png)

Inline:
![Screenshot 2022-08-29 at 16 06 53](https://user-images.githubusercontent.com/636911/187223399-d15f3882-a444-4b7c-b1c9-a33fe55100c7.png)


### How to test the changes in this Pull Request:

1. RH or User Fields create a checkbox with a very long label.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
