### PR TITLE
Wisdom tracker needed the addons.php file loaded.

### DIFF
--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -446,6 +446,9 @@ class PMPro_Wisdom_Integration {
 	 * @return array The list of Add Ons categorized by active, inactive, and update available.
 	 */
 	public function get_addons_info() {
+		// This file only is usually only required when is_admin().
+		require_once( PMPRO_DIR . '/includes/addons.php' );
+		
 		// Build the list of Add Ons data to track.
 		$addons      = pmpro_getAddons();
 		$plugin_info = get_site_transient( 'update_plugins' );


### PR DESCRIPTION
Our (opt in) tracking cron was failing because a function in the includes/addons.php file was not available, since that file is only included in the admin dashboard and WP cron runs outside the "admin".

This fix simply requires that file in place as needed there. The addons.php file hooks up some plugin update related things that typically only happen on admin, but shouldn't affect other crons in any negative way.