### PR TITLE
Cancelled Subscriptions now in a toggle box that defaults to collapsed

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
@@ -133,110 +133,118 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 		// Show cancelled subscriptions for the user.
 		$cancelled_subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user->ID, null, array( 'cancelled' ) );
 
-		if ( $cancelled_subscriptions ) {
-			// Optionally wrap table in scrollable box.
-			$subscriptions_classes = array();
-			if ( ! empty( $cancelled_subscriptions ) && count( $cancelled_subscriptions ) > 10 ) {
-				$subscriptions_classes[] = "pmpro_scrollable";
-			}
-			$subscriptions_class = implode( ' ', array_unique( $subscriptions_classes ) );
-			?>
-			<h3>
-				<?php
-					printf(
-						esc_html__( 'Cancelled Subscriptions (%d)', 'paid-memberships-pro' ),
-						number_format_i18n( count( $cancelled_subscriptions ) )
-					);
-				?>
-			</h3>
-			<div id="member-history-subscriptions" class="<?php echo esc_attr( $subscriptions_class ); ?>">
-				<table class="wp-list-table widefat striped fixed" width="100%" cellpadding="0" cellspacing="0" border="0">
-					<thead>
-						<tr>
-							<th><?php esc_html_e( 'Level', 'paid-memberships-pro' ); ?></th>
-							<th><?php esc_html_e( 'Created', 'paid-memberships-pro' ); ?></th>
-							<th><?php esc_html_e( 'Ended', 'paid-memberships-pro' ); ?></th>
-							<th><?php esc_html_e( 'Orders', 'paid-memberships-pro' ); ?></th>
-						</tr>
-					</thead>
-					<tbody>
+		if ( $cancelled_subscriptions ) { ?>
+		<div class="pmpro_section" data-visibility="hidden" data-activated="false">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="false">
+					<span class="dashicons dashicons-arrow-down-alt2"></span>
 					<?php
-						foreach ( $cancelled_subscriptions as $cancelled_subscription ) {
-							$level = pmpro_getLevel( $cancelled_subscription->get_membership_level_id() );
-							?>
+						printf(
+							esc_html__( 'Cancelled Subscriptions (%d)', 'paid-memberships-pro' ),
+							number_format_i18n( count( $cancelled_subscriptions ) )
+						);
+					?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside" style="display: none;">
+			<?php
+				// Optionally wrap table in scrollable box.
+				$subscriptions_classes = array();
+				if ( ! empty( $cancelled_subscriptions ) && count( $cancelled_subscriptions ) > 10 ) {
+					$subscriptions_classes[] = "pmpro_scrollable";
+				}
+				$subscriptions_class = implode( ' ', array_unique( $subscriptions_classes ) );
+				?>
+				<div id="member-history-subscriptions" class="<?php echo esc_attr( $subscriptions_class ); ?>">
+					<table class="wp-list-table widefat striped fixed" width="100%" cellpadding="0" cellspacing="0" border="0">
+						<thead>
 							<tr>
-								<td>
-									<?php if ( ! empty( $level ) ) {
-										echo esc_html( $level->name );
-									} elseif ( $cancelled_subscription->get_membership_level_id() > 0 ) {
-										echo '['. esc_html( 'deleted', 'paid-memberships-pro' ).']';
-									} else {
-										esc_html_e( '&#8212;', 'paid-memberships-pro' );
-									}
-									?>
-									<div class="row-actions">
-										<?php
-											$actions = [
-												'view'   => sprintf(
-													'<a href="%1$s">%2$s</a>',
-													esc_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $cancelled_subscription->get_id() ), admin_url('admin.php' ) ) ),
-													esc_html__( 'View Details', 'paid-memberships-pro' )
-												)
-											];
-
-											$actions_html = [];
-
-											foreach ( $actions as $action => $link ) {
-												$actions_html[] = sprintf(
-													'<span class="%1$s">%2$s</span>',
-													esc_attr( $action ),
-													$link
-												);
-											}
-
-											if ( ! empty( $actions_html ) ) {
-												echo implode( ' | ', $actions_html );
-											}
+								<th><?php esc_html_e( 'Level', 'paid-memberships-pro' ); ?></th>
+								<th><?php esc_html_e( 'Created', 'paid-memberships-pro' ); ?></th>
+								<th><?php esc_html_e( 'Ended', 'paid-memberships-pro' ); ?></th>
+								<th><?php esc_html_e( 'Orders', 'paid-memberships-pro' ); ?></th>
+							</tr>
+						</thead>
+						<tbody>
+						<?php
+							foreach ( $cancelled_subscriptions as $cancelled_subscription ) {
+								$level = pmpro_getLevel( $cancelled_subscription->get_membership_level_id() );
+								?>
+								<tr>
+									<td>
+										<?php if ( ! empty( $level ) ) {
+											echo esc_html( $level->name );
+										} elseif ( $cancelled_subscription->get_membership_level_id() > 0 ) {
+											echo '['. esc_html( 'deleted', 'paid-memberships-pro' ).']';
+										} else {
+											esc_html_e( '&#8212;', 'paid-memberships-pro' );
+										}
 										?>
-									</div>
-								</td>
-								<td>
-									<?php
-										echo esc_html( sprintf(
-											// translators: %1$s is the date and %2$s is the time.
-											__( '%1$s at %2$s', 'paid-memberships-pro' ),
-											esc_html( $cancelled_subscription->get_startdate( get_option( 'date_format' ) ) ),
-											esc_html( $cancelled_subscription->get_startdate( get_option( 'time_format' ) ) )
-										) );
-									?>
-								</td>
-								<td>
-									<?php 
-										echo ! empty( $cancelled_subscription->get_enddate() ) 
-											? esc_html( sprintf(
+										<div class="row-actions">
+											<?php
+												$actions = [
+													'view'   => sprintf(
+														'<a href="%1$s">%2$s</a>',
+														esc_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $cancelled_subscription->get_id() ), admin_url('admin.php' ) ) ),
+														esc_html__( 'View Details', 'paid-memberships-pro' )
+													)
+												];
+
+												$actions_html = [];
+
+												foreach ( $actions as $action => $link ) {
+													$actions_html[] = sprintf(
+														'<span class="%1$s">%2$s</span>',
+														esc_attr( $action ),
+														$link
+													);
+												}
+
+												if ( ! empty( $actions_html ) ) {
+													echo implode( ' | ', $actions_html );
+												}
+											?>
+										</div>
+									</td>
+									<td>
+										<?php
+											echo esc_html( sprintf(
 												// translators: %1$s is the date and %2$s is the time.
 												__( '%1$s at %2$s', 'paid-memberships-pro' ),
-												esc_html( $cancelled_subscription->get_enddate( get_option( 'date_format' ) ) ),
-												esc_html( $cancelled_subscription->get_enddate( get_option( 'time_format' ) ) )
-											) )
-											: '&#8212;';
-									?>
-								</td>
-								<td>
-									<?php
-									// Display the number of orders for this subscription and link to the orders page filtered by this subscription.
-									$orders_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE subscription_transaction_id = %s", $cancelled_subscription->get_subscription_transaction_id() ) );
-									?>
-									<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 's' => $cancelled_subscription->get_subscription_transaction_id() ), admin_url( 'admin.php' ) ) ); ?>"><?php echo esc_html( number_format_i18n( $orders_count ) ); ?></a>
-								</td>
-							</tr>
-							<?php
-						}
-					?>
-					</tbody>
-				</table>
-			</div>
-			<?php
+												esc_html( $cancelled_subscription->get_startdate( get_option( 'date_format' ) ) ),
+												esc_html( $cancelled_subscription->get_startdate( get_option( 'time_format' ) ) )
+											) );
+										?>
+									</td>
+									<td>
+										<?php 
+											echo ! empty( $cancelled_subscription->get_enddate() ) 
+												? esc_html( sprintf(
+													// translators: %1$s is the date and %2$s is the time.
+													__( '%1$s at %2$s', 'paid-memberships-pro' ),
+													esc_html( $cancelled_subscription->get_enddate( get_option( 'date_format' ) ) ),
+													esc_html( $cancelled_subscription->get_enddate( get_option( 'time_format' ) ) )
+												) )
+												: '&#8212;';
+										?>
+									</td>
+									<td>
+										<?php
+										// Display the number of orders for this subscription and link to the orders page filtered by this subscription.
+										$orders_count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->pmpro_membership_orders WHERE subscription_transaction_id = %s", $cancelled_subscription->get_subscription_transaction_id() ) );
+										?>
+										<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 's' => $cancelled_subscription->get_subscription_transaction_id() ), admin_url( 'admin.php' ) ) ); ?>"><?php echo esc_html( number_format_i18n( $orders_count ) ); ?></a>
+									</td>
+								</tr>
+								<?php
+							}
+						?>
+						</tbody>
+					</table>
+				</div>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end pmpro_section -->
+		<?php
 		}
 		// Show a message if there are no active or cancelled subscriptions.
 		if ( empty( $active_subscriptions ) && empty( $cancelled_subscriptions ) ) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -1027,7 +1027,7 @@ body[class*="memberships_page_pmpro-"] {
 	cursor: not-allowed;	
 }
 
-.pmpro_admin-pmpro-member .pmpro_section {
+.pmpro_admin-pmpro-member .pmpro_section:not(.pmpro_admin-pmpro-member .pmpro_section .pmpro_section) {
 	margin: 0;
 	padding: calc( var(--pmpro--spacing--medium) / 2 ) var(--pmpro--spacing--medium);
 }
@@ -1133,6 +1133,25 @@ body[class*="memberships_page_pmpro-"] {
 	display: flex;
 	flex-direction: row;
 	gap: calc( var(--pmpro--spacing--medium) / 2 );
+}
+
+/* Single Member - Subscriptions Panel */
+.pmpro_admin-pmpro-member #pmpro-member-edit-subscriptions-panel .pmpro_section .pmpro_section_inside {
+	padding: 0;
+}
+
+.pmpro_admin-pmpro-member #member-history-subscriptions table.widefat {
+	border: none;
+	border-radius: 0;
+}
+
+.pmpro_admin-pmpro-member #member-history-subscriptions table.widefat thead th:first-child,
+.pmpro_admin-pmpro-member #member-history-subscriptions table.widefat thead th:last-child {
+	border-radius: 0;
+}
+
+.pmpro_admin-pmpro-member #member-history-subscriptions table.widefat thead th {
+	border-top: none;
 }
 
 /* Single Member - Orders Panel */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This change puts the "Cancelled subscriptions" in a toggle box so it isn't taking up real estate or distracting for the active subs.

This still uses the scrollable box, but in the future we may consider pagination, ajax search/filters, or an ajax-based "load more".

![Screenshot 2023-11-17 at 12 58 53 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/3406cb8e-fd46-4a6a-9662-cfdd8ed1f2c9)


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
