### PR TITLE
Memberlist Export Joindate produces same result as table

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -98,7 +98,7 @@
 		$headers[] = 'Content-Disposition: attachment; filename="members_list.csv"';
 
 	//set default CSV file headers, using comma as delimiter
-	$csv_file_header = "id,username,firstname,lastname,email,billing firstname,billing lastname,address1,address2,city,state,zipcode,country,phone,membership,initial payment,fee,term,discount_code_id,discount_code,joined";
+	$csv_file_header = "id,username,firstname,lastname,email,billing firstname,billing lastname,address1,address2,city,state,zipcode,country,phone,membership,initial payment,fee,term,discount_code_id,discount_code,joined,user_registered";
 
 	if($l == "oldmembers")
 		$csv_file_header .= ",ended";
@@ -435,6 +435,7 @@
 			}
 
 			//joindate and enddate
+			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));
 			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->user_registered)));
 
 			if($theuser->membership_id)

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -435,7 +435,7 @@
 			}
 
 			//joindate and enddate
-			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));
+			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->user_registered)));
 
 			if($theuser->membership_id)
 			{

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -435,8 +435,8 @@
 			}
 
 			//joindate and enddate
-			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));
 			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->user_registered)));
+			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));			
 
 			if($theuser->membership_id)
 			{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In the export we reference the joindate `array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->user_registered)));` While in the table we reference `user_registered` 

I've tested an export with referencing $theuser->user_registered and we get the same results that the user sees in the table.

This issue came up on a customer's site where I suspect they had some users imported. 

The start date showed fine in the table but gave a 1970 date when exporting. 

### How to test the changes in this Pull Request:

1. Export a member list as normal from the Members tab. 
2. As mentioned above though, this issue was experienced on a customer site with the possibility of users who were imported - making this change just produced the same results in the export as one sees in the member list table.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Member list export join date now references the user_registration date in an export 
