### PR TITLE
Adding !!membership_level_confirmation_message!! to admin checkout emails

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -577,6 +577,13 @@
 			}
 
 			$membership_level = pmpro_getSpecificMembershipLevelForUser($user->ID, $invoice->membership_id);
+
+			$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
+			if ( ! empty( $confirmation_in_email ) ) {
+				$confirmation_message = $membership_level->confirmation;
+			} else {
+				$confirmation_message = '';
+			}
 			
 			$this->email = get_bloginfo("admin_email");
 			$this->subject = sprintf(__("Member checkout for %s at %s", 'paid-memberships-pro' ), $membership_level->name, get_option("blogname"));	
@@ -589,6 +596,7 @@
 								'siteemail' => pmpro_getOption( 'from_email' ),
 								'membership_id' => $membership_level->id,
 								'membership_level_name' => $membership_level->name,
+								'membership_level_confirmation_message' => $confirmation_message,
 								'membership_cost' => pmpro_getLevelCost($membership_level),								
 								'login_link' => pmpro_login_url(),
 								'login_url' => pmpro_login_url(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The `!!membership_level_confirmation_message!!` email template variable was not being set up for admin checkout emails. This PR adds that email template variable.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
