### PR TITLE
Add confirmation when switching tab with changes

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -908,11 +908,25 @@ window.addEventListener("DOMContentLoaded", () => {
 	const tabs = document.querySelectorAll('#pmpro-edit-user-div [role="tab"]');
 	const tabList = document.querySelector('#pmpro-edit-user-div [role="tablist"]');
 	const togglePassVisibility = document.querySelector('#pmpro-edit-user-div .toggle-pass-visibility');
+	const inputs = document.querySelectorAll('#pmpro-edit-user-div input, #pmpro-edit-user-div textarea, #pmpro-edit-user-div select');
 
 	if ( tabs && tabList ) {
+		// Track whether an input has been changed.
+		let inputChanged = false;
+		inputs.forEach((input) => {
+			input.addEventListener('change', function(e) {
+				inputChanged = true;
+			});
+		});
+
 		// Add a click event handler to each tab
 		tabs.forEach((tab) => {
-			tab.addEventListener("click", pmpro_changeTabs);
+			tab.addEventListener("click", function (e) {
+				if ( pmpro_changeTabs(e, inputChanged ) ) {
+					// If we changed tabs, reset the inputChanged flag.
+					inputChanged = false;
+				}
+			});
 		});
 
 		// Enable arrow navigation between tabs in the tab list
@@ -958,8 +972,16 @@ window.addEventListener("DOMContentLoaded", () => {
 	}
 });
 
-function pmpro_changeTabs(e) {
+function pmpro_changeTabs( e, inputChanged ) {
 	e.preventDefault();
+
+	if ( inputChanged ) {
+		const answer = window.confirm('You have unsaved changes. Are you sure you want to switch tabs?');
+		if ( ! answer ) {
+			return false;
+		}
+	}
+
 	const target = e.target;
 	const parent = target.parentNode;
 	const grandparent = parent.parentNode;
@@ -981,4 +1003,6 @@ function pmpro_changeTabs(e) {
 	grandparent.parentNode
 	.querySelector(`#${target.getAttribute("aria-controls")}`)
 	.removeAttribute("hidden");
+
+	return true;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
