### PR TITLE
Fixing Stripe payment IDs not saving at checkout

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1929,7 +1929,7 @@ class PMProGateway_stripe extends PMProGateway {
 				return false;
 			}
 			// Payment should now be processed.
-			$payment_transaction_id = $payment_intent->charges->data[0]->id;
+			$payment_transaction_id = $payment_intent->latest_charge;
 
 			// Note the customer so that we can create a subscription if needed..
 			$customer = $payment_intent->customer;
@@ -1972,8 +1972,8 @@ class PMProGateway_stripe extends PMProGateway {
 			}
 
 			// If we needed to charge an initial payment, it was successful.
-			if ( ! empty( $order->stripe_payment_intent->charges->data[0]->id ) ) {
-				$payment_transaction_id = $order->stripe_payment_intent->charges->data[0]->id;
+			if ( ! empty( $order->stripe_payment_intent->latest_charge ) ) {
+				$payment_transaction_id = $order->stripe_payment_intent->latest_charge;
 			}
 		}
 
@@ -4095,7 +4095,7 @@ class PMProGateway_stripe extends PMProGateway {
 	public function clean_up( &$order ) {
     pmpro_method_should_be_private( '2.7.0' );
 		if ( ! empty( $order->stripe_payment_intent ) && 'succeeded' == $order->stripe_payment_intent->status ) {
-			$order->payment_transaction_id = $order->stripe_payment_intent->charges->data[0]->id;
+			$order->payment_transaction_id = $order->stripe_payment_intent->latest_charge;
 		}
 
 		if ( empty( $order->subscription_transaction_id ) && ! empty( $order->stripe_subscription ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The `charges` property of Stripe PaymentIntents has been removed. Switching to `latest_charge instead.

See Stripe API Version `2022-11-15` breaking changes here: https://stripe.com/docs/upgrades

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
