### PR TITLE
Updating confirmation page logic for 3.0

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -36,7 +36,7 @@ if ( empty( $pmpro_invoice ) ) {
 		$pmpro_invoice->user->membership_level = $pmpro_invoice->membership_level; // Backwards compatibility.
 
 		// Start building the confirmation message.
-		if ( empty( $pmpro_invoice->membership_level ) ) {
+		if ( 'success' != $pmpro_invoice->status ) {
 			$confirmation_message = '<p>' . __('Your payment has been submitted. Your membership will be activated shortly.', 'paid-memberships-pro' ) . '</p>';
 		} else {
 			$confirmation_message = '<p>' . sprintf(__('Thank you for your membership to %s. Your %s membership is now active.', 'paid-memberships-pro' ), get_bloginfo("name"), $pmpro_invoice->membership_level->name) . '</p>';

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -10,7 +10,15 @@
  *
  * @author Paid Memberships Pro
  */
-global $wpdb, $current_user, $pmpro_invoice, $pmpro_msg, $pmpro_msgt;
+global $wpdb, $pmpro_invoice, $pmpro_msg, $pmpro_msgt;
+
+// If this file is loaded, $pmpro_invoice should have been set by preheaders/confirmation.php. If not, show an error.
+if ( empty( $pmpro_invoice ) ) {
+	$pmpro_msg = __( 'There was an error retrieving your invoice. Please contact the site owner.', 'paid-memberships-pro' );
+	$pmpro_msgt = 'pmpro_error';
+}
+
+// Output page contents.
 ?>
 <div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_confirmation_wrap' ) ); ?>">
 	<?php
@@ -21,70 +29,71 @@ global $wpdb, $current_user, $pmpro_invoice, $pmpro_msg, $pmpro_msgt;
 		<?php
 	}
 
-	// Start building the confirmation message.
-	if ( empty( $current_user->membership_level ) ) {
-		$confirmation_message = '<p>' . __('Your payment has been submitted. Your membership will be activated shortly.', 'paid-memberships-pro' ) . '</p>';
-	} else {
-		$confirmation_message = '<p>' . sprintf(__('Thank you for your membership to %s. Your %s membership is now active.', 'paid-memberships-pro' ), get_bloginfo("name"), $current_user->membership_level->name) . '</p>';
-	}
+	// Check that we have an invoice.
+	if ( ! empty( $pmpro_invoice ) ) {
+		$pmpro_invoice->getUser();
+		$pmpro_invoice->getMembershipLevel();
+		$pmpro_invoice->user->membership_level = $pmpro_invoice->membership_level; // Backwards compatibility.
 
-	// Add the level confirmation message if set.
-	$level_message = $wpdb->get_var("SELECT l.confirmation FROM $wpdb->pmpro_membership_levels l LEFT JOIN $wpdb->pmpro_memberships_users mu ON l.id = mu.membership_id WHERE mu.status = 'active' AND mu.user_id = '" . intval( $current_user->ID ) . "' LIMIT 1");
-	if ( ! empty( $level_message ) ) {
-		$confirmation_message .= wpautop( stripslashes( $level_message ) );
-	}
+		// Start building the confirmation message.
+		if ( empty( $pmpro_invoice->membership_level ) ) {
+			$confirmation_message = '<p>' . __('Your payment has been submitted. Your membership will be activated shortly.', 'paid-memberships-pro' ) . '</p>';
+		} else {
+			$confirmation_message = '<p>' . sprintf(__('Thank you for your membership to %s. Your %s membership is now active.', 'paid-memberships-pro' ), get_bloginfo("name"), $pmpro_invoice->membership_level->name) . '</p>';
+		}
 
-	// Get the invoice if we have one.
-	$confirmation_invoice = ( ! empty( $pmpro_invoice ) && ! empty( $pmpro_invoice->id ) ) ? $pmpro_invoice : false;
+		// Add the level confirmation message if set.
+		$level_message = $wpdb->get_var("SELECT confirmation FROM $wpdb->pmpro_membership_levels WHERE id = '" . intval( $pmpro_invoice->membership_id ) . "' LIMIT 1");
+		if ( ! empty( $level_message ) ) {
+			$confirmation_message .= wpautop( stripslashes( $level_message ) );
+		}
 
-	// Add some details to the confirmation message about the invoice.
-	if ( ! empty( $confirmation_invoice ) ) {
-		$confirmation_invoice->getUser();
-		$confirmation_invoice->getMembershipLevel();
-		$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s.', 'paid-memberships-pro' ), $current_user->user_email ) . '</p>';
-	} else {
-		$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account. A welcome email has been sent to %s.', 'paid-memberships-pro' ), $current_user->user_email ) . '</p>';
-	}
+		// Add some details to the confirmation message about the invoice.
+		if ( pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+			$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s.', 'paid-memberships-pro' ), $pmpro_invoice->user->user_email ) . '</p>';
+		} else {
+			$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account. A welcome email has been sent to %s.', 'paid-memberships-pro' ), $pmpro_invoice->user->user_email ) . '</p>';
+		}
 
-	/**
-	 * Allow devs to filter the confirmation message.
-	 * We also have a function in includes/filters.php that applies the the_content filters to this message.
-	 * @param string $confirmation_message The confirmation message.
-	 * @param object $pmpro_invoice The PMPro Invoice/Order object.
-	 */
-	$confirmation_message = apply_filters("pmpro_confirmation_message", $confirmation_message, $pmpro_invoice);
-	echo wp_kses_post( $confirmation_message );
+		/**
+		 * Allow devs to filter the confirmation message.
+		 * We also have a function in includes/filters.php that applies the the_content filters to this message.
+		 * @param string $confirmation_message The confirmation message.
+		 * @param object $pmpro_invoice The PMPro Invoice/Order object.
+		 */
+		$confirmation_message = apply_filters( "pmpro_confirmation_message", $confirmation_message, $pmpro_invoice );
+		echo wp_kses_post( $confirmation_message );
 
-	if ( ! empty( $confirmation_invoice ) ) {
-		// Show the invoice, but make sure we don't show $pmpro_msg again.
-		$pmpro_msg = false;
-		$pmpro_msgt = false;
-		echo pmpro_loadTemplate( 'invoice' );
-	} else {
-		?>
-		<ul>
-			<li><strong><?php esc_html_e('Account', 'paid-memberships-pro' );?>:</strong> <?php echo esc_html( $current_user->display_name );?> (<?php echo esc_html( $current_user->user_email );?>)</li>
-			<li><strong><?php esc_html_e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php if(!empty($current_user->membership_level)) echo esc_html( $current_user->membership_level->name ); else esc_html_e("Pending", 'paid-memberships-pro' );?></li>
-			<?php if( !empty( $current_user->membership_level->expiration_period ) && $current_user->membership_level->expiration_period == 'Hour' && apply_filters( 'pmpro_confirmation_display_hour_expiration', true, $current_user ) ){ ?>
-			<li><strong><?php esc_html_e('Expires In', 'paid-memberships-pro' );?>:</strong> <?php echo esc_html( $current_user->membership_level->expiration_number . ' ' . pmpro_translate_billing_period( $current_user->membership_level->expiration_period, $current_user->membership_level->expiration_number ) ); ?></li>
-			<?php }
+		if (  ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+			// If the invoice is not free, show the full invoice, but make sure we don't show $pmpro_msg again.
+			$pmpro_msg = false;
+			$pmpro_msgt = false;
+			echo pmpro_loadTemplate( 'invoice' );
+		} else {
+			// The invoice is free, so we don't need to show a full invoice.
 			?>
-		</ul>
-		<?php
+			<ul>
+				<li><strong><?php esc_html_e('Account', 'paid-memberships-pro' );?>:</strong> <?php echo esc_html( $pmpro_invoice->user->display_name );?> (<?php echo esc_html( $pmpro_invoice->user->user_email );?>)</li>
+				<li><strong><?php esc_html_e('Membership Level', 'paid-memberships-pro' );?>:</strong> <?php if(!empty($pmpro_invoice->membership_level)) echo esc_html( $pmpro_invoice->membership_level->name ); else esc_html_e("Pending", 'paid-memberships-pro' );?></li>
+				<?php if( !empty( $pmpro_invoice->membership_level->expiration_period ) && $pmpro_invoice->membership_level->expiration_period == 'Hour' && apply_filters( 'pmpro_confirmation_display_hour_expiration', true, $pmpro_invoice->user ) ){ ?>
+				<li><strong><?php esc_html_e('Expires In', 'paid-memberships-pro' );?>:</strong> <?php echo esc_html( $pmpro_invoice->membership_level->expiration_number . ' ' . pmpro_translate_billing_period( $pmpro_invoice->membership_level->expiration_period, $pmpro_invoice->membership_level->expiration_number ) ); ?></li>
+				<?php }
+				?>
+			</ul>
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actions_nav' ) ); ?>">
+					<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actions_nav-right' ) ); ?>"><a href="<?php echo esc_url( pmpro_url( 'account' ) ); ?>"><?php esc_html_e( 'View Your Membership Account &rarr;', 'paid-memberships-pro' ); ?></a></span>
+				</div> <!-- end pmpro_actions_nav -->
+			<?php
+		}
+
+		// Show a message about account activation if the invoice is not yet successful.
+		if ( 'success' != $pmpro_invoice->status ) {
+			?>
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_alert' ) ); ?>">
+				<p><?php esc_html_e( 'If your account is not activated within a few minutes, please contact the site owner.', 'paid-memberships-pro' ); ?></p>
+			</div> <!-- pmpro_message -->
+			<?php
+		}
 	}
-
-	// Show a link to the Membership Account page if the user has a membership level and did not have an invoice displayed.
-	if ( ! empty( $current_user->membership_level ) && empty( $confirmation_invoice ) ) { ?>
-		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actions_nav' ) ); ?>">
-			<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actions_nav-right' ) ); ?>"><a href="<?php echo esc_url( pmpro_url( 'account' ) ); ?>"><?php esc_html_e( 'View Your Membership Account &rarr;', 'paid-memberships-pro' ); ?></a></span>
-		</div> <!-- end pmpro_actions_nav -->
-	<?php }
-
-	// Show a message about account activation if the user does not have a membership level.
-	if ( empty( $current_user->membership_level ) ) { ?>
-		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_alert' ) ); ?>">
-			<p><?php esc_html_e( 'If your account is not activated within a few minutes, please contact the site owner.', 'paid-memberships-pro' ); ?></p>
-		</div> <!-- pmpro_message -->
-	<?php } ?>
-
+	?>
 </div> <!-- end pmpro_confirmation_wrap -->

--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -49,7 +49,7 @@ if ( empty( $pmpro_invoice ) ) {
 		}
 
 		// Add some details to the confirmation message about the invoice.
-		if ( pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+		if ( ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
 			$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account and a receipt for your initial membership invoice. A welcome email with a copy of your initial membership invoice has been sent to %s.', 'paid-memberships-pro' ), $pmpro_invoice->user->user_email ) . '</p>';
 		} else {
 			$confirmation_message .= '<p>' . sprintf( __( 'Below are details about your membership account. A welcome email has been sent to %s.', 'paid-memberships-pro' ), $pmpro_invoice->user->user_email ) . '</p>';

--- a/preheaders/confirmation.php
+++ b/preheaders/confirmation.php
@@ -38,16 +38,15 @@ if ( empty( $pmpro_invoice ) || empty( $confirmation_level ) ) {
 $user_level = pmpro_getSpecificMembershipLevelForUser( $current_user->ID, $confirmation_level );
 $current_user->membership_level = $user_level; // Backwards compatibility.
 
+// If the user doesn't have the level they are confirming (including pending checkouts), redirect them to the account page.
 if ( ! in_array( $pmpro_invoice->status, array( 'pending', 'token' ) ) && empty( $user_level ) ) {
-	// The user does not have a membership level (including pending checkouts).
-	// Redirect them to the account page.
 	$redirect_url = pmpro_url( 'account' );
 	wp_redirect( $redirect_url );
 	exit;
-} elseif ( ! empty( $user_level ) && pmpro_isLevelFree( $user_level ) ) {
-	// User checked out for a free level. We are not going to show the invoice on the confirmation page.
-	$pmpro_invoice = null;
-} elseif ( in_array( $pmpro_invoice->status, array( 'pending', 'token' ) ) ) {
+}
+
+// If the payment hasn't completed, enqueue JS to check for completion.
+if ( in_array( $pmpro_invoice->status, array( 'pending', 'token' ) ) ) {
 	// Enqueue PMPro Confirmation script.
 	wp_register_script(
 		'pmpro_confirmation',

--- a/preheaders/confirmation.php
+++ b/preheaders/confirmation.php
@@ -15,7 +15,7 @@ if ( ! is_user_logged_in() ) {
 
 // If there was a level passed, grab it.
 $confirmation_level = ! empty( $_REQUEST['pmpro_level'] ) ? intval( $_REQUEST['pmpro_level'] ) : null;
-$confirmation_level = empty( $confirmation_level ) && ! empty( $_REQUEST['level'] ) ? intval( $_REQUEST['level'] ) : null; // Backwards compatibility.
+$confirmation_level = empty( $confirmation_level ) && ! empty( $_REQUEST['level'] ) ? intval( $_REQUEST['level'] ) : $confirmation_level; // Backwards compatibility.
 
 // Get the corresponding invoice.
 $pmpro_invoice = new MemberOrder();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The main functional change in this PR is that the `$pmpro_invoice` global is no longer being unset during the confirmation preheader if the checkout was free. Instead, free checkouts are accounted for in the logic of the confirmation page itself.

The other changes in the confirmation page template code basically make the template rely solely on the `MemberOrder` passed in via `$pmpro_invoice` instead of pulling information from other sources. This eliminates the need to use the `$current_user` global and grab the membership level for the user separately.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
