### PR TITLE
Require membership block overhaul

### DIFF
--- a/blocks/src/membership/block.json
+++ b/blocks/src/membership/block.json
@@ -7,13 +7,17 @@
 	"description": "Nest blocks within this wrapper to control the inner block visibility by membership level or for non-members only.",
 	"keywords": [ "block visibility", "conditional", "content", "hide", "hidden", "private", "restrict", "paid memberships pro", "pmpro" ],
 	"attributes": {
+		"invert_restrictions": {
+			"type": "string",
+			"default": "0"
+		},
+		"segment":{
+			"type": "string",
+			"default": "all"
+		},
 		"levels": {
 			"type": "array",
 			"default":[]
-		},
-		"uid": {
-			"type": "string",
-			"default":""
 		},
 		"show_noaccess": {
 			"type": "string",

--- a/blocks/src/membership/edit.js
+++ b/blocks/src/membership/edit.js
@@ -64,11 +64,6 @@ export default function Edit(props) {
 		setAttributes({ segment: newSegment, levels: [] });
 	}
 
-	// Build the visibility component.
-	function setInvertRestrictions() {
-		setAttributes({ invert_restrictions: invert_restrictions === '1' ? '0' : '1' });
-	}
-
 	// Build an array of checkboxes for each level.
 	var checkboxes = pmpro.all_level_values_and_labels.map(function (level) {
 		function setLevelsAttribute(nowChecked) {
@@ -106,7 +101,7 @@ export default function Edit(props) {
 							icon="visibility"
 							variant={invert_restrictions === '0' ? 'primary' : 'secondary'}
 							style={ { flexGrow: '1', justifyContent: 'center' } }
-							onClick={() => setInvertRestrictions('0')} // Set to '0' to show content
+							onClick={() => setAttributes({ invert_restrictions: '0' })}
 						>
 							{__('Show', 'your-text-domain')}
 						</Button>
@@ -116,7 +111,7 @@ export default function Edit(props) {
 							icon="hidden"
 							variant={invert_restrictions === '1' ? 'primary' : 'secondary'}
 							style={ { flexGrow: '1', justifyContent: 'center' } }
-							onClick={() => setInvertRestrictions('1')} // Set to '1' to hide content
+							onClick={() => setAttributes({ invert_restrictions: '1' })}
 						>
 							{__('Hide', 'your-text-domain')}
 						</Button>

--- a/blocks/src/membership/edit.js
+++ b/blocks/src/membership/edit.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * WordPress dependencies
  */
-import { CheckboxControl, PanelBody, SelectControl } from '@wordpress/components';
+import { CheckboxControl, PanelBody, SelectControl, ToggleControl, IconButton } from '@wordpress/components';
 import { InnerBlocks, useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
 /**
@@ -24,24 +24,62 @@ import './editor.scss';
  * @return {WPElement} Element to render.
  */
 export default function Edit(props) {
+	// Set up the block.
 	const blockProps = useBlockProps({});
-	const all_levels = [{ value: 0, label: __( "Non-Members", 'paid-memberships-pro' ) }].concat(pmpro.all_level_values_and_labels);
-	const { attributes: { levels, uid, show_noaccess }, setAttributes, isSelected } = props;
+	const { attributes: { invert_restrictions, segment, levels, show_noaccess }, setAttributes, isSelected } = props;
 
-	if (uid === '') {
-		var rand = Math.random() + "";
-		setAttributes({ uid: rand });
+	// Handle migrations from PMPro < 3.0.
+	// If levels is not empty and segment is 'all', we  need to migrate.
+	if (levels.length > 0 && segment == 'all') {
+		// If '0' is in levels, then restrictions should be inverted.
+		if (levels.includes('0')) {
+			// If '0' was the only element, then the segment should be 'all'.
+			if (levels.length == 1) {
+				setAttributes({ invert_restrictions: '1', segment: 'all', levels: [] });
+			} else {
+				// Otherwise, the segment should be 'specific' and we need to change the levels array to
+				// all level IDs that were not previously selected.
+				const newLevels = pmpro.all_level_values_and_labels
+					.map((level) => level.value + '')
+					.filter((levelID) => !levels.includes(levelID));
+				setAttributes({ invert_restrictions: '1', segment: 'specific', levels: newLevels });
+			}
+		} else {
+			// If '0' is not in levels, then we do not need to invert subscriptions and just need to change the segment to 'specific'.
+			setAttributes({ invert_restrictions: '0', segment: 'specific' });
+		}
 	}
 
+	// Helper function to select/deselect all levels.
 	function selectAllLevels(selectAll) {
-		const allLevelValues = all_levels.map((level) => level.value + '');
+		const allLevelValues = pmpro.all_level_values_and_labels.map((level) => level.value + '');
 		// If selectAll is true, set newLevels to all values. If false, set it to an empty array.
 		const newLevels = selectAll ? allLevelValues : [];
 		setAttributes({ levels: newLevels });
 	}
 
+	// Helper function to handle changes to the segment attribute.
+	function handleSegmentChange(newSegment) {
+		// Set the segment attribute and clear the levels array.
+		setAttributes({ segment: newSegment, levels: [] });
+	}
+
+	// Build the visibility component.
+	function toggleVisibility() {
+		setAttributes({ invert_restrictions: invert_restrictions === '1' ? '0' : '1' });
+	}
+	var segment_label = 
+		<div>
+			<IconButton
+				icon={invert_restrictions === '1' ? 'hidden' : 'visibility'}
+				label={invert_restrictions === '1' ? __('Hide content from these users', 'your-text-domain') : __('Show content to these users', 'your-text-domain')}
+				onClick={toggleVisibility}
+			/>
+			{ invert_restrictions=='0' ? __( 'Show this block to:', 'paid-memberships-pro' ) : __( 'Hide this block from:', 'paid-memberships-pro' ) }
+		</div>;
+
 	// Build an array of checkboxes for each level.
-	var checkboxes = all_levels.map(function (level) {
+	var checkboxes = pmpro.all_level_values_and_labels.map(function (level) {
 		function setLevelsAttribute(nowChecked) {
 			if (nowChecked && !(levels.some((levelID) => levelID == level.value))) {
 				// Add the level.
@@ -66,24 +104,41 @@ export default function Edit(props) {
 	return [
 		isSelected && (
 			<InspectorControls>
-				<PanelBody>
-					<p><strong>{ __( 'Which membership levels can view this block?', 'paid-memberships-pro' ) }</strong></p>
-					<p>
-						{ __( 'Select', 'paid-memberships-pro' ) } <a href="#" onClick={(event) => { event.preventDefault(); selectAllLevels(true); }}>{ __('All', 'paid-memberships-pro') }</a> | <a href="#" onClick={(event) => { event.preventDefault(); selectAllLevels(false); }}>{ __( 'None', 'paid-memberships-pro' ) }</a>
-					</p>
-					<div class="pmpro-block-inspector-scrollable">
-						{checkboxes}
-					</div>
-					<p><strong>{ __( 'What should users without access see?', 'paid-memberships-pro' ) }</strong></p>
+				<PanelBody
+					title={__( 'Restriction Settings', 'paid-memberships-pro' )}
+					initialOpen={true}
+				>
 					<SelectControl
-						value={show_noaccess}
-						help={ __ ( "Modify the 'no access' message on the Memberships > Advanced Settings page.", "paid-memberships-pro" ) }
+						value={segment}
+						label={ segment_label }
 						options={[
-							{ label: __( 'Show nothing', 'paid-memberships-pro' ), value: '0' },
-							{ label: __( "Show the 'no access' message", 'paid-memberships-pro' ), value: '1' },
+							{ label: __( 'All Members', 'paid-memberships-pro' ), value: 'all' },
+							{ label: __( 'Specific Membership Levels', 'paid-memberships-pro' ), value: 'specific' },
+							{ label: __( 'Logged-In Users', 'paid-memberships-pro' ), value: 'logged_in' }
 						]}
-						onChange={(show_noaccess) => setAttributes({ show_noaccess })}
+						onChange={(segment) => handleSegmentChange(segment) }
 					/>
+					{ segment=='specific' && <>
+						<p><strong>{ __( 'Membership Levels', 'paid-memberships-pro' ) }</strong></p>
+						<p>
+							{ __( 'Select', 'paid-memberships-pro' ) } <a href="#" onClick={(event) => { event.preventDefault(); selectAllLevels(true); }}>{ __('All', 'paid-memberships-pro') }</a> | <a href="#" onClick={(event) => { event.preventDefault(); selectAllLevels(false); }}>{ __( 'None', 'paid-memberships-pro' ) }</a>
+						</p>
+						<div class="pmpro-block-inspector-scrollable">
+							{checkboxes}
+						</div>
+					</> }
+					{ invert_restrictions=='0' && <>
+						<SelectControl
+							value={show_noaccess}
+							label={ __( 'Show No Access Message?', 'paid-memberships-pro' ) }
+							help={ __ ( "Modify the 'no access' message on the Memberships > Advanced Settings page.", "paid-memberships-pro" ) }
+							options={[
+								{ label: __( 'No - Hide this block if the user does not have access', 'paid-memberships-pro' ), value: '0' },
+								{ label: __( "Yes - Show the 'no access' message if the user does not have access", 'paid-memberships-pro' ), value: '1' },
+							]}
+							onChange={(show_noaccess) => setAttributes({ show_noaccess })}
+						/>
+					</> }
 				</PanelBody>
 			</InspectorControls>
 		),

--- a/blocks/src/membership/edit.js
+++ b/blocks/src/membership/edit.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * WordPress dependencies
  */
-import { CheckboxControl, PanelBody, SelectControl, ToggleControl, IconButton } from '@wordpress/components';
+import { CheckboxControl, PanelBody, SelectControl, Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { InnerBlocks, useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
 /**
@@ -65,18 +65,9 @@ export default function Edit(props) {
 	}
 
 	// Build the visibility component.
-	function toggleVisibility() {
+	function setInvertRestrictions() {
 		setAttributes({ invert_restrictions: invert_restrictions === '1' ? '0' : '1' });
 	}
-	var segment_label = 
-		<div>
-			<IconButton
-				icon={invert_restrictions === '1' ? 'hidden' : 'visibility'}
-				label={invert_restrictions === '1' ? __('Hide content from these users', 'your-text-domain') : __('Show content to these users', 'your-text-domain')}
-				onClick={toggleVisibility}
-			/>
-			{ invert_restrictions=='0' ? __( 'Show this block to:', 'paid-memberships-pro' ) : __( 'Hide this block from:', 'paid-memberships-pro' ) }
-		</div>;
 
 	// Build an array of checkboxes for each level.
 	var checkboxes = pmpro.all_level_values_and_labels.map(function (level) {
@@ -105,12 +96,35 @@ export default function Edit(props) {
 		isSelected && (
 			<InspectorControls>
 				<PanelBody
-					title={__( 'Restriction Settings', 'paid-memberships-pro' )}
+					title={__( 'Restriction Settings', 'paid-memberships-pro' ) }
 					initialOpen={true}
 				>
+					<HStack>
+						{/* Button to toggle visibility to "show" mode */}
+						<Button
+							className="pmpro-block-require-membership-element__set-show-button"
+							icon="visibility"
+							variant={invert_restrictions === '0' ? 'primary' : 'secondary'}
+							style={ { flexGrow: '1', justifyContent: 'center' } }
+							onClick={() => setInvertRestrictions('0')} // Set to '0' to show content
+						>
+							{__('Show', 'your-text-domain')}
+						</Button>
+						{/* Button to toggle visibility to "hide" mode */}
+						<Button
+							className="pmpro-block-require-membership-element__set-hide-button"
+							icon="hidden"
+							variant={invert_restrictions === '1' ? 'primary' : 'secondary'}
+							style={ { flexGrow: '1', justifyContent: 'center' } }
+							onClick={() => setInvertRestrictions('1')} // Set to '1' to hide content
+						>
+							{__('Hide', 'your-text-domain')}
+						</Button>
+					</HStack>
+					<br />
 					<SelectControl
 						value={segment}
-						label={ segment_label }
+						label={ invert_restrictions === '1' ? __('Hide content from:', 'paid-memberships-pro') : __('Show content to:', 'paid-memberships-pro') }
 						options={[
 							{ label: __( 'All Members', 'paid-memberships-pro' ), value: 'all' },
 							{ label: __( 'Specific Membership Levels', 'paid-memberships-pro' ), value: 'specific' },
@@ -127,6 +141,7 @@ export default function Edit(props) {
 							{checkboxes}
 						</div>
 					</> }
+					<br />
 					{ invert_restrictions=='0' && <>
 						<SelectControl
 							value={show_noaccess}

--- a/blocks/src/membership/editor.scss
+++ b/blocks/src/membership/editor.scss
@@ -7,3 +7,9 @@
 .wp-block-pmpro-membership .block-editor-inner-blocks {
 	margin: 8px;
 }
+
+.pmpro-block-require-membership-element__set-hide-button.is-secondary,
+.pmpro-block-require-membership-element__set-show-button.is-secondary {
+	box-shadow: inset 0 0 0 1px #777;
+	color: #777;
+}

--- a/blocks/src/membership/render.php
+++ b/blocks/src/membership/render.php
@@ -3,16 +3,43 @@
  * Render the Membership Required block on the frontend.
  */
 $output = '';
-if ( ! array_key_exists( 'levels', $attributes ) || empty( $attributes['levels'] ) ) {
-	// Assume require any membership level, and do not show to non-members.
-	if ( pmpro_hasMembershipLevel() ) {
-		$output = do_blocks( $content );
+
+if ( ! array_key_exists( 'segment', $attributes ) || empty( $attributes['segment'] ) ) {
+	// Legacy setup for PMPro < 3.0.
+	if ( ! array_key_exists( 'levels', $attributes ) || empty( $attributes['levels'] ) ) {
+		// Assume require any membership level, and do not show to non-members.
+		if ( pmpro_hasMembershipLevel() ) {
+			$output = do_blocks( $content );
+		}
+	} else {
+		if ( pmpro_hasMembershipLevel( $attributes['levels'] ) ) {
+			$output = do_blocks( $content );
+		} elseif ( ! empty( $attributes['show_noaccess'] ) ) {
+			$output = pmpro_get_no_access_message( NULL, $attributes['levels'] );
+		}
 	}
 } else {
-	if ( pmpro_hasMembershipLevel( $attributes['levels'] ) ) {
+	// Setup for PMPro >= 3.0.
+	switch ( $attributes['segment'] ) {
+		case 'all':
+			$levels_to_check = $attributes['invert_restrictions'] == '0' ? null : '0';
+			break;
+		case 'specific':
+			// If inverting restrictions, we need to make all level IDs negative.
+			$levels_to_check = array_map( function( $level ) use ( $attributes ) {
+				return $attributes['invert_restrictions'] == '0' ? $level : '-' . $level;
+			}, $attributes['levels'] );
+			break;
+		case 'logged_in':
+			$levels_to_check = $attributes['invert_restrictions'] == '0' ? 'L' : '-L';
+			break;
+	}
+
+	if ( pmpro_hasMembershipLevel( $levels_to_check ) ) {
 		$output = do_blocks( $content );
-	} elseif ( ! empty( $attributes['show_noaccess'] ) ) {
+	} elseif ( ! empty( $attributes['show_noaccess'] ) && $attributes['invert_restrictions'] == '0' ) {
 		$output = pmpro_get_no_access_message( NULL, $attributes['levels'] );
 	}
 }
+
 echo $output;

--- a/blocks/src/membership/render.php
+++ b/blocks/src/membership/render.php
@@ -4,7 +4,7 @@
  */
 $output = '';
 
-if ( ! array_key_exists( 'segment', $attributes ) || empty( $attributes['segment'] ) ) {
+if ( 'all' === $attributes['segment'] && ! empty( $attributes['levels'] ) ) {
 	// Legacy setup for PMPro < 3.0.
 	if ( ! array_key_exists( 'levels', $attributes ) || empty( $attributes['levels'] ) ) {
 		// Assume require any membership level, and do not show to non-members.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
- Add option to "exclude memberships" to require membership block
- Update Require Membership block to have a dropdown to show to all members, specific levels, and logged-in users

Warning: The settings to this new Require Membership block is one-way. If you test this PR and then revert back to an older version of PMPro, your Require Membership block settings may no longer be correct.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
