### PR TITLE
Bug: No notice of failed/successful payment information update

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -144,7 +144,7 @@
 
 			<input type="hidden" name="level" value="<?php echo esc_attr($level->id);?>" />
 
-			<div id="pmpro_message" <?php if(! $pmpro_msg) ?> style="display:none" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"> <?php if($pmpro_msg) echo wp_kses_post( $pmpro_msg ); ?></div>
+			<div id="pmpro_message" <?php if(! $pmpro_msg) { ?> style="display:none" <?php } ?> class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"> <?php if($pmpro_msg) echo wp_kses_post( $pmpro_msg ); ?></div>
 
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_alert', 'pmpro_account_loggedin' ) ); ?>">
 				<?php

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -144,7 +144,7 @@
 
 			<input type="hidden" name="level" value="<?php echo esc_attr($level->id);?>" />
 
-			<div id="pmpro_message" <?php if(! $pmpro_msg) { ?> style="display:none" <?php } ?> class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"> <?php if($pmpro_msg) echo wp_kses_post( $pmpro_msg ); ?></div>
+			<div id="pmpro_message" <?php if(! $pmpro_msg) { ?> style="display:none" <?php } ?> class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>"> <?php if($pmpro_msg) { echo wp_kses_post( $pmpro_msg ); } ?></div>
 
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_alert', 'pmpro_account_loggedin' ) ); ?>">
 				<?php


### PR DESCRIPTION
<img width="959" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/b5791fbe-9da3-4fd7-b93e-e86708bb2825">
<img width="897" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/f7035d71-6342-4f8e-a30c-9cfbc0ceb5ad">


* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Just fix how PHP opens and closes wrapping style attribute in the alert message. 

Resolves #2500 .

### How to test the changes in this Pull Request:

Check steps to reproduce in the isse #2500 itself/
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
