### PR TITLE
Fix fatal in case all the pmpro_reports were unset

### DIFF
--- a/adminpages/reports.php
+++ b/adminpages/reports.php
@@ -22,27 +22,29 @@ if ( ! empty( $_REQUEST[ 'report' ] ) ) {
 
 	<?php
 } else {
-	$pieces = array_chunk( $pmpro_reports, ceil( count( $pmpro_reports ) / 2 ), true );
-	foreach ( $pieces[0] as $report => $title ) {
-		add_meta_box(
-			'pmpro_report_' . $report,
-			$title,
-			'pmpro_report_' . $report . '_widget',
-			'memberships_page_pmpro-reports',
-			'advanced'
-		);
-	}
-	
-	foreach ( $pieces[1] as $report => $title ) {
-		add_meta_box(
-			'pmpro_report_' . $report,
-			$title,
-			'pmpro_report_' . $report . '_widget',
-			'memberships_page_pmpro-reports',
-			'side'
-		);
-	}
-	
+    if( ! empty( $pmpro_reports ) ) {
+        $pieces = array_chunk( $pmpro_reports, ceil( count( $pmpro_reports ) / 2 ), true );
+        foreach ( $pieces[0] as $report => $title ) {
+            add_meta_box(
+                'pmpro_report_' . $report,
+                $title,
+                'pmpro_report_' . $report . '_widget',
+                'memberships_page_pmpro-reports',
+                'advanced'
+            );
+        }
+
+        foreach ( $pieces[1] as $report => $title ) {
+            add_meta_box(
+                'pmpro_report_' . $report,
+                $title,
+                'pmpro_report_' . $report . '_widget',
+                'memberships_page_pmpro-reports',
+                'side'
+            );
+        }
+    }
+
 	?>
 	<form id="pmpro-reports-form" method="post" action="admin-post.php">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR does not perform the `array_chunk` if the array is empty.

### How to test the changes in this Pull Request:

```php
global $pmpro_reports;
unset( $pmpro_reports['login'] );
unset( $pmpro_reports['sales'] );
unset( $pmpro_reports['memberships'] );
```

Then load the pmpro-reports page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
