### PR TITLE
Cancel subscription on frontend user deletion.

### DIFF
--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -18,6 +18,11 @@ function pmpro_delete_user( $user_id ) {
 		} else {
 			// okay, guessing they didn't have a level
 		}
+	} 
+	
+	// Assume the user is being deleted from the frontend by deleting their own account, we'd most likely want to cancel their subscription in this case.
+	if ( ! is_admin() ) {
+		pmpro_changeMembershipLevel( 0, $user_id );
 	}
 
 	//Remove all membership history for this user from the pmpro_memberships_users table

--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -10,18 +10,16 @@ function pmpro_delete_user( $user_id ) {
 		return false;
 	}
 
-	//Disable any active subscriptions that are associated with the account
-	if ( isset( $_REQUEST['pmpro_delete_active_subscriptions'] ) && 
+	// Delete is happening from the backend by an admin.
+	if ( ! empty( $_REQUEST['pmpro_delete_user_from_admin'] ) ) {
+		// Was the checkbox to delete active subscriptions checked?
+		if ( isset( $_REQUEST['pmpro_delete_active_subscriptions'] ) && 
 		$_REQUEST['pmpro_delete_active_subscriptions'] == '1' ) {
-		if ( pmpro_changeMembershipLevel( 0, $user_id ) ) {
-			// okay
-		} else {
-			// okay, guessing they didn't have a level
+			pmpro_changeMembershipLevel( 0, $user_id );
 		}
-	} 
-	
-	// Assume the user is being deleted from the frontend by deleting their own account, we'd most likely want to cancel their subscription in this case.
-	if ( ! is_admin() ) {
+
+	} else {
+		// Change the member's level before deleting, assuming their account is being deleted elsewhere.
 		pmpro_changeMembershipLevel( 0, $user_id );
 	}
 
@@ -81,6 +79,7 @@ function pmpro_delete_user_form_notice( $current_user, $userids ) {
 			?>
 		</div>
 		<p><input type='checkbox' name='pmpro_delete_active_subscriptions' id='pmpro_delete_active_subscriptions' value='1' /><label for='pmpro_delete_active_subscriptions'><?php esc_html_e('Cancel any related membership levels first. This may trigger cancellations at the gateway or other third party services.', 'paid-memberships-pro' ); ?></label></p>
+		<input type='hidden' name='pmpro_delete_user_from_admin' value='1' />
 		<?php
 	}
 		


### PR DESCRIPTION
* ENHANCEMENT: Automatically cancel subscription when user deletes their own profile from the frontend.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?