### PR TITLE
Fix radio button always showing asterisk

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -142,11 +142,13 @@ jQuery(document).ready(function(){
 		jQuery( '.pmpro_required' ).closest( '.pmpro_checkout-field' ).append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
 	}
 
-	//move asterisk for some field types
-	if ( jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ) ) {
-		jQuery( '.pmpro_checkout-field-radio' ).find( ".pmpro_asterisk" ).remove();
-		jQuery( '.pmpro_checkout-field-radio' ).find( 'label' ).first().append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
-	}
+	//Loop through all radio type fields and move the asterisk.
+	jQuery('.pmpro_checkout-field-radio').each(function () {
+		if (jQuery(this).find('span').hasClass('pmpro_asterisk')) {
+			jQuery(this).find(".pmpro_asterisk").remove();
+			jQuery(this).find('label').first().append('<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>');
+		}
+	});
     
     //move asterisk before hint <p>'s
     jQuery( 'span.pmpro_asterisk' ).each(function() {


### PR DESCRIPTION
* BUG FIX: Fixed an issue where radio button would always show asterisk even when not required. This now applies the asterisk to each and every radio button individually to support multiple radio buttons at checkout.

Resolves: #2293 

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?