### PR TITLE
Escape pmpro_url return

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -155,7 +155,7 @@ function pmpro_url( $page = null, $querystring = '', $scheme = null ) {
 
 	if ( ! empty( $url ) ) {
 
-		$url = esc_url_raw( add_query_arg( $query_args, $url ) );
+		$url = add_query_arg( $query_args, $url );
 
 		// figure out scheme
 		if ( is_ssl() ) {
@@ -168,7 +168,7 @@ function pmpro_url( $page = null, $querystring = '', $scheme = null ) {
 	 */
 	$url = apply_filters( 'pmpro_url', $url, $page, $querystring, $scheme );
 
-	return $url;
+	return esc_url_raw( $url );
 }
 
 function pmpro_isLevelFree( &$level ) {


### PR DESCRIPTION
* ENHANCEMENT: esc_url when returning the URL inside the pmpro_url() function.

This helps developers when calling pmpro_url() to not need to escape during the output of the URL. We were already doing this but using the filter could bypass the esc_url_raw. I moved things around.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?