### PR TITLE
Fix Report Titles for Sales Report

### DIFF
--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -844,9 +844,11 @@ function pmpro_report_sales_page()
 				
 				// Adjust the title if we have a date or not so it reads better.
 				if ( $date ) {
-					$title = sprintf( esc_html__( '%s %s for %s', 'paid-memberships-pro' ), ucwords( $period ), ucwords( $type ), ucwords( $date ) );
+					// translators: %1$s is the report period, %2$s is the report type, %3$s is the date.
+					$title = sprintf( esc_html__( '%1$s %2$s for %3$s', 'paid-memberships-pro' ), ucwords( $period ), ucwords( $type ), ucwords( $date ) );
 				} else {
-					$title = sprintf( esc_html__( '%s %s' ) , ucwords( $period_title ), ucwords( $type ) );
+					// translators: %1$s is the report period, %2$s is the report type.
+					$title = sprintf( esc_html__( '%1$s %2$s', 'paid-memberships-pro' ) , ucwords( $period_title ), ucwords( $type ) );
 
 				}
 			?>


### PR DESCRIPTION
Improves the readability of titles for sales report, specifically Last 7 Days, Last 30 Days and Last 12 Months.

Adding a small note here, I did not make the Last X Days placeholder sprintf translatable as it's output is just `(%s %s)` and doesn't make total sense for this but the actual strings are translatable so that's why it's been omitted. See this code - https://github.com/strangerstudios/paid-memberships-pro/pull/2488/files#diff-fd41fe130e45fdd593becf8e34c099fff45ddb06a41c23ad041d3386fff2228dR848


![Screenshot 2023-05-30 at 15 00 14](https://github.com/strangerstudios/paid-memberships-pro/assets/12629136/ee468930-6bab-4935-af05-c71d44450b24)

**Steps to test:**

1. Navigate to reports and view the sales report.
2. Filter the report to show one of the Last X Days or Last 12 Months options.
3. See the new change.



### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?