### PR TITLE
Continue loop if fields are for admins only

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -701,7 +701,7 @@ function pmpro_show_user_fields_in_frontend_profile( $user, $withlocations = fal
 
 			// Bail if there are no fields to show on the front-end profile.
 			if ( ! $show_fields ) {
-				return;
+				continue;
 			}
 			?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you have fields for admin only, the former code would stop the loop and return the function... so every other field following wouldn't appear.

This update changes the logic so the fields continue and the loop keep going.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* BUG FIX: Fixed case where user fields wouldn't show for users if earlier fields/groups were only for admins.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
