### PR TITLE
PHP8+: reduce developer warnings

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -242,7 +242,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	/**
 	 * Get the table data
 	 *
-	 * @return Array or integer if $count parameter = true
+	 * @return array|int if $count parameter = true
 	 */
 	private function sql_table_data( $count = false ) {
 		global $wpdb;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Found this warning:
<img width="1144" alt="Screenshot 2022-12-05 at 11 49 32" src="https://user-images.githubusercontent.com/636911/205619589-cd4da3fd-a05a-47ee-ad1e-b0293e8a6359.png">

Caused by the docblock for `sql_table_data` function.
Fixed by using better docblock syntax for multiple return types.

### How to test the changes in this Pull Request:

1. Open your editor and set PHP8+
2. Gonna see that warning because of the static analyzer

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
