### PR TITLE
Invoices for one-time Stripe Checkout payments

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1804,6 +1804,11 @@ class PMProGateway_stripe extends PMProGateway {
 			$checkout_session_params['payment_intent_data'] = $payment_intent_data;
 		}
 
+		// For one-time payments, make sure that we create an invoice.
+		if ( empty( $subscription_data ) ) {
+			$checkout_session_params['invoice_creation']['enabled'] = true;
+		}
+
 		try {
 			$checkout_session = Stripe_Checkout_Session::create( $checkout_session_params );
 		} catch ( Throwable $th ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Set Stripe Checkout to create Invoices for one-item payments. This will allow one-time payments to show as Invoices in the Stripe Customer Portal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
