### PR TITLE
Add compatibility for Avada Theme

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -46,6 +46,11 @@ function pmpro_compatibility_checker() {
 			'check_type'  => 'class',
 			'check_value' => 'Jetpack',
 		],
+		[
+			'file' 		  => 'avada.php',
+			'check_type'  => 'constant',
+			'check_value' => 'AVADA_VERSION'
+		]
 	];
 
 	foreach ( $compat_checks as $value ) {

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -49,7 +49,7 @@ function pmpro_compatibility_checker() {
 		[
 			'file' 		  => 'avada.php',
 			'check_type'  => 'constant',
-			'check_value' => 'AVADA_VERSION'
+			'check_value' => 'FUSION_BUILDER_VERSION'
 		]
 	];
 

--- a/includes/compatibility/avada.php
+++ b/includes/compatibility/avada.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Compatibility for Avada Theme.
+ */
+
+ // Unhook the_content changes for Avada.
+function pmpro_remove_content_changes_avada() {
+	remove_filter( 'the_content', 'pmpro_membership_content_filter', 5 );
+}
+add_action( 'awb_remove_third_party_the_content_changes', 'pmpro_remove_content_changes_avada', 5 );
+
+// Add the_content restriction back for Avada.
+function pmpro_readd_content_changes_avada() {
+	add_filter( 'the_content', 'pmpro_membership_content_filter', 5 );
+}
+add_action( 'awb_readd_third_party_the_content_changes', 'pmpro_readd_content_changes_avada', 99 );


### PR DESCRIPTION
* BUG FIX/ENHANCEMENT: Add compatibility for Avada Theme. Fixes issue where Avada Layouts/Elements run through the_content such as header, title, footer etc.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
