### PR TITLE
Fix for fatal error on site health check page if login/password is required for ftp account

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -318,7 +318,7 @@ class PMPro_Site_Health {
 
 		WP_Filesystem();
 
-		if ( ! $wp_filesystem ) {
+        if ( ! $wp_filesystem || ! is_object($wp_filesystem) || ( is_wp_error($wp_filesystem->errors) && $wp_filesystem->errors->has_errors() ) ) {
 			return new WP_Error( 'access-denied', __( 'Unable to verify', 'paid-memberships-pro' ) );
 		}
 
@@ -489,7 +489,7 @@ class PMPro_Site_Health {
 
 		WP_Filesystem();
 
-		if ( ! $wp_filesystem ) {
+        if ( ! $wp_filesystem || ! is_object($wp_filesystem) || ( is_wp_error($wp_filesystem->errors) && $wp_filesystem->errors->has_errors() ) ) {
 			return __( 'Unable to access .htaccess file', 'paid-memberships-pro' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There is an error on the site health check page caused by paid-memberships-pro plugin due insufficient check for calling some methods.

Resolves:

Stack trace:
#0 ../wp-admin/includes/class-wp-filesystem-ftpext.php(420): ftp_nlist()
#1 ../wp-content/plugins/paid-memberships-pro/classes/class-pmpro-site-health.php(489): WP_Filesystem_FTPext->exists()
#2 ../wp-content/plugins/paid-memberships-pro/classes/class-pmpro-site-health.php(102): PMPro_Site_Health->get_htaccess_cache_usage()
#3 ../wp-includes/class-wp-hook.php(308): PMPro_Site_Health->debug_information()
#4 ../wp-includes/plugin.php(205): WP_Hook->apply_filters()
#5 ../wp-admin/includes/class-wp-debug-data.php(1457): apply_filters()
#6 ../wp-admin/site-health-info

### How to test the changes in this Pull Request:

1. Set different permissions for wp folder that require login/password for ftp
2. Go to /wp-admin/site-health.php?tab=debug

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
