### PR TITLE
Set Field class methods to static to avoid PHP8 Errors

### DIFF
--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -438,7 +438,7 @@ function pmpro_report_track_values($type, $user_id = NULL) {
 	//set cookie for visits
 	if( $type === 'visits' && empty( $_COOKIE['pmpro_visit'] ) ) {
 		// The secure parameter is set to is_ssl(), true if HTTPS.
-        setcookie( 'pmpro_visit', '1', null, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+        setcookie( 'pmpro_visit', '1', 0, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
     }
 
 	//some vars for below

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -408,7 +408,7 @@ class PMPro_Field {
 	}
 
 	// Save function for users table field.
-	function saveUsersTable( $user_id, $name, $value ) {
+	static function saveUsersTable( $user_id, $name, $value ) {
 		// Special sanitization needed for certain user fields.
 		if ( $name === 'user_url' ) {
 			$value = esc_url_raw( $value );
@@ -422,7 +422,7 @@ class PMPro_Field {
 	}
 
 	// Save function for user taxonomy field.
-	function saveTermRelationshipsTable( $user_id, $name, $value ) {
+	static function saveTermRelationshipsTable( $user_id, $name, $value ) {
 		// Get the taxonomy to save for.
 		if ( isset( $this->taxonomy ) ) {
 			$taxonomy = $this->taxonomy;
@@ -451,7 +451,7 @@ class PMPro_Field {
 	}
 
 	//save function for files
-	function saveFile($user_id, $name, $value)
+	static function saveFile($user_id, $name, $value)
 	{			
 		//setup some vars
 		$file = array_map( 'sanitize_text_field', $_FILES[$name] );
@@ -631,7 +631,7 @@ class PMPro_Field {
 	}
 
     //fix date then update user meta
-    function saveDate($user_id, $name, $value)
+    static function saveDate($user_id, $name, $value)
     {
         if ( isset( $this->sanitize ) && true === $this->sanitize ) {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sets methods in the Field class to static to prevent errors being thrown in PHP8

A fix to prevent an error being thrown when visiting a page for the first time while setting the visit cookie has also been applied. 

### How to test the changes in this Pull Request:

1. Set up Register Helper fields
2. Proceed through the checkout process
3. No errors should be visible or in the error logs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Ensures that methods in the Field class don't throw errors with PHP8+