### PR TITLE
required asterisk now appears before the hint paragraph if found

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -147,6 +147,14 @@ jQuery(document).ready(function(){
 		jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ).remove();
 		jQuery( '.pmpro_checkout-field-radio' ).find( 'label' ).first().append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
 	}
+    
+    //move asterisk before hint <p>'s
+    jQuery( 'span.pmpro_asterisk' ).each(function() {
+        var prev = jQuery(this).prev();
+        if ( prev.is('p') ) {
+            jQuery(this).insertBefore(prev);
+        }
+    });
 
 	//unhighlight error fields when the user edits them
 	jQuery('.pmpro_error').bind("change keyup input", function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The required field asterisk was appearing on a new line below the field hint for some field types. This PR introduces new JS to detect and fix this placement. It should look like this now:

<img width="702" alt="Screen Shot 2022-11-05 at 12 46 52 PM" src="https://user-images.githubusercontent.com/33220397/200131774-98c608f3-d2b0-405b-80e7-d588be9a536b.png">

### How to test the changes in this Pull Request:

1. Add a textarea or select field with a hint.
2. Make sure it is also required.
3. Note the placement of the required asterisk.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX/ENHANCEMENT: The required field asterisk now appears correctly if a hint is used on a textarea, select, or other user field.
