### PR TITLE
Updating select field type label; now support select2 field type in user fields

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1380,7 +1380,8 @@ function pmpro_get_field_html( $field = null ) {
                         <option value="textarea" <?php selected( $field_type, 'textarea' ); ?>><?php esc_html_e( 'Text Area', 'paid-memberships-pro' ); ?></option>
                         <option value="checkbox" <?php selected( $field_type, 'checkbox' ); ?>><?php esc_html_e( 'Checkbox', 'paid-memberships-pro' ); ?></option>
                         <option value="radio" <?php selected( $field_type, 'radio' ); ?>><?php esc_html_e( 'Radio', 'paid-memberships-pro' ); ?></option>
-                        <option value="select" <?php selected( $field_type, 'select' ); ?>><?php esc_html_e( 'Select', 'paid-memberships-pro' ); ?></option>
+                        <option value="select" <?php selected( $field_type, 'select' ); ?>><?php esc_html_e( 'Select / Dropdown', 'paid-memberships-pro' ); ?></option>
+                        <option value="select2" <?php selected( $field_type, 'select2' ); ?>><?php esc_html_e( 'Select2 / Autocomplete', 'paid-memberships-pro' ); ?></option>
                         <option value="multiselect" <?php selected( $field_type, 'multiselect' ); ?>><?php esc_html_e( 'Multi Select', 'paid-memberships-pro' ); ?></option>
                         <option value="file" <?php selected( $field_type, 'file' ); ?>><?php esc_html_e( 'File', 'paid-memberships-pro' ); ?></option>
                         <option value="number" <?php selected( $field_type, 'number' ); ?>><?php esc_html_e( 'Number', 'paid-memberships-pro' ); ?></option>
@@ -1542,7 +1543,7 @@ function pmpro_load_user_fields_from_settings() {
             }
             
             // Figure out options.
-            $option_types = array( 'radio', 'select', 'multiselect' );
+            $option_types = array( 'radio', 'select', 'select2', 'multiselect' );
             if ( in_array( $settings_field->type, $option_types ) ) {
                 $options = array();
                 $settings_options = explode( "\n", $settings_field->options );

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -410,7 +410,7 @@ function pmpro_userfields_prep_click_events() {
         var fieldtype = jQuery(this).val();
         var fieldoptions = fieldsettings.find('textarea[name=pmpro_userfields_field_options]').parents('.pmpro_userfield-field-setting');        
         
-        var optiontypes = ['radio', 'select', 'multiselect']; // eventually checkboxgroup and select2
+        var optiontypes = ['radio', 'select', 'select2' , 'multiselect']; // eventually checkboxgroup
         
         if( jQuery.inArray( fieldtype, optiontypes ) > -1 ) {            
             fieldoptions.show();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updated the label for select-type field to say "Select / Dropdown".

Now supporting select2 field type in user field settings GUI.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added no-code fields support for select2 field type.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
