### PR TITLE
Now cancelling membership if max PPE retries used

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -237,7 +237,6 @@ if ( $txn_type == "recurring_payment" ) {
  * @param array List of txn types to be treated as failures.
  */
 $failed_payment_txn_types = apply_filters( 'pmpro_paypal_renewal_failed_txn_types', array(
-	'recurring_payment_suspended_due_to_max_failed_payment', // && 'suspended' == $profile_status
 	'recurring_payment_suspended',
 	'recurring_payment_skipped',
 	'subscr_failed'
@@ -256,7 +255,7 @@ if ( in_array( $txn_type, $failed_payment_txn_types ) ) {
 }
 
 // Recurring Payment Profile Cancelled or Failed (PayPal Express)
-if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_payment_failed' ) {
+if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_payment_failed' || $txn_type == 'recurring_payment_suspended_due_to_max_failed_payment' ) {
 	//find last order
 	$last_subscription_order = new MemberOrder();
 	if ( $last_subscription_order->getLastMemberOrderBySubscriptionTransactionID( $recurring_payment_id ) == false ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If all retries are used  for a PayPal subscription, PPE would suspend the subscription. This did not trigger a membership cancellation in PMPro.

This PR updates the IPN handler logic to cancel the user's membership if all PayPal retries are used.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
