### PR TITLE
Avoiding timezone math in SQL - WP Playground Compatibility

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -219,7 +219,7 @@ function pmpro_dashboard_welcome_callback() { ?>
 function pmpro_dashboard_report_recent_members_callback() {
 	global $wpdb;
 
-	$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, UNIX_TIMESTAMP( CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone) ) as startdate, UNIX_TIMESTAMP( CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone) ) as enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id WHERE mu.membership_id > 0 AND mu.status = 'active' GROUP BY u.ID ORDER BY u.user_registered DESC LIMIT 5";
+	$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, mu.enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id WHERE mu.membership_id > 0 AND mu.status = 'active' GROUP BY u.ID ORDER BY u.user_registered DESC LIMIT 5";
 
 	$sqlQuery = apply_filters( 'pmpro_members_list_sql', $sqlQuery );
 
@@ -241,6 +241,9 @@ function pmpro_dashboard_report_recent_members_callback() {
                 </tr>
             <?php } else {
     			foreach ( $theusers as $auser ) {
+					// Make sure that enddate is still a timestamp.
+					$auser->enddate = pmpro_convert_utc_datetime_to_timestamp( $auser->enddate );
+
     				$auser = apply_filters( 'pmpro_members_list_user', $auser );
     				//get meta
     				$theuser = get_userdata( $auser->ID ); ?>

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -379,7 +379,7 @@
 				{
 					$code = $wpdb->get_row(
 						$wpdb->prepare("
-						SELECT *, UNIX_TIMESTAMP(CONVERT_TZ(starts, '+00:00', @@global.time_zone)) as starts, UNIX_TIMESTAMP(CONVERT_TZ(expires, '+00:00', @@global.time_zone)) as expires
+						SELECT *
 						FROM $wpdb->pmpro_discount_codes
 						WHERE id = %d LIMIT 1",
 						$edit ),
@@ -401,7 +401,7 @@
 				{
 					$code = $wpdb->get_row(
 						$wpdb->prepare("
-						SELECT *, UNIX_TIMESTAMP(CONVERT_TZ(starts, '+00:00', @@global.time_zone)) as starts, UNIX_TIMESTAMP(CONVERT_TZ(expires, '+00:00', @@global.time_zone)) as expires
+						SELECT *
 						FROM $wpdb->pmpro_discount_codes
 						WHERE id = %d LIMIT 1",
 						$copy ),
@@ -409,6 +409,12 @@
 					);
 
 					$temp_code = $code;
+				}
+
+				// Make sure that starts and ends are timetsamps.
+				if ( ! empty( $code ) ) {
+					$code->starts = pmpro_convert_utc_datetime_to_timestamp( $code->starts );
+					$code->expires = pmpro_convert_utc_datetime_to_timestamp( $code->expires );
 				}
 
 				// didn't find a discount code, let's add a new one...

--- a/adminpages/login-csv.php
+++ b/adminpages/login-csv.php
@@ -70,7 +70,7 @@ if ( $limit ) {
 }
 
 if ( $s ) {
-	$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate, UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->usermeta um ON u.ID = um.user_id LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id WHERE (u.user_login LIKE '%" . esc_sql( $s ) . "%' OR u.user_email LIKE '%" . esc_sql( $s ) . "%' OR um.meta_value LIKE '%" . esc_sql( $s ) . "%') ";
+	$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, u.user_registered as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, mu.startdate, mu.enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->usermeta um ON u.ID = um.user_id LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id WHERE (u.user_login LIKE '%" . esc_sql( $s ) . "%' OR u.user_email LIKE '%" . esc_sql( $s ) . "%' OR um.meta_value LIKE '%" . esc_sql( $s ) . "%') ";
 
 	if ( $l == 'all' ) {
 		$sqlQuery .= " AND mu.status = 'active' AND mu.membership_id > 0 ";
@@ -80,7 +80,7 @@ if ( $s ) {
 
 	$sqlQuery .= "GROUP BY u.ID ORDER BY user_registered DESC";
 } else {
-	$sqlQuery  = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate, UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id";
+	$sqlQuery  = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, u.user_registered as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, mu.startdate, mu.enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id";
 	$sqlQuery .= ' WHERE 1=1 ';
 
 	if ( $l == 'all' ) {
@@ -234,6 +234,11 @@ for ( $ic = 1; $ic <= $iterations; $ic ++ ) {
 
 	foreach ( $theusers as $user ) {
 		$csvoutput = array();
+
+		// Make sure that joindate, startdate, and enddate are all timestamps.
+		$user->joindate = pmpro_convert_utc_datetime_to_timestamp( $user->joindate );
+		$user->startdate = pmpro_convert_utc_datetime_to_timestamp( $user->startdate );
+		$user->enddate = pmpro_convert_utc_datetime_to_timestamp( $user->enddate );
 
 		// Get the visits, views and logins arrays. Set it to an object.
 		$visits = (object) pmpro_reports_get_values_for_user( 'visits', $user->ID );

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -340,7 +340,7 @@
 				DISTINCT u.ID,
 				u.user_login,
 				u.user_email,
-				UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate,
+				u.user_registered as joindate,
 				u.user_login,
 				u.user_nicename,
 				u.user_url,
@@ -351,7 +351,7 @@
 				mu.initial_payment,
 				mu.billing_amount,
 				mu.cycle_period,
-				UNIX_TIMESTAMP(CONVERT_TZ(max(mu.enddate), '+00:00', @@global.time_zone)) as enddate,
+				max(mu.enddate) as enddate,
 				m.name as membership
 			FROM {$wpdb->users} u
 			LEFT JOIN {$wpdb->usermeta} um ON u.ID = um.user_id
@@ -380,6 +380,10 @@
 		foreach($usr_data as $theuser) {
 
 			$csvoutput = array();
+
+			// Make sure that joindate and enddate are timestamps.
+			$theuser->joindate = pmpro_convert_utc_datetime_to_timestamp( $theuser->joindate );
+			$theuser->enddate = pmpro_convert_utc_datetime_to_timestamp( $theuser->enddate );
 
 			//process usermeta
 			$metavalues = new stdClass();

--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -132,7 +132,7 @@ function pmpro_report_login_page()
 
 		if($s)
 		{
-			$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate, UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->usermeta um ON u.ID = um.user_id LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id WHERE (u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%') ";
+			$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, u.user_registered as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, mu.startdate, mu.enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->usermeta um ON u.ID = um.user_id LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id WHERE (u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR um.meta_value LIKE '%" . esc_sql($s) . "%') ";
 
 			if($l == "all")
 				$sqlQuery .= " AND mu.status = 'active' AND mu.membership_id > 0 ";
@@ -143,7 +143,7 @@ function pmpro_report_login_page()
 		}
 		else
 		{
-			$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate, UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id";
+			$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS u.ID, u.user_login, u.user_email, u.user_registered as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit, mu.startdate, mu.enddate, m.name as membership FROM $wpdb->users u LEFT JOIN $wpdb->pmpro_memberships_users mu ON u.ID = mu.user_id AND mu.status = 'active' LEFT JOIN $wpdb->pmpro_membership_levels m ON mu.membership_id = m.id";
 			$sqlQuery .= " WHERE 1=1 ";
 
 			if($l == "all")
@@ -221,6 +221,11 @@ function pmpro_report_login_page()
 			<?php
 				foreach($theusers as $auser)
 				{
+					// Make sure that joindate, startdate, and enddate are all timestamps.
+					$auser->joindate = pmpro_convert_utc_datetime_to_timestamp( $auser->joindate );
+					$auser->startdate = pmpro_convert_utc_datetime_to_timestamp( $auser->startdate );
+					$auser->enddate = pmpro_convert_utc_datetime_to_timestamp( $auser->enddate );
+
 					//get meta
 					$theuser = get_userdata($auser->ID);
 					$visits = pmpro_reports_get_values_for_user("visits", $auser->ID);

--- a/classes/class-pmpro-discount-code-list-table.php
+++ b/classes/class-pmpro-discount-code-list-table.php
@@ -195,7 +195,7 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 			$sqlQuery = "SELECT COUNT( DISTINCT id ) FROM $wpdb->pmpro_discount_codes ";
 		} else {
 			//Includes uses for each discount code as 'used' so we can sort by it later
-			$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS *, UNIX_TIMESTAMP(CONVERT_TZ(starts, '+00:00', @@global.time_zone)) as starts, UNIX_TIMESTAMP(CONVERT_TZ(expires, '+00:00', @@global.time_zone)) as expires, (SELECT COUNT(*) FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = do.id) as used FROM $wpdb->pmpro_discount_codes as do ";			
+			$sqlQuery = "SELECT SQL_CALC_FOUND_ROWS *, starts, expires, (SELECT COUNT(*) FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = do.id) as used FROM $wpdb->pmpro_discount_codes as do ";			
 		}
 
 		if ( ! empty( $s ) ) {
@@ -226,6 +226,12 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 			$sql_table_data = $wpdb->get_var( $sqlQuery );
 		} else {
 			$sql_table_data = $wpdb->get_results( $sqlQuery );
+
+			// Make sure that starts and ends are timetsamps.
+			foreach ( $sql_table_data as $code ) {
+				$code->starts = pmpro_convert_utc_datetime_to_timestamp( $code->starts );
+				$code->expires = pmpro_convert_utc_datetime_to_timestamp( $code->expires );
+			}
 		}
 
 		return $sql_table_data;

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -305,9 +305,9 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			$sqlQuery =
 				"
 				SELECT u.ID, u.user_login, u.user_email, u.display_name,
-				UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, SUM(mu.initial_payment+ mu.billing_amount) as fee, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit,
-				UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate,
-				UNIX_TIMESTAMP(CONVERT_TZ(max(mu.enddate), '+00:00', @@global.time_zone)) as enddate, m.name as membership
+				u.user_registered as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, SUM(mu.initial_payment+ mu.billing_amount) as fee, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit,
+				mu.startdate,
+				max(mu.enddate) as enddate, m.name as membership
 				";
 		}
 
@@ -382,6 +382,13 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			$sql_table_data = $wpdb->get_var( $sqlQuery );
 		} else {
 			$sql_table_data = $wpdb->get_results( $sqlQuery, ARRAY_A );
+
+			// Make sure that joindate, startdate, and enddate are timestamps.
+			foreach ( $sql_table_data as $key => $value ) {
+				$sql_table_data[$key]['joindate'] = pmpro_convert_utc_datetime_to_timestamp( $value['joindate'] );
+				$sql_table_data[$key]['startdate'] = pmpro_convert_utc_datetime_to_timestamp( $value['startdate'] );
+				$sql_table_data[$key]['enddate'] = pmpro_convert_utc_datetime_to_timestamp( $value['enddate'] );
+			}
 		}
 
 		return $sql_table_data;

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1097,12 +1097,18 @@
 			//check if there is an entry in memberships_users first
 			if(!empty($this->user_id))
 			{
-				$sqlQuery = $wpdb->prepare( "SELECT l.id as level_id, l.name, l.description, l.allow_signups, l.expiration_number, l.expiration_period, mu.*, UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate, UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_membership_levels l LEFT JOIN $wpdb->pmpro_memberships_users mu ON l.id = mu.membership_id WHERE mu.status = 'active' AND l.id = %d AND mu.user_id = %d LIMIT 1", $this->membership_id, $this->user_id );
+				$sqlQuery = $wpdb->prepare( "SELECT l.id as level_id, l.name, l.description, l.allow_signups, l.expiration_number, l.expiration_period, mu.*, mu.startdate, mu.enddate, l.name, l.description, l.allow_signups FROM $wpdb->pmpro_membership_levels l LEFT JOIN $wpdb->pmpro_memberships_users mu ON l.id = mu.membership_id WHERE mu.status = 'active' AND l.id = %d AND mu.user_id = %d LIMIT 1", $this->membership_id, $this->user_id );
 				$this->membership_level = $wpdb->get_row( $sqlQuery );
 
 				//fix the membership level id
 				if(!empty($this->membership_level->level_id))
 					$this->membership_level->id = $this->membership_level->level_id;
+
+				// Fix the membership level startdate and enddate to be timestamps.
+				if ( ! empty( $this->membership_level ) ) {
+					$this->membership_level->startdate = pmpro_convert_utc_datetime_to_timestamp( $this->membership_level->startdate );
+					$this->membership_level->enddate = pmpro_convert_utc_datetime_to_timestamp( $this->membership_level->enddate );
+				}
 			}
 
 			//okay, do I have a discount code to check? (if there is no membership_level->membership_id value, that means there was no entry in memberships_users)

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -316,12 +316,12 @@
 				$this->data['membership_level_name'] = pmpro_implodeToEnglish($wpdb->get_col("SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode("','", $old_level_id) . "')"));
 
 				//start and end date
-				$startdate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) as startdate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND membership_id = '" . $old_level_id[0] . "' AND status IN('inactive', 'cancelled', 'admin_cancelled') ORDER BY id DESC");
+				$startdate = pmpro_convert_utc_datetime_to_timestamp( $wpdb->get_var("SELECT startdate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND membership_id = '" . $old_level_id[0] . "' AND status IN('inactive', 'cancelled', 'admin_cancelled') ORDER BY id DESC") );
 				if(!empty($startdate))
 					$this->data['startdate'] = date_i18n(get_option('date_format'), $startdate);
 				else
 					$this->data['startdate'] = "";
-				$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) as enddate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND membership_id = '" . $old_level_id[0] . "' AND status IN('inactive', 'cancelled', 'admin_cancelled') ORDER BY id DESC");
+				$enddate = pmpro_convert_utc_datetime_to_timestamp( $wpdb->get_var("SELECT enddate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND membership_id = '" . $old_level_id[0] . "' AND status IN('inactive', 'cancelled', 'admin_cancelled') ORDER BY id DESC") );
 				if(!empty($enddate))
 					$this->data['enddate'] = date_i18n(get_option('date_format'), $enddate);
 				else
@@ -606,7 +606,7 @@
 				}
 			}
 			
-			$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
+			$enddate = pmpro_convert_utc_datetime_to_timestamp( $wpdb->get_var("SELECT enddate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1") );
 			if( $enddate ) {
 				$this->data["membership_expiration"] = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
 			} else {
@@ -726,7 +726,7 @@
 				$this->data["discount_code"] = "";
 			}
 			
-			$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
+			$enddate = pmpro_convert_utc_datetime_to_timestamp( $wpdb->get_var("SELECT enddate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1") );
 			if( $enddate ) {
 				$this->data["membership_expiration"] = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
 			} else {
@@ -1118,7 +1118,7 @@
 				$this->data["discount_code"] = "";
 			}
 		
-			$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
+			$enddate = pmpro_convert_utc_datetime_to_timestamp( $wpdb->get_var("SELECT enddate FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1") );
 			if($enddate)
 				$this->data["membership_expiration"] = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
 			else

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1718,7 +1718,7 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 
 	// get code from db
 	if ( ! $error ) {
-		$dbcode = $wpdb->get_row( "SELECT *, UNIX_TIMESTAMP(CONVERT_TZ(starts, '+00:00', @@global.time_zone)) as starts, UNIX_TIMESTAMP(CONVERT_TZ(expires, '+00:00', @@global.time_zone)) as expires FROM $wpdb->pmpro_discount_codes WHERE code ='" . esc_sql( $code ) . "' LIMIT 1" );
+		$dbcode = $wpdb->get_row( "SELECT * FROM $wpdb->pmpro_discount_codes WHERE code ='" . esc_sql( $code ) . "' LIMIT 1" );
 
 		// did we find it?
 		if ( empty( $dbcode->id ) ) {
@@ -1729,8 +1729,8 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 	// check if the code has started
 	if ( ! $error ) {
 		// fix the date timestamps
-		$dbcode->starts = strtotime( date_i18n( 'm/d/Y', $dbcode->starts ) );
-		$dbcode->expires = strtotime( date_i18n( 'm/d/Y', $dbcode->expires ) );
+		$dbcode->starts = strtotime( date_i18n( 'm/d/Y', pmpro_convert_utc_datetime_to_timestamp( $dbcode->starts ) ) );
+		$dbcode->expires = strtotime( date_i18n( 'm/d/Y', pmpro_convert_utc_datetime_to_timestamp( $dbcode->expires ) ) );
 
 		// today
 		$today = strtotime( date_i18n( 'm/d/Y H:i:00', current_time( 'timestamp' ) ) );
@@ -1985,13 +1985,19 @@ function pmpro_getMembershipLevelForUser( $user_id = null, $force = false ) {
 				mu.trial_amount,
 				mu.trial_limit,
 				mu.code_id as code_id,
-				UNIX_TIMESTAMP( CONVERT_TZ(startdate, '+00:00', @@global.time_zone) ) as startdate,
-				UNIX_TIMESTAMP( CONVERT_TZ(enddate, '+00:00', @@global.time_zone) ) as enddate
+				mu.startdate,
+				mu.enddate
 			FROM {$wpdb->pmpro_membership_levels} AS l
 			JOIN {$wpdb->pmpro_memberships_users} AS mu ON (l.id = mu.membership_id)
 			WHERE mu.user_id = $user_id AND mu.status = 'active'
 			LIMIT 1"
 		);
+
+		// For each startdate and enddate, change it into a timestamp.
+		if ( ! empty( $all_membership_levels[ $user_id ] ) ) {
+			$all_membership_levels[ $user_id ]->startdate = pmpro_convert_utc_datetime_to_timestamp( $all_membership_levels[ $user_id ]->startdate );
+			$all_membership_levels[ $user_id ]->enddate = pmpro_convert_utc_datetime_to_timestamp( $all_membership_levels[ $user_id ]->enddate );
+		}
 
 		// if null, change to false to avoid user meta conflicts
 		if ( empty( $all_membership_levels[ $user_id ] ) ) {
@@ -2082,8 +2088,8 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 				mu.trial_amount,
 				mu.trial_limit,
 				mu.code_id as code_id,
-				UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) as startdate,
-				UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) as enddate
+				mu.startdate,
+				mu.enddate
 			FROM {$wpdb->pmpro_membership_levels} AS l
 			JOIN {$wpdb->pmpro_memberships_users} AS mu ON (l.id = mu.membership_id)
 			WHERE mu.user_id = $user_id" . ( $include_inactive ? '' : " AND mu.status = 'active'
@@ -2098,6 +2104,14 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 			$levels[$key]->initial_payment = pmpro_round_price( $level->initial_payment );
 			$levels[$key]->billing_amount = pmpro_round_price( $level->billing_amount );
 			$levels[$key]->trial_amount = pmpro_round_price( $level->trial_amount );
+		}
+	}
+
+	// Convert startdate and enddate to timestamps.
+	if ( ! empty( $levels ) ) {
+		foreach ( $levels as $key => $level ) {
+			$levels[$key]->startdate = pmpro_convert_utc_datetime_to_timestamp( $level->startdate );
+			$levels[$key]->enddate = pmpro_convert_utc_datetime_to_timestamp( $level->enddate );
 		}
 	}
 
@@ -2502,12 +2516,12 @@ if ( ! function_exists( 'pmpro_getMemberStartdate' ) ) {
 			global $wpdb;
 
 			if ( ! empty( $level_id ) ) {
-				$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND membership_id IN(" . (int) $level_id . ") AND user_id = '" . $user_id . "' ORDER BY id LIMIT 1";
+				$sqlQuery = "SELECT startdate FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND membership_id IN(" . (int) $level_id . ") AND user_id = '" . $user_id . "' ORDER BY id LIMIT 1";
 			} else {
-				$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND user_id = '" . esc_sql( $user_id ) . "' ORDER BY id LIMIT 1";
+				$sqlQuery = "SELECT startdate FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND user_id = '" . esc_sql( $user_id ) . "' ORDER BY id LIMIT 1";
 			}
 
-			$startdate = apply_filters( 'pmpro_member_startdate', $wpdb->get_var( $sqlQuery ), $user_id, $level_id );
+			$startdate = apply_filters( 'pmpro_member_startdate', pmpro_convert_utc_datetime_to_timestamp( $wpdb->get_var( $sqlQuery ) ), $user_id, $level_id );
 
 			$pmpro_startdates[ $user_id ][ $level_id ] = $startdate;
 		}
@@ -4399,3 +4413,39 @@ function pmpro_sanitize_period( $period ) {
 
 	return $sanitized_period;
 }
+
+/**
+ * Converts a UTC datetime pulled from the database into a UTC timestamp.
+ *
+ * In the past, we used to pull these dates directly from the db as timestamps using something like:
+ * UNIX_TIMESTAMP( CONVERT_TZ(startdate, '+00:00', @@global.time_zone) ) as startdate,
+ *
+ * When we were doing those conversions, the dates were stored in the db in UTC, but if the server was set to a different timezone,
+ * UNIX_TIMESTAMP would incorrectly assume that those dates were in the server's timezone and try to "convert them to UTC".
+ * CONVERT_TZ was needed to undo the unnecessary conversion.
+ *
+ * This is complex and some database types don't support CONVERT_TZ. So now, we are just going to pull the dates
+ * as strings and convert them to timestamps here in PHP.
+ *
+ * @since TBD.
+ *
+ * @param string $datetime The datetime string to convert.
+ * @return int|null The timestamp or null if the datetime string was invalid (including 0000-00-00 00:00:00).
+ */
+function pmpro_convert_utc_datetime_to_timestamp( $datetime ) {
+	// If the datetime is empty, return null.
+	if ( empty( $datetime ) ) {
+		return null;
+	}
+
+	// If the datetime is 0000-00-00 00:00:00, return null.
+	if ( $datetime === '0000-00-00 00:00:00' ) {
+		return null;
+	}
+
+	// Convert the datetime to a timestamp.
+	$timestamp = strtotime( $datetime . ' UTC' );
+
+	return $timestamp;
+}
+

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -1,12 +1,12 @@
 <?php 
 /**
  * Template: Invoice
- * Version: 2.0
+ * Version: TBD
  *
  * See documentation for how to override the PMPro templates.
  * @link https://www.paidmembershipspro.com/documentation/templates/
  *
- * @version 2.0
+ * @version TBD
  *
  * @author Paid Memberships Pro
  */
@@ -115,7 +115,7 @@
 	else
 	{
 		//Show all invoices for user if no invoice ID is passed
-		$invoices = $wpdb->get_results("SELECT o.*, UNIX_TIMESTAMP(CONVERT_TZ(o.timestamp, '+00:00', @@global.time_zone)) as timestamp, l.name as membership_level_name FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_membership_levels l ON o.membership_id = l.id WHERE o.user_id = '$current_user->ID' AND o.status NOT IN('review', 'token', 'error') ORDER BY timestamp DESC");
+		$invoices = $wpdb->get_results("SELECT o.*, o.timestamp, l.name as membership_level_name FROM $wpdb->pmpro_membership_orders o LEFT JOIN $wpdb->pmpro_membership_levels l ON o.membership_id = l.id WHERE o.user_id = '$current_user->ID' AND o.status NOT IN('review', 'token', 'error') ORDER BY timestamp DESC");
 		if($invoices)
 		{
 			?>
@@ -132,6 +132,8 @@
 			<?php
 				foreach($invoices as $invoice)
 				{
+					// Make sure that timestamp is actually a timestamp.
+					$invoice->timestamp = pmpro_convert_utc_datetime_to_timestamp( $invoice->timestamp );
 					?>
 					<tr>
 						<td><a href="<?php echo esc_url( pmpro_url("invoice", "?invoice=" . $invoice->code ) ) ?>"><?php echo esc_html( date_i18n( get_option("date_format"), strtotime( get_date_from_gmt( date( 'Y-m-d H:i:s', $invoice->timestamp ) ) ) ) )?></a></td>

--- a/shortcodes/membership.php
+++ b/shortcodes/membership.php
@@ -55,11 +55,14 @@ function pmpro_shortcode_membership($atts, $content=null, $code="")
 	{		
 		//okay, this post requires membership. start by getting the user's startdate
 		if(!empty($levels))
-			$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND membership_id IN(" . implode(",", array_map( 'intval', $levels ) ) . ") AND user_id = '" . esc_sql( $current_user->ID ) . "' ORDER BY id LIMIT 1";
+			$sqlQuery = "SELECT startdate FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND membership_id IN(" . implode(",", array_map( 'intval', $levels ) ) . ") AND user_id = '" . esc_sql( $current_user->ID ) . "' ORDER BY id LIMIT 1";
 		else
-			$sqlQuery = "SELECT UNIX_TIMESTAMP(CONVERT_TZ(startdate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND user_id = '" . esc_sql( $current_user->ID ) . "' ORDER BY id LIMIT 1";
+			$sqlQuery = "SELECT startdate FROM $wpdb->pmpro_memberships_users WHERE status = 'active' AND user_id = '" . esc_sql( $current_user->ID ) . "' ORDER BY id LIMIT 1";
 
 		$startdate = $wpdb->get_var($sqlQuery);
+
+		// Convert startdate to timestamp.
+		$startdate = pmpro_convert_utc_datetime_to_timestamp( $startdate );
 
 		//adjust start date to 12AM
 		$startdate = strtotime(date_i18n("Y-m-d", $startdate));

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -36,7 +36,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 	$order->getLastMemberOrder();
 	$mylevels = pmpro_getMembershipLevelsForUser();
 	$pmpro_levels = pmpro_getAllLevels(false, true); // just to be sure - include only the ones that allow signups
-	$invoices = $wpdb->get_results("SELECT *, UNIX_TIMESTAMP(CONVERT_TZ(timestamp, '+00:00', @@global.time_zone)) as timestamp FROM $wpdb->pmpro_membership_orders WHERE user_id = '$current_user->ID' AND status NOT IN('review', 'token', 'error') ORDER BY timestamp DESC LIMIT 6");
+	$invoices = $wpdb->get_results("SELECT * FROM $wpdb->pmpro_membership_orders WHERE user_id = '$current_user->ID' AND status NOT IN('review', 'token', 'error') ORDER BY timestamp DESC LIMIT 6");
 	?>
 	<div id="pmpro_account">
 		<?php if(in_array('membership', $sections) || in_array('memberships', $sections)) { ?>
@@ -268,6 +268,9 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 					{
 						if($count++ > 4)
 							break;
+
+						// Make sure that timestamp is actually a timestamp.
+						$invoice->timestamp = pmpro_convert_utc_datetime_to_timestamp( $invoice->timestamp );
 
 						//get an member order object
 						$invoice_id = $invoice->id;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Some site setups, including WP Playground, do not support SQL functions such as `CONVERT_TZ()`. In order to fix that incompatibility, this PR moves the logic to convert SQL datetimes to timestamps into PHP (specifically the new function `pmpro_convert_utc_datetime_to_timestamp()`).

In the past, we used to pull these dates directly from the db as timestamps using something like:
`UNIX_TIMESTAMP( CONVERT_TZ(startdate, '+00:00', @@global.time_zone) ) as startdate`

When we were doing those conversions, the dates were stored in the db in UTC, but if the server was set to a different timezone, `UNIX_TIMESTAMP()` would incorrectly assume that those dates were in the server's timezone and try to "convert them to UTC". `CONVERT_TZ()` was needed to undo the unnecessary conversion.

Related to #2551, but does not close.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
