### PR TITLE
Simplifying pause mode checks

### DIFF
--- a/adminpages/admin_header.php
+++ b/adminpages/admin_header.php
@@ -178,9 +178,9 @@
 				if ( pmpro_is_paused() ) {
 					// Link to reactivate the notification about pause mode if has cap.
 					if ( current_user_can( 'pmpro_manage_pause_mode' ) ) { ?>
-						<a class="pmpro_paused_tag" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-dashboard', 'show_pause_notification' => '1' ), admin_url( 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Paused', 'paid-memberships-pro' ); ?></a>
+						<a class="pmpro_paused_tag" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-dashboard', 'show_pause_notification' => '1' ), admin_url( 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Crons Disabled', 'paid-memberships-pro' ); ?></a>
 					<?php } else { ?>
-						<span class="pmpro_paused_tag"><?php esc_html_e( 'Paused', 'paid-memberships-pro' ); ?></span>
+						<span class="pmpro_paused_tag"><?php esc_html_e( 'Crons Disabled', 'paid-memberships-pro' ); ?></span>
 					<?php }
 				}
 			?>

--- a/css/admin.css
+++ b/css/admin.css
@@ -118,7 +118,7 @@
 }
 
 .pmpro_banner .pmpro_meta .pmpro_paused_tag {
-	color: #ffb900;
+	color: #ff3333;
 	font-weight: bold;
 	text-decoration: none;
 }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -93,26 +93,10 @@ add_action( 'admin_init', 'pmpro_init_site_health_integration' );
  * @since 2.10
  */
 function pmpro_site_url_check() {
-
-	//Checking if a stored site URL exists on first time installs
-	if ( empty( pmpro_getOption( 'last_known_url' ) ) ) {
-		pmpro_setOption( 'last_known_url', get_site_url() );
-	}
-
-	if ( ! pmpro_is_paused() ) {
-		//We aren't paused, check if the domains match
-		if( ! pmpro_compare_siteurl() ) {
-			//Site URL's don't match - enable pause mode
-			pmpro_setOption( 'pause_mode', true );				
-		} else {
-			//Site URL's do match - disable pause mode
-			pmpro_setOption( 'pause_mode', false );				
-		}
-	} else {
+	if ( pmpro_is_paused() ) {
 		//We are paused, show a notice.
 		add_action( 'admin_notices', 'pmpro_pause_mode_notice' );
 	}
-
 }
 add_action( 'admin_init', 'pmpro_site_url_check' );
 
@@ -127,8 +111,7 @@ function pmpro_handle_pause_mode_actions() {
 	if ( current_user_can( 'pmpro_manage_pause_mode' ) ) {
 		//We're attempting to reactivate all services.
 		if( ! empty( $_REQUEST['pmpro-reactivate-services'] ) ) {			
-			pmpro_setOption( 'last_known_url', get_site_url() );
-			pmpro_setOption( 'pause_mode', false );			
+			delete_option( 'pmpro_last_known_url' );
 		}
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4389,16 +4389,14 @@ function pmpro_compare_siteurl() {
 	$site_url = get_site_url();
 
 	$current_url = pmpro_getOption( 'last_known_url' );
-
-	if( empty( $current_url ) ) {
-		return false;
+	
+	// If we don't have a current URL yet, set it to the site URL.
+	if ( empty( $current_url ) ) {
+		pmpro_setOption( 'last_known_url', $site_url );
+		$current_url = $site_url;
 	}
 
-	if( $site_url !== $current_url ) {
-		return false;
-	}
-
-	return true;
+	return ( $site_url === $current_url );
 }
 
 /**
@@ -4408,14 +4406,14 @@ function pmpro_compare_siteurl() {
  * @return bool True if the the site is in pause mode
  */
 function pmpro_is_paused() {
-	$pause_mode = pmpro_getOption( 'pause_mode' );
-	
-	//We haven't saved the option or it isn't in pause mode
-	if( empty( $pause_mode ) || $pause_mode === false ) {
-		return false;
+	// If the current site URL is different than the last known URL, then we are in pause mode.
+	if ( ! pmpro_compare_siteurl() ) {
+		return true;
 	}
 
-	return true;
+	// Other pause conditions can eventually be added here.
+
+	return false;
 }
 
 /**
@@ -4423,8 +4421,10 @@ function pmpro_is_paused() {
  *
  * @param $state bool true or false if in pause mode state
  * @since 2.10
+ * @deprecated TBD No longer using `pmpro_pause_mode` option
  * @return bool True if the option has been updated
  */
 function pmpro_set_pause_mode( $state ) {
+	_deprecated_function( __FUNCTION__, 'TBD' );
 	return pmpro_setOption( 'pause_mode', $state );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4386,10 +4386,15 @@ function pmpro_activating_plugin( $plugin = null ) {
  * @return bool True if the stored and current URL match
  */
 function pmpro_compare_siteurl() {
-	$site_url = get_site_url();
-
+	$site_url = get_site_url( null, '', 'https' ); // Always get the https version of the site URL.=
 	$current_url = pmpro_getOption( 'last_known_url' );
-	
+
+	// If the current URL is http://, change it to https:// for backwards compatibility.
+	if ( 'http://' === substr( $current_url, 0, 7 ) ) {
+		$current_url = 'https://' . substr( $current_url, 7 );
+		pmpro_setOption( 'last_known_url', $current_url );
+	}
+
 	// If we don't have a current URL yet, set it to the site URL.
 	if ( empty( $current_url ) ) {
 		pmpro_setOption( 'last_known_url', $site_url );
@@ -4411,8 +4416,7 @@ function pmpro_is_paused() {
 		return true;
 	}
 
-	// Other pause conditions can eventually be added here.
-
+	// We should never filter this function. We will never change this function to do anything else without lots and lots of discussion and thought.
 	return false;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
No longer using `pmpro_pause_mode` option to track when a site is in pause mode. Instead, we are now calculating whether a site is paused on an as-needed basis.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
