### PR TITLE
Fixes a fatal error on payment settings page with Spanish lang

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2447,7 +2447,7 @@ class PMProGateway_stripe extends PMProGateway {
 						} else {
 							$application_fee_percentage = self::get_application_fee_percentage();
 							if ( ! empty( $application_fee_percentage ) ) {
-								echo sprintf( esc_html__( 'Note: You are using the free Stripe payment gateway integration. This includes an additional %s fee for payment processing. This fee is removed by activating a premium PMPro license.', 'paid-memberships-pro' ), intval( $application_fee_percentage ) . '%' );
+								echo esc_html__( sprintf( 'Note: You are using the free Stripe payment gateway integration. This includes an additional %s fee for payment processing. This fee is removed by activating a premium PMPro license.', intval( $application_fee_percentage ) . '%', 'paid-memberships-pro' ) );
 							} else {
 								esc_html_e( 'Note: You are using the free Stripe payment gateway integration. There is no additional fee for payment processing above what Stripe charges.', 'paid-memberships-pro' );
 							}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2447,7 +2447,7 @@ class PMProGateway_stripe extends PMProGateway {
 						} else {
 							$application_fee_percentage = self::get_application_fee_percentage();
 							if ( ! empty( $application_fee_percentage ) ) {
-								echo esc_html__( sprintf( 'Note: You are using the free Stripe payment gateway integration. This includes an additional %s fee for payment processing. This fee is removed by activating a premium PMPro license.', intval( $application_fee_percentage ) . '%', 'paid-memberships-pro' ) );
+								echo sprintf( esc_html__( 'Note: You are using the free Stripe payment gateway integration. This includes an additional %1s fee for payment processing. This fee is removed by activating a premium PMPro license.', 'paid-memberships-pro' ), intval( $application_fee_percentage ) . '%' );
 							} else {
 								esc_html_e( 'Note: You are using the free Stripe payment gateway integration. There is no additional fee for payment processing above what Stripe charges.', 'paid-memberships-pro' );
 							}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The original code made use of esc_html__ inside a sprintf. This works fine in English but fails with other languages, resulting in a fatal error. 

Putting the sprintf inside the esc_html__ instead (swapping them around) fixes the issue.

### How to test the changes in this Pull Request:

1. Switch the default language to Spanish
2. Ensure no license key is set or activate on a clean install
3. Go to Memberships > Settings > Payment Gateway & SSL
4. The page should load without issues. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixes a fatal error on the Payment Gateway & SSL settings page.