### PR TITLE
Change message on membership level save ("updated")

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -147,7 +147,12 @@
 		if ( empty( $wpdb->last_error ) ) {		
 			$edit = false;
 			$msg = 1;
-			$msgt = __( 'Membership level added successfully.', 'paid-memberships-pro' );
+
+			if ( ! empty( $saveid ) ) {
+				$msgt = __( 'Membership level updated successfully.', 'paid-memberships-pro' );
+			} else {
+				$msgt = __( 'Membership level added successfully.', 'paid-memberships-pro' );
+			}
 		} else {
 			$msg = -1;
 			$msgt = __( 'Error adding membership level.', 'paid-memberships-pro' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

@kimcoleman

> if you edit an existing membership level, then save changes, the success message says “membership level added successfully”. should say “updated”.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->