### PR TITLE
Fix double-prefix when using pmpro_setOption in wisdom integration

### DIFF
--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -34,7 +34,7 @@ class PMPro_Wisdom_Integration {
 	 *
 	 * @var string
 	 */
-	public $plugin_option = 'pmpro_wisdom_opt_out';
+	public $plugin_option = 'wisdom_opt_out';
 
 	/**
 	 * The plugin settings pages to include Wisdom notices on.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When enabling wisdom integration from the Allow button on a back-end notice, the Advanced Settings option was still set to no. This is because we were saving the user choice into a double prefixed option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
