### PR TITLE
Remove unused variable

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -886,8 +886,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			 */
 			$limit = apply_filters( 'pmpro_trigger_recent_members_limit', $limit );
 			
-			$response_type = isset( $params['response_type'] ) ? sanitize_text_field( $params['response_type'] ) : null;
-			
 			if ( empty( $params['level_status'] ) ) {
 				$level_status = [ 'active' ];
 			} else {


### PR DESCRIPTION
* Remove unused variable in the rest API for a Zapier event.

This feels almost not worth the effort but while debugging Zapier native integration, specifically this function I noticed an unused variable that we will never use.
