### PR TITLE
Add wpautop to confirmation message

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -29,8 +29,9 @@
 
 	//confirmation message for this level
 	$level_message = $wpdb->get_var("SELECT l.confirmation FROM $wpdb->pmpro_membership_levels l LEFT JOIN $wpdb->pmpro_memberships_users mu ON l.id = mu.membership_id WHERE mu.status = 'active' AND mu.user_id = '" . intval( $current_user->ID ) . "' LIMIT 1");
-	if(!empty($level_message))
-		$confirmation_message .= "\n" . stripslashes($level_message) . "\n";
+	if ( ! empty( $level_message ) ) {
+		$confirmation_message .= wpautop( stripslashes( $level_message ) );
+	}
 ?>
 
 <?php if(!empty($pmpro_invoice) && !empty($pmpro_invoice->id)) { ?>


### PR DESCRIPTION
* ENHANCEMENT: Use wpautop() for membership confirmation message. This fixes an issue where Elementor and possibly other solutions were not honoring the `\n` as paragraphs.

Resolves: https://github.com/strangerstudios/paid-memberships-pro/issues/2480

Side note, we escape the entire confirmation when returning it lower down with wp_kses_post.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?