### PR TITLE
Only show renewals or new on charts

### DIFF
--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -312,7 +312,7 @@ function pmpro_report_sales_page()
 			}
 		}
 	}
-	
+
 	$average = 0;
 	if ( 0 !== $units_in_period ) {
 		$average = $total_in_period / $units_in_period; // Not including this unit.
@@ -482,8 +482,8 @@ function pmpro_report_sales_page()
 								<?php echo wp_json_encode( (int) $value[0] - $value[1] ); ?>,
 								<?php echo wp_json_encode( (int) $value[0] ); ?>,
 							<?php } else { ?>
-								<?php if( $new_renewals == 'new_renewals' || $new_renewals == 'only_renewals' ) { echo wp_json_encode( pmpro_escape_price( pmpro_formatPrice( $value[1] ) ) ).','; } ?>
-								<?php if( $new_renewals == 'new_renewals' || $new_renewals == 'only_new' ) {  echo wp_json_encode( pmpro_escape_price( pmpro_formatPrice( $value[0] - $value[1] ) ) ); } ?>,
+								<?php echo wp_json_encode( pmpro_escape_price( pmpro_formatPrice( $value[1] ) ) ); ?>,
+								<?php echo wp_json_encode( pmpro_escape_price( pmpro_formatPrice( $value[0] - $value[1] ) ) ); ?>,								
 								<?php echo wp_json_encode( pmpro_escape_price( pmpro_formatPrice( $value[0] ) ) ); ?>,
 							<?php } ?>
 						),
@@ -494,12 +494,11 @@ function pmpro_report_sales_page()
 						<?php } else { ?>
 							<?php if( $new_renewals == 'new_renewals' || $new_renewals == 'only_renewals' ) { echo wp_json_encode( pmpro_round_price( $value[1] ) ).','; } ?>
 							<?php if( $new_renewals == 'new_renewals' || $new_renewals == 'only_new' ) {echo wp_json_encode( pmpro_round_price( $value[0] - $value[1] ) ).','; } ?>
-							<?php if( $new_renewals != '1' ) { echo wp_json_encode( pmpro_round_price( $average ) ); } ?>,
+							<?php echo wp_json_encode( pmpro_round_price( $average ) ); ?>,
 						<?php } ?>
 					],
 				<?php } ?>
 			]);
-
 			var options = {
 				title: pmpro_report_title_sales(),
 				titlePosition: 'top',
@@ -540,13 +539,13 @@ function pmpro_report_sales_page()
 				},
 				seriesType: 'bars',
 				series: {
-					2: {
+					<?php if( $new_renewals == 'new_renewals' ) { echo 2; } else { echo 1; } ?> : {
 						type: 'line',
 						color: '#B00000',
 						enableInteractivity: false,
 						lineDashStyle: [4, 1], 
 					},
-					1: {<?php
+					<?php if( $new_renewals == 'new_renewals' ) { echo 1; } else { echo 2; } ?>: {<?php
 						if ( $type === 'sales') {
 							echo "color: '#0099C6'"; // Lighter Blue for "Sales" chart.
 						} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows you to show both New and Renewals, Only New or Only Renewals on your Sales & Revenue chart

### How to test the changes in this Pull Request:

1. Navigate to Memberships > Reports > Sales & Revenue
2. Choose if you want to show both or only new or only renewals from the dropdown


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

You can now choose if you'd like to only view New or Renewals on your Sales & Revenue chart
