### PR TITLE
User fields not always included in the admin confirmation email. #2471

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -627,7 +627,7 @@ function pmpro_show_user_fields_in_profile( $user, $withlocations = false ) {
 	global $pmpro_user_fields;
 
 	//which fields are marked for the profile
-	$profile_fields = pmpro_get_user_fields_for_profile_and_email($user->ID, $withlocations);
+	$profile_fields = pmpro_get_user_fields_for_profile($user->ID, $withlocations);
 
 	//show the fields
 	if(!empty($profile_fields) && $withlocations)
@@ -694,7 +694,7 @@ function pmpro_show_user_fields_in_frontend_profile( $user, $withlocations = fal
 	global $pmpro_user_fields;
 
 	//which fields are marked for the profile
-	$profile_fields = pmpro_get_user_fields_for_profile_and_email($user->ID, $withlocations);
+	$profile_fields = pmpro_get_user_fields_for_profile($user->ID, $withlocations);
 
 	//show the fields
 	if ( ! empty( $profile_fields ) && $withlocations ) {
@@ -926,37 +926,51 @@ function pmpro_get_user_fields_for_csv() {
 }
 
 /**
- * Get user fields which are marked to show in the profile or if it's an admin confirmation email.
+ * Get user fields which are marked to show in the profile.
  * If a $user_id is passed in, get fields based on the user's level.
  */
-function pmpro_get_user_fields_for_profile_and_email($user_id, $withlocations = false, $for_notifications = false) {
-    global $pmpro_user_fields;
+function pmpro_get_user_fields_for_profile( $user_id, $withlocations = false ) {
+	global $pmpro_user_fields;
 
-    $profile_fields = array();
-
-    if ( ! empty($pmpro_user_fields) ) {
-        foreach ( $pmpro_user_fields as $where => $fields ) {
-            foreach ( $fields as $field ) {
-                if ( ! pmpro_is_field($field) || ! pmpro_check_field_for_level($field, "profile", $user_id) ) {
+	$profile_fields = array();
+	if(!empty($pmpro_user_fields))
+	{
+		//cycle through groups
+		foreach($pmpro_user_fields as $where => $fields)
+		{
+			//cycle through fields
+			foreach($fields as $field)
+			{
+				if( ! pmpro_is_field( $field ) ) {
+                    continue;
+                }
+                
+                if ( ! pmpro_check_field_for_level( $field, "profile", $user_id ) ) {
                     continue;
                 }
 
-                $add_field = $for_notifications ||
-                    ( (! empty($field->profile) && ( $field->profile === "admins" || $field->profile === "admin" || $field->profile === "only_admin" ) ) &&
-			        ( current_user_can('manage_options') || current_user_can('pmpro_membership_manager' ) ) );
+				if(!empty($field->profile) && ($field->profile === "admins" || $field->profile === "admin" || $field->profile === "only_admin"))
+				{
+					if( current_user_can( 'manage_options' ) || current_user_can( 'pmpro_membership_manager' ) )
+					{
+						if($withlocations)
+							$profile_fields[$where][] = $field;
+						else
+							$profile_fields[] = $field;
+					}
+				}
+				elseif(!empty($field->profile))
+				{
+					if($withlocations)
+						$profile_fields[$where][] = $field;
+					else
+						$profile_fields[] = $field;
+				}
+			}
+		}
+	}
 
-                if ($add_field) {
-                    if ($withlocations) {
-                        $profile_fields[$where][] = $field;
-                    } else {
-                        $profile_fields[] = $field;
-                    }
-                }
-            }
-        }
-    }
-
-    return $profile_fields;
+	return $profile_fields;
 }
 
 /**
@@ -975,7 +989,7 @@ function pmpro_save_user_fields_in_profile( $user_id )
 	if ( !current_user_can( 'edit_user', $user_id ) )
 		return false;
 
-	$profile_fields = pmpro_get_user_fields_for_profile_and_email($user_id);
+	$profile_fields = pmpro_get_user_fields_for_profile($user_id);
 
 	//save our added fields in session while the user goes off to PayPal
 	if(!empty($profile_fields))
@@ -1044,7 +1058,7 @@ function pmpro_add_user_fields_to_email( $email ) {
 		if(!empty($user_id))
 		{
 			//get meta fields
-			$fields = pmpro_get_user_fields_for_profile_and_email($user_id, false, true );
+			$fields = pmpro_get_user_fields_for_profile($user_id);
 
 			//add to bottom of email
 			if(!empty($fields))

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1050,37 +1050,35 @@ function pmpro_add_user_fields_to_email( $email ) {
 	global $wpdb;
 
 	//only update admin confirmation emails
-	if(!empty($email) && strpos($email->template, "checkout") !== false && strpos($email->template, "admin") !== false)
-	{
+	if(!empty($email) && strpos($email->template, "checkout") !== false && strpos($email->template, "admin") !== false) {
 		//get the user_id from the email
 		$user_id = $wpdb->get_var("SELECT ID FROM $wpdb->users WHERE user_email = '" . $email->data['user_email'] . "' LIMIT 1");
 
-		if(!empty($user_id))
-		{
+		if(!empty($user_id)) {
 			//get meta fields
-			$fields = pmpro_get_user_fields_for_profile($user_id);
+			$fields_groups = pmpro_get_user_fields();
 
 			//add to bottom of email
-			if(!empty($fields))
-			{
+			if(!empty($fields_groups)) {
 				$email->body .= "<p>" . __( 'Extra Fields:', 'paid-memberships-pro' ) . "<br />";
-				foreach($fields as $field)
-				{
-                    if( ! pmpro_is_field( $field ) ) {
-                        continue;
-                    }
+				//cycle through groups
+				foreach( $fields_groups as $where => $fields ) {
+					//cycle through fields
+					foreach( $fields as $field ) {
+						if( ! pmpro_is_field( $field ) ) {
+							continue;
+						}
+						$email->body .= "- " . $field->label . ": ";
+						$value = get_user_meta($user_id, $field->meta_key, true);
+						if($field->type == "file" && is_array($value) && !empty($value['fullurl']))
+							$email->body .= $value['fullurl'];
+						elseif(is_array($value))
+							$email->body .= implode(", ", $value);
+						else
+							$email->body .= $value;
 
-					$email->body .= "- " . $field->label . ": ";
-
-					$value = get_user_meta($user_id, $field->meta_key, true);
-					if($field->type == "file" && is_array($value) && !empty($value['fullurl']))
-						$email->body .= $value['fullurl'];
-					elseif(is_array($value))
-						$email->body .= implode(", ", $value);
-					else
-						$email->body .= $value;
-
-					$email->body .= "<br />";
+						$email->body .= "<br />";
+					}
 				}
 				$email->body .= "</p>";
 			}


### PR DESCRIPTION
EDIT

After last commit

<img width="995" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/dcf65f05-c382-454a-8a92-6079d6e3a362">


 * Add a flag to the function that retrieves user fields for profile to let it avoid user profile settings.
 * Refactor the function
 * Rename the function since now it also retrieves for email confirmation

<img width="960" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/e6e1ff7a-1f45-4fb0-9518-ccff0ed652bb">
<img width="1389" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/6d268fc0-47c1-4d2b-9049-19be66775a72">

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:
steps are described in the issue below.
https://github.com/strangerstudios/paid-memberships-pro/issues/2471
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
[bugfixing] Fixes bug with confirmation email and user field show in the profile setting.
