### PR TITLE
Making membership a select2 when editing order

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -426,11 +426,33 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 							<td>
 								<?php
 									if ( in_array( 'membership_id', $read_only_fields ) && $order_id > 0 ) {
-									echo esc_html( $order->membership_id );
-									} else { 
+										echo esc_html( $order->membership_id );
+									} else {
+										// Get the order's current membership level ID.
 										$membership_id = ! empty( $_REQUEST['membership_id'] ) ? intval( $_REQUEST['membership_id'] ) : $order->membership_id;
+
+										// Get all membership levels.
+										$levels = pmpro_getAllLevels( true, true );
+
 										?>
-										<input id="membership_id" name="membership_id" type="text" value="<?php echo esc_attr( $membership_id ); ?>" size="10" />
+										<select id="membership_id" name="membership_id">
+											<option value="0" <?php selected( $membership_id, 0 ); ?>>-- <?php _e("None", 'paid-memberships-pro' );?> --</option>
+											<?php
+											// If the current membership level is not in the list, add it as "Deleted level #[membership_id]".
+											if ( ! empty( $membership_id ) && ! in_array( $membership_id, wp_list_pluck( $levels, 'id' ) ) ) {
+												?>
+												<option value="<?php echo esc_attr( $membership_id ); ?>" selected><?php echo esc_html( sprintf( __( 'Deleted level #%d', 'paid-memberships-pro' ), $membership_id ) ); ?></option>
+												<?php
+											}
+
+											// Add the rest of the levels.
+											foreach ( $levels as $level ) {
+												?>
+												<option value="<?php echo esc_attr( $level->id ); ?>" <?php selected( $membership_id, $level->id ); ?>><?php echo esc_html( $level->name ); ?></option>
+												<?php
+											}
+											?>
+										</select>
 										<?php
 									}
 								?>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -438,10 +438,10 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 										<select id="membership_id" name="membership_id">
 											<option value="0" <?php selected( $membership_id, 0 ); ?>>-- <?php _e("None", 'paid-memberships-pro' );?> --</option>
 											<?php
-											// If the current membership level is not in the list, add it as "Deleted level #[membership_id]".
+											// If the current membership level is not in the list, add it as "ID {membership_id} [deleted]".
 											if ( ! empty( $membership_id ) && ! in_array( $membership_id, wp_list_pluck( $levels, 'id' ) ) ) {
 												?>
-												<option value="<?php echo esc_attr( $membership_id ); ?>" selected><?php echo esc_html( sprintf( __( 'Deleted level #%d', 'paid-memberships-pro' ), $membership_id ) ); ?></option>
+												<option value="<?php echo esc_attr( $membership_id ); ?>" selected><?php echo esc_html( sprintf( __( 'ID %d [deleted]', 'paid-memberships-pro' ), $membership_id ) ); ?></option>
 												<?php
 											}
 

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -1006,3 +1006,10 @@ function pmpro_changeTabs( e, inputChanged ) {
 
 	return true;
 }
+
+/**
+ * Edit Order Page
+ */
+jQuery(document).ready(function () {
+    jQuery('.pmpro_admin-pmpro-orders select#membership_id').select2();
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When editing a level, the option to choose a membership level is now a select2.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
