### PR TITLE
Fixed attribute setting for Require membership block.

### DIFF
--- a/blocks/membership/block.js
+++ b/blocks/membership/block.js
@@ -58,8 +58,8 @@ const all_levels = [{ value: 0, label: "Non-Members" }].concat( pmpro.all_level_
                  default:'',
              },
              show_noaccess: {
-                 type: 'boolean',
-                 default: false,
+                 type: 'string',
+                 default: '0',
              },
          },
          edit: props => {


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the dropdown "What should users without access see?" for the Require Membership Block would reset on each page load.

Resolves: https://github.com/strangerstudios/paid-memberships-pro/issues/2243

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?