### PR TITLE
Set default options to false instead of ''

### DIFF
--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -467,8 +467,8 @@ class PMPro_Wisdom_Integration {
 			unset( $level_data->confirmation );
 
 			// Add Set Expiration Date/Subscription Delay info.
-			$level_data->set_expiration_date = get_option( 'pmprosed_' . $level_id , '' );
-			$level_data->subscription_delay  = get_option( 'pmpro_subscription_delay_' . $level_id , '' );
+			$level_data->set_expiration_date = get_option( 'pmprosed_' . $level_id );
+			$level_data->subscription_delay  = get_option( 'pmpro_subscription_delay_' . $level_id );
 
 			// Add if a category is set.
 			$categories = $wpdb->get_col(


### PR DESCRIPTION
* BUG FIX: Potential fix for some PHP 8 Errors where empty options were set to blank strings and causing a fatal error. Rather let it default to false.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
