### PR TITLE
Change “Pay with Credit Card” Text on Billing Page

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -964,17 +964,9 @@ class PMProGateway_stripe extends PMProGateway {
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_checkout-field pmpro_checkout-field-payment-request-button', 'pmpro_checkout-field-payment-request-button' ) ); ?>">
 					<div id="payment-request-button"><!-- Alternate payment method will be inserted here. --></div>
 					<h4 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_checkout-field pmpro_payment-credit-card', 'pmpro_payment-credit-card' ) ); ?>">
-					<?php
-						$current_page_id = get_the_ID();
-						$billing_page_id = (int) pmpro_getOption("billing_page_id");
-
-						// if it's checkout page then the label should be Pay With Credit Card but if it's billing page this should show Update your Payment Information
-						if( $current_page_id === $billing_page_id ){
-							esc_html_e( 'Update your Payment Information', 'paid-memberships-pro' );
-						}else{
-							esc_html_e( 'Pay with Credit Card', 'paid-memberships-pro' );
-						}						
-					?>
+						<?php
+						echo esc_html( pmpro_is_checkout() ? __( 'Pay with Credit Card', 'paid-memberships-pro' ) : __( 'Credit Card', 'paid-memberships-pro' ) );					
+						?>
 					</h4>
 				</div>
 				<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I have added a condition so that on the billing page, the text "Pay with Credit Card" has been changed to "Update your Payment Information."
Resolves #2244 

### How to test the changes in this Pull Request:

1. Go to the Membership Billing page and you can see the "Pay with Credit Card" text has been updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
