### PR TITLE
Remove duplicated country array key VE (Venezuela)

### DIFF
--- a/includes/countries.php
+++ b/includes/countries.php
@@ -5,7 +5,7 @@
 
 	$pmpro_countries = array(
 		'AD' => __( 'Andorra', 'paid-memberships-pro' ),
-    	'AE' => __( 'United Arab Emirates', 'paid-memberships-pro' ),
+		'AE' => __( 'United Arab Emirates', 'paid-memberships-pro' ),
 		'AF' => __( 'Afghanistan', 'paid-memberships-pro' ),
 		'AG' => __( 'Antigua and Barbuda', 'paid-memberships-pro' ),
 		'AI' => __( 'Anguilla', 'paid-memberships-pro' ),
@@ -251,7 +251,6 @@
 		'ZM' => __( 'Zambia', 'paid-memberships-pro' ),
 		'ZW' => __( 'Zimbabwe', 'paid-memberships-pro' ),
 	  	'USAF' => __( 'US Armed Forces', 'paid-memberships-pro' ),
-		'VE' => __( 'Venezuela', 'paid-memberships-pro' ),
 	);
 
 	asort($pmpro_countries);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Found a duplicated key, removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

