### PR TITLE
Wisdom: update block notice if already chosen

### DIFF
--- a/classes/class-pmpro-wisdom-tracker.php
+++ b/classes/class-pmpro-wisdom-tracker.php
@@ -808,6 +808,8 @@ class PMPro_Wisdom_Tracker {
 			if ( $this->marketing ) {
 				$this->set_can_collect_email( false );
 			}
+		} elseif ( false !== pmpro_getOption( 'pmpro_wisdom_opt_out' ) ) {
+			$this->update_block_notice();
 		} else {
 			// Display the notice requesting permission to track
 			// Retrieve current plugin information

--- a/classes/class-pmpro-wisdom-tracker.php
+++ b/classes/class-pmpro-wisdom-tracker.php
@@ -808,7 +808,7 @@ class PMPro_Wisdom_Tracker {
 			if ( $this->marketing ) {
 				$this->set_can_collect_email( false );
 			}
-		} elseif ( false !== pmpro_getOption( 'pmpro_wisdom_opt_out' ) ) {
+		} elseif ( false !== pmpro_getOption( 'wisdom_opt_out' ) ) {
 			$this->update_block_notice();
 		} else {
 			// Display the notice requesting permission to track


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Easier to be tested in production. Go through the wizard and make a choice (enable tracking yes or no).
Then you gonna see the Tracking notice bugging you even if you already made a choice.
This is because we were not checking the option value to be !== false (which means a choice has been made).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

