### PR TITLE
getOptionRenaming - preheaders, scheduled, services and shortcode

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -47,7 +47,7 @@ if (empty($pmpro_billing_order->gateway)) {
     //no order
     $besecure = false;
 } elseif ($pmpro_billing_order->gateway == "paypalexpress") {
-    $besecure = pmpro_getOption("use_ssl");
+    $besecure = get_option("pmpro_use_ssl");
     //still they might have website payments pro setup
     if ($gateway == "paypal") {
         //$besecure = true;
@@ -59,7 +59,7 @@ if (empty($pmpro_billing_order->gateway)) {
     $show_check_payment_instructions = true;
 } else {
     //$besecure = true;
-    $besecure = pmpro_getOption("use_ssl");
+    $besecure = get_option("pmpro_use_ssl");
 }
 
 // this variable is checked sometimes to know if the page should show billing fields
@@ -260,7 +260,7 @@ if ($submit) {
         $pmpro_billing_order->billing->zip = $bzipcode;
         $pmpro_billing_order->billing->phone = $bphone;
 
-        //$gateway = pmpro_getOption("gateway");
+        //$gateway = get_option("pmpro_gateway");
         $pmpro_billing_order->gateway = $gateway;
         $pmpro_billing_order->setGateway();
         

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -21,7 +21,8 @@ if ( ! empty( $_REQUEST['gateway'] ) ) {
 }
 
 //set valid gateways - the active gateway in the settings and any gateway added through the filter will be allowed
-if ( get_option( "pmpro_gateway", true ) == "paypal" ) {
+if ( get_option( "pmpro_gateway" ) == "paypal" ) {
+
 	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( "paypal", "paypalexpress" ) );
 } else {
 	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( get_option( "pmpro_gateway", true ) ) );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -17,14 +17,14 @@ if ( ! empty( $_REQUEST['gateway'] ) ) {
 } elseif ( ! empty( $_REQUEST['review'] ) ) {
 	$gateway = "paypalexpress";
 } else {
-	$gateway = pmpro_getOption( "gateway" );
+	$gateway = get_option( "pmpro_gateway" );
 }
 
 //set valid gateways - the active gateway in the settings and any gateway added through the filter will be allowed
-if ( pmpro_getOption( "gateway", true ) == "paypal" ) {
+if ( get_option( "pmpro_gateway", true ) == "paypal" ) {
 	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( "paypal", "paypalexpress" ) );
 } else {
-	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( pmpro_getOption( "gateway", true ) ) );
+	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( get_option( "pmpro_gateway", true ) ) );
 }
 
 //let's add an error now, if an invalid gateway is set
@@ -66,7 +66,7 @@ if ( ! pmpro_isLevelFree( $pmpro_level ) ) {
 	//require billing and ssl
 	$pagetitle            = __( "Checkout: Payment Information", 'paid-memberships-pro' );
 	$pmpro_requirebilling = true;
-	$besecure             = pmpro_getOption( "use_ssl" );
+	$besecure             = get_option( "pmpro_use_ssl" );
 } else {
 	//no payment so we don't need ssl
 	$pagetitle            = __( "Set Up Your Account", 'paid-memberships-pro' );
@@ -104,7 +104,7 @@ $skip_account_fields = apply_filters( "pmpro_skip_account_fields", $skip_account
 
 //some options
 global $tospage;
-$tospage = pmpro_getOption( "tospage" );
+$tospage = get_option( "pmpro_tospage" );
 if ( $tospage ) {
 	$tospage = get_post( $tospage );
 }
@@ -834,7 +834,7 @@ if ( ! empty( $pmpro_confirmed ) ) {
 //default values
 if ( empty( $submit ) ) {
 	//show message if the payment gateway is not setup yet
-	if ( $pmpro_requirebilling && ! pmpro_getOption( "gateway", true ) ) {
+	if ( $pmpro_requirebilling && ! get_option( "pmpro_gateway", true ) ) {
 		if ( pmpro_isAdmin() ) {
 			$pmpro_msg = sprintf( __( 'You must <a href="%s">set up a Payment Gateway</a> before any payments will be processed.', 'paid-memberships-pro' ), admin_url( '/admin.php?page=pmpro-paymentsettings' ) );
 		} else {

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -25,7 +25,8 @@ if ( get_option( "pmpro_gateway" ) == "paypal" ) {
 
 	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( "paypal", "paypalexpress" ) );
 } else {
-	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( get_option( "pmpro_gateway", true ) ) );
+	$valid_gateways = apply_filters( "pmpro_valid_gateways", array( get_option( "pmpro_gateway" ) ) );
+
 }
 
 //let's add an error now, if an invalid gateway is set

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -836,7 +836,8 @@ if ( ! empty( $pmpro_confirmed ) ) {
 //default values
 if ( empty( $submit ) ) {
 	//show message if the payment gateway is not setup yet
-	if ( $pmpro_requirebilling && ! get_option( "pmpro_gateway", true ) ) {
+	if ( $pmpro_requirebilling && ! get_option( "pmpro_gateway" ) ) {
+
 		if ( pmpro_isAdmin() ) {
 			$pmpro_msg = sprintf( __( 'You must <a href="%s">set up a Payment Gateway</a> before any payments will be processed.', 'paid-memberships-pro' ), admin_url( '/admin.php?page=pmpro-paymentsettings' ) );
 		} else {

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -297,7 +297,7 @@ function pmpro_cron_admin_activity_email() {
 		return;
 	}
 	
-	$frequency = pmpro_getOption( 'activity_email_frequency' );
+	$frequency = get_option( 'pmpro_activity_email_frequency' );
 	if ( empty( $frequency ) ) {
 		$frequency = 'week';
 	}

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -409,7 +409,7 @@ function pmpro_ipnValidate() {
 	}
 
 	//post back to PayPal system to validate
-	$gateway_environment = pmpro_getOption( "gateway_environment" );
+	$gateway_environment = get_option( "pmpro_gateway_environment" );
 	if ( $gateway_environment == "sandbox" ) {
 		$paypal_url = 'https://www.' . $gateway_environment . '.paypal.com/cgi-bin/webscr';
 	} else {
@@ -487,7 +487,7 @@ function pmpro_ipnCheckReceiverEmail( $email ) {
 		$email = array( $email );
 	}
 
-	if ( ! in_array( strtolower( pmpro_getOption( 'gateway_email' ) ), $email ) ) {
+	if ( ! in_array( strtolower( get_option( 'pmpro_gateway_email' ) ), $email ) ) {
 		$r = false;
 	} else {
 		$r = true;
@@ -511,7 +511,7 @@ function pmpro_ipnCheckReceiverEmail( $email ) {
 		}
 
 		//not yours
-		ipnlog( "ERROR: receiver_email (" . $receiver_email . ") and business email (" . $business . ") did not match (" . pmpro_getOption( 'gateway_email' ) . ")" );
+		ipnlog( "ERROR: receiver_email (" . $receiver_email . ") and business email (" . $business . ") did not match (" . get_option( 'pmpro_gateway_email' ) . ")" );
 
 		return false;
 	}

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -42,22 +42,22 @@
 			$livemode = ! empty( $post_event->livemode );
 		} else {
 			// No event data passed in body, so use current environment.
-			$livemode = pmpro_getOption( 'gateway_environment' ) === 'live';
+			$livemode = get_option( 'pmro_gateway_environment' ) === 'live';
 		}
 	}
 	else
 	{
 		$event_id = sanitize_text_field($_REQUEST['event_id']);
-		$livemode = pmpro_getOption( 'gateway_environment' ) === 'live'; // User is testing, so use current environment.
+		$livemode = get_option( 'pmro_gateway_environment' ) === 'live'; // User is testing, so use current environment.
 	}
 
 	try {
 		if ( PMProGateway_stripe::using_legacy_keys() ) {
-			$secret_key = pmpro_getOption( "stripe_secretkey" );
+			$secret_key = get_option( "pmro_stripe_secretkey" );
 		} elseif ( $livemode ) {
-			$secret_key = pmpro_getOption( 'live_stripe_connect_secretkey' );
+			$secret_key = get_option( 'pmpro_live_stripe_connect_secretkey' );
 		} else {
-			$secret_key = pmpro_getOption( 'sandbox_stripe_connect_secretkey' );
+			$secret_key = get_option( 'pmpro_sandbox_stripe_connect_secretkey' );
 		}
 		Stripe\Stripe::setApiKey( $secret_key );
 	} catch ( Exception $e ) {

--- a/services/twocheckout-ins.php
+++ b/services/twocheckout-ins.php
@@ -236,9 +236,9 @@
 
 		//is this a return call or notification
 		if(empty($params['message_type']))
-			$check = Twocheckout_Return::check( $params, pmpro_getOption( 'twocheckout_secretword' ) );
+			$check = Twocheckout_Return::check( $params, get_option( 'pmpro_twocheckout_secretword' ) );
 		else
-			$check = Twocheckout_Notification::check( $params, pmpro_getOption( 'twocheckout_secretword' ) );
+			$check = Twocheckout_Notification::check( $params, get_option( 'pmpro_twocheckout_secretword' ) );
 
 		if( empty ( $check ) )
 			$r = false;	//HTTP failure

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -163,7 +163,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actionlinks' ) ); ?>">
 					<?php
 						// Get the edit profile and change password links if 'Member Profile Edit Page' is set.
-						if ( ! empty( pmpro_getOption( 'member_profile_edit_page_id' ) ) ) {
+						if ( ! empty( get_option( 'pmpro_member_profile_edit_page_id' ) ) ) {
 							$edit_profile_url = pmpro_url( 'member_profile_edit' );
 							$change_password_url = add_query_arg( 'view', 'change-password', pmpro_url( 'member_profile_edit' ) );
 						} elseif ( ! pmpro_block_dashboard() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Renames pmpro_getOption to use get_option in all instances in the preheaders, scheduled, services and shortcode folders.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
