### PR TITLE
Fixing issue where fields may not show on profile

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1418,7 +1418,7 @@ function pmpro_get_field_html( $field = null ) {
                 <label>
                     <?php esc_html_e( 'Show field on user profile?', 'paid-memberships-pro' ); ?><br />
                     <select name="pmpro_userfields_field_profile">
-                        <option <?php selected( empty( $field_profile ), 0);?>><?php esc_html_e( '[Inherit Group Setting]', 'paid-memberships-pro' ); ?></option>
+                        <option value="" <?php selected( empty( $field_profile ), 0);?>><?php esc_html_e( '[Inherit Group Setting]', 'paid-memberships-pro' ); ?></option>
                         <option value="yes" <?php selected( $field_profile, 'yes' );?>><?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></option>
                         <option value="admins" <?php selected( $field_profile, 'admins' );?>><?php esc_html_e( 'Yes (only admins)', 'paid-memberships-pro' ); ?></option>
                         <option value="no" <?php selected( $field_profile, 'no' );?>><?php esc_html_e( 'No', 'paid-memberships-pro' ); ?></option>
@@ -1527,6 +1527,8 @@ function pmpro_load_user_fields_from_settings() {
         
         foreach ( $group->fields as $settings_field ) {
             // Figure out field profile from settings and group profile.
+			// Check if $settings_field->profile begins and ends with brakcets.
+			$bracketed = 
             if ( empty( $settings_field->profile ) || $settings_field->profile === '[Inherit Group Setting]' ) {
                 $profile = $group_profile;
             } else {

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1527,8 +1527,6 @@ function pmpro_load_user_fields_from_settings() {
         
         foreach ( $group->fields as $settings_field ) {
             // Figure out field profile from settings and group profile.
-			// Check if $settings_field->profile begins and ends with brakcets.
-			$bracketed = 
             if ( empty( $settings_field->profile ) || $settings_field->profile === '[Inherit Group Setting]' ) {
                 $profile = $group_profile;
             } else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
On sites where the string `[Inherit Group Setting]` is localized, user fields will not show on the user profile. This is because of the following check: `if ( empty( $settings_field->profile ) || $settings_field->profile === '[Inherit Group Setting]' )`.

This PR changes the `[Inherit Group Setting]` option to save a value of `""` on the field profile setting so that `empty( $settings_field->profile )` is `true`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
