### PR TITLE
2.10.6 ugprade, check for sensitive data in ordermeta

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -127,6 +127,11 @@ class PMPro_Site_Health {
 		// Automatically add information about constants set.
 		$info['pmpro']['fields'] = array_merge( $info['pmpro']['fields'], self::get_constants() );
 
+		if ( function_exists( 'pmpro_add_site_health_info_2_10_6' ) ) {
+			// If the 2.10.6 update cleaned up sensitive order meta data, we want to show that.
+			$info = pmpro_add_site_health_info_2_10_6( $info );
+		}
+
 		return $info;
 	}
 

--- a/includes/updates/upgrade_2_10_6.php
+++ b/includes/updates/upgrade_2_10_6.php
@@ -9,12 +9,15 @@
 	2. Loop through and scrub the AccountNumbers.
 */
 function pmpro_upgrade_2_10_6() {
-    global $wpdb;
-    $sqlQuery = "SELECT pmpro_membership_order_id
-                 FROM $wpdb->pmpro_membership_ordermeta
-                 WHERE meta_key = 'checkout_request_vars'
-                    AND meta_value LIKE '%AccountNumber%'
-                    AND meta_value NOT LIKE '%XXXXXXXXXXXX%'
+	global $wpdb;
+	$sqlQuery = "SELECT pmpro_membership_order_id
+				FROM $wpdb->pmpro_membership_ordermeta
+				WHERE meta_key = 'checkout_request_vars'
+					AND (
+						( meta_value LIKE '%:\"AccountNumber\";%' AND meta_value NOT LIKE '%XXXXXXXXXXXX%' )
+						OR ( meta_value LIKE '%:\"CVV\";%' )
+						OR ( meta_value LIKE '%:\"add_sub_accounts_password\";%' )
+					)
 				ORDER BY meta_id";
 	$order_ids = $wpdb->get_col( $sqlQuery );
 
@@ -43,10 +46,13 @@ function pmpro_upgrade_2_10_6_ajax() {
 	
 	//get orders
 	$sqlQuery = "SELECT pmpro_membership_order_id
-                 FROM $wpdb->pmpro_membership_ordermeta
-                 WHERE meta_key = 'checkout_request_vars'
-                    AND meta_value LIKE '%AccountNumber%'
-                    AND meta_value NOT LIKE '%XXXXXXXXXXXX%'
+				FROM $wpdb->pmpro_membership_ordermeta
+				WHERE meta_key = 'checkout_request_vars'
+					AND (
+						( meta_value LIKE '%:\"AccountNumber\";%' AND meta_value NOT LIKE '%XXXXXXXXXXXX%' )
+						OR ( meta_value LIKE '%:\"CVV\";%' )
+						OR ( meta_value LIKE '%:\"add_sub_accounts_password\";%' )
+					)
 				ORDER BY meta_id";
 	$order_ids = $wpdb->get_col( $sqlQuery );
 
@@ -85,6 +91,9 @@ function pmpro_upgrade_2_10_6_helper_scrub_account_numbers_in_orders( $order_ids
         if ( ! empty( $request_vars['CVV'] ) ) {
             unset( $request_vars['CVV'] );
         }
+		if ( ! empty( $request_vars['add_sub_accounts_password'] ) ) {
+			unset( $request_vars['add_sub_accounts_password'] );
+		}
 
         // Save updated values.
         update_pmpro_membership_order_meta( $order_id, 'checkout_request_vars', $request_vars );

--- a/includes/updates/upgrade_2_10_6.php
+++ b/includes/updates/upgrade_2_10_6.php
@@ -129,11 +129,6 @@ function pmpro_add_site_health_info_2_10_6( $info ) {
 	return $info;
 }
 
-// Only load these functions we haven't already updated to db version 2.96
-if ( $pmpro_db_version >= 2.96 ) {
-	return;
-}
-
 function pmpro_upgrade_2_10_6() {
 	global $wpdb;
 	$sqlQuery = "SELECT pmpro_membership_order_id

--- a/includes/updates/upgrade_2_10_6.php
+++ b/includes/updates/upgrade_2_10_6.php
@@ -8,13 +8,60 @@
 	1. Find all rows in wp_pmpro_membership_ordermeta where unscrubbed AccountNumbers show up.
 	2. Loop through and scrub the AccountNumbers.
 */
+
+/**
+ * Show admin notice if site was affected.
+ */
+function pmpro_upgrade_2_10_6_notice() {
+	// Check if we need to show the notice.
+	if ( ! get_option( 'pmpro_upgrade_2_10_6_notice' ) ) {
+		return;
+	}
+
+	// Only show on PMPro admin pages.
+	if ( empty( $_REQUEST['page'] ) || strpos( $_REQUEST['page'], 'pmpro' ) === false ) {
+		return;
+	}
+
+	// Check if the user has dismissed the notice.
+	if ( ! empty( $_REQUEST['pmpro-hide-upgrade_2_10_6-notice'] ) ) {
+		delete_option( 'pmpro_upgrade_2_10_6_notice' );
+		return;
+	}
+
+	// Show a dismissable notice. Do not show a link to scrub data.
+	?>
+	<div class="notice notice-warning" id="pmpro-upgrade-2-10-6-notice">
+		<p>
+			<?php
+			printf(
+				wp_kses_post(
+					__( 'Paid Memberships Pro has detected potentially sensitive customer information in the PMPro order meta table. This information will be safely removed from your database. For more information, read our <a href="%s">post here</a>.', 'paid-memberships-pro' )
+				),
+				esc_url( 'https://www.paidmembershipspro.com/pmpro-update-2-10-6/' )
+			);
+			?>
+		</p>
+		<p>
+			<a href="<?php echo esc_url( add_query_arg( 'pmpro-hide-upgrade_2_10_6-notice', '1' ) ); ?>"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></a>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'pmpro_upgrade_2_10_6_notice' );
+
+// Only load these functions if we need to call them.
+if ( $pmpro_db_version >= 2.95 ) {
+	return;
+}
+
 function pmpro_upgrade_2_10_6() {
 	global $wpdb;
 	$sqlQuery = "SELECT pmpro_membership_order_id
 				FROM $wpdb->pmpro_membership_ordermeta
 				WHERE meta_key = 'checkout_request_vars'
 					AND (
-						( meta_value LIKE '%:\"AccountNumber\";%' AND meta_value NOT LIKE '%XXXXXXXXXXXX%' )
+						( meta_value LIKE '%:\"AccountNumber\";%' AND meta_value NOT LIKE '%:\"AccountNumber\";s:16:\"XXXXXXXXXXXX%' )
 						OR ( meta_value LIKE '%:\"CVV\";%' )
 						OR ( meta_value LIKE '%:\"add_sub_accounts_password\";%' )
 					)
@@ -22,6 +69,9 @@ function pmpro_upgrade_2_10_6() {
 	$order_ids = $wpdb->get_col( $sqlQuery );
 
 	if(!empty($order_ids)) {
+		// Set an option so that we know to show the admin a notice that they may have been affected.
+		update_option( 'pmpro_upgrade_2_10_6_notice', true );
+
 		if(count($order_ids) > 10) {
 			//if more than 10 orders, we'll need to do this via AJAX
 			pmpro_addUpdate( 'pmpro_upgrade_2_10_6_ajax' );
@@ -30,7 +80,6 @@ function pmpro_upgrade_2_10_6() {
 			pmpro_upgrade_2_10_6_helper_scrub_account_numbers_in_orders( $order_ids, false );
 		}
 	}
-
 	pmpro_setOption( 'db_version', '2.106' );
 	return 2.106;
 }
@@ -49,7 +98,7 @@ function pmpro_upgrade_2_10_6_ajax() {
 				FROM $wpdb->pmpro_membership_ordermeta
 				WHERE meta_key = 'checkout_request_vars'
 					AND (
-						( meta_value LIKE '%:\"AccountNumber\";%' AND meta_value NOT LIKE '%XXXXXXXXXXXX%' )
+						( meta_value LIKE '%:\"AccountNumber\";%' AND meta_value NOT LIKE '%:\"AccountNumber\";s:16:\"XXXXXXXXXXXX%' )
 						OR ( meta_value LIKE '%:\"CVV\";%' )
 						OR ( meta_value LIKE '%:\"add_sub_accounts_password\";%' )
 					)

--- a/includes/updates/upgrade_2_10_6.php
+++ b/includes/updates/upgrade_2_10_6.php
@@ -1,0 +1,96 @@
+<?php
+/*
+	Upgrade to 2.10.6
+    
+    A number of misconfigured sites might have stored sensitive payment data
+    in the pmpro_membership_ordermeta table.
+
+	1. Find all rows in wp_pmpro_membership_ordermeta where unscrubbed AccountNumbers show up.
+	2. Loop through and scrub the AccountNumbers.
+*/
+function pmpro_upgrade_2_10_6() {
+    global $wpdb;
+    $sqlQuery = "SELECT pmpro_membership_order_id
+                 FROM $wpdb->pmpro_membership_ordermeta
+                 WHERE meta_key = 'checkout_request_vars'
+                    AND meta_value LIKE '%AccountNumber%'
+                    AND meta_value NOT LIKE '%XXXXXXXXXXXX%'
+				ORDER BY meta_id";
+	$order_ids = $wpdb->get_col( $sqlQuery );
+
+	if(!empty($order_ids)) {
+		if(count($order_ids) > 10) {
+			//if more than 10 orders, we'll need to do this via AJAX
+			pmpro_addUpdate( 'pmpro_upgrade_2_10_6_ajax' );
+		} else {
+			//less than 10, let's just do them now
+			pmpro_upgrade_2_10_6_helper_scrub_account_numbers_in_orders( $order_ids, false );
+		}
+	}
+
+	pmpro_setOption( 'db_version', '2.106' );
+	return 2.106;
+}
+
+/*
+	If a site has > 100 orders then we run this pasrt of the update via AJAX from the updates page.
+*/
+function pmpro_upgrade_2_10_6_ajax() {
+	global $wpdb;
+
+	//keeping track of which order we're working on
+	$last_order_id = get_option( 'pmpro_upgrade_2_10_6_last_order_id', 0 );
+	
+	//get orders
+	$sqlQuery = "SELECT pmpro_membership_order_id
+                 FROM $wpdb->pmpro_membership_ordermeta
+                 WHERE meta_key = 'checkout_request_vars'
+                    AND meta_value LIKE '%AccountNumber%'
+                    AND meta_value NOT LIKE '%XXXXXXXXXXXX%'
+				ORDER BY meta_id";
+	$order_ids = $wpdb->get_col( $sqlQuery );
+
+	if(empty($order_ids)) {
+		//done with this update
+		pmpro_removeUpdate('pmpro_upgrade_2_10_6_ajax');
+		delete_option( 'pmpro_upgrade_2_10_6_last_order_id' );
+	} else {
+		pmpro_upgrade_2_10_6_helper_scrub_account_numbers_in_orders( $order_ids, true );
+	}
+}
+
+/**
+ * Scrub AccountNumbers and other sensitive data from ordermeta.
+ *
+ * @param array(int) $order_ids to scrub.
+ * @param bool $update_last_order_id. Should be true if updating via ajax.
+ */
+function pmpro_upgrade_2_10_6_helper_scrub_account_numbers_in_orders( $order_ids, $update_last_order_id ) {
+	global $wpdb;
+	
+	require_once( ABSPATH . "/wp-includes/pluggable.php" );
+	
+    foreach( $order_ids as $order_id ) {
+		$request_vars = get_pmpro_membership_order_meta( $order_id, 'checkout_request_vars', true );
+        
+        // Skip if we didn't get an array.
+        if ( ! is_array( $request_vars ) ) {
+            continue;
+        }
+
+        // Unset sensitive data.
+        if ( ! empty( $request_vars['AccountNumber'] ) ) {
+            unset( $request_vars['AccountNumber'] );
+        }
+        if ( ! empty( $request_vars['CVV'] ) ) {
+            unset( $request_vars['CVV'] );
+        }
+
+        // Save updated values.
+        update_pmpro_membership_order_meta( $order_id, 'checkout_request_vars', $request_vars );
+	}
+
+	if ( $update_last_order_id ) {
+		update_option( 'pmpro_upgrade_2_10_6_last_order_id', $last_order_id );
+	}
+}

--- a/includes/updates/upgrade_2_10_6.php
+++ b/includes/updates/upgrade_2_10_6.php
@@ -129,8 +129,8 @@ function pmpro_add_site_health_info_2_10_6( $info ) {
 	return $info;
 }
 
-// Only load these functions if we need to call them.
-if ( $pmpro_db_version >= 2.95 ) {
+// Only load these functions we haven't already updated to db version 2.96
+if ( $pmpro_db_version >= 2.96 ) {
 	return;
 }
 

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -318,6 +318,15 @@ function pmpro_checkForUpgrades()
 		pmpro_upgrade_2_10();
 		pmpro_setOption( 'db_version', '2.95' );		
 	}
+
+	/**
+	 * Version 2.10.6
+	 * Check for sensitive information in ordermeta.
+	 */
+	if ( $pmpro_db_version < 2.106 ) {
+		require_once( PMPRO_DIR . "/includes/updates/upgrade_2_10_6.php" );
+		pmpro_upgrade_2_10_6();
+	}
 }
 
 function pmpro_db_delta()

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -323,8 +323,8 @@ function pmpro_checkForUpgrades()
 	 * Version 2.10.6
 	 * Check for sensitive information in ordermeta.
 	 */
-	if ( $pmpro_db_version < 2.106 ) {
-		require_once( PMPRO_DIR . "/includes/updates/upgrade_2_10_6.php" );
+	require_once( PMPRO_DIR . "/includes/updates/upgrade_2_10_6.php" ); // Need to include this for admin notice.
+	if ( $pmpro_db_version < 2.96 ) { // 2.96 since 2.106 would be lower than previous update.
 		pmpro_upgrade_2_10_6();
 	}
 }

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -325,7 +325,7 @@ function pmpro_checkForUpgrades()
 	 */
 	require_once( PMPRO_DIR . "/includes/updates/upgrade_2_10_6.php" ); // Need to include this for admin notice.
 	if ( $pmpro_db_version < 2.96 ) { // 2.96 since 2.106 would be lower than previous update.
-		pmpro_upgrade_2_10_6();
+		pmpro_upgrade_2_10_6(); // This function will update the db version.
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related: https://github.com/strangerstudios/paid-memberships-pro/pull/2468

This PR adds an upgrade check to see if full AccountNumber information was stored in the checkout_request_vars entries of the wp_pmpro_membership_ordermeta table, and if so removes that data.

We are not sure how common this is. It seems to require some amount of customization or misconfiguration for this to happen.

We should consider also showing a notice to explain the issue so admins can check for issues in backups and clean those of sensitive data.

### How to test the changes in this Pull Request:

Again, this issue does not seem to happen on standard installs of PMPro. But we can fake the issue and trigger the cleanup using the steps below.

1. Use the Stripe gateway and choose the option to handle payments "offsite". This enables the saving of request vars.
2. Add a user field for all levels called "AccountNumber". This field will get saved to the checkout_request_vars meta.
3. Checkout 1-11 times or so.
4. Update the pmpro_db_version option in the DB to something < 2.106

This should trigger the upgrade check, which will find and fix the affected ordermeta rows.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: On upgrade, this version will check for sensitive data in the wp_pmpro_membership_ordermeta table and  if found scrub that data.
