### PR TITLE
[bugfixing][release ASAP wanted] 'header_name' variable exposed in some email templates

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -124,8 +124,15 @@
 			$this->data = apply_filters("pmpro_email_data", $this->data, $this);	//filter
 
 			// Handle backwards compatibility for the new !!header_name!! variable.
-			if( empty ($this->data['header_name'] ) && ! empty( $this->data['name'] ) ) {
-				$this->data['header_name'] = $this->data['name'];
+			if( empty ($this->data['header_name'] ) ) {
+				$email_user = get_user_by( 'email', $this->email );
+				if( $email_user ) {
+					$this->data['header_name'] = $email_user->display_name;
+				} elseif ( ! empty ( $this->data['name'] ) ) {
+					$this->data['header_name'] = $this->data['name'];
+				} else {
+					$this->data['header_name'] = __( 'User', 'paid-memberships-pro' );
+				}
 			}
 			
 			//swap data into body and subject line


### PR DESCRIPTION
 Add better fallback for find recipient name and assign to header_name variable. this will fix a bug found in the
 “subscription cancelled” email template that is likely present in some other templates, that is actively affecting websites. 

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

I tested locally, by tweaking code to have null header name, later passed a null parameter to get_user_by to get a false response and checked that flow too. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
