### PR TITLE
Fix timezone offset when filtering orders by date-range

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -113,9 +113,9 @@ if ( empty( $filter ) || $filter === 'all' ) {
 	$start_date = $start_year . '-' . $start_month . '-' . $start_day;
 	$end_date   = $end_year . '-' . $end_month . '-' . $end_day;
 
-	// add times to dates
-	$start_date = $start_date . ' 00:00:00';
-	$end_date   = $end_date . ' 23:59:59';
+	// add times to dates and localize
+	$start_date = get_gmt_from_date( $start_date . ' 00:00:00' );
+	$end_date   = get_gmt_from_date( $end_date . ' 23:59:59' );
 
 	$condition = "o.timestamp BETWEEN '" . esc_sql( $start_date ) . "' AND '" . esc_sql( $end_date ) . "'";
 } elseif ( $filter == 'predefined-date-range' ) {
@@ -135,9 +135,9 @@ if ( empty( $filter ) || $filter === 'all' ) {
 		$end_date   = date( 'Y-m-d', strtotime( "last day of December $year", $now ) );
 	}
 
-	// add times to dates
-	$start_date = $start_date . ' 00:00:00';
-	$end_date   = $end_date . ' 23:59:59';
+	// add times to dates and localize
+	$start_date = get_gmt_from_date( $start_date . ' 00:00:00' );
+	$end_date   = get_gmt_from_date( $end_date . ' 23:59:59' );
 
 	$condition = "o.timestamp BETWEEN '" . esc_sql( $start_date ) . "' AND '" . esc_sql( $end_date ) . "'";
 } elseif ( $filter == 'within-a-level' ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #2363.

### How to test the changes in this Pull Request:

1. Set a wp time offset different than UTC
2. Filter orders list based on a certain start/end date
3. You gonna see orders from yesterday/tomorrow based on the +/- of the timezone
4. Apply the patch and it's fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
