### PR TITLE
Fix warnings in case all the pmpro_reports were unset except one

### DIFF
--- a/adminpages/reports.php
+++ b/adminpages/reports.php
@@ -34,14 +34,16 @@ if ( ! empty( $_REQUEST[ 'report' ] ) ) {
             );
         }
 
-        foreach ( $pieces[1] as $report => $title ) {
-            add_meta_box(
-                'pmpro_report_' . $report,
-                $title,
-                'pmpro_report_' . $report . '_widget',
-                'memberships_page_pmpro-reports',
-                'side'
-            );
+        if( ! empty( $pieces[1] ) ) {
+	        foreach ( $pieces[1] as $report => $title ) {
+		        add_meta_box(
+			        'pmpro_report_' . $report,
+			        $title,
+			        'pmpro_report_' . $report . '_widget',
+			        'memberships_page_pmpro-reports',
+			        'side'
+		        );
+	        }
         }
     }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Additional case to be considered (from #2343).
`$pieces[1]` is null when there's just one widget.

### How to test the changes in this Pull Request:

1. unset all the reports' widgets except one
2. load the reports page
3. check the logs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->