### PR TITLE
Fixing timing of pmpro_discount_code_used with Stripe Checkout

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -999,8 +999,8 @@ function pmpro_stripe_webhook_change_membership_level( $morder ) {
 						current_time( 'mysql' )
 					)	
 				);
-				do_action( 'pmpro_discount_code_used', $discount_code_id, $morder->user_id, $morder->id );
 			}
+			do_action( 'pmpro_discount_code_used', $discount_code_id, $morder->user_id, $morder->id );
 		}
 
 		//save first and last name fields


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Other gateways currently run the `pmpro_discount_code_used` filter if a discount code was used, even if the discount code can no longer be found in the database. Some add ons, such as the PMPro Group Discount Codes Add On, rely on this behavior.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
