### PR TITLE
Fixing the ! typo here to fix issues with add ons that were using the…

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -441,7 +441,7 @@ if ( function_exists( 'pmpro_displayAds' ) && pmpro_displayAds() ) {
 		                                    name="<?php echo esc_attr( $field['field_name'] ); ?>">
 		                                <?php
 		                                	//For associative arrays, we use the array keys as values. For numerically indexed arrays, we use the array values.
-		                                	$is_associative = !empty($field['is_associative']) || !(bool)count(array_filter(array_keys($field['options']), 'is_string'));
+		                                	$is_associative = !empty($field['is_associative']) || (bool)count(array_filter(array_keys($field['options']), 'is_string'));
 		                                	foreach ($field['options'] as $key => $option) {
 		                                    	if(!$is_associative) $key = $option;
 		                                    	?>


### PR DESCRIPTION
In 2.12 we added a check so settings added via the `pmpro_custom_advanced_settings` filter could be set with an `is_associative` property which would force fields to save the specific array keys as the values even if those values looked like a non-associative array (starting at 0 and incrementing by 1).

We also accidentally added an extra ! to that line, which broke old settings (e.g. in the Level Cost Text add on) that were set up as non-associative arrays of options and expecting to be saved as "no" and "yes" instead of 0 and 1.

To test this, I changed both the Lifter Streamline option (the new one using the is_associative property) and settings from the Custom Level Cost Text add on. All settings save and work as expected when turned on and off.

Users of the Level Cost Text add on (and some others) who had settings saved as 0/1 accidentally may need to set and save the settings on the advanced settings page to make sure the correct values are stored in the DB.