### PR TITLE
Remove associative array check when trying to get the label value.

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1639,11 +1639,6 @@ function pmpro_get_label_for_user_field_value( $field_name, $field_value ) {
                 continue;
             }
             
-            // Check if this is a user field with an associative array of values.
-            if ( ! array_keys( $user_field->options ) !== range( 0, count( $user_field->options ) - 1 ) ) {
-                continue;
-            }
-            
 			// Replace meta values with their corresponding labels.
 			if ( is_array( $field_value ) ) {
 				foreach ( $field_value as $key => $value ) {


### PR DESCRIPTION
* ENHANCEMENT: Remove associative array check in the pmpro_get_label_for_user_field_value as not all associative arrays (key/values) are identical.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Create a select field in User Fields that have a key:value pair. Make sure that the key is underscored for example: `my_value:My Value` etc.
2. Use the Directory Add On to display this field or even the `[pmpro_member]` shortcode to output the values of the field created in step 1.
3. See that the value output would be 'my_value' instead of 'My Value'.
4. Apply this PR and test again, 'My Value' is displayed whenever the `pmpro_get_label_for_user_field_value` is called.

Some notes, this function is only called in the `pmpro_member` shortcode and now the Directory Add On and should have minimal impact.


