### PR TITLE
Fixing file type user fields on main site of multisite

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -534,12 +534,13 @@ class PMPro_Field {
 		*/
 		//check for a register helper directory in wp-content
 		$upload_dir = wp_upload_dir();
-		$pmprorh_dir = $upload_dir['basedir'] . "/pmpro-register-helper/" . $user->user_login . "/";
+		$dir_path = $upload_dir['basedir'] . "/pmpro-register-helper/" . $user->user_login . "/";
+		$dir_url  = $upload_dir['baseurl'] . "/pmpro-register-helper/" . $user->user_login . "/";
 		
 		//create the dir and subdir if needed
-		if(!is_dir($pmprorh_dir))
+		if(!is_dir($dir_path))
 		{
-			wp_mkdir_p($pmprorh_dir);
+			wp_mkdir_p($dir_path);
 		}
 					
 		//if we already have a file for this field, delete it
@@ -553,7 +554,7 @@ class PMPro_Field {
 		$filename = sanitize_file_name( $file['name'] );
 		$count = 0;
 					
-		while(file_exists($pmprorh_dir . $filename))
+		while(file_exists($dir_path . $filename))
 		{
 			if($count)
 				$filename = str_lreplace("-" . $count . "." . $filetype['ext'], "-" . strval($count+1) . "." . $filetype['ext'], $filename);
@@ -567,11 +568,14 @@ class PMPro_Field {
 				die( __( "Error uploading file. Too many files with the same name.", "paid-memberships-pro" ) );
 		}
 
+		$file_path = $dir_path . $filename;
+		$file_url = $dir_url . $filename;
+
 		//save file
 		if(strpos($file['tmp_name'], $upload_dir['basedir']) !== false)
 		{
 			//was uploaded and saved to $_SESSION
-			rename($file['tmp_name'], $pmprorh_dir . $filename);			
+			rename($file['tmp_name'], $file_path);			
 		}
 		else
 		{
@@ -582,33 +586,22 @@ class PMPro_Field {
 			}
 			
 			//it was just uploaded
-			move_uploaded_file($file['tmp_name'], $pmprorh_dir . $filename);				
+			move_uploaded_file($file['tmp_name'], $file_path);				
 		}
 		
 		// If file is an image, save a preview thumbnail.
 		if ( $filetype && 0 === strpos( $filetype['type'], 'image/' ) ) {
-			$preview_file = wp_get_image_editor( $pmprorh_dir . $filename );
+			$preview_file = wp_get_image_editor( $file_path );
 			if ( ! is_wp_error( $preview_file ) ) {
 				$preview_file->resize( 200, NULL, false );
 				$preview_file->generate_filename( 'pmprorh_preview' );
 				$preview_file = $preview_file->save();
 			}
 		}
-		
-		// Our folder in the uploads directory that we want to save files to.
-		$upload_dir = '/pmpro-register-helper/' . $user->user_login . '/';
-
-		// If multisite, prefix the directory with the current blog ID specific folder.
-		if ( is_multisite() ) {
-			$upload_dir = '/sites/' . get_current_blog_id() . $upload_dir;
-		}
-
-		// Get the full uploads directory URL we want to save files to.
-		$upload_path = content_url( '/uploads' . $upload_dir );
 
 		// Swap slashes for Windows
-		$pmprorh_dir = str_replace( "\\", "/", $pmprorh_dir );
-		$upload_path = str_replace( "\\", "/", $upload_path );
+		$file_path = str_replace( "\\", "/", $file_path );
+		$file_url = str_replace( "\\", "/", $file_url );
 		if ( ! empty( $preview_file ) && ! is_wp_error( $preview_file ) ) {
 			$preview_file['path'] = str_replace( "\\", "/", $preview_file['path'] );
 		}
@@ -616,14 +609,14 @@ class PMPro_Field {
 		$file_meta_value_array = array(
 			'original_filename'	=> $file['name'],
 			'filename'			=> $filename,
-			'fullpath'			=> $pmprorh_dir . $filename,
-			'fullurl'			=> $upload_path . $filename,
+			'fullpath'			=> $file_path,
+			'fullurl'			=> $file_url,
 			'size'				=> $file['size'],
 		);
 
 		if ( ! empty( $preview_file ) && ! is_wp_error( $preview_file ) ) {
 			$file_meta_value_array['previewpath'] = $preview_file['path'];
-			$file_meta_value_array['previewurl'] = $upload_path . $preview_file['file'];			
+			$file_meta_value_array['previewurl'] = $dir_url .  $preview_file['file'];
 		}
 		
 		//save filename in usermeta


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing issue where file type user fields on a multisite install may have the incorrect  URL saved to user meta. Previously, we tried to always build the multisite URL by adding a `/sites/[blog_id]/` prefix to the URL, but that should not be  added for the main site of a multisite.

This PR changes the URL determination  process to completely rely on WP, so it should always be accurate.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Set up a multisite install
2. On the “main” site, install PMPro and set up a “file” user field
3. Complete checkout filling the file field (I’m using pngs)
4. Navigate to the frontend profile and see that the attachment shows as a “?” (not found)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
