### PR TITLE
Exit when using wp_redirect

### DIFF
--- a/adminpages/wizard/save-steps.php
+++ b/adminpages/wizard/save-steps.php
@@ -95,6 +95,7 @@ function pmpro_init_save_wizard_data() {
 		// Before redirecting to next step, save the step we're redirecting to.
 		pmpro_setOption( 'wizard_step', $step );
 		wp_redirect( $next_step );
+		exit;
 	}
 
 	/**
@@ -138,7 +139,7 @@ function pmpro_init_save_wizard_data() {
 		// Save the step should they come back at a later stage.
 		pmpro_setOption( 'wizard_step', 'memberships' );
 		wp_redirect( $next_step );
-
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Not fixing a bug here, just stay compliant to the guidelines.
When merging this in, please consider there are 2-3 more cases (in includes/login.php) where using wp_redirect without exit.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

