### PR TITLE
Issue 1819 Email Header variable returning incorrect user name for ad…

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -1005,7 +1005,7 @@
 
 			$this->data = array(
 								'subject' => $this->subject, 
-								'name' => $user->display_name, 
+								'name' => $user->display_name,
 								'user_login' => $user->user_login,
 								'sitename' => get_option( 'blogname' ),
 								'siteemail' => pmpro_getOption( 'from_email' ),
@@ -1275,14 +1275,15 @@
 
 			$this->data = array(
 				'subject' => $this->subject, 
-				'name' => $user->display_name, 
-				'display_name' => $user->display_name, 
+				'name' => $this->get_admin_name($this->email),
+				'display_name' => $this->get_admin_name($this->email),
+				'related_user_name' => $user->display_name,
 				'user_login' => $user->user_login, 
 				'user_email' => $user->user_email, 
 				'sitename' => get_option('blogname'), 
 				'membership_id' => $membership_level_id, 
 				'membership_level_name' => $membership_level_name,
-				'siteemail' => get_bloginfo('admin_email'), 
+				'siteemail' => $this->email,
 				'login_link' => pmpro_login_url(), 
 				'login_url' => pmpro_login_url(),
 				'levels_url' => pmpro_url( 'levels' )
@@ -1458,4 +1459,16 @@
 						
 			return $this->sendEmail();
 		}
+
+		/**
+		 * Gets the admin user name.
+		 *
+		 * @param string $email The admin email address.
+		 * @return string The admin user display name.
+		 */
+		private function get_admin_name($email) {
+			$admin = get_user_by('email', $email );
+			return $admin ? $admin->display_name : 'admin';
+		}
+
 	}

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -44,7 +44,7 @@ $pmpro_email_templates_defaults = array(
 	'admin_change_admin'       => array(
 		'subject'     => __( "Membership for !!user_login!! at !!sitename!! has been changed", 'paid-memberships-pro' ),
 		'description' => __('Admin Change (admin)', 'paid-memberships-pro'),
-		'body' => __( '<p>An administrator at !!sitename!! has changed a membership level for !!name!!.</p>
+		'body' => __( '<p>An administrator at !!sitename!! has changed a membership level for !!related_user_name!!.</p>
 
 <p>!!membership_change!!</p>
 


### PR DESCRIPTION
…mins.

 * Add a function to get admin name by email
 * Add that name to the sendAdminChangeEmail function array data.
 * Add a new 'related_user_name' field to have both. admin name to be notified an user being modified
 * Change template accordingly
 
 
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/1678457/234600581-d773c519-1dae-4ef8-bbbb-095d2e3895b7.png">


### All Submissions:

* [ x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

 * Add a function to get admin name by email
 * Add that name to the sendAdminChangeEmail function array data.
 * Add a new 'related_user_name' field to have both. admin name to be notified an user being modified
 * Change template accordingly

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #1819 .

### How to test the changes in this Pull Request:

1. Go to any  non admin user profile.
2. Change user's membership current level 
3. Check `Send the user an email about this change.` checkbox
4. Check inbox and see if header email matches with admin user or modified user.

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
