### PR TITLE
Idea: Filter to hide the setup wizard links in admin.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2915,7 +2915,10 @@ function pmpro_show_setup_wizard_link() {
 		$show = false;
 	}
 
-	return $show;
+	/**
+	 * Filter to determine if the Setup Wizard link should show. Allows you to bypass whether or not to show the link.
+	 */
+	return apply_filters( 'pmpro_show_setup_wizard_link', $show );
 }
 
 /**


### PR DESCRIPTION
Added in a filter to show/hide the setup wizard based on custom conditions. I assume web developers won't want their customer's running through the setup wizard in some instances and want to hide it from them as things may be overwritten or added when running through the setup wizard?

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
