### PR TITLE
Add content restriction settings to Elementor containers

### DIFF
--- a/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
@@ -12,6 +12,7 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 		// Filter elementor render_content hook
 		add_action( 'elementor/widget/render_content', array( $this, 'pmpro_elementor_render_content' ), 10, 2 );
 		add_action( 'elementor/frontend/section/should_render', array( $this, 'pmpro_elementor_should_render' ), 10, 2 );
+		add_action( 'elementor/frontend/container/should_render', array( $this, 'pmpro_elementor_should_render' ), 10, 2 );
 
 	}
 

--- a/includes/compatibility/elementor/class-pmpro-elementor.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor.php
@@ -18,7 +18,11 @@ class PMPro_Elementor {
         array(
             'element' => 'section',
             'action'  => 'section_advanced',
-        )
+		),
+		array(
+			'element' => 'container',
+			'action'  => 'section_layout'
+		)
     );
     public $section_name = 'pmpro_elementor_section';
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I added the PMPro content restriction settings onto the experimental Elementor container widget. By default the setting is only added to sections and when the Elementor container feature is enabled you can only create containers which are missing the content restriction settings. I needed this on one of my sites and thought I'd share my solution.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added an entry for the Elementor container to `PMPro_Elementor->locations`
> Added `pmpro_elementor_should_render` to the container's `should_render` action
