### PR TITLE
Adjusts Members Per Level Query For Better Accuracy

### DIFF
--- a/adminpages/reports/members-per-level.php
+++ b/adminpages/reports/members-per-level.php
@@ -79,7 +79,13 @@ function pmpro_report_get_active_members_per_level() {
 	global $wpdb, $pmpro_levels;
 
 	// Query to get active members per level.
-	$sqlQuery = "SELECT membership_id, count(*) as total_active_members FROM $wpdb->pmpro_memberships_users WHERE `status` = 'active' GROUP BY membership_id ORDER BY total_active_members DESC";
+	$sqlQuery = "SELECT membership_id, count(*) as total_active_members 
+	FROM $wpdb->pmpro_memberships_users as mu 
+	LEFT JOIN $wpdb->users as u on u.ID = mu.id 
+	WHERE mu.status = 'active' 
+	GROUP BY membership_id 
+	ORDER BY total_active_members DESC";
+	
 	$results = $wpdb->get_results( $sqlQuery );
 
 	return $results;

--- a/adminpages/reports/members-per-level.php
+++ b/adminpages/reports/members-per-level.php
@@ -81,8 +81,9 @@ function pmpro_report_get_active_members_per_level() {
 	// Query to get active members per level.
 	$sqlQuery = "SELECT membership_id, count(*) as total_active_members 
 	FROM $wpdb->pmpro_memberships_users as mu 
-	LEFT JOIN $wpdb->users as u on u.ID = mu.id 
+	LEFT JOIN $wpdb->users as u on u.ID = mu.user_id 
 	WHERE mu.status = 'active' 
+	AND u.ID IS NOT NULL
 	GROUP BY membership_id 
 	ORDER BY total_active_members DESC";
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Left Joins into the WP users table to get members with accounts that exist on the site. 

The current numbers appear to report on orphaned accounts that no longer exist - this should improve accuracy. 

### How to test the changes in this Pull Request:

1. Delete a user account that has order/member history
2. Navigate to /wp-admin/admin.php?page=pmpro-reports&report=members_per_level
3. Members per level should show a more accurate value and exclude those user accounts that don't exist. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

