### PR TITLE
Fixing logic for invalidkey password reset error

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -802,7 +802,7 @@ function pmpro_do_password_reset() {
 	// If the key is expired or invalid, figure out the correct error code.
 	if ( is_wp_error( $check ) ) {
 		$error_code = $check->get_error_code() == 'expired_key' ? 'expiredkey' : 'invalidkey';	
-	} elseif ( gettype( $check ) !== 'WP_User' ) {
+	} elseif ( ! is_a( $check,  'WP_User' ) ) {
 		// Probably null/false returned from a plugin filtering the check.
 		$error_code = 'invalidkey';
 	}
@@ -846,7 +846,8 @@ function pmpro_do_password_reset() {
 
 		// Parameter checks OK, reset password.
 		// Note: Can't sanitize the password.
-		reset_password( $user, $_POST['pass1'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// $check must be a WP_User object at this point, otherwise $error_code would be set and we'd have already redirected.
+		reset_password( $check, $_POST['pass1'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		wp_redirect( add_query_arg( urlencode( 'password' ), urlencode( 'changed' ), $redirect_url ) );
 	} else {
 		esc_html_e( 'Invalid Request', 'paid-memberships-pro' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issue where password resets may incorrectly show `invalidkey`.

Switching to using `is_a()` instead of `gettype()` as `gettype()` only returns the string "object", not the class name "WP_User".

Also fixing incorrect variable name `$user`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
