### PR TITLE
Reworks the password reset email filter

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -841,15 +841,16 @@ add_action( 'login_form_resetpass', 'pmpro_do_password_reset' );
  */
 function pmpro_password_reset_email_filter( $message, $key, $user_login ) {
 
-	$login_page_id = pmpro_getOption( 'login_page_id' );
-    if ( ! empty ( $login_page_id ) ) {
-		$login_url = get_permalink( $login_page_id );
-		if ( strpos( $login_url, '?' ) ) {
-			// Login page permalink contains a '?', so we need to replace the '?' already in the login URL with '&'.
-			$message = str_replace( network_site_url( 'wp-login.php' ) . '?', $login_url . '&', $message );
-		}
-		$message = str_replace( network_site_url( 'wp-login.php' ), $login_url, $message );
+	$login_url = pmpro_url( 'login' );
+	if ( ! $login_url ) {
+		return $message;
 	}
+
+	if ( strpos( $login_url, '?' ) ) {
+		// Login page permalink contains a '?', so we need to replace the '?' already in the login URL with '&'.
+		$message = str_replace( network_site_url( 'wp-login.php' ) . '?', $login_url . '&', $message );
+	}
+	$message = str_replace( network_site_url( 'wp-login.php' ), $login_url, $message );
 
 	return $message;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reworks the password reset email filter to return early if our login page doesn't exist

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
