### PR TITLE
PHP 8.1 warning: Array to string conversion with [pmpro_member] #2618

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -4,6 +4,12 @@
 */
 function pmpro_member_shortcode($atts, $content=null, $code='')
 {
+	//Bail if $atts is null or empty
+	if( !$atts || empty($atts) ) {
+		echo esc_html__( "fields attribute is required in the pmpro_member shortcode", 'paid-memberships-pro' );
+	 	return;
+	}
+	
 	// $atts    ::= array of attributes
 	// $content ::= text within enclosing form of shortcode element
 	// $code    ::= the shortcode found, when == callback name
@@ -14,6 +20,13 @@ function pmpro_member_shortcode($atts, $content=null, $code='')
 		'user_id' => $current_user->ID,
 		'field' => NULL
 	), $atts));
+	
+	//Bail if there's no field attribute
+	if( !$field ) {
+		echo esc_html__( "fields attribute is required in the pmpro_member shortcode", 'paid-memberships-pro' );
+		return;
+	}
+
 	
 	/*
 		- pmpro_next_payment()


### PR DESCRIPTION
 * This happens when required field attribute is not present. Added validation to avoid this scenario. Adding a document update request too.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added validations and Bail to $atts parameter s and $fields var after extracting shortcode to ensure that fields attribute was passed and avoid the warning.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes https://github.com/strangerstudios/paid-memberships-pro/issues/2618

### How to test the changes in this Pull Request:

1.  Run steps described in the issue above.
2. Check that instead ow watning and / or array word print it bails and print the validation message.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
