### PR TITLE
Now always sending billing address to Stripe

### DIFF
--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -81,14 +81,14 @@ jQuery( document ).ready( function( $ ) {
 		// Double check in case a discount code made the level free.
 		if ( typeof pmpro_require_billing === 'undefined' || pmpro_require_billing ) {
 			// Get the data needed to create a payment method for this checkout.
-			if ( pmproStripe.verifyAddress ) {
+			if ( $( '#baddress1' ).length ) {
 				address = {
-					line1: $( '#baddress1' ).val(),
-					line2: $( '#baddress2' ).val(),
-					city: $( '#bcity' ).val(),
-					state: $( '#bstate' ).val(),
-					postal_code: $( '#bzipcode' ).val(),
-					country: $( '#bcountry' ).val(),
+					line1: $( '#baddress1' ).length ? $( '#baddress1' ).val() : '',
+					line2: $( '#baddress2' ).length ? $( '#baddress2' ).val() : '',
+					city: $( '#bcity' ).length ? $( '#bcity' ).val() : '',
+					state: $( '#bstate' ).length ? $( '#bstate' ).val() : '',
+					postal_code: $( '#bzipcode' ).length ? $( '#bzipcode' ).val() : '',
+					country: $( '#bcountry' ).length ? $( '#bcountry' ).val() : '',
 				}
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
if you set the “Show Billing Address Fields” Stripe setting to “No” but are showing the billing fields another way (for example the Address for Free Levels Add On), the billing address will not be attached to the user’s payment method when creating it in Stripe. This would cause recurring orders in PMPro to not show the user’s billing address.


Here is the code that causes this: https://github.com/strangerstudios/paid-memberships-pro/blob/5b90aae69b195fae20467731eb05bd3bb9346f41/js/pmpro-stripe.js#L84


This PR ignores the “Show Billing Address Fields” setting in the `pmpro-stripe.js` code and to just always send the billing address if we have it.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
