### PR TITLE
Sanitize Getfile URL using sanitize_url instead of sanitize_text_field

### DIFF
--- a/services/getfile.php
+++ b/services/getfile.php
@@ -25,7 +25,7 @@
 	global $wpdb;
 
 	// Get the file path.
-	$uri = sanitize_text_field( $_SERVER['REQUEST_URI'] );
+	$uri = sanitize_url( $_SERVER['REQUEST_URI'] );
 
 	// Remove the query string from the path.
 	$uri_parts = explode( '?', $uri );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sanitizes the getfile URL by using sanitize_url instead of sanitize_text_field as this function strips too much out of the URL, resulting in the URL breaking

### How to test the changes in this Pull Request:

1. Set up getfile to protect files on the site
2. Reference a file that contains dashes, underscores and other characers (even spaces)
3. The file should load/redirect without breaking. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Changed how we sanitize the getfile URL