### PR TITLE
Fixes a Fatal Error when Auth Key constant is not defined

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1507,8 +1507,17 @@
 			static $count = 0;
 			$count++;
 
+			if( defined( 'AUTH_KEY' ) && defined( 'SECURE_AUTH_KEY' ) ) {
+				$auth_code = AUTH_KEY;
+				$secure_auth_code = SECURE_AUTH_KEY;
+			} else {
+				//Generate our own random string and hash it
+				$auth_code = md5( rand() );
+				$secure_auth_code = md5( rand() );
+			}
+
 			while( empty( $code ) ) {
-				$scramble = md5( AUTH_KEY . microtime() . SECURE_AUTH_KEY . $count );
+				$scramble = md5( $auth_code . microtime() . $secure_auth_code . $count );
 				$code = substr( $scramble, 0, 10 );
 				$code = apply_filters( 'pmpro_random_code', $code, $this );	//filter
 				$check = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE code = %s LIMIT 1", $code ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1742,8 +1742,17 @@ function pmpro_getDiscountCode( $seed = null ) {
 	static $count = 0;
 	$count++;
 
+	if( defined( 'AUTH_KEY' ) && defined( 'SECURE_AUTH_KEY' ) ) {
+		$auth_code = AUTH_KEY;
+		$secure_auth_code = SECURE_AUTH_KEY;
+	} else {
+		//Generate our own random string and hash it
+		$auth_code = md5( rand() );
+		$secure_auth_code = md5( rand() );
+	}
+
 	while ( empty( $code ) ) {
-		$scramble = md5( AUTH_KEY . microtime() . $seed . SECURE_AUTH_KEY . $count );
+		$scramble = md5( $auth_code . microtime() . $seed . $secure_auth_code . $count );
 		$code = substr( $scramble, 0, 10 );
 		$check = $wpdb->get_var( "SELECT code FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $code ) . "' LIMIT 1" );
 		if ( $check || is_numeric( $code ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checks if the AUTH_KEY constant is present, otherwise creates a value for it. This appears to only be an issue with Local as those constants don't get set. 

Resolves #2450.

### How to test the changes in this Pull Request:

1. Remove your WP Salts or setup a new site using LocalWP
2. Try to checkout
3. No error should be present 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fixed a fatal error during checkout when testing on LocalWP