### PR TITLE
Add support to comma separated levels

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -783,13 +783,14 @@ function pmpro_showRequiresMembershipMessage() {
  * Function to check if a user has specified membership levels.
  *
  * pmpro_hasMembershipLevel() checks if the passed user is a member of the passed level
- * $level may either be the ID or name of the desired membership_level. (or an array of such)
+ * $level may either be the ID or name of the desired membership_level. (or an array of such or a comma separated string)
  * If $user_id is omitted, the value will be retrieved from $current_user.
  *
  *  Return values:
  *   * Success returns boolean true.
  *   * Failure returns a string containing the error message.
  *
+ * @since TBD Added support to pass comma separated value to $levels
  * @since 1.8.5 Added 'e' option for expired members.
  * @since 1.0.0
  *
@@ -819,7 +820,18 @@ function pmpro_hasMembershipLevel( $levels = null, $user_id = null ) {
 		$return = ! empty( $membership_levels );
 	} else {
 		if ( ! is_array( $levels ) ) {
-			$levels = array( $levels );
+		//we'll assume is a string
+        $levels_str = (string)$levels;
+        // If no comma, just make the value and array how we used to
+        if ( strpos( $levels_str, ',' ) === false ) {
+            $levels = array( $levels );
+        } else {
+            // We have a string with at least 1 comma in it, turn it into an array and check again.
+            $level_ids = explode( ',', $levels_str );
+            // Trim whitespace from the levels ids or names.
+            $levels = array_map( 'trim', $level_ids );
+        }
+
 		}
 
 		if ( empty( $membership_levels ) ) {


### PR DESCRIPTION

<img width="715" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/08013db1-5cf9-449e-b9d4-4cd378835c12">
non logged
<img width="1009" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/595a4955-2dce-4aee-8095-135b16040688">
logged
<img width="1034" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/82a5b991-df55-4ff6-878d-696d03824c63">
<img width="861" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/2ae7b8e9-a7ed-4fbf-8ee9-2871ce948a0b">


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds support to pass levels parameter to pmpro_hasMembershipLevel function as a comma separated String value.

### How to test the changes in this Pull Request:

1. Add woocomerce
2. Add The events calendar
3. Add the event tickets
4. Add the event ticket plus.
5. Add the tec memebers only ticket https://github.com/mt-support/tec-labs-members-only-tickets
6. Go to ticket settings and in  membership settings add a comma separated value levels
7. Create an event 
8. Create a ticket 
9.  Restrict in woocomerce side the event by same level added in the ticket setting.
10. Check if it's visible thus pmpro_hasMembershipLevel supported the comma separated values passed in settings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added support to pass comma separated values to pmpro_hasMembershipLevel function
