### PR TITLE
Escaping string values in pmpro_membershiplevels_page_action_links filter

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1069,6 +1069,8 @@
 			/**
 			 * Filter the Membership Levels page title action links.
 			 *
+			 * @since 2.9
+			 *
 			 * @param array $pmpro_membershiplevels_page_action_links Page action links.
 			 * @return array $pmpro_membershiplevels_page_action_links Page action links.
 			 */
@@ -1078,8 +1080,11 @@
 			foreach ( $pmpro_membershiplevels_page_action_links as $pmpro_membershiplevels_page_action_link ) {
 				
 				// If the value is not an array, assume it's a string of HTML.
+				// Passing a string is not the intended use of this filter, but we
+				// are handling it here for backwards compatibility
+				// and for developers who expect the filter to work differently.
 				if ( ! is_array( $pmpro_membershiplevels_page_action_link ) ) {
-					echo $pmpro_membershiplevels_page_action_link;
+					echo esc_html( $pmpro_membershiplevels_page_action_link );
 					continue;
 				}
 

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -1070,6 +1070,7 @@
 			 * Filter the Membership Levels page title action links.
 			 *
 			 * @since 2.9
+			 * @since TBD Deprecating strings as $pmpro_membershiplevels_page_action_links values.
 			 *
 			 * @param array $pmpro_membershiplevels_page_action_links Page action links.
 			 * @return array $pmpro_membershiplevels_page_action_links Page action links.
@@ -1079,12 +1080,8 @@
 			// Display the links.
 			foreach ( $pmpro_membershiplevels_page_action_links as $pmpro_membershiplevels_page_action_link ) {
 				
-				// If the value is not an array, assume it's a string of HTML.
-				// Passing a string is not the intended use of this filter, but we
-				// are handling it here for backwards compatibility
-				// and for developers who expect the filter to work differently.
+				// If the value is not an array, it is not in the correct format. Continue.
 				if ( ! is_array( $pmpro_membershiplevels_page_action_link ) ) {
-					echo esc_html( $pmpro_membershiplevels_page_action_link );
 					continue;
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Escaping string values in pmpro_membershiplevels_page_action_links filter and updating inline docs.

We could potentially use a function other than `esc_html()` to have more control over how the string is escaped, but as this case should never come up if the filter is being used correctly, escaping aggressively seems like a reasonable solution. In cases where this is over-escaping (ex escaping `<a href=...`), the code adding the link should be updated to use the filter correctly with the expected array input.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
