### PR TITLE
Member History and Order Timestamps Now Correlate

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -501,8 +501,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 							$timestamp = $order->getTimestamp();
 						} else {
 							$timestamp = current_time( 'timestamp' );
-						}
-						
+						}						
 						$year   = date( 'Y', $timestamp );
 						$month  = date( 'n', $timestamp );
 						$day    = date( 'j', $timestamp );

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -502,7 +502,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 						} else {
 							$timestamp = current_time( 'timestamp' );
 						}
-
+						
 						$year   = date( 'Y', $timestamp );
 						$month  = date( 'n', $timestamp );
 						$day    = date( 'j', $timestamp );

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -416,7 +416,7 @@ function pmpro_membership_history_profile_fields( $user ) {
 	global $wpdb;
 
 	//Show all invoices for user
-	$invoices = $wpdb->get_results( $wpdb->prepare( "SELECT mo.*, UNIX_TIMESTAMP(mo.timestamp) as timestamp, du.code_id as code_id FROM $wpdb->pmpro_membership_orders mo LEFT JOIN $wpdb->pmpro_discount_codes_uses du ON mo.id = du.order_id WHERE mo.user_id = %d ORDER BY mo.timestamp DESC", $user->ID ));
+	$invoices = $wpdb->get_results( $wpdb->prepare( "SELECT mo.*, UNIX_TIMESTAMP(mo.timestamp) as timestamp, du.code_id as code_id, mo.timestamp as order_timestamp FROM $wpdb->pmpro_membership_orders mo LEFT JOIN $wpdb->pmpro_discount_codes_uses du ON mo.id = du.order_id WHERE mo.user_id = %d ORDER BY mo.timestamp DESC", $user->ID ));
 
 	$levelshistory = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->pmpro_memberships_users WHERE user_id = %d ORDER BY id DESC", $user->ID ) );
 	
@@ -462,11 +462,14 @@ function pmpro_membership_history_profile_fields( $user ) {
 					<tr>
 						<td>
 							<?php
+
+								$order_timestamp = strtotime( $invoice->order_timestamp );
+								
 								echo esc_html( sprintf(
 									// translators: %1$s is the date and %2$s is the time.
 									__( '%1$s at %2$s', 'paid-memberships-pro' ),
-									esc_html( date_i18n( get_option( 'date_format' ), $invoice->timestamp ) ),
-									esc_html( date_i18n( get_option( 'time_format' ), $invoice->timestamp ) )
+									esc_html( date_i18n( get_option( 'date_format' ), $order_timestamp ) ),
+									esc_html( date_i18n( get_option( 'time_format' ), $order_timestamp ) )
 								) );
 							?>
 						</td>

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -462,9 +462,6 @@ function pmpro_membership_history_profile_fields( $user ) {
 					<tr>
 						<td>
 							<?php
-
-								$order_timestamp = strtotime( $invoice->order_timestamp );
-								
 								echo esc_html( sprintf(
 									// translators: %1$s is the date and %2$s is the time.
 									__( '%1$s at %2$s', 'paid-memberships-pro' ),

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -416,7 +416,7 @@ function pmpro_membership_history_profile_fields( $user ) {
 	global $wpdb;
 
 	//Show all invoices for user
-	$invoices = $wpdb->get_results( $wpdb->prepare( "SELECT mo.*, UNIX_TIMESTAMP(mo.timestamp) as timestamp, du.code_id as code_id, mo.timestamp as order_timestamp FROM $wpdb->pmpro_membership_orders mo LEFT JOIN $wpdb->pmpro_discount_codes_uses du ON mo.id = du.order_id WHERE mo.user_id = %d ORDER BY mo.timestamp DESC", $user->ID ));
+	$invoices = $wpdb->get_results( $wpdb->prepare( "SELECT mo.*, du.code_id as code_id FROM $wpdb->pmpro_membership_orders mo LEFT JOIN $wpdb->pmpro_discount_codes_uses du ON mo.id = du.order_id WHERE mo.user_id = %d ORDER BY mo.timestamp DESC", $user->ID ));
 
 	$levelshistory = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->pmpro_memberships_users WHERE user_id = %d ORDER BY id DESC", $user->ID ) );
 	

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -465,8 +465,8 @@ function pmpro_membership_history_profile_fields( $user ) {
 								echo esc_html( sprintf(
 									// translators: %1$s is the date and %2$s is the time.
 									__( '%1$s at %2$s', 'paid-memberships-pro' ),
-									esc_html( date_i18n( get_option( 'date_format' ), $order_timestamp ) ),
-									esc_html( date_i18n( get_option( 'time_format' ), $order_timestamp ) )
+									esc_html( date_i18n( get_option( 'date_format' ), strtotime( get_date_from_gmt( $invoice->timestamp ) ) ) ),
+									esc_html( date_i18n( get_option( 'time_format' ), strtotime( get_date_from_gmt( $invoice->timestamp ) ) ) )
 								) );
 							?>
 						</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The member history page found in the edit profile page references an invoice timestamp. This has been changed to reference the order timestamp as people expect the two to match when clicking through from the member history.

Resolves #2447
Resolves #2206

### How to test the changes in this Pull Request:

1. Edit a user profile and scroll down to the Member History Section
2. Take note of an order's timestamp, click Edit
3. The timestamp should match what you saw in member history

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

The member history and order timestamps now show as the same times