### PR TITLE
Avoiding NULL enddates - WP Playground Compatibility

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1094,6 +1094,11 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 			$level['startdate'] = preg_replace( '/\'/', '', $level['startdate'] );
 			$level['enddate'] = preg_replace( '/\'/', '', $level['enddate'] );
 
+			// If enddate is "NULL", convert it to 0000-00-00 00:00:00.
+			if ( $level['enddate'] === 'NULL' ) {
+				$level['enddate'] = '0000-00-00 00:00:00';
+			}
+
 			$sql = $wpdb->prepare(
 				"
 					INSERT INTO {$wpdb->pmpro_memberships_users}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Some site setups, including WP Playground, have trouble passing `'NULL'` for a datetime value. In these cases, it is defaulting to the current date instead of `0000-00-00 00:00:00` like we assume it would.

This PR updates our `pmpro_changeMembershipLevel()` function to specifically set `0000-00-00 00:00:00` to avoid this issue.

Related to https://github.com/strangerstudios/paid-memberships-pro/issues/2551, but does not close.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
