### PR TITLE
Add pmpro_checkout_message filter at bottom

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -551,7 +551,7 @@ if ( empty( $default_gateway ) ) {
 	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_submit' ) ); ?>">
 		<hr />
 		<?php if ( $pmpro_msg ) { ?>
-			<div id="pmpro_message_bottom" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"><?php echo wp_kses_post( $pmpro_msg ); ?></div>
+			<div id="pmpro_message_bottom" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"><?php echo wp_kses_post( apply_filters( 'pmpro_checkout_message', $pmpro_msg, $pmpro_msgt ) ); ?></div>
 		<?php } else { ?>
 			<div id="pmpro_message_bottom" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message' ) ); ?>" style="display: none;"></div>
 		<?php } ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When hooking into the `pmpro_checkout_message` filter to adjust the returned string it only displayed at the top message on the checkout page and not on the bottom message by the submit button. Adding this filter at the bottom as well should allow displaying the filtered message in both locations.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Add custom code that hooks into the `pmpro_checkout_message` filter and set a custom checkout error.
2. Check out for a paid membership level using Stripe as the payment gateway and the testing credit card number `4000000000000002` that should be declined.
3. Observer that the custom error message is displayed in both locations on the checkout page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Added a pmpro_checkout_message filter at the bottom of the checkout page that can be used to filter error messages shown at checkout.
