### PR TITLE
Fixing one-time payments with Stripe Checkout

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1817,7 +1817,7 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		// For one-time payments, make sure that we create an invoice.
-		if ( empty( $subscription_data ) ) {
+		if ( $checkout_session_params['mode'] === 'payment' ) {
 			$checkout_session_params['invoice_creation']['enabled'] = true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Making sure `mode` is `payment` before enabling `invoice_creation` when sending user to Stripe Checkout.

I do not see why this change should make a practical difference, but looking to fix the following error and this PR is more verbose:

> Could not create checkout session. You can only enable invoice creation when `mode` is set to `payment`. Invoices are created automatically when `mode` is set to `subscription`, and are unsupported when set to `setup`. To learn more visit https://stripe.com/docs/payments/checkout/post-payment-invoices.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
