### PR TITLE
Skipping account fields if user was just created

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -509,6 +509,9 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 					//setting some cookies
 					wp_set_current_user( $user_id, $username );
 					wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
+
+					// Skip the account fields since we just created an account.
+					$skip_account_fields = true;
 				}
 			} else {
 				$user_id = $current_user->ID;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
After our "create users before payment" change, a bug was introduced where the Account Information checkout box would still show if a user account was created during that page load. This would be the case if a payment fails and the user has to be shown the checkout form again.

This PR makes sure that the Account Information box does not show if a WordPress user was just created.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

Check out with fraudulent Stripe test card: 4100000000000019

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
