### PR TITLE
Hide popup if outside the popup is clicked.

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -793,7 +793,6 @@ jQuery(document).ready(function () {
 
     // Hide the popup if clicked outside the popup.
     jQuery(document).on('click', function (e) {
-        e.preventDefault();
         // Check if the clicked element is the close button or outside the pmpro-popup-wrap
         if ( jQuery(e.target).closest('.pmpro-popup-wrap').length === 0 ) {
             jQuery('.pmpro-popup-overlay').hide();

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -87,6 +87,14 @@ function pmpro_admin_prep_click_events() {
     });
 }
 
+// Hide the popup if clicked outside the popup.
+jQuery(document).on('click', function (e) {
+    // Check if the clicked element is the close button or outside the pmpro-popup-wrap
+    if ( jQuery(e.target).closest('.pmpro-popup-wrap').length === 0 ) {
+        jQuery('.pmpro-popup-overlay').hide();
+    }
+});
+
 /** JQuery to hide the notifications. */
 jQuery(document).ready(function () {
     jQuery(document).on('click', '.pmpro-notice-button.notice-dismiss', function () {
@@ -789,14 +797,6 @@ jQuery(document).ready(function () {
     jQuery('.pmproPopupCloseButton').click(function (e) {
         e.preventDefault();
         jQuery('.pmpro-popup-overlay').hide();
-    });
-
-    // Hide the popup if clicked outside the popup.
-    jQuery(document).on('click', function (e) {
-        // Check if the clicked element is the close button or outside the pmpro-popup-wrap
-        if ( jQuery(e.target).closest('.pmpro-popup-wrap').length === 0 ) {
-            jQuery('.pmpro-popup-overlay').hide();
-        }
     });
 
     // Hide the popup banner if "ESC" is pressed.

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -791,6 +791,15 @@ jQuery(document).ready(function () {
         jQuery('.pmpro-popup-overlay').hide();
     });
 
+    // Hide the popup if clicked outside the popup.
+    jQuery(document).on('click', function (e) {
+        e.preventDefault();
+        // Check if the clicked element is the close button or outside the pmpro-popup-wrap
+        if ( jQuery(e.target).closest('.pmpro-popup-wrap').length === 0 ) {
+            jQuery('.pmpro-popup-overlay').hide();
+        }
+    });
+
     // Hide the popup banner if "ESC" is pressed.
     jQuery(document).keyup(function (e) {
         if (e.key === 'Escape') {


### PR DESCRIPTION
* ENHANCEMENT: Added functionality to close popup notifications if clicked outside of the modal.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/paid-memberships-pro/issues/2682.

### How to test the changes in this Pull Request:

1. Connect to Stripe Connect, see the popup.
2. Click inside the modal to ensure it still works for copying/pasting. Should not close in this instance.
3. Click anywhere on the screen outside the modal/popup to close it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
