### PR TITLE
Adds Avada compat for the Series Add On

### DIFF
--- a/includes/compatibility/avada.php
+++ b/includes/compatibility/avada.php
@@ -6,11 +6,13 @@
  // Unhook the_content changes for Avada.
 function pmpro_remove_content_changes_avada() {
 	remove_filter( 'the_content', 'pmpro_membership_content_filter', 5 );
+	remove_filter( 'the_content', 'pmpros_the_content' );
 }
 add_action( 'awb_remove_third_party_the_content_changes', 'pmpro_remove_content_changes_avada', 5 );
 
 // Add the_content restriction back for Avada.
 function pmpro_readd_content_changes_avada() {
 	add_filter( 'the_content', 'pmpro_membership_content_filter', 5 );
+	add_filter( 'the_content', 'pmpros_the_content' );
 }
 add_action( 'awb_readd_third_party_the_content_changes', 'pmpro_readd_content_changes_avada', 99 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avada runs the_content filter in the header and footer areas. The same compat checks we have in place apply to the Series Add On now. 

### How to test the changes in this Pull Request:

1. Create a series
2. View the series 
3. The series should only be added to the content of the page and not duplicated in the header and footer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?