### PR TITLE
Fix Authorize.net sites using profile start date filter

### DIFF
--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -151,36 +151,7 @@ class PMProGateway_authorizenet extends PMProGateway
 			if($this->authorize($order))
 			{
 				$this->void($order);
-				if(!pmpro_isLevelTrial($order->membership_level))
-				{
-					//subscription will start today with a 1 period trial
-					$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");
-					$order->TrialBillingPeriod = $order->BillingPeriod;
-					$order->TrialBillingFrequency = $order->BillingFrequency;
-					$order->TrialBillingCycles = 1;
-					$order->TrialAmount = 0;
-
-					//add a billing cycle to make up for the trial, if applicable
-					if(!empty($order->TotalBillingCycles))
-						$order->TotalBillingCycles++;
-				}
-				elseif($order->InitialPayment == 0 && $order->TrialAmount == 0)
-				{
-					//it has a trial, but the amount is the same as the initial payment, so we can squeeze it in there
-					$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");
-					$order->TrialBillingCycles++;
-
-					//add a billing cycle to make up for the trial, if applicable
-					if(!empty($order->TotalBillingCycles))
-						$order->TotalBillingCycles++;
-				}
-				else
-				{
-					//add a period to the start date to account for the initial payment
-					$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s", strtotime("+ " . $order->BillingFrequency . " " . $order->BillingPeriod, current_time("timestamp")));
-				}
-
-				$order->ProfileStartDate = apply_filters("pmpro_profile_start_date", $order->ProfileStartDate, $order);
+				$order->ProfileStartDate = pmpro_calculate_profile_start_date( $order, 'Y-m-d\TH:i:s' );
 				return $this->subscribe($order);
 			}
 			else
@@ -198,36 +169,7 @@ class PMProGateway_authorizenet extends PMProGateway
 				//set up recurring billing
 				if(pmpro_isLevelRecurring($order->membership_level))
 				{
-					if(!pmpro_isLevelTrial($order->membership_level))
-					{
-						//subscription will start today with a 1 period trial
-						$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");
-						$order->TrialBillingPeriod = $order->BillingPeriod;
-						$order->TrialBillingFrequency = $order->BillingFrequency;
-						$order->TrialBillingCycles = 1;
-						$order->TrialAmount = 0;
-
-						//add a billing cycle to make up for the trial, if applicable
-						if(!empty($order->TotalBillingCycles))
-							$order->TotalBillingCycles++;
-					}
-					elseif($order->InitialPayment == 0 && $order->TrialAmount == 0)
-					{
-						//it has a trial, but the amount is the same as the initial payment, so we can squeeze it in there
-						$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");
-						$order->TrialBillingCycles++;
-
-						//add a billing cycle to make up for the trial, if applicable
-						if(!empty($order->TotalBillingCycles))
-							$order->TotalBillingCycles++;
-					}
-					else
-					{
-						//add a period to the start date to account for the initial payment
-						$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s", strtotime("+ " . $order->BillingFrequency . " " . $order->BillingPeriod, current_time("timestamp")));
-					}
-
-					$order->ProfileStartDate = apply_filters("pmpro_profile_start_date", $order->ProfileStartDate, $order);
+					$order->ProfileStartDate = pmpro_calculate_profile_start_date( $order, 'Y-m-d\TH:i:s' );
 					if($this->subscribe($order))
 					{
 						return true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In most PMPro payment gateways, we calculate a "profile start date" when setting up a payment subscription. This value is intended to hold the day that the first subscription payment will be charged and is filtered by some of our add ons (ex Subscription Delays and Proration) to change the first subscription payment date.

In Authorize.net, however, the profile start date did not work in the same way. Instead of being set to the first payment date, the profile start date was being set to the current date and a "1 cycle free trial" was being set up to delay the first recurring payment.

Although this approach works when only considering core PMPro, the approach is different than all other PMPro gateways and causes issues when Add Ons/custom code use the `pmpro_profile_start_date` filter to modify the profile start date. The effect of this bug would be a free "1 cycle free trial" whenever the `pmpro_profile_start_date` filter was used while setting up an Authorize.net subscription.

The proposed  solution in this pull request is simply to update the Authorize.net subscription code to match the other gateways in core PMPro.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
