### PR TITLE
Close popups in admin by pressing "esc"

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1283,6 +1283,13 @@
 			jQuery('.pmproPopupCloseButton').click(function() {
 				jQuery('.pmpro-popup-overlay').hide();
 			});
+			    // Hide the popup banner if "ESC" is pressed.
+			jQuery(document).keyup(function (e) {
+				if (e.key === 'Escape') {
+					jQuery('.pmpro-popup-overlay').hide();
+				}
+			});
+
 			<?php if( ! empty( $_REQUEST['showpopup'] ) ) { ?>addLevel();<?php } ?>
 		} );
 		function addLevel() {

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1283,7 +1283,8 @@
 			jQuery('.pmproPopupCloseButton').click(function() {
 				jQuery('.pmpro-popup-overlay').hide();
 			});
-			    // Hide the popup banner if "ESC" is pressed.
+			
+			// Hide the popup banner if "ESC" is pressed.
 			jQuery(document).keyup(function (e) {
 				if (e.key === 'Escape') {
 					jQuery('.pmpro-popup-overlay').hide();

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -784,6 +784,13 @@ jQuery( document ).ready( function() {
         jQuery('.pmpro-popup-overlay').hide();
     });
 
+    // Hide the popup banner if "ESC" is pressed.
+    jQuery(document).keyup(function (e) {
+        if (e.key === 'Escape') {
+            jQuery('.pmpro-popup-overlay').hide();
+        }
+    });
+
     jQuery('#pmpro-admin-add-ons-list .action-button .pmproAddOnActionButton').click(function( e ) {
         e.preventDefault();
 


### PR DESCRIPTION
*ENHANCEMENT: Added the ability to press "esc" to close the levels and Add Ons license popup modal.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?