### PR TITLE
Updating admin change email for 3.0

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -1195,32 +1195,17 @@
 		/**
 		 * Send an email to the member when an admin has changed their membership level.
 		 *
-		 * @deprecated TBD
-		 *
 		 * @param object $user The WordPress user object.
 		 */
 		function sendAdminChangeEmail($user = NULL)
 		{
-			_deprecated_function( __FUNCTION__, 'TBD' );
-
 			global $current_user, $wpdb;
 			if(!$user)
 				$user = $current_user;
 			
 			if(!$user)
 				return false;
-			
-			//make sure we have the current membership level data
-			$user->membership_level = pmpro_getMembershipLevelForUser($user->ID, true);
-
-			if(!empty($user->membership_level) && !empty($user->membership_level->name)) {
-				$membership_level_name = $user->membership_level->name;
-				$membership_level_id = $user->membership_level->id;
-			} else {
-				$membership_level_name = __('None', 'paid-memberships-pro');
-				$membership_level_id = '';
-			}
-						
+	
 			$this->email = $user->user_email;
 			$this->subject = sprintf(__("Your membership at %s has been changed", "paid-memberships-pro"), get_option("blogname"));
 
@@ -1231,27 +1216,17 @@
 				'user_login' => $user->user_login, 
 				'user_email' => $user->user_email, 
 				'sitename' => get_option( 'blogname' ), 
-				'membership_id' => $membership_level_id, 
-				'membership_level_name' => $membership_level_name, 
 				'siteemail' => pmpro_getOption( 'from_email' ), 
 				'login_link' => pmpro_login_url(), 
 				'login_url' => pmpro_login_url(),
 				'levels_url' => pmpro_url( 'levels' )
 			);
 
-			if(!empty($user->membership_level) && !empty($user->membership_level->ID)) {
-				$this->data["membership_change"] = sprintf(__("The new level is %s.", 'paid-memberships-pro' ), $user->membership_level->name);
+			// If the user no longer has a membership level, set the membership_change text to "Membership has been cancelled."
+			if ( ! pmpro_hasMembershipLevel( null, $user->ID ) ) {
+				$this->data['membership_change'] = __( 'Your membership has been cancelled.', 'paid-memberships-pro' );
 			} else {
-				$this->data["membership_change"] = __("Your membership has been cancelled.", "paid-memberships-pro");
-			}
-
-			if(!empty($user->membership_level->enddate))
-			{
-					$this->data["membership_change"] .= " " . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $user->membership_level->enddate));
-			}
-			elseif(!empty($this->expiration_changed))
-			{
-				$this->data["membership_change"] .= " " . __("This membership does not expire.", 'paid-memberships-pro' );
+				$this->data['membership_change'] = __( 'You can view your current memberships by logging in and visiting your membership account page.', 'paid-memberships-pro' );
 			}
 
 			$this->template = apply_filters("pmpro_email_template", "admin_change", $this);
@@ -1262,31 +1237,16 @@
 		/**
 		 * Send an email to the admin when an admin has changed a member's membership level.
 		 *
-		 * @deprecated TBD
-		 *
 		 * @param object $user The WordPress user object.
 		 */
 		function sendAdminChangeAdminEmail($user = NULL)
 		{
-			_deprecated_function( __FUNCTION__, 'TBD' );
-
 			global $current_user, $wpdb;
 			if(!$user)
 				$user = $current_user;
 			
 			if(!$user)
 				return false;
-
-			//make sure we have the current membership level data
-			$user->membership_level = pmpro_getMembershipLevelForUser($user->ID, true);
-						
-			if(!empty($user->membership_level) && !empty($user->membership_level->name)) {
-				$membership_level_name = $user->membership_level->name;
-				$membership_level_id = $user->membership_level->id;
-			} else {
-				$membership_level_name = __('None', 'paid-memberships-pro');
-				$membership_level_id = '';
-			}
 
 			$this->email = get_bloginfo("admin_email");
 			$this->subject = sprintf(__("Membership for %s at %s has been changed", "paid-memberships-pro"), $user->user_login, get_option("blogname"));
@@ -1298,27 +1258,17 @@
 				'user_login' => $user->user_login, 
 				'user_email' => $user->user_email, 
 				'sitename' => get_option('blogname'), 
-				'membership_id' => $membership_level_id, 
-				'membership_level_name' => $membership_level_name,
 				'siteemail' => get_bloginfo('admin_email'), 
 				'login_link' => pmpro_login_url(), 
 				'login_url' => pmpro_login_url(),
 				'levels_url' => pmpro_url( 'levels' )
 			);
 
-			if(!empty($user->membership_level) && !empty($user->membership_level->ID)) {
-				$this->data["membership_change"] = sprintf(__("The new level is %s.", 'paid-memberships-pro' ), $user->membership_level->name);
+			// If the user no longer has a membership level, set the membership_change text to "Membership has been cancelled."
+			if ( ! pmpro_hasMembershipLevel( null, $user->ID ) ) {
+				$this->data['membership_change'] = __( "The user's membership has been cancelled.", 'paid-memberships-pro' );
 			} else {
-				$this->data["membership_change"] = __("Membership has been cancelled.", 'paid-memberships-pro' );	
-			}
-			
-			if(!empty($user->membership_level) && !empty($user->membership_level->enddate))
-			{
-					$this->data["membership_change"] .= " " . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $user->membership_level->enddate));
-			}
-			elseif(!empty($this->expiration_changed))
-			{
-				$this->data["membership_change"] .= " " . __("This membership does not expire.", 'paid-memberships-pro' );
+				$this->data['membership_change'] = __( "You can view the user's current memberships from their Edit User page.", 'paid-memberships-pro' );
 			}
 
 			$this->template = apply_filters("pmpro_email_template", "admin_change_admin", $this);

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -302,6 +302,20 @@ function pmpro_membership_level_profile_fields($user)
 					?>
 					</td>
 				</tr>
+				<?php
+				// Hidden row to be shown when a change is made. This is used to show the "send membership change email" option.
+				?>
+				<tr id="pmpro_level_change_options" style="display: none;">
+					<th>
+						<?php esc_html_e( 'Membership Change Options', 'paid-memberships-pro' ); ?>
+					</th>
+					<td>
+						<label for="pmpro_send_change_email">
+							<input type="checkbox" id="pmpro_send_change_email" name="pmpro_send_change_email" value="1" />
+							<?php esc_html_e( 'Send membership change email to member.', 'paid-memberships-pro' ); ?>
+						</label>
+					</td>
+				</tr>
 				<script>
 					jQuery( document ).ready( function() {
 						// Show/hide the expiration date field when the level select is changed.
@@ -329,6 +343,9 @@ function pmpro_membership_level_profile_fields($user)
 								// Hide the expiration fields.
 								jQuery( this ).next( 'p' ).hide();
 							}
+
+							// Show the "level change" options.
+							jQuery( '#pmpro_level_change_options' ).show();
 						} );
 
 						// Show/hide the expiration date field when the checkbox is clicked.
@@ -338,6 +355,9 @@ function pmpro_membership_level_profile_fields($user)
 							} else {
 								jQuery( this ).next( 'input' ).hide();
 							}
+
+							// Show the "level change" options.
+							jQuery( '#pmpro_level_change_options' ).show();
 						} );
 
 						// Show/hide the expiration date and subscription fields when the "has level" checkbox is toggled.
@@ -357,6 +377,9 @@ function pmpro_membership_level_profile_fields($user)
 								// Show the subscription cancel fields.
 								jQuery( this ).parent().parent().next().next().find('label').show();
 							}
+
+							// Show the "level change" options.
+							jQuery( '#pmpro_level_change_options' ).show();
 						} );
 					} );
 				</script>
@@ -527,6 +550,21 @@ function pmpro_membership_level_profile_fields_update() {
 				array( '%s' ),
 				array( '%s', '%d', '%d' )
 			);
+		}
+	}
+
+	// If any level changes were made and the admin wants to send an email, do it.
+	if ( ! empty( $levels_to_add ) || ! empty( $levels_to_remove ) || ! empty( $levels_to_update ) ) {
+		if ( ! empty( $_REQUEST['pmpro_send_change_email'] ) ) {
+			$edited_user = get_userdata( $user_id );
+
+			// Send an email to the user.
+			$myemail = new PMProEmail();
+			$myemail->sendAdminChangeEmail( $edited_user );
+
+			// Send an email to the admin.
+			$myemail = new PMProEmail();
+			$myemail->sendAdminChangeAdminEmail( $edited_user );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Making the "admin changed" email MMPU-compatible by updating the `!!membership_change!!` template variable to be generic instead of listing the individual levels that were changed.

It is possible that we may want to remove that variable altogether, though this may break sites that are already using that variable in custom email templates. Maybe that is ok since we are upgrading to 3.0. This is at least a start in the right direction.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
