### PR TITLE
MemberOrder: Initialize $tax to float and keep it consistent

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -80,7 +80,7 @@
 		 *
 		 * @var float
 		 */
-		private $tax = null;
+		private $tax = 0.00;
 
 		/**
 		 * Discount Code Amount

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -628,7 +628,7 @@
 			$order->user_id = "";
 			$order->membership_id = "";
 			$order->subtotal = "";
-			$order->tax = "";
+			$order->tax = 0.00;
 			$order->couponamount = "";
 			$order->total = "";
 			$order->payment_type = "";
@@ -705,7 +705,7 @@
 				$this->Email = $wpdb->get_var( $wpdb->prepare( "SELECT user_email FROM $wpdb->users WHERE ID = %d LIMIT 1", $this->user_id ) );
 
 				$this->subtotal = $dbobj->subtotal;
-				$this->tax = $dbobj->tax;
+				$this->tax = (float)$dbobj->tax;
 				$this->couponamount = $dbobj->couponamount;
 				$this->certificate_id = $dbobj->certificate_id;
 				$this->certificateamount = $dbobj->certificateamount;
@@ -1182,7 +1182,7 @@
 			$tax_rate = get_option("pmpro_tax_rate");
 
 			//default
-			$tax = 0;
+			$tax = 0.00;
 
 			//calculate tax
 			if($tax_state && $tax_rate)
@@ -1209,7 +1209,7 @@
 				$values['billing_country'] = $this->billing->country;
 
 			//filter
-			$tax = apply_filters("pmpro_tax", $tax, $values, $this);
+			$tax = (float)apply_filters("pmpro_tax", $tax, $values, $this);
 			return $tax;
 		}
 
@@ -1294,10 +1294,13 @@
 			//Todo: Tax?!, Coupons, Certificates, affiliates
 			if(empty($this->subtotal))
 				$this->subtotal = $amount;
-			if(isset($this->tax))
+
+			if ( ! empty( $this->tax ) ) {
 				$tax = $this->tax;
-			else
-				$tax = $this->getTax(true);
+			} else {
+				$tax = $this->getTax( true );
+			}
+
 			$this->certificate_id = "";
 			$this->certificateamount = "";
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since we already initialized subtotal and total to 0.00 (float), only tax was missing.
Also, it has to be kept consistent all around, because any case in which $order->tax is not a float, might cause issue.

Weird case examples (losing digits):
```php
$order->tax      = $order->total - $order->subtotal
// float(0) = float(1) - float(0.82)

php > $a = 0;
php > $a = round( 12.34 - 1.72 );
php > var_dump( $a );
float(11)
```

The isset($this->tax) also has to be changed to ! empty(), because:
```php
php > $a = null;
php > var_dump( isset( $a ) );
bool(false)
php > $a = 0.00;
php > var_dump( isset( $a ) );
bool(true)
```

### How to test the changes in this Pull Request:

1. Siteground w/ PHP 7.4, WP latest
2. Use a snippet like the following and you gonna see some lost digits at the end.

```php
add_action( 'pmpro_added_order', function ( $order ) {
	global $wpdb;

	$order->subtotal = pmprovat_calculate_subtotal( $order->total, 0.42 );
	$order->tax      = round( $order->total - $order->subtotal, 2 );

	$wpdb->update(
		$wpdb->pmpro_membership_orders,
		array( 'tax' => $order->tax, 'subtotal' => $order->subtotal, 'notes' => $order->notes ),
		array( 'id' => $order->id ),
		array( '%s', '%s', '%s' ),
		array( '%d' )
	);

	return $order;
} );
```


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally? Yes 2.x
* [ ] To be tested on 3.0 branch
* [ ] To consider if we want to apply the same rules to total/subtotal which are still initialized to empty string into `getEmptyMemberOrder()`
