### PR TITLE
Cleaning up level preheader

### DIFF
--- a/preheaders/levels.php
+++ b/preheaders/levels.php
@@ -12,27 +12,3 @@ if ($default_level) {
     wp_redirect(pmpro_url("checkout", "?level=" . $default_level));
     exit;
 }
-
-global $wpdb, $pmpro_msg, $pmpro_msgt;
-if (isset($_REQUEST['msg'])) {
-    if ($_REQUEST['msg'] == 1) {
-        $pmpro_msg = __('Your membership status has been updated - Thank you!', 'paid-memberships-pro' );
-    } else {
-        $pmpro_msg = __('Sorry, your request could not be completed - please try again in a few moments.', 'paid-memberships-pro' );
-        $pmpro_msgt = "pmpro_error";
-    }
-} else {
-    $pmpro_msg = false;
-}
-
-global $pmpro_levels, $pmpro_level_order;
-
-
-/**
- * This actually isn't needed to draw the levels page.
- * But, there may be custom code that relies on the ordered global of Membership Levels array here.
- * We will evenutally deprecate this.
- *
- */
-$pmpro_levels = pmpro_sort_levels_by_order( pmpro_getAllLevels(false, true) );
-$pmpro_levels = apply_filters( 'pmpro_levels_array', $pmpro_levels );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Removing functionality marked to be deprecated and code that is no longer used.

`$pmpro_levels` is being set directly in the levels page template now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
