### PR TITLE
Fixes No orders found issue

### DIFF
--- a/adminpages/orders-csv.php
+++ b/adminpages/orders-csv.php
@@ -226,7 +226,8 @@ if ( ! empty( $s ) ) {
 	}
 
 	$sqlQuery .= ") ";
-	$sqlQuery .= "AND " . esc_sql( $condition ) . " ";
+	//Not escaping here because we escape the values in the condition statement
+	$sqlQuery .= "AND " . $condition . " ";
 	$sqlQuery .= "GROUP BY o.id ORDER BY o.id DESC, o.timestamp DESC ";
 
 } else {
@@ -235,8 +236,8 @@ if ( ! empty( $s ) ) {
 	if ( $filter === 'with-discount-code' ) {
 		$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON o.id = dc.order_id ";
 	}
-
-	$sqlQuery .= "WHERE " . esc_sql( $condition ) . ' ORDER BY o.id DESC, o.timestamp DESC ';
+	//Not escaping here because we escape the values in the condition statement
+	$sqlQuery .= "WHERE " . $condition . ' ORDER BY o.id DESC, o.timestamp DESC ';
 }
 
 if ( ! empty( $start ) && ! empty( $limit ) ) {

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1380,7 +1380,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 			}
 			$sqlQuery .= ') ';
 
-			$sqlQuery .= 'AND ' . esc_sql( $condition ) . ' ';
+			$sqlQuery .= 'AND ' . $condition . ' ';
 
 			$sqlQuery .= 'GROUP BY o.id ORDER BY o.id DESC, o.timestamp DESC ';
 		} else {
@@ -1390,7 +1390,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 				$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON o.id = dc.order_id ";
 			}
 
-			$sqlQuery .= "WHERE " . esc_sql( $condition ) . ' ORDER BY o.id DESC, o.timestamp DESC ';
+			$sqlQuery .= "WHERE " . $condition . ' ORDER BY o.id DESC, o.timestamp DESC ';
 		}
 
 		$sqlQuery .= "LIMIT " . esc_sql( $start ) . "," . esc_sql( $limit );

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1380,7 +1380,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 			}
 			$sqlQuery .= ') ';
 
-			//Not escaping here because we escape the start and end dates in the condition statement
+			//Not escaping here because we escape the values in the condition statement
 			$sqlQuery .= 'AND ' . $condition . ' ';
 
 			$sqlQuery .= 'GROUP BY o.id ORDER BY o.id DESC, o.timestamp DESC ';
@@ -1390,7 +1390,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 			if ( $filter === 'with-discount-code' ) {
 				$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON o.id = dc.order_id ";
 			}
-			//Not escaping here because we escape the start and end dates in the condition statement
+			//Not escaping here because we escape the values in the condition statement
 			$sqlQuery .= "WHERE " . $condition . ' ORDER BY o.id DESC, o.timestamp DESC ';
 		}
 

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -1380,6 +1380,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 			}
 			$sqlQuery .= ') ';
 
+			//Not escaping here because we escape the start and end dates in the condition statement
 			$sqlQuery .= 'AND ' . $condition . ' ';
 
 			$sqlQuery .= 'GROUP BY o.id ORDER BY o.id DESC, o.timestamp DESC ';
@@ -1389,7 +1390,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 			if ( $filter === 'with-discount-code' ) {
 				$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON o.id = dc.order_id ";
 			}
-
+			//Not escaping here because we escape the start and end dates in the condition statement
 			$sqlQuery .= "WHERE " . $condition . ' ORDER BY o.id DESC, o.timestamp DESC ';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Additional SQL escaping seems to add backslashes to the dates in the filter 'Within date range'.

Each date has escaping on it though so removed the additional escape around the main statement.

### How to test the changes in this Pull Request:

1. Navigate to Orders
2. Click on the 'Show' dropdown and select 'Within Date Range' - specify your date
3. Results should now be returned within the range.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed a bug that caused no results to be returned when filtering orders within a date range.
