### PR TITLE
Avoiding ambiguous column name - WP Playground Compatibility

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2087,7 +2087,7 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 			FROM {$wpdb->pmpro_membership_levels} AS l
 			JOIN {$wpdb->pmpro_memberships_users} AS mu ON (l.id = mu.membership_id)
 			WHERE mu.user_id = $user_id" . ( $include_inactive ? '' : " AND mu.status = 'active'
-			GROUP BY ID" )
+			GROUP BY l.id" )
 		);
 		wp_cache_set( $cache_key, $levels, 'pmpro', 3600 );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Some site setups, including WP Playground, are stricter about ambiguous column names in SQL queries. This fixes an issue that is caused by this in WP Playground by providing more context around a `GROUP BY` variable in our `pmpro_getMembershipLevelsForUser()` function.

Related to #2551, but does not close.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
