### PR TITLE
Adding the members per level report specifically for 2.10.1+ report requirements

### DIFF
--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -53,9 +53,10 @@ require_once( PMPRO_DIR . '/classes/class-pmpro-admin-activity-email.php' );    
 require_once( PMPRO_DIR . '/includes/filters.php' );                // filters, hacks, etc, moved into the plugin
 require_once( PMPRO_DIR . '/includes/reports.php' );                // load reports for admin (reports may also include tracking code, etc)
 
-require_once( PMPRO_DIR . '/adminpages/reports/logins.php' );		// load the Logins report
-require_once( PMPRO_DIR . '/adminpages/reports/memberships.php' );		// load the Memberships report
-require_once( PMPRO_DIR . '/adminpages/reports/sales.php' );		// load the Sales report
+require_once( PMPRO_DIR . '/adminpages/reports/logins.php' );			 // load the Logins report
+require_once( PMPRO_DIR . '/adminpages/reports/memberships.php' );		 // load the Memberships report
+require_once( PMPRO_DIR . '/adminpages/reports/members-per-level.php' ); // load the Members Per Level report
+require_once( PMPRO_DIR . '/adminpages/reports/sales.php' );			 // load the Sales report
 
 require_once( PMPRO_DIR . '/includes/admin.php' );                  // admin notices and functionality
 require_once( PMPRO_DIR . '/includes/adminpages.php' );             // dashboard pages


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
2.10.1+ specifically requires each report file to avoid conflicts with weird hosting setups that didn't delete files on plugin upgrade. This adds support for the Members Per Level new report for this cycle work.
