### PR TITLE
Escaping before the filter here so it can be overriden.

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -493,14 +493,15 @@ if ( empty( $default_gateway ) ) {
 	 * Hook to run formatting filters before displaying the content of your "Terms of Service" page at checkout.
 	 *
 	 * @since 2.4.1
+	 * @since 2.10.1 We escape the content BEFORE the filter, so it can be overridden.
 	 *
 	 * @param string $pmpro_tos_content The content of the post assigned as the Terms of Service page.
 	 * @param string $tospage The post assigned as the Terms of Service page.
 	 *
 	 * @return string $pmpro_tos_content
 	 */
-	$pmpro_tos_content = apply_filters( 'pmpro_tos_content', do_shortcode( $tospage->post_content ), $tospage );
-	echo wp_kses_post( $pmpro_tos_content );
+	$pmpro_tos_content = apply_filters( 'pmpro_tos_content', wp_kses_post( do_shortcode( $tospage->post_content ) ), $tospage );
+	echo $pmpro_tos_content; //phpcs:ignore Content escaped above, but filtering allowed.
 ?>
 				</div> <!-- end pmpro_license -->
 				<?php


### PR DESCRIPTION
### All Submissions:

Updating the TOS display to run wp_kses_post BEFORE the pmpro_tos_content filter to allow users of that filter to add JS or otherwise avoid having the content escaped.

This is required if folks were adding content via the pmpro_tos_content filter that would get stripped by wp_kses_post or if e.g. the TOS page was using JS to generate itself from a thirdparty service. (See the related issue.)

Resolves #2385.

Additionally, you may need to run this code gist to output the unescaped content from the assigned TOS page: https://gist.github.com/ideadude/2ce102d7fd554172e4e2a98d80e74352

### How to test the changes in this Pull Request:

1. Somehow create a TOS page with some JavaScript in it. You could use a custom shortcode.
2. Choose that TOS page in the advanced settings.
3. View the checkout page. The JS in the TOS is escaped.
4. BUT if you add JS via the pmpro_tos_content filter or use that filter to return the original post content, your JS will show and run.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Now running the pmpro_tos_content filter AFTER the TOS page content is escaped. This could be used to override that escaping if needed.
