### PR TITLE
Now only declaring recatcha_get_html at checkout

### DIFF
--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -48,6 +48,7 @@ function pmpro_init_recaptcha() {
 	// TODO: Remove this in a future version.
 	if ( ! function_exists( 'recaptcha_get_html' ) ) {
 		function recaptcha_get_html() {
+			_deprecated_function( 'recaptcha_get_html', 'TBD', 'pmpro_recaptcha_get_html');
 			return pmpro_recaptcha_get_html();
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes compatibility with other plugins that also declare a function `recaptcha_get_html()`, such as Avada forms.

Also marking our `recaptcha_get_html()` function as deprecated as it should be removed in 3.0.

### How to test the changes in this Pull Request:

1. Set up a site using Avada and reCAPTCHA v3
2. Set up an Avada form enforcing reCAPTCHA
3. See that the reCAPTCHA badge shows correctly when viewing the form while this PR is being used

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
