### PR TITLE
Making sure account number is not saved in database when sending to Stripe Checkout

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1650,10 +1650,22 @@ class PMProGateway_stripe extends PMProGateway {
 		// Save some checkout information in the order so that we can access it when the payment is complete.
 		// Save the request variables.
 		$request_vars = $_REQUEST;
-		unset( $request_vars['password'] );
-		unset( $request_vars['password2'] );
-		unset( $request_vars['password2_copy'] );
-		unset( $request_vars['AccountNumber'] );
+		// Unset restricted request variables.
+		$restricted_vars = array(
+			'password',
+			'password2',
+			'password2_copy',
+			'AccountNumber',
+			'CVV',
+			'ExpirationMonth',
+			'ExpirationYear',
+			'add_sub_accounts_password', // Creating users at checkout with Sponsored Members.
+		);
+		foreach ( $restricted_vars as $key ) {
+			if ( isset( $request_vars[ $key ] ) ) {
+				unset( $request_vars[ $key ] );
+			}
+		}
 		update_pmpro_membership_order_meta( $morder->id, 'checkout_request_vars', $request_vars );
 
 		// Save the checkout level.

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1653,6 +1653,7 @@ class PMProGateway_stripe extends PMProGateway {
 		unset( $request_vars['password'] );
 		unset( $request_vars['password2'] );
 		unset( $request_vars['password2_copy'] );
+		unset( $request_vars['AccountNumber'] );
 		update_pmpro_membership_order_meta( $morder->id, 'checkout_request_vars', $request_vars );
 
 		// Save the checkout level.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When PMPro sends a user to Stripe Checkout to pay, it saves all $_REQUEST variables so that it can process the checkout when the payment is complete. Normally, credit card fields are not shown when Stripe Checkout enabled, but there are cases when they could be. For example, if multiple gateways are being used and some of them have credit card fields.

This PR ensures that the AccountNumber value in $_REQUEST is never saved to the database.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
