### PR TITLE
Fixed login error code always showing invalid.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -886,7 +886,7 @@ add_filter( 'authenticate', 'pmpro_authenticate_username_password', 30, 3);
  * @since 2.3
  *
  */
-function pmpro_login_failed( $username ) {
+function pmpro_login_failed( $username, $error ) {
 
 	$login_page = pmpro_getOption( 'login_page_id' );
 	if ( empty( $login_page ) ) {
@@ -902,7 +902,8 @@ function pmpro_login_failed( $username ) {
 
 	if ( $referrer && ! strstr( $referrer, 'wp-login' ) && ! strstr( $referrer, 'wp-admin' ) ) {
 		if ( ! strstr( $referrer, '?login=failed') ) {
-			wp_redirect( add_query_arg( array( 'action'=>'failed', 'username' => sanitize_text_field( $username ), 'redirect_to' => urlencode( $redirect_to ) ), pmpro_login_url() ) );
+			$error_code = $error->get_error_code();
+			wp_redirect( add_query_arg( array( 'action'=> $error_code, 'username' => sanitize_text_field( $username ), 'redirect_to' => urlencode( $redirect_to ) ), pmpro_login_url() ) );		
 		} else {
 			wp_redirect( add_query_arg( 'action', 'loggedout', pmpro_login_url() ) );
 		}

--- a/includes/login.php
+++ b/includes/login.php
@@ -315,7 +315,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 	$message = '';
 	$msgt = 'pmpro_alert';
 	if ( isset( $_GET['action'] ) ) {
-		$username = isset( $_GET['username'] ) ? esc_html( $_GET['username'] ) : '';
+		$username = isset( $_GET['username'] ) ? sanitize_text_field( $_GET['username'] ) : '';
 		switch ( sanitize_text_field( $_GET['action'] ) ) {
 			case 'failed':
 				$message = __( 'There was a problem with your username or password.', 'paid-memberships-pro' );

--- a/includes/login.php
+++ b/includes/login.php
@@ -324,6 +324,10 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 				$message = __( 'Unknown username. Check again or try your email address.', 'paid-memberships-pro' );
 				$msgt = 'pmpro_error';
 				break;
+			case 'invalid_email' :
+				$message = __( 'Unknown email address. Check again or try your username.', 'paid-memberships-pro' );
+				$msgt = 'pmpro_error';
+				break;
 			case 'empty_username':
 				$message = __( 'Empty username. Please enter your username and try again.', 'paid-memberships-pro' );
 				$msgt = 'pmpro_error';

--- a/includes/login.php
+++ b/includes/login.php
@@ -215,7 +215,7 @@ function pmpro_lostpassword_url( $redirect = '' ) {
 		return wp_lostpassword_url( $redirect );
 	}
 
-	$args = array( 'action' => 'lostpassword' );
+	$args = array( 'action' => 'reset_pass' );
     if ( ! empty( $redirect ) ) {
         $args['redirect_to'] = urlencode( $redirect );
     }
@@ -315,13 +315,18 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 	$message = '';
 	$msgt = 'pmpro_alert';
 	if ( isset( $_GET['action'] ) ) {
+		$username = isset( $_GET['username'] ) ? esc_html( $_GET['username'] ) : '';
 		switch ( sanitize_text_field( $_GET['action'] ) ) {
 			case 'failed':
 				$message = __( 'There was a problem with your username or password.', 'paid-memberships-pro' );
 				$msgt = 'pmpro_error';
 				break;
 			case 'invalid_username':
-				$message = __( 'Unknown username. Check again or try your email address.', 'paid-memberships-pro' );
+				$message =sprintf(
+				/* translators: %s: User name. */
+				__( '<strong>Error:</strong> The username <strong>%s</strong> is not registered on this site. If you are unsure of your username, try your email address instead.', 'paid-memberships-pro' ),
+				$username
+				);
 				$msgt = 'pmpro_error';
 				break;
 			case 'invalid_email' :
@@ -329,21 +334,28 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 				$msgt = 'pmpro_error';
 				break;
 			case 'empty_username':
-				$message = __( 'Empty username. Please enter your username and try again.', 'paid-memberships-pro' );
+				$message = __( '<strong>Error:</strong> The username field is empty.', 'paid-memberships-pro');
 				$msgt = 'pmpro_error';
 				break;
 			case 'empty_password':
-				$message = __( 'Empty password. Please enter your password and try again.', 'paid-memberships-pro' );
+				$message = __( '<strong>Error:</strong> The password field is empty.', 'paid-memberships-pro' );
 				$msgt = 'pmpro_error';
 				break;
 			case 'incorrect_password':
-				$message = __( 'The password you entered for the user is incorrect. Please try again.', 'paid-memberships-pro' );
+				$message = sprintf(
+				/* translators: %s: User name. */
+				__( '<strong>Error:</strong> The password you entered for the username %s is incorrect.', 'paid-memberships-pro' ),
+				'<strong>' . $username . '</strong>'
+			) .
+			' <a href="' . pmpro_lostpassword_url() . '">' .
+			__( 'Lost your password?' ) .
+			'</a>';
 				$msgt = 'pmpro_error';
 				break;
 			case 'recovered':
 				$message = __( 'Check your email for the confirmation link.', 'paid-memberships-pro' );
 				break;
-			case 'confirmaction':
+			case 'confirmation':
 				// Check if we are processing a confirmaction for a Data Request.
 				$request_id = pmpro_confirmaction_handler();
 				$message = _wp_privacy_account_request_confirmed_message( $request_id );
@@ -863,7 +875,7 @@ add_filter( 'wp_new_user_notification_email', 'pmpro_password_reset_email_filter
 
 	// For some reason, WP core doesn't recognize this error.
 	if ( ! empty( $username ) && empty( $password ) ) {
-		$user = new WP_Error( 'invalid_username', __( 'There was a problem with your username or password.', 'paid-memberships-pro' ) );
+		$user = new WP_Error( 'empty_password',__( '<strong>Error:</strong> The password field is empty.', 'paid-memberships-pro' ) );
 	}
 
 	// check what page the login attempt is coming from
@@ -874,7 +886,11 @@ add_filter( 'wp_new_user_notification_email', 'pmpro_password_reset_email_filter
 		$error = $user->get_error_code();
 
 		if ( $error ) {
-				wp_redirect( add_query_arg( 'action', urlencode( $error ), pmpro_login_url() ) );
+				$error_args = array(
+					'action' => urlencode( $error ),
+					'username' => sanitize_text_field( $username )
+				);
+				wp_redirect( add_query_arg( $error_args, pmpro_login_url() ) );
 			} else {
 				wp_redirect( pmpro_login_url() );
 			}

--- a/includes/login.php
+++ b/includes/login.php
@@ -348,7 +348,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 				'<strong>' . $username . '</strong>'
 			) .
 			' <a href="' . pmpro_lostpassword_url() . '">' .
-			__( 'Lost your password?' ) .
+			__( 'Lost your password?', 'paid-memberships-pro' ) .
 			'</a>';
 				$msgt = 'pmpro_error';
 				break;


### PR DESCRIPTION
* BUG FIX: Fixed an issue where our frontend login failure would always return the same error message which isn't clear. This now supports the other cases we try to support when the login fails and shows a clearer message.

Resolves: https://github.com/strangerstudios/paid-memberships-pro/issues/2359

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Try logging in with incorrect details. You may use a combination of correct username, incorrect password or a username that doesn't exist.
2. See the error message now changes to the correct warnings we set out here - https://github.com/strangerstudios/paid-memberships-pro/blob/dev/includes/login.php#L318-L348

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* BUG FIX/ENHANCMENT: Improved error message functionality during the failed login process on the frontend.
