### PR TITLE
Fix where orders link wasn't showing for unlimited use codes

### DIFF
--- a/classes/class-pmpro-discount-code-list-table.php
+++ b/classes/class-pmpro-discount-code-list-table.php
@@ -368,7 +368,7 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 				),
 			];
 
-			if ( 0 < (int) $item->uses ) {
+			if ( 0 < (int) $item->used ) {
 				$actions['orders'] = sprintf(
 					'<a title="%1$s" href="%2$s">%3$s</a>',
 					esc_attr__( 'View Orders', 'paid-memberships-pro' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Small fix where the "Orders" row action wasn't showing for codes with unlimited uses. We were incorrectly checking the code's total uses, but should rather be checking count of times used (which means there are orders to show when linking over).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed issue where row action to view a discount code's orders was not showing for unlimited use codes.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
