### PR TITLE
Switching IDs for new levels in wizard to 0

### DIFF
--- a/adminpages/wizard/save-steps.php
+++ b/adminpages/wizard/save-steps.php
@@ -166,7 +166,7 @@ function pmpro_init_save_wizard_data() {
 			$free_level_name = ! empty( $_REQUEST['pmpro-wizard__free-level-name'] ) ? sanitize_text_field( $_REQUEST['pmpro-wizard__free-level-name'] ) : sanitize_text_field( __( 'Free', 'paid-memberships-pro' ) );
 
 			$levels_array['free'] = array(
-				'id'                => -1,
+				'id'                => 0,
 				'name'              => $free_level_name,
 				'description'       => '',
 				'confirmation'      => '',
@@ -190,7 +190,7 @@ function pmpro_init_save_wizard_data() {
 			$period          = ! empty( $_REQUEST['cycle_period'] ) ? sanitize_text_field( $_REQUEST['cycle_period'] ) : 'Month';
 
 			$levels_array['paid'] = array(
-				'id'                => -1,
+				'id'                => 0,
 				'name'              => $paid_level_name,
 				'description'       => '',
 				'confirmation'      => '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes bug in [WordPress Playground](https://wasm.wordpress.net/?theme=memberlite&url=/wp-admin) where only one level would be created with an ID of `-1`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
