### PR TITLE
Setting new payment method as default after Authorize.net update billing flow

### DIFF
--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -769,6 +769,67 @@ class PMProGateway_authorizenet extends PMProGateway
 
 			if($resultCode == "Ok" || $code == "Ok")
 			{
+				// Subscription successfully updated. Let's also set the new payment profile to be default.
+				$customer_profile_id = intval( $this->substring_between($this->response, "<customerProfileId>", "</customerProfileId>") );
+				$payment_profile_id  = intval( $this->substring_between($this->response, "<customerPaymentProfileId>", "</customerPaymentProfileId>") );
+				if ( ! empty( $customer_profile_id ) && ! empty( $payment_profile_id ) ) {
+					sleep(10); // Wait for the subscription to be updated. 5 seemed to be too quick, 10 seems to be enough.
+
+					$this->content =
+						"<?xml version=\"1.0\" encoding=\"utf-8\"?>" .
+						"<updateCustomerPaymentProfileRequest xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\">".
+						"<merchantAuthentication>".
+						"<name><![CDATA[" . $loginname . "]]></name>".
+						"<transactionKey>" . $transactionkey . "</transactionKey>".
+						"</merchantAuthentication>".
+						"<customerProfileId>" . $customer_profile_id . "</customerProfileId>".
+						"<paymentProfile>".
+						"<billTo>".
+						"<firstName><![CDATA[". substr($firstName, 0, 50) . "]]></firstName>".
+						"<lastName><![CDATA[" . substr($lastName, 0, 50) . "]]></lastName>".
+						"<address><![CDATA[". substr($address, 0, 60) . "]]></address>".
+						"<city><![CDATA[" . substr($city, 0, 40) . "]]></city>".
+						"<state><![CDATA[". substr($state, 0, 2) . "]]></state>".
+						"<zip>" . substr($zip, 0, 20) . "</zip>".
+						"<country>". substr($country, 0, 60) . "</country>".
+						"</billTo>".
+						"<payment>".
+						"<creditCard>".
+						"<cardNumber>" . $cardNumber . "</cardNumber>".
+						"<expirationDate>" . $expirationDate . "</expirationDate>";
+					if(!empty($cardCode))
+						$this->content .= "<cardCode>" . $cardCode . "</cardCode>";
+					$this->content .=
+						"</creditCard>".
+						"</payment>".
+						"<defaultPaymentProfile>true</defaultPaymentProfile>".
+						"<customerPaymentProfileId>" . $payment_profile_id . "</customerPaymentProfileId>".
+						"</paymentProfile>".
+						"</updateCustomerPaymentProfileRequest>";
+
+					//send the xml via curl
+					$this->response = $this->send_request_via_curl($host,$path,$this->content);
+					//echo $this->response . '<br><br>'; // If we tried to update too soon, error will say that customer profile or payment profile doesn't exist.
+
+					// In case we want to check that the payment profile was set to default.
+					/*
+					$this->content = 
+						"<?xml version=\"1.0\" encoding=\"utf-8\"?>" .
+						"<getCustomerProfileRequest xmlns=\"AnetApi/xml/v1/schema/AnetApiSchema.xsd\">".
+						"<merchantAuthentication>".
+						"<name><![CDATA[" . $loginname . "]]></name>".
+						"<transactionKey>" . $transactionkey . "</transactionKey>".
+						"</merchantAuthentication>".
+						"<customerProfileId>" . $customer_profile_id . "</customerProfileId>".
+						"<includeIssuerInfo>true</includeIssuerInfo>".
+						"</getCustomerProfileRequest>";
+					$this->response = $this->send_request_via_curl($host,$path,$this->content);
+					// Print entire repsonse.
+					echo $this->response;
+					wp_die();
+					*/
+
+				}
 				return true;
 			}
 			else


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
After we update an Authorize.net payment method, this PR adds another API call to set the new Payment Profile as the default for the Customer Profile in Authorize.net.

Needed to add a 10 second sleep before calling `updateCustomerPaymentProfileRequest`, otherwise setting the new payment method to "default" would fail. It would be great to find a more elegant solution for this. 

Should fix #2138, though not 100% sure. This is a weird issue. It may be necessary to instead delete all old Payment Profiles besides for the one that was just created, so this may be a next step.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out for an Authorize.net subscription
2. Uncomment the `// In case we want to check that the payment profile was set to default.` code in the PR
3. Use the update billing page to change payment methods4. 
4. Use inspect element to dig into the `getCustomerProfileRequest` response to make sure that `defaultPaymentProfile` is set to `true` for the new Payment Profile. May need to dig through the response a bit to find it.

Unfortunately, it doesn't seem like Authorize.net gives us a way to see the "Default" payment profile on their website.
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
