### PR TITLE
Bug Fix: Pagination fixed when searching orders

### DIFF
--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -349,7 +349,11 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 
 			//Not escaping here because we escape the values in the condition statement
 			$sqlQuery .= 'AND ' . $condition . ' ';
-			$sqlQuery .= 'GROUP BY o.id ORDER BY o.id DESC, o.timestamp DESC ';
+
+			if( ! $count ) {
+				$sqlQuery .= 'GROUP BY o.id ORDER BY o.id DESC, o.timestamp DESC ';
+			}
+			
 		} else {
 
 			if ( $filter === 'with-discount-code' ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Pagination on the orders page broke when searching


### How to test the changes in this Pull Request:

1. Navigate to Memberships > Orders and search for something
2. Results will be returned but the count will show as 1 and no page numbers
3. Once the fix has been applied the pagination shows as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

