### PR TITLE
Fix taxonomy user fields saving incorrectly in database.

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1350,9 +1350,19 @@ class PMPro_Field {
 		echo esc_html( $output );
 	}
 	
-	//from: http://stackoverflow.com/questions/173400/php-arrays-a-good-way-to-check-if-an-array-is-associative-or-numeric/4254008#4254008
-	function is_assoc($array) {			
-		return (bool)count(array_filter(array_keys($array), 'is_string'));
+	/**
+	 * Defining associative as integer array keys incrementing from 0.
+	 * 
+	 * Based off of https://stackoverflow.com/a/173479.
+	 *
+	 * @param array $array The array to check if it is associative.
+	 * @return bool True if the array is associative, false otherwise.
+	 */
+	function is_assoc( $array ) {
+		if ( empty( $array ) ) {
+			return false;
+		}
+		return array_keys( $array ) !== range( 0, count( $array ) - 1) ;
 	}
 
 	static function get_checkout_box_name_for_field( $field_name ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing issue where coded user fields linked to a taxonomy would save taxonomy label as meta value in database instead of the taxonomy ID. Affected field types are `select`, `select2`, `multiselect`, and `radio`.

It is worth noting that terms were still being added to users as expected. It is just the meta values in the database that are off here.

The cause of this issue are these lines:
https://github.com/strangerstudios/paid-memberships-pro/blob/702614f58840cc57990a8946f557d07730bf4965/classes/class-pmpro-field.php#L361-L367

Since `is_assoc()` only checked whether the `$options` keys are integers and taxonomy terms IDs are integers, that `$options` array was being "repaired" and the term label was becoming both the key and value.

The fix proposed in this PR is to update the the `is_assoc()` method of the PMPro_Field class to not only check whether array keys are integers, but also check that they are ascending from 0. This change maintains the original goal of saving option labels if a user does not provide specific keys, but also better avoids cases like taxonomy where the keys are MEANINGFUL integers.

A general edge case for this "repair options" functionality is if a site does literally want integers from 0-x as keys, in which case the `pmprorh_repair_non_associative_options` filter would need to be used. This will not be an issue for taxonomies though since those IDs should start at 1.

After this update, there is still the issue of fixing sites that already have incorrect data saved. I have just put together this code recipe which will fix users over time as they log into the site:
https://gist.github.com/dparker1005/aef07e835f7a854a5d0d59d4cdabd706

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Add code recipe to set up taxonomy user field.

> function my_pmpro_user_fields_user_taxonomy() {
> 
> 	// Require PMPro
> 	if ( ! function_exists( 'pmpro_add_user_taxonomy' ) ) {
> 		return;
> 	}
> 
> 	// Add new field group
> 	pmpro_add_field_group( 'business', 'Business Information', 'Complete the following information about your business.' );
> 
> 	// Add new user taxonomy with singular and plural name
> 	pmpro_add_user_taxonomy( 'industry', 'industries' );
> 
> 	// Define the fields
> 	$fields = array();
> 	$fields[] = new PMPro_Field(
> 		'industry',
> 		'select2',
> 		array(
> 			'label' => 'Industry',
> 			'profile' => true,
> 			'addmember' => true,
> 			'taxonomy' => 'industry',
> 		)
> 	);
> 	// Add fields into a new area of checkout page
> 	foreach ( $fields as $field ) {
> 		pmpro_add_user_field(
> 			'business',
> 			$field
> 		);
> 	}
> }
> add_action( 'init', 'my_pmpro_user_fields_user_taxonomy' );

2. Add terms to the new `industry` taxonomy
3. Check out as a new user, selecting some taxonomies
4. Check the user meta table of the database. If using current dev, see that taxonomy labels are stored. If using this PR, see that taxonomy IDs are stored.

### Testing the "upgrade" snippet
1. Perform steps 1-4 on current dev
2. Add snippet to site
3. Log out from test user
4. Log into test user again
5. Check database again and see that term labels have changed into IDs

Have also tested that user field UI on the profile page also shows the correct preselected options after the upgrade snippet as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
