### PR TITLE
Only show User Fields Group panels if there is a User ID to check

### DIFF
--- a/adminpages/member-edit.php
+++ b/adminpages/member-edit.php
@@ -23,10 +23,13 @@ function pmpro_member_edit_get_panels() {
 	$panels[] = new PMPro_Member_Edit_Panel_Other();
 
 	// Add user fields panels.
-	$profile_user_fields = pmpro_get_user_fields_for_profile( PMPro_Member_Edit_Panel::get_user()->ID, true );
-	if ( ! empty( $profile_user_fields ) ) {
-		foreach ( $profile_user_fields as $group_name => $user_fields ) {
-			$panels[] = new PMPro_Member_Edit_Panel_User_Fields( $group_name );
+	$user_id = PMPro_Member_Edit_Panel::get_user()->ID;
+	if ( $user_id ) {
+		$profile_user_fields = pmpro_get_user_fields_for_profile( $user_id, true );
+		if ( ! empty( $profile_user_fields ) ) {
+			foreach ( $profile_user_fields as $group_name => $user_fields ) {
+				$panels[] = new PMPro_Member_Edit_Panel_User_Fields( $group_name );
+			}
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This change will only show the User Field groups on the Edit Member screen once there is a true User ID to check field groups for.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
