### PR TITLE
private methods weren't encoding. let's only return a subset of data …

### DIFF
--- a/includes/services.php
+++ b/includes/services.php
@@ -127,7 +127,7 @@ function pmpro_get_order_json() {
 		'id' => (int)$order->id,
 		'user_id' => (int)$order->user_id,
 		'membership_id' => (int)$order->membership_id,
-		'code' => sanitize_text_field( $order->code ),
+		'code' => esc_html( $order->code ),
 		'Email' => sanitize_email( $order->Email ),		
 	);
 	

--- a/includes/services.php
+++ b/includes/services.php
@@ -112,6 +112,7 @@ add_action('wp_ajax_pmpro_orders_print_view', 'pmpro_orders_print_view');
  * Get order JSON.
  *
  * @since 1.8.6
+ * @since 2.9.10 - Only returns a subset of data. Only email is really used.
  */
 function pmpro_get_order_json() {
 	// only admins can get this
@@ -121,7 +122,16 @@ function pmpro_get_order_json() {
 	
 	$order_id = intval( $_REQUEST['order_id'] );
 	$order = new MemberOrder($order_id);
-	echo json_encode($order);
+		
+	$r = array(
+		'id' => (int)$order->id,
+		'user_id' => (int)$order->user_id,
+		'membership_id' => (int)$order->membership_id,
+		'code' => sanitize_text_field( $order->code ),
+		'Email' => sanitize_email( $order->Email ),		
+	);
+	
+	echo wp_json_encode($r);
 	exit;
 }
 add_action('wp_ajax_pmpro_get_order_json', 'pmpro_get_order_json');


### PR DESCRIPTION
…anyway.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since we updated the MemberOrder to use private properties, calls to `json_encode( $order )` were failing. This update instead creates an array $r and populates a few escaped values in there which encodes fine.

Also using wp_json_encode instead of just json_encode.

Resolves 2329.

### How to test the changes in this Pull Request:

1. Go to the orders screen in the dashboard.
2. Hover over an order and click "email".
3. Note the email is prepopulated again. Click send.
4. The email is sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issue where Invoice Emails would fail to send from the orders page of the dashboard.
