### PR TITLE
Alter filter searches logic to support multiple categories

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -251,10 +251,19 @@ function pmpro_search_filter($query)
 			$sql = "SELECT category_id FROM $wpdb->pmpro_memberships_categories";
 		}							
         $hidden_cat_ids = array_values(array_unique($wpdb->get_col($sql)));
-				
+		
         //make this work
         if( $hidden_cat_ids ) {
-			$query->set( 'category__not_in', array_merge( $query->get( 'category__not_in' ), $hidden_cat_ids ) );
+
+			// Get all registered category ID's so we may remove the ones we need to hide. This is to support posts that may belong to multiple categories and only one of them is hidden.
+			$all_cat_ids = get_terms( array(
+				'taxonomy' => 'category',
+				'fields'   => 'ids',
+				'get'      => 'all',
+			));
+
+			// Show only these categories to members.
+			$query->set( 'category__in', array_merge( $query->get( 'category__in' ), array_diff( $all_cat_ids, $hidden_cat_ids ) ) );
 						
 			//filter so posts in this member's categories are allowed
 			add_action( 'posts_where', 'pmpro_posts_where_unhide_cats' );


### PR DESCRIPTION
* Alter search functionality/filtering for posts that may be part of more than one category.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves [2510](https://github.com/strangerstudios/paid-memberships-pro/issues/2510)
