### PR TITLE
Fixing orders REST API endpoint

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -717,7 +717,37 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				return new WP_REST_Response( 'No order code sent.', 400 );
 			}
 
-			return new WP_REST_Response( new MemberOrder( $code ), 200 );
+			// Build the order object to return.
+			// Need to do this because the order object now has private properties.
+			$order = new MemberOrder( $code );
+			$order_data_to_return = new stdClass();
+			if ( ! empty( $order->id ) ) {
+				$order_data_to_return->id = $order->id;
+				$order_data_to_return->code = $order->code;
+				$order_data_to_return->user_id = $order->user_id;
+				$order_data_to_return->membership_id = $order->membership_id;
+				$order_data_to_return->billing = $order->billing;
+				$order_data_to_return->subtotal = $order->subtotal;
+				$order_data_to_return->tax = $order->tax;
+				$order_data_to_return->total = $order->total;
+				$order_data_to_return->payment_type = $order->payment_type;
+				$order_data_to_return->cardtype = $order->cardtype;
+				$order_data_to_return->accountnumber = $order->accountnumber;
+				$order_data_to_return->expirationmonth = $order->expirationmonth;
+				$order_data_to_return->expirationyear = $order->expirationyear;
+				$order_data_to_return->status = $order->status;
+				$order_data_to_return->gateway = $order->gateway;
+				$order_data_to_return->gateway_environment = $order->gateway_environment;
+				$order_data_to_return->payment_transaction_id = $order->payment_transaction_id;
+				$order_data_to_return->subscription_transaction_id = $order->subscription_transaction_id;
+				$order_data_to_return->timestamp = $order->timestamp;
+				$order_data_to_return->affiliate_id = $order->affiliate_id;
+				$order_data_to_return->affiliate_subid = $order->affiliate_subid;
+				$order_data_to_return->notes = $order->notes;
+				$order_data_to_return->checkout_id = $order->checkout_id;
+			}
+
+			return new WP_REST_Response( $order_data_to_return, 200 );
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A couple versions ago, we changed MemberOrder properties to be private. Since then, our Orders API endpoint hasn't been working.

This fixes the endpoint.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
