### PR TITLE
Marking Table Layout Plugin Pages as deprecated

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -183,6 +183,10 @@ function pmpro_get_deprecated_add_ons() {
 			'file' => 'pmpro-register-helper.php',
 			'label' => 'Register Helper',
 			'message' => $pmpro_register_helper_message
+		),
+		'pmpro-table-pages' => array(
+			'file' => 'pmpro-table-pages.php',
+			'label' => 'Table Layout Plugin Pages'
 		)
 	);
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the Table Layout Plugin Pages Add On to the deprecated plugins check

Resolves #2484

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Marking Table Layout Plugin Pages Add On as deprecated
