### PR TITLE
Fixing PHP 8 errors in Braintree library

### DIFF
--- a/includes/lib/Braintree/lib/Braintree/Digest.php
+++ b/includes/lib/Braintree/lib/Braintree/Digest.php
@@ -50,8 +50,8 @@ class Digest
         $outerPad = str_repeat(chr(0x5C), 64);
 
         for ($i = 0; $i < 20; $i++) {
-            $innerPad{$i} = $keyDigest{$i} ^ $innerPad{$i};
-            $outerPad{$i} = $keyDigest{$i} ^ $outerPad{$i};
+            $innerPad[$i] = $keyDigest[$i] ^ $innerPad[$i];
+            $outerPad[$i] = $keyDigest[$i] ^ $outerPad[$i];
         }
 
         return sha1($outerPad.pack($pack, sha1($innerPad.$message)));

--- a/includes/lib/Braintree/lib/Braintree/Error/ValidationErrorCollection.php
+++ b/includes/lib/Braintree/lib/Braintree/Error/ValidationErrorCollection.php
@@ -120,8 +120,11 @@ class ValidationErrorCollection extends Collection
     private function _inspect($errors, $scope = null)
     {
         $eOutput = '[' . __CLASS__ . '/errors:[';
-        foreach($errors AS $error => $errorObj) {
-            $outputErrs[] = "({$errorObj->error['code']} {$errorObj->error['message']})";
+        $outputErrs = [];
+         foreach($errors AS $error => $errorObj) {
+            if (is_array($errorObj->error)) {
+                $outputErrs[] = "({$errorObj->error['code']} {$errorObj->error['message']})";
+            }
         }
         $eOutput .= join(', ', $outputErrs) . ']]';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing fatal error when processing Braintree webhooks using PHP 8.

Copied this commit from the Braintree SDK repo: https://github.com/braintree/braintree_php/commit/fb493fa31b316b4c6f3105c17d88018fbaa511cb

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
