### PR TITLE
Inconsistent autogenerated values for user fields with options. #2619

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1582,13 +1582,21 @@ function pmpro_load_user_fields_from_settings() {
             if ( in_array( $settings_field->type, $option_types ) ) {
                 $options = array();
                 $settings_options = explode( "\n", $settings_field->options );
+				//Let's check if the user wants to use the value as the label, is there any ':' in any option ?
+				$assume_intetion_to_use_value_as_label = pmpro_strposa( ":", $settings_options );
                 foreach( $settings_options as $settings_option ) {
+					//this option has a label and a value
                     if ( strpos( $settings_option, ':' ) !== false ) {
                         $parts = explode( ':', $settings_option );
                         $options[trim( $parts[0] )] = trim( $parts[1] );
-                    } else {
-                        $options[] = $settings_option;
-                    }
+					} else {
+						$settings_option = trim( $settings_option );
+						if( $assume_intetion_to_use_value_as_label ) {
+							$options[$settings_option] = $settings_option;
+						} else {
+							$options[] = $settings_option;
+						}
+					}
                 }
             } else {
                 $options = false;
@@ -1689,4 +1697,23 @@ function pmpro_get_label_for_user_field_value( $field_name, $field_value ) {
 		}
 	}
 	return $field_value;
+}
+
+/**
+ * Do a strpos search within an array. Should we move this to a Util class instead ?
+ *
+ * @param string $needle The string to search for.
+ * @param array $haystacks The array of strings to search in.
+ * @return bool True if the needle is found in any of the haystacks, false otherwise.
+ * @since TBD
+ */
+function pmpro_strposa( $needle, $haystacks ) {
+	foreach( $haystacks as $haystack ) {
+		if( strpos($haystack, $needle) !== false ) {
+			// stop on first true result
+			return true;
+		}
+	}
+
+	return false;
 }


### PR DESCRIPTION
 * If there's a key, we assume the intention was for the other options to use the values as keys.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


Resolves [2619](https://github.com/strangerstudios/paid-memberships-pro/issues/2619).
Check the options to see if we have a key on any of its option then let's assume the intention was for the other options to use the values as keys. Check for a ':' and if it exists we name all the key after its values. 

### How to test the changes in this Pull Request:

1. Create different user fields with selects
2. Add different combinations with only values, with single key/value option, with empty key and a value, etc.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes Inconsistent autogenerated values for user fields with options
