### PR TITLE
PR3 - Pause Mode Functionality

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -109,6 +109,18 @@ class PMPro_Site_Health {
 					'label' => __( 'Library Conflicts', 'paid-memberships-pro' ),
 					'value' => self::get_library_conflicts(),
 				],
+				'pmpro-current-site-url' => [
+					'label' => __( 'Current Site URL', 'paid-memberships-pro' ),
+					'value' => self::get_current_site_url(),
+				],
+				'pmpro-recorded-site-url' => [
+					'label' => __( 'Recorded Site URL', 'paid-memberships-pro' ),
+					'value' => self::get_recorded_site_url(),
+				],
+				'pmpro-pause-mode' => [
+					'label' => __( 'Pause Mode', 'paid-memberships-pro' ),
+					'value' => self::get_pause_mode_state(),
+				],
 			],
 		];
 
@@ -598,5 +610,48 @@ class PMPro_Site_Health {
 		}
 
 		return $constants_formatted;
+	}
+
+	/**
+	 * Gets the current site URL
+	 *
+	 * @since TBD
+	 *
+	 * @return string 
+	 */
+	public function get_current_site_url() {
+
+		return get_site_url();
+
+	}
+	/**
+	 * Gets the recorded site URL
+	 *
+	 * @since TBD
+	 *
+	 * @return string 
+	 */
+	public function get_recorded_site_url() {
+
+		return pmpro_getOption( 'site_url' );
+
+	}
+	/**
+	 * Get the pause mode state
+	 *
+	 * @since TBD
+	 *
+	 * @return string What state is pause mode in 
+	 */
+	public function get_pause_mode_state() {
+
+		$pause_mode = pmpro_get_pause_mode();
+
+		if( $pause_mode ) {
+			return __( 'Enabled', 'paid-memberships-pro' );
+		}
+
+		return __( 'Disabled', 'paid-memberships-pro' );
+
 	}
 }

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -111,11 +111,11 @@ class PMPro_Site_Health {
 				],
 				'pmpro-current-site-url' => [
 					'label' => __( 'Current Site URL', 'paid-memberships-pro' ),
-					'value' => self::get_current_site_url(),
+					'value' => get_site_url(),
 				],
 				'pmpro-recorded-site-url' => [
-					'label' => __( 'Recorded Site URL', 'paid-memberships-pro' ),
-					'value' => self::get_recorded_site_url(),
+					'label' => __( 'Last Known Site URL', 'paid-memberships-pro' ),
+					'value' => pmpro_getOption( 'last_known_url' ),
 				],
 				'pmpro-pause-mode' => [
 					'label' => __( 'Pause Mode', 'paid-memberships-pro' ),
@@ -613,30 +613,6 @@ class PMPro_Site_Health {
 	}
 
 	/**
-	 * Gets the current site URL
-	 *
-	 * @since TBD
-	 *
-	 * @return string 
-	 */
-	public function get_current_site_url() {
-
-		return get_site_url();
-
-	}
-	/**
-	 * Gets the recorded site URL
-	 *
-	 * @since TBD
-	 *
-	 * @return string 
-	 */
-	public function get_recorded_site_url() {
-
-		return pmpro_getOption( 'site_url' );
-
-	}
-	/**
 	 * Get the pause mode state
 	 *
 	 * @since TBD
@@ -645,7 +621,7 @@ class PMPro_Site_Health {
 	 */
 	public function get_pause_mode_state() {
 
-		$pause_mode = pmpro_get_pause_mode();
+		$pause_mode = pmpro_is_paused();
 
 		if( $pause_mode ) {
 			return __( 'Enabled', 'paid-memberships-pro' );

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -131,6 +131,19 @@
 				return false;
 			}
 
+			$send_member_emails_admin = apply_filters( 'pmpro_send_member_emails_admin', true );
+
+			if( pmpro_get_pause_mode() && $send_member_emails_admin ) {
+				//Check if it's a member email and send it to the admin instead
+				if ( strpos( $this->template, 'admin' ) !== false ) {
+					//Admin template, do nothing
+				} else {
+					//Member template, send to admin
+					$this->email = get_bloginfo( 'admin_email' );
+					$this->subject = __('Redirected: ', 'paid-memberships-pro').$this->subject;
+				}
+			}
+
 			$this->email = apply_filters("pmpro_email_recipient", $temail->email, $this);
 			$this->from = apply_filters("pmpro_email_sender", $temail->from, $this);
 			$this->fromname = apply_filters("pmpro_email_sender_name", $temail->fromname, $this);

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -131,19 +131,6 @@
 				return false;
 			}
 
-			$send_member_emails_admin = apply_filters( 'pmpro_send_member_emails_admin', true );
-
-			if( pmpro_get_pause_mode() && $send_member_emails_admin ) {
-				//Check if it's a member email and send it to the admin instead
-				if ( strpos( $this->template, 'admin' ) !== false ) {
-					//Admin template, do nothing
-				} else {
-					//Member template, send to admin
-					$this->email = get_bloginfo( 'admin_email' );
-					$this->subject = __('Redirected: ', 'paid-memberships-pro').$this->subject;
-				}
-			}
-
 			$this->email = apply_filters("pmpro_email_recipient", $temail->email, $this);
 			$this->from = apply_filters("pmpro_email_sender", $temail->from, $this);
 			$this->fromname = apply_filters("pmpro_email_sender_name", $temail->fromname, $this);

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -97,9 +97,17 @@ function pmpro_site_url_check() {
 	}
 
 	//The WP_ENVIRONMENT_TYPE has been changed, we should pause everything
-	if( ! pmpro_is_production_site() ) {
+	//But only if we're not forcing pause mode to be turned off
+	//local forces the WP_ENVIRONMENT_TYPE to be set to local
+	if( ! pmpro_is_production_site() && ! pmpro_getOption( 'pause_mode_override' ) ) {
 		//Site URL's don't match - enable pause mode
 		pmpro_setOption( 'pause_mode', true );
+	}
+
+	if ( ! pmpro_is_production_site() && ! empty( $_REQUEST['pmpro-reactivate-services'] ) ) {
+		//We're on a staging site but want to activate services
+		pmpro_setOption( 'pause_mode_override', true ); 
+		pmpro_setOption( 'pause_mode', false );	
 	}
 
 	if( ! pmpro_is_paused() ){

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -85,58 +85,59 @@ function pmpro_init_site_health_integration() {
 add_action( 'admin_init', 'pmpro_init_site_health_integration' );
 
 /**
- * Compare stored and current site URL
+ * Compare stored and current site URL and decide if we should go into pause mode
  *
  * @since TBD
  */
 function pmpro_site_url_check() {
 
-	// Can the current user view the dashboard?
-	if ( current_user_can( 'manage_options' ) ) {
+	//Checking if a stored site URL exists on first time installs
+	if( empty( pmpro_getOption( 'last_known_url' ) ) ) {
+		pmpro_setOption( 'last_known_url', get_site_url() );
+	}
 
-		//Checking if a stored site URL exists on first time installs
-		if( empty( pmpro_getOption( 'site_url' ) ) ) {
-			pmpro_setOption( 'site_url', get_site_url() );
-		}
+	//The WP_ENVIRONMENT_TYPE has been changed, we should pause everything
+	if( ! pmpro_is_production_site() ) {
+		//Site URL's don't match - enable pause mode
+		pmpro_setOption( 'pause_mode', true );
+	}
 
-		//We're attempting to reactivate all services.
-		if( ! empty( $_REQUEST['pmpro-reactivate-services'] ) ) {			
-			pmpro_save_siteurl();
-			pmpro_set_pause_mode( false );
-			pmpro_maybe_schedule_crons();
-		}
-
-		//The WP_ENVIRONMENT_TYPE has been changed, we should pause everything
-		if( ! pmpro_is_production_site() ) {
+	if( ! pmpro_is_paused() ){
+		//We aren't paused, check if the domains match
+		if( ! pmpro_compare_siteurl() ) {
 			//Site URL's don't match - enable pause mode
-			pmpro_set_pause_mode( true );
-			//Clear all crons in pause mode
-			pmpro_clear_crons();
-		}
-
-		if( ! pmpro_get_pause_mode() ){
-			//We aren't paused, check if the domains match
-			if( ! pmpro_compare_siteurl() ) {
-				//Site URL's don't match - enable pause mode
-				pmpro_set_pause_mode( true );
-				//Clear all crons in pause mode
-				pmpro_clear_crons();
-			} else {
-				//Site URL's do match - disable pause mode
-				pmpro_set_pause_mode( false );
-				//Reschedule crons
-				pmpro_maybe_schedule_crons();
-			}
+			pmpro_setOption( 'pause_mode', true );				
 		} else {
-			//We are paused, show a notice.
-			add_action( 'admin_notices', 'pmpro_pause_mode_notice' );
+			//Site URL's do match - disable pause mode
+			pmpro_setOption( 'pause_mode', false );				
 		}
-
+	} else {
+		//We are paused, show a notice.
+		add_action( 'admin_notices', 'pmpro_pause_mode_notice' );
 	}
 
 }
+add_action( 'init', 'pmpro_site_url_check' );
 add_action( 'admin_init', 'pmpro_site_url_check' );
 
+/**
+ * Allows a user to deactivate pause mode and update the last known URL
+ *
+ * @since TBD
+ */
+function pmpro_handle_pause_mode_actions() {
+
+	// Can the current user view the dashboard?
+	if ( current_user_can( 'pmpro_manage_pause_mode' ) ) {
+		//We're attempting to reactivate all services.
+		if( ! empty( $_REQUEST['pmpro-reactivate-services'] ) ) {			
+			pmpro_setOption( 'last_known_url', get_site_url() );
+			pmpro_setOption( 'pause_mode', false );			
+		}
+	}
+
+}
+add_action( 'admin_init', 'pmpro_handle_pause_mode_actions' );
 /**
  * Display a notice about pause mode being enabled
  *
@@ -144,21 +145,25 @@ add_action( 'admin_init', 'pmpro_site_url_check' );
  */
 function pmpro_pause_mode_notice() {
 
-	if( pmpro_get_pause_mode() ) {
+	if( pmpro_is_paused() ) {
 
 		?>
 		<div class="notice notice-error">
 		<p>
-			<?php
+			<?php				
 				// translators: %s: Contains the URL to a blog post
 				printf(
 					__( '<strong>Warning:</strong> We have detected that your site URL has changed. All cron jobs and automated services have been disabled. Read more about this <a href="%s">here</a>', 'paid-memberships-pro' ), 'BLOG_POST_URL'
 				);
 			?>
 		</p>
+		<?php if ( current_user_can( 'pmpro_manage_pause_mode' ) ) { ?>
 		<p>
 			<a href='<?php echo admin_url( '?pmpro-reactivate-services=true' ); ?>' class='button'><?php _e( 'Update my primary domain and reactivate all services', 'paid-memberships-pro' ); ?></a>
 		</p>
+		<?php } else { ?>
+			<p><?php _e( 'Only users with the <code>pmpro_manage_pause_mode</code> capability are able to deactivate pause mode.', 'paid-memberships-pro' ); ?></p>
+		<?php } ?>
     	</div>
 		<?php
 	}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -117,7 +117,6 @@ function pmpro_site_url_check() {
 	}
 
 }
-add_action( 'init', 'pmpro_site_url_check' );
 add_action( 'admin_init', 'pmpro_site_url_check' );
 
 /**

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -68,6 +68,7 @@ function pmpro_get_capability_defs($role)
         'pmpro_discountcodes',
         'pmpro_userfields',
         'pmpro_updates',
+        'pmpro_manage_pause_mode'
     );
 
     return apply_filters( "pmpro_assigned_{$role}_capabilities", $cap_array);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4360,20 +4360,6 @@ function pmpro_is_production_site() {
 }
 
 /**
- * Save the current site URL to a PMPro option
- *
- * @since TBD
- * @return bool If true, site URL was saved. If false, site URL exists
- */
-function pmpro_save_siteurl() {
-
-	$site_url = get_site_url();
-
-	return pmpro_setOption( 'site_url', $site_url );
-
-}
-
-/**
  * Compare the stored site URL with the current site URL
  *
  * @since TBD
@@ -4383,7 +4369,7 @@ function pmpro_compare_siteurl() {
 
 	$site_url = get_site_url();
 
-	$current_url = pmpro_getOption( 'site_url' );
+	$current_url = pmpro_getOption( 'last_known_url' );
 
 	if( empty( $current_url ) ) {
 		return false;
@@ -4403,7 +4389,7 @@ function pmpro_compare_siteurl() {
  * @since TBD
  * @return bool True if the the site is in pause mode
  */
-function pmpro_get_pause_mode() {
+function pmpro_is_paused() {
 
 	$pause_mode = pmpro_getOption( 'pause_mode' );
 	

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4338,3 +4338,93 @@ function pmpro_activating_plugin( $plugin = null ) {
 	// Must be activating the $plugin specified.
 	return true;
 }
+
+
+/**
+ * Is the current site a production or staging site?
+ * 
+ * @since TBD
+ * @return bool True if we believe this is a production site
+ */
+function pmpro_is_production_site() {
+
+	/**
+	 * Check if the WP_ENVIRONMENT_TYPE is set and not in production
+	 */
+	if( defined( 'WP_ENVIRONMENT_TYPE' ) && WP_ENVIRONMENT_TYPE !== 'production' ) {
+		return false;
+	}
+
+	return true;
+
+}
+
+/**
+ * Save the current site URL to a PMPro option
+ *
+ * @since TBD
+ * @return bool If true, site URL was saved. If false, site URL exists
+ */
+function pmpro_save_siteurl() {
+
+	$site_url = get_site_url();
+
+	return pmpro_setOption( 'site_url', $site_url );
+
+}
+
+/**
+ * Compare the stored site URL with the current site URL
+ *
+ * @since TBD
+ * @return bool True if the stored and current URL match
+ */
+function pmpro_compare_siteurl() {
+
+	$site_url = get_site_url();
+
+	$current_url = pmpro_getOption( 'site_url' );
+
+	if( empty( $current_url ) ) {
+		return false;
+	}
+
+	if( $site_url !== $current_url ) {
+		return false;
+	}
+
+	return true;
+
+}
+
+/**
+ * Determine if the site is in pause mode or not
+ *
+ * @since TBD
+ * @return bool True if the the site is in pause mode
+ */
+function pmpro_get_pause_mode() {
+
+	$pause_mode = pmpro_getOption( 'pause_mode' );
+	
+	//We haven't saved the option or it isn't in pause mode
+	if( empty( $pause_mode ) || $pause_mode === false ) {
+		return false;
+	}
+
+	return true;
+
+}
+
+/**
+ * Set the pause mode status
+ *
+ * @param $state bool true or false if in pause mode state
+ * @since TBD
+ * @return bool True if the option has been updated
+ */
+function pmpro_set_pause_mode( $state ) {
+
+	return pmpro_setOption( 'pause_mode', $state );
+
+}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -302,7 +302,7 @@ function pmpro_checkForUpgrades()
 	 * Check the current domain and store it
 	 */
 	if ( $pmpro_db_version < 2.94 ) {
-		pmpro_save_siteurl();
+		pmpro_setOption( 'last_known_url', get_site_url() );
 		pmpro_setOption( 'db_version', '2.94' );
 	}
 }

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -296,6 +296,15 @@ function pmpro_checkForUpgrades()
 		pmpro_maybe_schedule_crons();
 		pmpro_setOption( 'db_version', '2.81' );
 	}
+
+	/**
+	 * Version 2.9.4
+	 * Check the current domain and store it
+	 */
+	if ( $pmpro_db_version < 2.94 ) {
+		pmpro_save_siteurl();
+		pmpro_setOption( 'db_version', '2.94' );
+	}
 }
 
 function pmpro_db_delta()

--- a/scheduled/adminactivityemail.php
+++ b/scheduled/adminactivityemail.php
@@ -6,5 +6,10 @@
 	define( 'WP_USE_THEMES', false );
 	require( '../../../../wp-load.php' );
 
+	//Don't let anything run if PMPro is paused
+	if( pmpro_is_paused() ) {
+		return;
+	}
+	
 	// This function is defined in /scheduled/crons.php.
 	pmpro_cron_admin_activity_email();

--- a/scheduled/creditcardexpiringwarnings.php
+++ b/scheduled/creditcardexpiringwarnings.php
@@ -6,5 +6,10 @@
 	define('WP_USE_THEMES', false);
 	require('../../../../wp-load.php');
 
+	//Don't let anything run if PMPro is paused
+	if( pmpro_is_paused() ) {
+		return;
+	}
+
 	//this function is defined in /scheduled/crons.php
 	pmpro_cron_credit_card_expiring_warnings();

--- a/scheduled/expirationwarnings.php
+++ b/scheduled/expirationwarnings.php
@@ -6,5 +6,10 @@
 	define('WP_USE_THEMES', false);
 	require('../../../../wp-load.php');	
 
+	//Don't let anything run if PMPro is paused
+	if( pmpro_is_paused() ) {
+		return;
+	}
+	
 	//this function is defined in /scheduled/crons.php
 	pmpro_cron_expiration_warnings();

--- a/scheduled/expirememberships.php
+++ b/scheduled/expirememberships.php
@@ -6,5 +6,10 @@
 	define('WP_USE_THEMES', false);
 	require('../../../../wp-load.php');
 
+	//Don't let anything run if PMPro is paused
+	if( pmpro_is_paused() ) {
+		return;
+	}
+	
 	//this function is defined in /scheduled/crons.php
 	pmpro_cron_expire_memberships();

--- a/scheduled/trialendingwarnings.php
+++ b/scheduled/trialendingwarnings.php
@@ -6,5 +6,10 @@
 	define('WP_USE_THEMES', false);
 	require('../../../../wp-load.php');	
 
+	//Don't let anything run if PMPro is paused
+	if( pmpro_is_paused() ) {
+		return;
+	}
+	
 	//this function is defined in /scheduled/crons.php
 	pmpro_cron_trial_ending_warnings();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moving your site to a staging site can result in unexpected changes such as crons running and live actions occurring. This will check if the site URL has changed and disable the PMPro crons. 

### How to test the changes in this Pull Request:

1. Install PMPro - check if the pmpro_site_url option has been created in the db
2. Change the current site URL or copy the site to another domain
3. A notice will appear notifying you of the change, which then puts the site in pause mode.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Core features can now temporarily be turned off or paused when setting up a staging site.
