### PR TITLE
Fix: Show popular add ons wizard complete

### DIFF
--- a/adminpages/wizard/done.php
+++ b/adminpages/wizard/done.php
@@ -11,7 +11,7 @@
 		$addon_list = array_slice( $addon_list, 0, 4 );
 	} else {
 		$addon_list = $addon_cats['popular'];
-		$addon_list = array_rand( $addon_list, 4 );
+		$addon_list = array_slice( $addon_list, 0, 4 );
 	}
 
 	// Did they choose collect payments? If so, show a nudge to complete the gateway setup.


### PR DESCRIPTION
* BUG FIX: Fixes an issue when not selecting site type during wizard wouldn't show any recommended Add Ons.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Run the wizard.
2. Do not select a site type, leave it as "Other"
3. Jump to the last step.