### PR TITLE
Deprecating global $pmpro_levels

### DIFF
--- a/adminpages/reports/members-per-level.php
+++ b/adminpages/reports/members-per-level.php
@@ -38,7 +38,8 @@ function pmpro_report_members_per_level_widget() {
 }
 
 function pmpro_report_members_per_level_page() {
-	global $pmpro_levels; ?>
+	$pmpro_levels = pmpro_getAllLevels( true );
+	?>
 	<h1 class="wp-heading-inline">
 		<?php esc_html_e( 'Active Members Per Level', 'paid-memberships-pro' ); ?>
 	</h1>
@@ -77,7 +78,7 @@ function pmpro_report_members_per_level_page() {
 
 // Returns an array of membership level IDs and the count of active members.
 function pmpro_report_get_active_members_per_level() {
-	global $wpdb, $pmpro_levels;
+	global $wpdb;
 
 	// Query to get active members per level.
 	$sqlQuery = "SELECT membership_id, count(*) as total_active_members 
@@ -95,7 +96,7 @@ function pmpro_report_get_active_members_per_level() {
 
 // Draw a pie chart of active members per level.
 function pmpro_report_draw_active_members_per_level_chart() {
-	global $pmpro_levels;
+	$pmpro_levels = pmpro_getAllLevels( true );
 	$cols = array();
 	$active_members = pmpro_report_get_active_members_per_level();
 	if ( ! empty( $active_members ) ) {

--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -25,7 +25,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 	 * @param string $frequency to send emails at. Determines length of time reported.
 	 */
 	public function sendAdminActivity( $frequency = '', $recipient = null ) {
-		global $wpdb, $pmpro_levels;
+		global $wpdb;
 
 		if ( ! in_array( $frequency, array( 'day', 'week', 'month', 'never' ), true ) ) {
 			$frequency = get_option( 'pmpro_activity_email_frequency' );

--- a/includes/compatibility/oxygen-builder.php
+++ b/includes/compatibility/oxygen-builder.php
@@ -6,7 +6,7 @@
  */
 if( function_exists( 'oxygen_vsb_register_condition' ) ) {
 
-    global $pmpro_levels;
+    $pmpro_levels = pmpro_getAllLevels( true );
 
     $oxygen_pmpro_levels = array( '0' => '[0] '.__( 'Non-Members', 'paid-memberships-pro' ) );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2290,6 +2290,8 @@ function pmpro_getLevel( $level ) {
 /**
  * Get all PMPro membership levels.
  *
+ * @since TBD deprecated the second `$use_cache` argument.
+ *
  * @param bool $include_hidden      Include levels marked as hidden/inactive.
  * @param bool $deprecated_argument No longer used.
  * @param bool $force               Resets the static var caches.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2290,11 +2290,12 @@ function pmpro_getLevel( $level ) {
 /**
  * Get all PMPro membership levels.
  *
- * @param bool $include_hidden Include levels marked as hidden/inactive.
- * @param bool $use_cache      If false, use $pmpro_levels global. If true use other caches.
- * @param bool $force          Resets the static var caches as well.
+ * @param bool $include_hidden      Include levels marked as hidden/inactive.
+ * @param bool $deprecated_argument No longer used.
+ * @param bool $force               Resets the static var caches.
  */
-function pmpro_getAllLevels( $include_hidden = false, $use_cache = false, $force = false ) {
+function pmpro_getAllLevels( $include_hidden = false, $deprecated_argument = false, $force = false ) {
+	// The global $pmpro_levels variable is deprecated and should no longer be used, but we'll set it for backwards compatibility.
 	global $pmpro_levels, $wpdb;
 
 	static $pmpro_all_levels;			// every single level
@@ -2306,16 +2307,13 @@ function pmpro_getAllLevels( $include_hidden = false, $use_cache = false, $force
 		$pmpro_visible_levels = NULL;
 	}
 
-	// just use the $pmpro_levels global
-	if ( ! empty( $pmpro_levels ) && ! $use_cache ) {
-		return $pmpro_levels;
-	}
-
 	// If use_cache is true check if we have something in a static var.
 	if ( $include_hidden && isset( $pmpro_all_levels ) ) {
+		$pmpro_levels = $pmpro_all_levels;
 		return $pmpro_all_levels;
 	}
 	if ( ! $include_hidden && isset( $pmpro_visible_levels ) ) {
+		$pmpro_levels = $pmpro_visible_levels;
 		return $pmpro_visible_levels;
 	}
 

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -11,8 +11,10 @@
  * @author Paid Memberships Pro
  */
 
-global $gateway, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $pmpro_requirebilling, $pmpro_level, $pmpro_levels, $tospage, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_default_country;
+global $gateway, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $wpdb, $current_user, $pmpro_msg, $pmpro_msgt, $pmpro_requirebilling, $pmpro_level, $tospage, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_default_country;
 global $discount_code, $username, $password, $password2, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth,$ExpirationYear;
+
+$pmpro_levels = pmpro_getAllLevels();
 
 /**
  * Filter to set if PMPro uses email or text as the type for email field inputs.

--- a/preheaders/account.php
+++ b/preheaders/account.php
@@ -34,3 +34,6 @@ if ( ! empty( $current_user->ID ) && empty( $current_user->membership_level->ID 
 		exit;
 	}
 }
+
+// Preventing conflicts with old account page templates and custom code that depend on the $pmpro_level global being set.
+pmpro_getAllLevels();

--- a/preheaders/account.php
+++ b/preheaders/account.php
@@ -1,5 +1,5 @@
 <?php
-global $current_user, $pmpro_msg, $pmpro_msgt, $pmpro_levels, $pmpro_pages;
+global $current_user, $pmpro_msg, $pmpro_msgt, $pmpro_pages;
 
 // Redirect to login.
 if ( ! is_user_logged_in() ) {
@@ -34,8 +34,3 @@ if ( ! empty( $current_user->ID ) && empty( $current_user->membership_level->ID 
 		exit;
 	}
 }
-
-/**
- * Add-Ons might need this global to be set.
- */
-$pmpro_levels = pmpro_getAllLevels();

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -815,6 +815,9 @@ if ( empty( $submit ) ) {
 	}
 }
 
+// Preventing conflicts with old checkout templates that depend on the $pmpro_level global being set.
+pmpro_getAllLevels();
+
 /**
  * Hook to run actions after the checkout preheader is loaded.
  * @since 2.1

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -1,5 +1,5 @@
 <?php
-global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_levels, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user;
+global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user;
 
 // we are on the checkout page
 add_filter( 'pmpro_is_checkout', '__return_true' );
@@ -87,10 +87,6 @@ if ( ! $besecure && ! empty( $_REQUEST['submit-checkout'] ) && is_ssl() ) {
 
 //action to run extra code for gateways/etc
 do_action( 'pmpro_checkout_preheader' );
-
-//get all levels in case we need them
-global $pmpro_levels;
-$pmpro_levels = pmpro_getAllLevels();
 
 // We set a global var for add-ons that are expecting it.
 $pmpro_show_discount_code = pmpro_show_discount_code();

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -4,7 +4,7 @@
 */
 function pmpro_shortcode_account($atts, $content=null, $code="")
 {
-	global $wpdb, $pmpro_msg, $pmpro_msgt, $pmpro_levels, $current_user, $levels;
+	global $wpdb, $pmpro_msg, $pmpro_msgt, $current_user, $levels;
 
 	// $atts    ::= array of attributes
 	// $content ::= text within enclosing form of shortcode element
@@ -35,7 +35,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 	add_filter( 'pmpro_disable_admin_membership_access', '__return_true', 15 ); // We want to show the actual levels for admins.
 	$mylevels = pmpro_getMembershipLevelsForUser();
 	remove_filter( 'pmpro_disable_admin_membership_access', '__return_true', 15 ); // Remove the filter so we don't mess up other stuff.
-	$pmpro_levels = pmpro_getAllLevels(false, true); // just to be sure - include only the ones that allow signups
+	$pmpro_levels = pmpro_getAllLevels(); // just to be sure - include only the ones that allow signups
 	$invoices = $wpdb->get_results("SELECT *, UNIX_TIMESTAMP(CONVERT_TZ(timestamp, '+00:00', @@global.time_zone)) as timestamp FROM $wpdb->pmpro_membership_orders WHERE user_id = '$current_user->ID' AND status NOT IN('review', 'token', 'error') ORDER BY timestamp DESC LIMIT 6");
 	?>
 	<div id="pmpro_account">

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -4,7 +4,7 @@
 */
 function pmpro_shortcode_account($atts, $content=null, $code="")
 {
-	global $wpdb, $pmpro_msg, $pmpro_msgt, $current_user, $levels;
+	global $wpdb, $current_user;
 
 	// $atts    ::= array of attributes
 	// $content ::= text within enclosing form of shortcode element


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Removing uses of the `$pmpro_levels` global besides for those needed for backwards compatibility. The `pmpro_getAllLevels()` function should be used instead.

Deprecating that global also allows simplifying the arguments for the `pmpro_getAllLevels()` function as the second `$use_cache` argument was unclear.

Looking at our Add Ons, it does not any use the `$pmpro_levels` global without setting it using `pmpro_getAllLevels()`, so backwards compatibility with our Add Ons should not be an issue. The following regex can be used to find all instances of the global being defined: `^(?=.*\bglobal\b)(?=.*\$pmpro_levels).*`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
