### PR TITLE
Oxygen Builder Compatibility

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -50,6 +50,11 @@ function pmpro_compatibility_checker() {
 			'file' 		  => 'avada.php',
 			'check_type'  => 'constant',
 			'check_value' => 'FUSION_BUILDER_VERSION'
+		],
+		[
+			'file' 		  => 'oxygen-builder.php',
+			'check_type'  => 'class',
+			'check_value' => 'OxyEl'
 		]
 	];
 

--- a/includes/compatibility/oxygen-builder.php
+++ b/includes/compatibility/oxygen-builder.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Oxygen Builder Compatibility.
+ *
+ * @since TBD
+ */
+if( function_exists( 'oxygen_vsb_register_condition' ) ) {
+
+    global $pmpro_levels;
+
+    $oxygen_pmpro_levels = array( '0' => '[0] '.__( 'Non-Members', 'paid-memberships-pro' ) );
+
+    if ( ! empty( $pmpro_levels ) ) {
+        foreach( $pmpro_levels as $pmpro_level ) {            
+            $oxygen_pmpro_levels[$pmpro_level->id] = '['.$pmpro_level->id.'] '.$pmpro_level->name;
+        }
+    }
+
+    oxygen_vsb_register_condition( 
+        __( 'Paid Memberships Pro Level', 'paid-memberships-pro' ), 
+        array( 'options' => $oxygen_pmpro_levels, 'custom' => true ), 
+        array( '', '==', '!=' ),
+        'pmpro_oxygen_builder_condition_callback', 
+        'Other'
+    );
+
+}
+
+function pmpro_oxygen_builder_condition_callback( $value, $operator ) {
+
+    preg_match_all("/([^[]+(?=]))/", $value, $matches); 
+
+    if( ! isset( $matches[1] ) ) {
+        return true;
+    }
+
+    if( ! isset( $matches[1][0] ) ) {
+        return true;        
+    }
+    
+    $level_id = (int) $matches[1][0];
+    
+    if( $operator === '==' ) {
+        //If they have the required level, show the element
+        if( pmpro_hasMembershipLevel( $level_id ) ) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        //If they don't have the required level, show the element
+        if( ! pmpro_hasMembershipLevel( $level_id ) ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces 'conditions' functionality in Oxygen Builder that allows you to show/hide elements based on a member's level

### How to test the changes in this Pull Request:

1. Click on an element in Oxygen Builder
2. Click on the Conditions tab/icon
3. Add a condition - Select 'Paid Memberships Pro Level' under Other and specify if the element should show/hide for a level or non-member.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Adds support for Oxygen Builder