### PR TITLE
Updating paused notification to include site URL and adjusted text

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -1190,7 +1190,8 @@ tr.pmpro_settings_divider td {
 }
 
 /* notifications */
-.pmpro_notification {
+.pmpro_notification,
+.notice.pmpro_notification {
 	background-color: #FFF;
 	border: 1px solid #ccd0d4;
 	box-shadow: 0 1px 4px rgba( 0, 0, 0, 0.15 );
@@ -1269,30 +1270,30 @@ tr.pmpro_settings_divider td {
 	margin-right: 5px;
 	white-space: break-spaces;
 }
-.pmpro_notification .button-dismiss {
+.pmpro_notification .button-secondary {
 	border-color: #C3C4C7;
 	color: #50575E;
 }
 .pmpro_notification-general h3 {
 	color: #567533;
 }
-.pmpro_notification-general .button:not(.button-dismiss) {
+.pmpro_notification-general .button:not(.button-secondary) {
 	background-color: #567533;
 	border-color: #456227;
 	color: #FFF;
 }
-.pmpro_notification-general .button:hover:not(.button-dismiss) {
+.pmpro_notification-general .button:hover:not(.button-secondary) {
 	background-color: #456227;
 }
 .pmpro_notification-error h3 {
 	color: #721C24;
 }
-.pmpro_notification-error .button:not(.button-dismiss) {
+.pmpro_notification-error .button:not(.button-secondary) {
 	background-color: #721C24;
 	border-color: #711B23;
 	color: #FFF;
 }
-.pmpro_notification-error .button:hover:not(.button-dismiss) {
+.pmpro_notification-error .button:hover:not(.button-secondary) {
 	background-color: #600027;
 	border-color: #600027;
 	color: #FFF;

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -174,11 +174,11 @@ function pmpro_pause_mode_notice() {
 			</div>
 			<div class="pmpro_notification-content">
 				<h3><?php esc_html_e( 'Site URL Change Detected', 'paid-memberships-pro' ); ?></h3>
-				<p><?php _e( '<strong>Warning:</strong> We have detected that your site URL has changed. All cron jobs and automated services have been disabled.', 'paid-memberships-pro' ); ?></p>
+				<p><?php printf( __( '<strong>Warning:</strong> We have detected that your site URL has changed. All PMPro-related cron jobs and automated services have been disabled. Paid Memberships Pro considers %s to be the site URL.', 'paid-memberships-pro' ), '<code>' . esc_url( pmpro_getOption( 'last_known_url' ) ) . '</code>' ); ?></p>
 				<?php if ( current_user_can( 'pmpro_manage_pause_mode' ) ) { ?>
 				<p>
-					<a href='<?php echo admin_url( '?pmpro-reactivate-services=true' ); ?>' class='button'><?php esc_html_e( 'Update my primary domain and reactivate all services', 'paid-memberships-pro' ); ?></a>
-					<a href='#' id="hide_pause_notification_button" class='button button-dismiss' value="hide_pause_notification"><?php esc_html_e( 'Dismiss notice and keep all services paused', 'paid-memberships-pro' ); ?></a>
+					<a href='#' id="hide_pause_notification_button" class='button' value="hide_pause_notification"><?php esc_html_e( 'Dismiss notice and keep all services paused', 'paid-memberships-pro' ); ?></a>
+					<a href='<?php echo admin_url( '?pmpro-reactivate-services=true' ); ?>' class='button button-secondary'><?php esc_html_e( 'Update my primary domain and reactivate all services', 'paid-memberships-pro' ); ?></a>
 				</p>
 				<?php } else { ?>
 					<p><?php _e( 'Only users with the <code>pmpro_manage_pause_mode</code> capability are able to deactivate pause mode.', 'paid-memberships-pro' ); ?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adjusted the warning notification shown when a site is paused. Swapped the more dominant "clickable" button to be the dismiss (not the notice to reenable services). Added site URL we think they should be on to the notice similar to the WooCommerce inspiration notice.

