### PR TITLE
declare properties for PHP 8.2+

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -2,10 +2,65 @@
 	class PMProEmail
 	{
 		
+		/**
+		 * Email address to send the email to.
+		 *
+		 * @var string $email
+		 * @since TBD
+		 */
+		public $email = '';
+
+		/**
+		 * From address to send the email from.
+		 *
+		 * @var string $from
+		 * @since TBD
+		 */
+		public $from = '';
+
+		/**
+		 * From name to send the email from.
+		 *
+		 * @var string $fromname
+		 * @since TBD
+		 */
+		public $fromname = '';
+
+		/**
+		 * Subject line for the email.
+		 *
+		 * @var string $subject
+		 * @since TBD
+		 */
+		public $subject = '';
+
+		/**
+		 * Template of the email address to use.
+		 *
+		 * @var string $template
+		 * @since TBD
+		 */
+		public $template = '';
+
+		/**
+		 * Data that accompanies the email.
+		 *
+		 * @var array $data
+		 * @since TBD
+		 */
+		public $data = '';
+
+		/**
+		 * Body content for the email
+		 *
+		 * @var string $body
+		 * @since TBD
+		 */
+		public $body = '';
+
 		function __construct()
 		{
-			$this->email = $this->from = $this->fromname = $this->subject = $this->template = $this->data = $this->body = NULL;
-		}					
+		}
 		
 		/**
 		 * Send an email to a member or admin. Uses the wp_mail function.


### PR DESCRIPTION
* BUG FIX: Fixes warnings on PHP8.2+ for "Deprecated: Creation of dynamic property" in some environments.

Note: Marking this as a draft PR for now, as we might want to refactor this class more.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?