### PR TITLE
Fixing setcookie argument for PHP8

### DIFF
--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -438,7 +438,7 @@ function pmpro_report_track_values($type, $user_id = NULL) {
 	//set cookie for visits
 	if( $type === 'visits' && empty( $_COOKIE['pmpro_visit'] ) ) {
 		// The secure parameter is set to is_ssl(), true if HTTPS.
-        setcookie( 'pmpro_visit', '1', null, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+        setcookie( 'pmpro_visit', '1', 0, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
     }
 
 	//some vars for below


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing PHP8 deprecation warning:
`Deprecated: setcookie(): Passing null to parameter #3 ($expires_or_options) of type array|int is deprecated in ...\wp-content\plugins\paid-memberships-pro\adminpages\reports\logins.php on line 441`

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
