### PR TITLE
Trims spacing on dropdown values to ensure consistent results

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -727,20 +727,13 @@ class PMPro_Field {
 			$r .= ">\n";
 			foreach($this->options as $ovalue => $option)
 			{
-
-				if( is_array( $value ) ) {
-					$selected = ( trim( $ovalue ) == array_walk( $value, 'trim' ) );
-				} else {
-					$selected = ( trim( $ovalue ) == trim( $value ) );
-				}	
-
 				$r .= '<option value="' . 
 					
 					
 					trim( $ovalue ) . '" ';
 				if(!empty($this->multiple) && in_array($ovalue, $value))
 					$r .= 'selected="selected" ';
-				elseif( $selected )
+				elseif ( ! empty( $ovalue ) && is_string( $value ) && trim( $ovalue ) == trim( $value ) )
 					$r .= 'selected="selected" ';
 				$r .= '>' . $option . "</option>\n";
 			}
@@ -817,7 +810,7 @@ class PMPro_Field {
 				$count++;
 				$r .= '<div class="pmpro_checkout-field-radio-item">';
 				$r .= '<input type="radio" id="pmprorh_field_' . $this->name . $count . '" name="' . $this->name . '" value="' . esc_attr($ovalue) . '" ';
-				if(!empty($ovalue) && trim( $ovalue ) == trim( $value ) )
+				if(!empty($ovalue) && is_string($value) && trim( $ovalue ) == trim( $value ) )
 					$r .= 'checked="checked"';
 				if(!empty($this->class))
 				$r .= 'class="' . $this->class . '" ';

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -730,10 +730,10 @@ class PMPro_Field {
 				$r .= '<option value="' . 
 					
 					
-					($ovalue) . '" ';
+					trim( $ovalue ) . '" ';
 				if(!empty($this->multiple) && in_array($ovalue, $value))
 					$r .= 'selected="selected" ';
-				elseif($ovalue == $value)
+				elseif( trim( $ovalue ) == trim( $value ) )
 					$r .= 'selected="selected" ';
 				$r .= '>' . $option . "</option>\n";
 			}

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -727,13 +727,20 @@ class PMPro_Field {
 			$r .= ">\n";
 			foreach($this->options as $ovalue => $option)
 			{
+
+				if( is_array( $value ) ) {
+					$selected = ( trim( $ovalue ) == array_walk( $value, 'trim' ) );
+				} else {
+					$selected = ( trim( $ovalue ) == trim( $value ) );
+				}	
+
 				$r .= '<option value="' . 
 					
 					
 					trim( $ovalue ) . '" ';
 				if(!empty($this->multiple) && in_array($ovalue, $value))
 					$r .= 'selected="selected" ';
-				elseif( trim( $ovalue ) == trim( $value ) )
+				elseif( $selected )
 					$r .= 'selected="selected" ';
 				$r .= '>' . $option . "</option>\n";
 			}

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -756,7 +756,7 @@ class PMPro_Field {
 			foreach($this->options as $ovalue => $option)
 			{
 				$r .= '<option value="' . esc_attr($ovalue) . '" ';
-				if(in_array($ovalue, $value))
+				if(in_array( trim( $ovalue ), $value ) )
 					$r .= 'selected="selected" ';
 				$r .= '>' . $option . "</option>\n";
 			}
@@ -788,7 +788,7 @@ class PMPro_Field {
 			foreach($this->options as $ovalue => $option)
 			{
 				$r .= '<option value="' . esc_attr($ovalue) . '" ';
-				if(in_array($ovalue, $value))
+				if( in_array( trim( $ovalue ), $value ) )
 					$r .= 'selected="selected" ';
 				$r .= '>' . $option . '</option>';
 			}
@@ -810,7 +810,7 @@ class PMPro_Field {
 				$count++;
 				$r .= '<div class="pmpro_checkout-field-radio-item">';
 				$r .= '<input type="radio" id="pmprorh_field_' . $this->name . $count . '" name="' . $this->name . '" value="' . esc_attr($ovalue) . '" ';
-				if(!empty($ovalue) && $ovalue == $value)
+				if(!empty($ovalue) && trim( $ovalue ) == trim( $value ) )
 					$r .= 'checked="checked"';
 				if(!empty($this->class))
 				$r .= 'class="' . $this->class . '" ';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Trims spacing around a dropdown's values so that checks validate when the value is selected

### How to test the changes in this Pull Request:

1. Create a dropdown field in User fields
2. set the values to have a space after each of them (normal whitespace)
3. Edit the profile using the fronend profile edit page. Choose a new value from the dropdown and save. It saves correctly as before - but it should show the correct/selected field from the dropdown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Trims whitespace from dropdown values