### PR TITLE
CSS adjustments for form field types

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -115,40 +115,6 @@ form.pmpro_form label,
 	margin: 0;
 	text-align: left;
 }
-form.pmpro_form #pmpro_payment_information_fields .pmpro_checkout-fields label {
-	display: block;
-	float: none;
-	max-width: initial;
-	min-width: initial;
-	text-align: left;
-	width: auto;
-}
-form.pmpro_form .pmpro_checkout-field-checkbox label {
-	cursor: pointer;
-	display: inline;
-	width: auto;
-}
-form.pmpro_form .pmpro_checkout-field-checkbox_grouped ul {
-	list-style: none;
-	margin-left: 0;
-	padding-left: 0;
-}
-form.pmpro_form .pmpro_checkout-field-checkbox_grouped li {
-	list-style: none;
-	margin-left: 0;
-	padding-left: 0;
-}
-form.pmpro_form .pmpro_checkout-field-radio-item {
-	margin-bottom: 0;
-}
-form.pmpro_form .pmpro_checkout-field-radio-item label {
-	cursor: pointer;
-	display: inline-block;
-	width: auto;
-}
-form.pmpro_form .pmpro_checkout-field-select select {
-	min-width: 50%;
-}
 form.pmpro_form label.pmpro_label-inline {
 	display: inline-block;
 }
@@ -158,27 +124,6 @@ form.pmpro_form label.pmpro_clickable {
 form.pmpro_form .pmpro_asterisk abbr {
 	border: none;
 	text-decoration: none;
-}
-form.pmpro_form input[type=checkbox]#tos {
-	width: auto;
-}
-form.pmpro_form,
-form.pmpro_form textarea,
-form.pmpro_form select,
-#loginform input[type=text],
-#loginform input[type=password] {
-	display: inline-block;
-	max-width: 90%;
-	min-height: 1.5rem;
-}
-form.pmpro_form .pmpro_checkout-field-bcity_state_zip .input,
-form.pmpro_form .pmpro_checkout-field-bcity_state_zip select {
-	max-width: 30%;
-}
-form.pmpro_form .pmpro_payment-cvv .input,
-form.pmpro_form .pmpro_payment-discount-code .input,
-form.pmpro_form #other_discount_code.input {
-	max-width: 40%;
 }
 form.pmpro_form .lite {
 	color: #666;
@@ -196,6 +141,91 @@ form.pmpro_form #pmpro_processing_message {
 	font-style: italic;
 	margin: 1em 0 0 0;
 	text-align: left;
+}
+
+/** General Field Types **/
+form.pmpro_form input[type=text],
+form.pmpro_form input[type=password],
+form.pmpro_form input[type=email],
+form.pmpro_form input[type=number],
+form.pmpro_form textarea,
+form.pmpro_form select,
+#loginform input[type=text],
+#loginform input[type=password] {
+	display: inline-block;
+	max-width: 90%;
+	min-height: 1.5rem;
+}
+
+/** Checkbox-specific field type **/
+form.pmpro_form .pmpro_checkout-field-checkbox label {
+	cursor: pointer;
+	display: inline;
+	width: auto;
+}
+form.pmpro_form .pmpro_checkout-field-checkbox input[type=checkbox] {
+	opacity: 1;
+}
+form.pmpro_form .pmpro_checkout-field-checkbox_grouped ul {
+	list-style: none;
+	margin-left: 0;
+	padding-left: 0;
+}
+form.pmpro_form .pmpro_checkout-field-checkbox_grouped li {
+	list-style: none;
+	margin-left: 0;
+	padding-left: 0;
+}
+
+/** Radio-specific field type **/
+form.pmpro_form .pmpro_checkout-fields .pmpro_checkout-field-radio-item {
+	margin-bottom: 0;
+}
+form.pmpro_form .pmpro_checkout-field-radio-item label {
+	cursor: pointer;
+	display: inline-block;
+	width: auto;
+}
+form.pmpro_form .pmpro_checkout-field-radio-item input[type=radio] {
+	opacity: 1;
+}
+
+/** Select-specific field type **/
+form.pmpro_form .pmpro_checkout-field-select select {
+	min-width: 50%;
+}
+
+/** Date-specific field type **/
+form.pmpro_form .pmpro_checkout-field-date select {
+	max-width: unset;
+	width: unset;
+}
+form.pmpro_form .pmpro_checkout-field-date input[type=text] {
+	margin-left: 5px;
+	max-width: unset;
+	width: unset;
+}
+
+/** Membership Checkout and Billing-specific Fields **/
+form.pmpro_form #pmpro_payment_information_fields .pmpro_checkout-fields label {
+	display: block;
+	float: none;
+	max-width: initial;
+	min-width: initial;
+	text-align: left;
+	width: auto;
+}
+form.pmpro_form .pmpro_checkout-field-bcity_state_zip .input,
+form.pmpro_form .pmpro_checkout-field-bcity_state_zip select {
+	max-width: 30%;
+}
+form.pmpro_form .pmpro_payment-cvv .input,
+form.pmpro_form .pmpro_payment-discount-code .input,
+form.pmpro_form #other_discount_code.input {
+	max-width: 40%;
+}
+form.pmpro_form input[type=checkbox]#tos {
+	width: auto;
 }
 
 /* Lost Password Frontend Form */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

2.9.4 has a CSS snafu where the form.pmpro_form is added to a selector list that sets up some field default display. That was done in error.

In this PR, I took a more specific look at our field CSS so that we are more hardened across various popular themes and for our most common field types in User Fields settings.

### Changelog entry

* BUG FIX/ENHANCEMENT: Improved CSS for frontend form fields.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
