### PR TITLE
Fixes Export Sales Report - Transient Error

### DIFF
--- a/adminpages/sales-csv.php
+++ b/adminpages/sales-csv.php
@@ -36,7 +36,7 @@ if(isset($_REQUEST['level']))
 else
 	$l = "";
 
-if ( isset( $_REQUEST[ 'discount_code' ] ) ) {
+if ( isset( $_REQUEST[ 'discount_code' ] ) && ! empty( $_REQUEST['discount_code'] ) ) {
 	$discount_code = intval( $_REQUEST[ 'discount_code' ] );
 } else {
 	$discount_code = '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some sites have experienced an issue in exporting sales data where a transient error is thrown even though there is data and the transient is set.

It appears that the discount_code variable is present in the URL but empty, resulting in the generated data having a hash that contains a discount code that is a string (empty) but the export results in an int (0). This PR fixes the issue

### How to test the changes in this Pull Request:

#488782 - Mods only - ticket where I was able to replicate and debug 

1. Navigate to Memberships > Resports > Sales & Revenue
2. Ensure report data is present. Ensure that no discount code has been used in filtering the data.
3. Export - data should export as expeced.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed an issue with exporting Sales & Revenue data