### PR TITLE
Fix trial wording for non $0 custom trials.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -445,7 +445,7 @@ function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
 
 	// trial part
 	if ( $level->trial_limit ) {
-		if ( (float)$level->trial_amount > 0 ) {
+		if ( (float)$level->trial_amount == 0 ) {
 			if ( $level->trial_limit == '1' ) {
 				$r .= ' ' . __( 'After your initial payment, your first payment is Free.', 'paid-memberships-pro' );
 			} else {


### PR DESCRIPTION
* BUG FIX: Fixed an issue where non-zero trials were saying pricing was free.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves [[XXX](https://github.com/strangerstudios/paid-memberships-pro/issues/2143).](https://github.com/strangerstudios/paid-memberships-pro/issues/2143)