### PR TITLE
Adding backwards compatibility for new parameter

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -906,8 +906,10 @@ add_filter( 'authenticate', 'pmpro_authenticate_username_password', 30, 3);
  *
  * @since 2.3
  *
+ * @param string $username The username of the user trying to log in.
+ * @param WP_Error|null $error Error object. Added in 2.10.
  */
-function pmpro_login_failed( $username, $error ) {
+function pmpro_login_failed( $username, $error = null ) {
 
 	$login_page = pmpro_getOption( 'login_page_id' );
 	if ( empty( $login_page ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#2360 added a required `$error` parameter to the `pmpro_login_failed()` function in PMPro v2.10. This broke backwards compatibility for some websites. Fixing by making the parameter optional.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
