### PR TITLE
Field required asterisks

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -399,6 +399,10 @@ class PMPro_Field {
             //use the save date function
             $this->save_function = array($this, "saveDate");
         }
+		elseif ( $this->type == 'hidden' ) {
+			// Don't show the label for the hidden field.
+			$this->showmainlabel = false;
+		}
 
 		return true;
 	}
@@ -818,7 +822,7 @@ class PMPro_Field {
 			if(!empty($this->html_attributes))
 				$r .= $this->getHTMLAttributes();		
 			$r .= ' /> ';
-			$r .= '<label class="pmprorh_checkbox_label" for="' . $this->name . '">' . $this->text . '</label> &nbsp; ';
+			$r .= '<label class="pmprorh_checkbox_label" for="' . $this->name . '">' . $this->text . '</label>';
 			$r .= '<input type="hidden" name="'.$this->name.'_checkbox" value="1" />';	//extra field so we can track unchecked boxes
 		}
 		
@@ -1017,6 +1021,9 @@ class PMPro_Field {
         }
         elseif($this->type == "readonly")
 		{				
+			if ( empty( $value ) ) {
+				$value = '&#8212;';
+			}
 			$r = $value;
 		}
 		else
@@ -1239,13 +1246,15 @@ class PMPro_Field {
 		?>
 		<div id="<?php echo esc_attr( $this->id );?>_div" class="pmpro_checkout-field<?php if(!empty($this->divclass)) echo ' ' . esc_attr( $this->divclass ); ?>">
 			<?php if(!empty($this->showmainlabel)) { ?>
-				<label for="<?php echo esc_attr($this->name);?>"><?php echo wp_kses_post( $this->label );?></label>
-				<?php 
-					if(!empty($this->required) && !empty($this->showrequired) && $this->showrequired === 'label')
-					{
-					?><span class="pmprorh_asterisk"> <abbr title="Required Field">*</abbr></span><?php
-					}
-				?>
+				<label for="<?php echo esc_attr($this->name);?>">
+					<?php echo wp_kses_post( $this->label );?>
+					<?php 
+						if(!empty($this->required) && !empty($this->showrequired) && $this->showrequired === 'label')
+						{
+						?><span class="pmpro_asterisk"> <abbr title="<?php esc_attr_e( 'Required Field' ,'paid-memberships-pro' ); ?>">*</abbr></span><?php
+						}
+					?>
+				</label>
 				<?php $this->display($value); ?>
 			<?php } else { ?>
 				<?php $this->display($value); ?>

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -115,40 +115,6 @@ form.pmpro_form label,
 	margin: 0;
 	text-align: left;
 }
-form.pmpro_form #pmpro_payment_information_fields .pmpro_checkout-fields label {
-	display: block;
-	float: none;
-	max-width: initial;
-	min-width: initial;
-	text-align: left;
-	width: auto;
-}
-form.pmpro_form .pmpro_checkout-field-checkbox label {
-	cursor: pointer;
-	display: inline;
-	width: auto;
-}
-form.pmpro_form .pmpro_checkout-field-checkbox_grouped ul {
-	list-style: none;
-	margin-left: 0;
-	padding-left: 0;
-}
-form.pmpro_form .pmpro_checkout-field-checkbox_grouped li {
-	list-style: none;
-	margin-left: 0;
-	padding-left: 0;
-}
-form.pmpro_form .pmpro_checkout-field-radio-item {
-	margin-bottom: 0;
-}
-form.pmpro_form .pmpro_checkout-field-radio-item label {
-	cursor: pointer;
-	display: inline-block;
-	width: auto;
-}
-form.pmpro_form .pmpro_checkout-field-select select {
-	min-width: 50%;
-}
 form.pmpro_form label.pmpro_label-inline {
 	display: inline-block;
 }
@@ -158,27 +124,6 @@ form.pmpro_form label.pmpro_clickable {
 form.pmpro_form .pmpro_asterisk abbr {
 	border: none;
 	text-decoration: none;
-}
-form.pmpro_form input[type=checkbox]#tos {
-	width: auto;
-}
-form.pmpro_form,
-form.pmpro_form textarea,
-form.pmpro_form select,
-#loginform input[type=text],
-#loginform input[type=password] {
-	display: inline-block;
-	max-width: 90%;
-	min-height: 1.5rem;
-}
-form.pmpro_form .pmpro_checkout-field-bcity_state_zip .input,
-form.pmpro_form .pmpro_checkout-field-bcity_state_zip select {
-	max-width: 30%;
-}
-form.pmpro_form .pmpro_payment-cvv .input,
-form.pmpro_form .pmpro_payment-discount-code .input,
-form.pmpro_form #other_discount_code.input {
-	max-width: 40%;
 }
 form.pmpro_form .lite {
 	color: #666;
@@ -196,6 +141,91 @@ form.pmpro_form #pmpro_processing_message {
 	font-style: italic;
 	margin: 1em 0 0 0;
 	text-align: left;
+}
+
+/** General Field Types **/
+form.pmpro_form input[type=text],
+form.pmpro_form input[type=password],
+form.pmpro_form input[type=email],
+form.pmpro_form input[type=number],
+form.pmpro_form textarea,
+form.pmpro_form select,
+#loginform input[type=text],
+#loginform input[type=password] {
+	display: inline-block;
+	max-width: 90%;
+	min-height: 1.5rem;
+}
+
+/** Checkbox-specific field type **/
+form.pmpro_form .pmpro_checkout-field-checkbox label {
+	cursor: pointer;
+	display: inline;
+	width: auto;
+}
+form.pmpro_form .pmpro_checkout-field-checkbox input[type=checkbox] {
+	opacity: 1;
+}
+form.pmpro_form .pmpro_checkout-field-checkbox_grouped ul {
+	list-style: none;
+	margin-left: 0;
+	padding-left: 0;
+}
+form.pmpro_form .pmpro_checkout-field-checkbox_grouped li {
+	list-style: none;
+	margin-left: 0;
+	padding-left: 0;
+}
+
+/** Radio-specific field type **/
+form.pmpro_form .pmpro_checkout-fields .pmpro_checkout-field-radio-item {
+	margin-bottom: 0;
+}
+form.pmpro_form .pmpro_checkout-field-radio-item label {
+	cursor: pointer;
+	display: inline-block;
+	width: auto;
+}
+form.pmpro_form .pmpro_checkout-field-radio-item input[type=radio] {
+	opacity: 1;
+}
+
+/** Select-specific field type **/
+form.pmpro_form .pmpro_checkout-field-select select {
+	min-width: 50%;
+}
+
+/** Date-specific field type **/
+form.pmpro_form .pmpro_checkout-field-date select {
+	max-width: unset;
+	width: unset;
+}
+form.pmpro_form .pmpro_checkout-field-date input[type=text] {
+	margin-left: 5px;
+	max-width: unset;
+	width: unset;
+}
+
+/** Membership Checkout and Billing-specific Fields **/
+form.pmpro_form #pmpro_payment_information_fields .pmpro_checkout-fields label {
+	display: block;
+	float: none;
+	max-width: initial;
+	min-width: initial;
+	text-align: left;
+	width: auto;
+}
+form.pmpro_form .pmpro_checkout-field-bcity_state_zip .input,
+form.pmpro_form .pmpro_checkout-field-bcity_state_zip select {
+	max-width: 30%;
+}
+form.pmpro_form .pmpro_payment-cvv .input,
+form.pmpro_form .pmpro_payment-discount-code .input,
+form.pmpro_form #other_discount_code.input {
+	max-width: 40%;
+}
+form.pmpro_form input[type=checkbox]#tos {
+	width: auto;
 }
 
 /* Lost Password Frontend Form */

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -142,7 +142,7 @@ jQuery(document).ready(function(){
 		jQuery( '.pmpro_required' ).closest( '.pmpro_checkout-field' ).append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
 	}
 
-	//add required to required fields
+	//move asterisk for some field types
 	if ( jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ) ) {
 		jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ).remove();
 		jQuery( '.pmpro_checkout-field-radio' ).find( 'label' ).first().append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -139,8 +139,14 @@ jQuery(document).ready(function(){
 
 	//add required to required fields
 	if ( ! jQuery( '.pmpro_required' ).next().hasClass( "pmpro_asterisk" ) ) {
-	   jQuery( '.pmpro_required' ).after( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
-  }
+		jQuery( '.pmpro_required' ).closest( '.pmpro_checkout-field' ).append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
+	}
+
+	//add required to required fields
+	if ( jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ) ) {
+		jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ).remove();
+		jQuery( '.pmpro_checkout-field-radio' ).find( 'label' ).first().append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
+	}
 
 	//unhighlight error fields when the user edits them
 	jQuery('.pmpro_error').bind("change keyup input", function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Some field types like radio, date, checkbox, and checkbox grouped were having a weird placement of the required asterisk.

This PR reworks how the required field is set up and will move it to a better position across field types.

**OLD WAY:**
<img width="882" alt="Screen Shot 2022-09-05 at 9 55 47 AM" src="https://user-images.githubusercontent.com/5312875/188511343-1814196d-2b52-4074-a9dc-f049098b3319.png">


**NEW WAY:**
<img width="306" alt="Screen Shot 2022-09-05 at 4 50 49 PM" src="https://user-images.githubusercontent.com/5312875/188511388-8525d054-8e5c-4560-85c1-e7f71f477049.png">

This PR also includes a fix for the "hidden" field type not to show the label.

It also adds a fallback "long dash" (the same HTML entity we use on the members list and other places in admin where the field is "empty" if the field is our readonly field type to show the dash if there is no value for the field.

(This won't show a dash in an empty form field element for any field with the readonly property on the form element, just the specific readonly field "type").

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
