### PR TITLE
Deleting spam users who do not complete checkout

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -35,6 +35,9 @@ function pmpro_get_crons() {
 		'pmpro_license_check_key'                  => [
 			'interval' => 'monthly',
 		],
+		'pmpro_cron_spam_pending'                  => [
+			'interval' => 'hourly',
+		],
 	];
 
 	/**

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -190,3 +190,23 @@ function pmpro_disable_checkout_for_spammers( $required_fields ) {
 	return $required_fields;
 }
 add_filter( 'pmpro_required_billing_fields', 'pmpro_disable_checkout_for_spammers' );
+
+/**
+ * Set a user meta value when a user is created during a PMPro checkout.
+ */
+function pmpro_set_spam_pending_user_meta( $user_id ) {
+	// Set a user meta value with the current timestamp.
+	update_user_meta( $user_id, 'pmpro_spam_pending', current_time( 'timestamp' ) );
+}
+add_action( 'pmpro_checkout_before_user_auth', 'pmpro_set_spam_pending_user_meta', 10 );
+
+/**
+ * After a checkout is complete, remove the pmpro_pending user meta value.
+ *
+ * @param int $user_id The user ID.
+ */
+function pmproabandoned_remove_spam_pending_user_meta( $user_id ) {
+	// Remove the user meta value.
+	delete_user_meta( $user_id, 'pmpro_spam_pending' );
+}
+add_action( 'pmpro_after_checkout', 'pmproabandoned_remove_spam_pending_user_meta', 10 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Deleting users who are registered with PMPro but do not complete the checkout process. This is helpful to delete spam accounts that fail the payment step and then bail.

As currently coded, this feature is powered by an hourly cron that deletes spam accounts 24 hours after creation. There is currently a filter to change that window of time and another filter to disable user deletion altogether.

Before releasing, we may want to make UI settings for this feature and we need to figure out how it should be set by default.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
