### PR TITLE
Created function to get all site types

### DIFF
--- a/adminpages/wizard/done.php
+++ b/adminpages/wizard/done.php
@@ -16,6 +16,7 @@
 	// Did they choose collect payments? If so, show a nudge to complete the gateway setup.
 	$configure_payment = pmpro_getOption( 'wizard_collect_payment', true );
 
+	$site_types = pmpro_wizard_get_site_types();
 ?>
 <div class="pmpro-wizard__step pmpro-wizard__step-4">
 				<div class="pmpro-wizard__step-header">
@@ -24,7 +25,14 @@
 				</div>
 				<div class="pmpro-wizard__field"> <!-- Recommended icons -->
 					<h1>What's next?</h1>
-					<p><?php _e( sprintf( "You indicated you're building a %s membership site. Here are some recommended Add Ons for your business.", "<strong>$site_type</strong>" ), 'paid-memberships-pro' ); ?></p>
+					<p>
+						<?php
+						if ( isset( $site_types[ $site_type ] ) ) {
+							echo sprintf( esc_html__( "You indicated you're building a %s membership site.", 'paid-memberships-pro' ), '<strong>' . esc_html( $site_types[ $site_type ] ) . '</strong>' ) . ' ';
+						}
+						esc_html_e( 'Here are some recommended Add Ons for your business.', 'paid-memberships-pro' );
+						?>
+					</p>
 					<div style="text-align:center;">
 					<?php
 						// Get some Add On recommendations and only show 3.

--- a/adminpages/wizard/general.php
+++ b/adminpages/wizard/general.php
@@ -35,9 +35,9 @@ global $pmpro_pages;
 							<option value=""><?php esc_html_e( '-- Select --', 'paid-memberships-pro' ); ?></option>
 							<?php
 							$site_types = pmpro_wizard_get_site_types();
-							foreach ( $site_types as $sale_type => $name ) {
+							foreach ( $site_types as $site_type_key => $name ) {
 								?>
-								<option value="<?php echo esc_attr( $sale_type ); ?>" <?php selected( $sale_type, $site_type ); ?>><?php echo esc_html( $name ); ?></option>
+								<option value="<?php echo esc_attr( $site_type_key ); ?>" <?php selected( $site_type_key, $site_type ); ?>><?php echo esc_html( $name ); ?></option>
 								<?php
 							}
 							?>

--- a/adminpages/wizard/general.php
+++ b/adminpages/wizard/general.php
@@ -33,14 +33,14 @@ global $pmpro_pages;
 						<p class="pmpro-wizard__field-description"><?php esc_html_e( 'Choose the answer that best fits the primary value of your membership site.', 'paid-memberships-pro' ); ?></p>
 						<select id="membership_site_type" name="membership_site_type" class="pmpro-wizard__field-block">
 							<option value=""><?php esc_html_e( '-- Select --', 'paid-memberships-pro' ); ?></option>
-							<option value="association" <?php selected( 'association', $site_type, true ); ?>><?php esc_html_e( 'Association', 'paid-memberships-pro' ); ?></option>
-							<option value="community" <?php selected( 'community', $site_type, true ); ?>><?php esc_html_e( 'Community', 'paid-memberships-pro' ); ?></option>
-							<option value="courses" <?php selected( 'courses', $site_type, true ); ?>><?php esc_html_e( 'Courses', 'paid-memberships-pro' ); ?></option>
-							<option value="digital_downloads" <?php selected( 'digital_downloads', $site_type, true ); ?>><?php esc_html_e( 'Digital Downloads', 'paid-memberships-pro' ); ?></option>
-							<option value="directory" <?php selected( 'directory', $site_type, true ); ?>><?php esc_html_e( 'Directory/Profiles', 'paid-memberships-pro' ); ?></option>
-							<option value="physical_products" <?php selected( 'physical_products', $site_type, true ); ?>><?php esc_html_e( 'Physical Products', 'paid-memberships-pro' ); ?></option>
-							<option value="premium_content" <?php selected( 'premium_content', $site_type, true ); ?>><?php esc_html_e( 'Premium Content', 'paid-memberships-pro' ); ?></option>
-							<option value="other" <?php selected( 'other', $site_type, true ); ?>><?php esc_html_e( 'Other', 'paid-memberships-pro' ); ?></option>
+							<?php
+							$site_types = pmpro_wizard_get_site_types();
+							foreach ( $site_types as $sale_type => $name ) {
+								?>
+								<option value="<?php echo esc_attr( $sale_type ); ?>" <?php selected( $sale_type, $site_type ); ?>><?php echo esc_html( $name ); ?></option>
+								<?php
+							}
+							?>
 						</select>
 					</div>
 					<div class="pmpro-wizard__field">

--- a/adminpages/wizard/wizard.php
+++ b/adminpages/wizard/wizard.php
@@ -11,6 +11,28 @@ if ( empty( $_REQUEST['step'] ) ) {
 	$active_step = 'general';
 }
 
+/**
+ * Helper function to get all site types and their human-readable labels.
+ * Can only be used within the wizard.
+ *
+ * @since TBD.
+ *
+ * @return array
+ */
+function pmpro_wizard_get_site_types() {
+	// These values will all be escaped when displayed.
+	return array(
+		'association'       => __( 'Association', 'paid-memberships-pro' ),
+		'community'         => __( 'Community', 'paid-memberships-pro' ),
+		'courses'           => __( 'Courses', 'paid-memberships-pro' ),
+		'digital_downloads' => __( 'Digital Downloads', 'paid-memberships-pro' ),
+		'directory'         => __( 'Directory/Profiles', 'paid-memberships-pro' ),
+		'physical_products' => __( 'Physical Products', 'paid-memberships-pro' ),
+		'premium_content'   => __( 'Premium Content', 'paid-memberships-pro' ),
+		'other'             => __( 'Other', 'paid-memberships-pro' ),
+	);
+}
+
 ?>
 <div class="pmpro-wizard">
 	<div style="background-image: url('/wp-content/plugins/paid-memberships-pro/images/bg_icons-white.png');background-repeat: repeat;background-size: 50%;position: absolute; top: 0; left: 0; width: 100%;height: 100vh;opacity: .5; z-index: -1;"></div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Created a function to hold all the site types that are available in the wizard. This will make it easier to update the list going forwards if we add more site types.

Creating that function also allows us to fix an issue on the "Done" page where the site type would not be in a localized, human-friendly format. For example, you may have seen: "You indicated you're building a physical_products membership site. Here are some recommended Add Ons for your business."

We are also no longer including some of that line if the user did not choose a site type, and are now only showing them "Here are some recommended Add Ons for your business."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
