### PR TITLE
maybe_cancel sub for BuddyPress/Boss

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -60,7 +60,12 @@ function pmpro_compatibility_checker() {
 			'file'		  => 'lifterlms.php',
 			'check_type'  => 'function',
 			'check_value' => 'llms'
-		]
+		],
+		[
+			'file'		  => 'buddypress.php',
+			'check_type'  => 'class',
+			'check_value' => 'BuddyPress' //BuddyBoss uses this class, too.
+		],
 	];
 
 	foreach ( $compat_checks as $value ) {

--- a/includes/compatibility/buddypress.php
+++ b/includes/compatibility/buddypress.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * All BuddyPress/BuddyBoss compatibility goes in here.
+ */
+
+/**
+ * Cancel all active subscriptions right before the user deletes their own account. 
+ * The 'bp_core_pre_delete_account' is primarily used for self-deletions, as requested through Settings.
+ * 
+ * @see https://www.buddyboss.com/resources/reference/functions/bp_core_delete_account/
+ *
+ * @param int $user_id - The user ID that is about to be deleted from WordPress.
+ * @since TBD
+ */
+function pmpro_buddypress_cancel_sub_self_delete( $user_id ) {
+
+    if ( pmpro_maybe_cancel_subscription( 'buddypress' ) ) {
+        pmpro_changeMembershipLevel( 0, $user_id );
+    }
+}
+add_action( 'bp_core_pre_delete_account', 'pmpro_buddypress_cancel_sub_self_delete' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4399,3 +4399,14 @@ function pmpro_sanitize_period( $period ) {
 
 	return $sanitized_period;
 }
+
+/**
+ * Filter to automatically cancel subscriptions in certain cases. Primarily used for account deletion.
+ * 
+ * @since TBD
+ * @param string $action The action that is triggering the function. Helps to identify where the call is coming from.
+ * @return boolean $cancel_subscription Whether or not to cancel the subscription.
+ */
+function pmpro_maybe_cancel_subscription( $action = null ) {
+	return apply_filters( 'pmpro_maybe_cancel_subscription', false, $action );
+}


### PR DESCRIPTION
* Created a new function called pmpro_maybe_cancel_subscription which is filterable and tended to be used for account deletion.

Filterable by 'pmpro_maybe_cancel_subscription' which returns true/false when called.

TODO: Add an option/setting for this to allow site owners to automatically delete subscriptions when deleting users. Could be used for other areas of PMPro and supports "actions" parameter to know where this function is being called from to give developers even more control with the filter.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
