### PR TITLE
Refactor logic on the password reset/lost password functionality.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -789,6 +789,11 @@ function pmpro_do_password_reset() {
 		return;
 	}
 
+	// We're on the default WP page, let's not try to interfere.
+	if ( ! empty( $_REQUEST['wp-submit'] ) ) {
+		return;
+	}
+
 	$rp_key = sanitize_text_field( $_REQUEST['rp_key'] );
 	$rp_login = sanitize_text_field( $_REQUEST['rp_login'] );
 
@@ -864,6 +869,11 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login ) {
 
 	$login_url = pmpro_url( 'login' );
 	if ( ! $login_url ) {
+		return $message;
+	}
+
+	// Don't replace the password reset link if it came from the default WP form. (Our form uses 'submit')
+	if ( ! empty( $_REQUEST['wp-submit'] ) ) {
 		return $message;
 	}
 

--- a/includes/login.php
+++ b/includes/login.php
@@ -647,12 +647,6 @@ function pmpro_reset_password_redirect() {
 		return;
 	}
 
-	// While doing the redirect, if the pages initial load isn't our login page. Don't redirect. (i.e. Another plugin called this password reset)
-	$current_page_slug = get_permalink();
-	if ( $current_page_slug !== $login_url ) {
-		return;
-	}
-
 	// Get current REQUEST PARAMS and just add it to ours and then redirect to our login_url
 	$redirect_url = add_query_arg( array_map( 'sanitize_text_field', $_REQUEST ), $login_url );
 
@@ -790,7 +784,6 @@ function pmpro_do_password_reset() {
 	if ( ! $redirect_url ) {
 		return;
 	}
-
 
 	// Request came from elsewhere, let's bail.
 	if ( ! isset( $_REQUEST['pmpro_form_used'] ) ) {

--- a/includes/login.php
+++ b/includes/login.php
@@ -631,7 +631,7 @@ add_action( 'login_form_lostpassword', 'pmpro_lost_password_redirect' );
  */
 function pmpro_reset_password_redirect() {
 	
-	// We're not just trying to load the password reset page, let's try to redirect.
+	// Don't redirect if the form is being submitted, i.e. POST.
 	if ( 'GET' != $_SERVER['REQUEST_METHOD'] ) {
 		return;
 	}

--- a/includes/login.php
+++ b/includes/login.php
@@ -588,6 +588,7 @@ function pmpro_lost_password_form() { ?>
 		</div> <!-- end pmpro_lost_password-fields -->
 		<div class="<?php echo pmpro_get_element_class( 'pmpro_submit' ); ?>">
 			<input type="submit" name="submit" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit' ); ?>" value="<?php esc_attr_e( 'Get New Password', 'paid-memberships-pro' ); ?>" />
+			<input type="hidden" name="pmpro_form_used" value="1" />
 		</div>
 	</form>
 	<?php
@@ -721,6 +722,7 @@ function pmpro_reset_password_form() {
 			</div> <!-- end pmpro_reset_password-fields -->
 			<div class="<?php echo pmpro_get_element_class( 'pmpro_submit' ); ?>">
 				<input type="submit" name="submit" id="resetpass-button" class="<?php echo pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit' ); ?>" value="<?php esc_attr_e( 'Reset Password', 'paid-memberships-pro' ); ?>" />
+				<input type="hidden" name="pmpro_form_used" value="1" />
 			</div>
 		</form>
 		<?php
@@ -789,8 +791,9 @@ function pmpro_do_password_reset() {
 		return;
 	}
 
-	// We're on the default WP page, let's not try to interfere.
-	if ( ! empty( $_REQUEST['wp-submit'] ) ) {
+
+	// Request came from elsewhere, let's bail.
+	if ( ! isset( $_REQUEST['pmpro_form_used'] ) ) {
 		return;
 	}
 
@@ -872,8 +875,8 @@ function pmpro_password_reset_email_filter( $message, $key, $user_login ) {
 		return $message;
 	}
 
-	// Don't replace the password reset link if it came from the default WP form. (Our form uses 'submit')
-	if ( ! empty( $_REQUEST['wp-submit'] ) ) {
+	// Don't replace the password reset link if it came from elsewhere.
+	if ( ! isset( $_REQUEST['pmpro_form_used'] ) ) {
 		return $message;
 	}
 


### PR DESCRIPTION
### Changelog entry

* BUG FIX/ENHANCEMENT: Improved the Lost Password/Reset Password functionality provided by the frontend login. This now honors password requests coming from elsewhere and will try not override relevant information when we detect this (i.e. requests from wp-login.php will continue the flow throughout wp-login.php and not be redirected to the /login frontend page of PMPro and vice versa).

### All Submissions:

The focus of this PR is to support Paid Memberships Pro frontend password reset functionality (Lost password and resetting the password) as well as honoring the wp-login.php flow (as users of a site can navigate to both URL's to do the same functionality).

Improvements to the redirect to password reset page has been simplified which was causing majority of our conflicts.

PMPro makes use of some custom query parameters to process these requests and we try to replace URL's and parameters with our own when the request comes from our page/forms. This PR should solve these cases, and potentially fix issues where we hijack URLs/emails mistakenly.  (See steps below to test this PR).

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/paid-memberships-pro/issues/1667 (and other issues that may not have been marked here).

### How to test the changes in this Pull Request:

Before testing this pull request, please test password reset from Paid Memberships Pro frontend login page, and then password reset from the wp-login.php (default) password reset functionality. Issues have been occurring between these two areas and other plugins like TML (and most likely others) hijack the process and there's no easy way to prevent this right now.

1. Set your PMPro Log In page, in the page settings, to a page that uses `[pmpro_login]` or the block.
2. Navigate to your /login frontend page from step 1, reset your password and follow the steps. (All steps should remain in the /login path/frontend page without redirecting).
3. Navigate to wp-login.php and reset your password through the default WordPress page. Your entire journey during this step should remain on the wp-login.php path (No hijacking or replacing of URLs should occur).

This could also be tested with other plugins like TML or a frontend login plugin but for the purposes of this PR was to focus on the two points: PMPro Log In and wp-login.php. I noticed other plugins hijack our requests and nuke all other requests which make it difficult to support but it could fix some compatibility issues we've seen in the past.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
