### PR TITLE
Add Member (User info tab) Updates

### DIFF
--- a/adminpages/member-edit.php
+++ b/adminpages/member-edit.php
@@ -57,7 +57,7 @@ function pmpro_member_edit_get_panels() {
  * @since TBD
  */
 function pmpro_member_edit_display() {
-	global $current_user, $pmpro_msg, $pmpro_msgt, $pmpro_error_fields;
+	global $current_user;
 
 	// Get the user that we are editing.
 	$user = PMPro_Member_Edit_Panel::get_user();

--- a/adminpages/member-edit.php
+++ b/adminpages/member-edit.php
@@ -57,7 +57,7 @@ function pmpro_member_edit_get_panels() {
  * @since TBD
  */
 function pmpro_member_edit_display() {
-	global $current_user, $pmpro_msg, $pmpro_msgt;
+	global $current_user, $pmpro_msg, $pmpro_msgt, $pmpro_error_fields;
 
 	// Get the user that we are editing.
 	$user = PMPro_Member_Edit_Panel::get_user();
@@ -92,19 +92,7 @@ function pmpro_member_edit_display() {
 		?>
 	</h1>
 
-	<?php
-		if ( $pmpro_msg ) {
-			?>
-			<div role="alert" id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">
-				<?php echo wp_kses_post( $pmpro_msg ); ?>
-			</div>
-			<?php
-		} else {
-			?>
-			<div id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message' ) ); ?>" style="display: none;"></div>
-			<?php
-		}
-	?>
+	<?php pmpro_showMessage(); ?>
 
 	<div id="pmpro-edit-user-div">
 		<nav id="pmpro-edit-user-nav" role="tablist" aria-labelledby="pmpro-edit-user-menu">

--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -88,7 +88,7 @@ abstract class PMPro_Member_Edit_Panel {
 				if ( ! empty( $this->submit_text ) ) {
 					?>
 					<p class="submit">
-						<input type="submit" name="submit" class="button button-primary" value="<?php echo esc_attr( $this->submit_text ); ?>">
+						<input id="submit" type="submit" name="submit" class="button button-primary" value="<?php echo esc_attr( $this->submit_text ); ?>">
 					</p>
 					<?php
 				}

--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -45,7 +45,7 @@ abstract class PMPro_Member_Edit_Panel {
 			aria-selected="<?php echo $is_selected ? 'true' : 'false' ?>"
 			aria-controls="pmpro-member-edit-<?php echo esc_attr( $this->slug ) ?>-panel"
 			id="pmpro-member-edit-<?php echo esc_attr( $this->slug ) ?>-tab"
-			<?php echo ( empty( self::get_user()->ID ) ) ? 'disabled="disabled"' : ''; ?>
+			<?php echo ( empty( self::get_user()->ID ) && $this->slug != 'user_info'  ) ? 'disabled="disabled"' : ''; ?>
 			tabindex="<?php echo ( $is_selected ) ? '0' : '-1' ?>"
 		>
 			<?php

--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -86,9 +86,12 @@ abstract class PMPro_Member_Edit_Panel {
 
 				// Display the submit button.
 				if ( ! empty( $this->submit_text ) ) {
+					// If this is the selected panel, set the submit button ID.
+					// Needed for the 'user-profile' script on the user info panel when creating a new user.
+					$submit_id = $is_selected ? 'submit' : ''; 
 					?>
 					<p class="submit">
-						<input id="submit" type="submit" name="submit" class="button button-primary" value="<?php echo esc_attr( $this->submit_text ); ?>">
+						<input id="<?php echo esc_attr( $submit_id ); ?>" type="submit" name="submit" class="button button-primary" value="<?php echo esc_attr( $this->submit_text ); ?>">
 					</p>
 					<?php
 				}

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -7,7 +7,7 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 	public function __construct() {
 		$user = self::get_user();
 		$this->slug = 'user_info';
-		$this->title = __( 'User Info', 'paid-memberships-pro' );
+		$this->title = empty( $user->ID ) ? __( 'Add New User', 'paid-memberships-pro' ) : __( 'User Info', 'paid-memberships-pro' );
 		$this->title_link = empty( $user->ID ) ? '' : '<a href="' . esc_url( add_query_arg( array( 'user_id' => intval( $user->ID ) ), admin_url( 'user-edit.php' ) ) ) . '" target="_blank" class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users">' . esc_html__( 'Edit User', 'paid-memberships-pro' ) . '</a>';
 		$this->submit_text = empty( $user->ID ) ? __( 'Create User ') : __( 'Update User Info', 'paid-memberships-pro' );
 	}
@@ -17,6 +17,7 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 	 */
 	protected function display_panel_contents() {
 		// Populate values from form.
+		// TO DO: Is it strange that we populate these from the form then override with the $user object immediately after?
 		$user_login = ! empty( $_POST['user_login'] ) ? sanitize_user( $_POST['user_login'] ) : '';
 		$user_email = ! empty( $_POST['email'] ) ? stripslashes( sanitize_email( $_POST['email'] ) ) : '';
 		$first_name = ! empty( $_POST['first_name'] ) ? stripslashes( sanitize_text_field( $_POST['first_name'] ) ): '';
@@ -27,7 +28,7 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 		// If we are edting a user, get the user information.
 		$user = self::get_user();
 		if ( ! empty( $user->ID ) ) {
-			$user_login = $user->user_login;
+			$user_login = empty( $user_login ) ? $user->user_login : $user_login;
 			$user_email = $user->user_email;
 			$first_name = $user->first_name;
 			$last_name = $user->last_name;
@@ -53,7 +54,7 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 					</label>
 				</th>
 				<td>
-					<input type="text" name="user_login" id="user_login" autocapitalize="none" autocorrect="off" autocomplete="off" required <?php if ( ! empty( $_REQUEST['user_id'] ) ) { ?>disabled="disabled"<?php } ?> value="<?php echo esc_attr( $user_login ) ?>">
+					<input type="text" name="user_login" id="user_login" autocapitalize="none" autocorrect="off" autocomplete="off" required <?php $user->ID ?'disabled="disabled"' : ''; ?> value="<?php echo esc_attr( $user_login ) ?>">
 					<?php if ( $user->ID ) { ?>
 						<p class="description"><?php esc_html_e( 'Usernames cannot be changed.', 'paid-memberships-pro' ); ?></p>
 					<?php } ?>
@@ -108,10 +109,10 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 					</td>
 				</tr>
 				<tr class="form-field">
-					<th scope="row"><label for="send_password"><?php esc_html_e( 'Send User Notification', 'paid-memberships-pro' ); ?></label></th>
+					<th scope="row"><label for="send_user_notification"><?php esc_html_e( 'Send User Notification', 'paid-memberships-pro' ); ?></label></th>
 					<td>
-						<input type="checkbox" name="send_password" id="send_password">
-						<label for="send_password"><?php esc_html_e( 'Send the new user an email about their account.', 'paid-memberships-pro' ); ?></label>
+						<input type="checkbox" name="send_user_notification" id="send_user_notification">
+						<label for="send_user_notification"><?php esc_html_e( 'Send the new user an email about their account.', 'paid-memberships-pro' ); ?></label>
 						<p class="description"><?php esc_html_e( 'This will send the user an email with their username and a link to reset their password. For security reasons, this email does not include the unencrypted password.', 'paid-memberships-pro' ); ?></p>
 					</td>
 				</tr>
@@ -159,127 +160,156 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 	public function save() {
 		global $wpdb, $pmpro_msgt, $pmpro_msg;
 
+		// Get all roles for the site.
+		$wp_roles = wp_roles();
+
+		// Get the user we are editing or set up a new blank user.
 		$user = self::get_user();
+		$update = $user->ID ? true : false;
 
-		// Populate values from form.
-		$user_login = ! empty( $_POST['user_login'] ) ? sanitize_user( $_POST['user_login'] ) : $user->user_login;
-		$user_email = ! empty( $_POST['email'] ) ? stripslashes( sanitize_email( $_POST['email'] ) ) : '';
-		$first_name = ! empty( $_POST['first_name'] ) ? stripslashes( sanitize_text_field( $_POST['first_name'] ) ): '';
-		$last_name = ! empty( $_POST['last_name'] ) ? stripslashes( sanitize_text_field( $_POST['last_name'] ) ) : '';	
-		$role = ! empty( $_POST['role'] ) ? sanitize_text_field( $_POST['role'] ) : get_option( 'default_role' );
-		$user_notes = ! empty( $_POST['user_notes'] ) ? stripslashes( sanitize_textarea_field( $_POST['user_notes'] ) ) : '';
+		if ( ! $update && isset( $_POST['user_login'] ) ) {
+			$user->user_login = sanitize_user( wp_unslash( $_POST['user_login'] ), true );
+		}
 
-		// Update the email address in signups, if present.
-		// Alterred from wp-admin/user-edit.php.
-		if ( is_multisite() ) {
-			$user = get_userdata( $user->ID );
+		$pass1 = '';
+		if ( isset( $_POST['pass1'] ) ) {
+			$pass1 = trim( $_POST['pass1'] );
+		}
 
-			if ( $user->user_login && isset( $_POST['email'] ) && is_email( $_POST['email'] ) && $wpdb->get_var( $wpdb->prepare( "SELECT user_login FROM {$wpdb->signups} WHERE user_login = %s", $user->user_login ) ) ) {
-				$wpdb->query( $wpdb->prepare( "UPDATE {$wpdb->signups} SET user_email = %s WHERE user_login = %s", $_POST['email'], $user_login ) );
+		if ( isset( $_POST['role'] ) && current_user_can( 'promote_users' ) && ( ! $user->ID || current_user_can( 'promote_user', $user->ID ) ) ) {
+			$new_role = sanitize_text_field( $_POST['role'] );
+
+			// If the new role isn't editable by the logged-in user die with error.
+			$editable_roles = get_editable_roles();
+			if ( ! empty( $new_role ) && empty( $editable_roles[ $new_role ] ) ) {
+				wp_die( __( 'Sorry, you are not allowed to give users that role.', 'paid-memberships-pro' ), 403 );
+			}
+
+			$potential_role = isset( $wp_roles->role_objects[ $new_role ] ) ? $wp_roles->role_objects[ $new_role ] : false;
+
+			/*
+			 * Don't let anyone with 'promote_users' edit their own role to something without it.
+			 * Multisite super admins can freely edit their roles, they possess all caps.
+			 */
+			if (
+				( is_multisite() && current_user_can( 'manage_network_users' ) ) ||
+				get_current_user_id() !== $user->ID ||
+				( $potential_role && $potential_role->has_cap( 'promote_users' ) )
+			) {
+				$user->role = $new_role;
 			}
 		}
-		
-		// check for required fields
-		$pmpro_required_user_fields = apply_filters(
-			'pmpro_required_user_fields', array(
-				'user_login' => $user_login,
-				'user_email' => $user_email,
-			)
-		);
-		$pmpro_error_fields = array();
-		foreach ( $pmpro_required_user_fields as $key => $value ) {
-			if ( empty( $value ) ) {
-				$pmpro_error_fields[] = $key;
-			}
+
+		if ( isset( $_POST['email'] ) ) {
+			$user->user_email = sanitize_text_field( wp_unslash( $_POST['email'] ) );
+		}
+		if ( isset( $_POST['first_name'] ) ) {
+			$user->first_name = sanitize_text_field( $_POST['first_name'] );
+		}
+		if ( isset( $_POST['last_name'] ) ) {
+			$user->last_name = sanitize_text_field( $_POST['last_name'] );
 		}
 
-		if ( ! empty( $pmpro_error_fields ) ) {
-			pmpro_setMessage( __( 'Please fill out all required fields:', 'paid-memberships-pro' ) . ' ' . implode( ', ', $pmpro_error_fields ), 'pmpro_error' );
+		// Build the array of potential error messages and error fields.
+		$errors = array();
+
+		/* checking that username has been typed */
+		if ( '' === $user->user_login ) {
+			$errors['user_login'] = __( 'Please enter a username.', 'paid-memberships-pro' );
 		}
 
-		// Check that the email and username are available.
-		$ouser      = get_user_by( 'login', $user_login );
-		$oldem_user = get_user_by( 'email', $user_email );
-
-		/**
-		 * This hook can be used to allow multiple accounts with the same email address.
-		 * This is also set in preheaders/checkout.php
-		 * @todo Abstract to a function so we only have one filter.
-		 * Return null to allow duplicate users with the same email.
-		 */
-		$oldemail = apply_filters( "pmpro_checkout_oldemail", ( false !== $oldem_user ? $oldem_user->user_email : null ) );
-
-		if ( ! empty( $ouser->user_login ) && $ouser->id !== $user->ID ) {
-			pmpro_setMessage( __( "That username is already taken. Please try another.", 'paid-memberships-pro' ), "pmpro_error" );
-			$pmpro_error_fields[] = "username";
+		// Check for blank password when adding a user.
+		if ( ! $update && empty( $pass1 ) ) {
+			$errors['pass1'] = __( 'Please enter a password.', 'paid-memberships-pro' );
 		}
 
-		if ( ! empty( $oldemail ) && $oldem_user->id !== $user->ID ) {
-			pmpro_setMessage( __( "That email address is already in use. Please log in, or use a different email address.", 'paid-memberships-pro' ), "pmpro_error" );
-			$pmpro_error_fields[] = "bemail";
-			$pmpro_error_fields[] = "bconfirmemail";
+		// Check for "\" in password.
+		if ( str_contains( wp_unslash( $pass1 ), '\\' ) ) {
+			$errors['pass1'] = __( 'Passwords may not contain the character "\\".', 'paid-memberships-pro' );
 		}
 
-		// okay so far?
+		if ( ! empty( $pass1 ) ) {
+			$user->user_pass = $pass1;
+		}
 
-		if ( $pmpro_msgt != 'pmpro_error' ) {
-			// User data.
-			$user_to_post = array( 
-				'ID' => self::get_user()->ID,
-				'user_login' => $user_login,
-				'user_email' => $user_email,
-				'first_name' => $first_name,
-				'last_name' => $last_name,
+		if ( ! $update && isset( $_POST['user_login'] ) && ! validate_username( $_POST['user_login'] ) ) {
+			$errors['user_login'] = __( 'This username is invalid because it uses illegal characters. Please enter a valid username.', 'paid-memberships-pro' );
+		}
+
+		if ( ! $update && username_exists( $user->user_login ) ) {
+			$errors['user_found'] = sprintf(
+				__('A user with username %1$s already exists. <a href="%2$s">Click here to edit this member</a>.', 'paid-memberships-pro'),
+				esc_html( $user->user_login ),
+				esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => username_exists( $user->user_login ) ), admin_url( 'admin.php' ) ) )
 			);
-
-			// Set the role if the current user has permission.
-			if ( ! IS_PROFILE_PAGE && current_user_can( 'promote_user', $user->ID ) ) {
-				$user_to_post['role'] = $role;
-			}
-
-			// For new users, set the password.
-			if ( ! $user->ID ) {
-				$user_to_post['user_pass'] = empty( sanitize_text_field( $_REQUEST[ 'pass1' ] ) ) ? wp_generate_password() : sanitize_text_field( $_REQUEST[ 'pass1' ] );
-				unset( $_REQUEST[ 'pass1' ] );
-			}
-
-			// Update or insert user.
-			$updated_id = ! empty( $_REQUEST['user_id'] ) ? wp_update_user($user_to_post) : wp_insert_user($user_to_post);
 		}
 
-		if ( ! $updated_id ) {
-			// Error during user update/insert.
-			if ( ! empty( $_REQUEST['user_id'] ) ) {
-				pmpro_setMessage( __( 'Error updating user.', 'paid-memberships-pro' ), 'pmpro_error' );
-			} else {
-				pmpro_setMessage( __( 'Error creating user.', 'paid-memberships-pro' ), 'pmpro_error' );
-			}
-		} elseif ( $pmpro_msgt === 'pmpro_error' ) {		
-			// There was another error above.
-			if ( ! empty( $_REQUEST['user_id'] ) ) {
-				$pmpro_msg = esc_html__( 'There was an error updating this user: ', 'paid-memberships-pro' ) . $pmpro_msg;
-			} else {
-				$pmpro_msg = esc_html__( 'There was an error adding this user: ', 'paid-memberships-pro' ) . $pmpro_msg;
-			}
+		/** This filter is documented in wp-includes/user.php */
+		$illegal_logins = (array) apply_filters( 'illegal_user_logins', array() );
+	
+		if ( in_array( strtolower( $user->user_login ), array_map( 'strtolower', $illegal_logins ), true ) ) {
+			$errors['user_login'] = __( 'Sorry, that username is not allowed.', 'paid-memberships-pro' );
+		}
+
+		// Checking email address.
+		if ( empty( $user->user_email ) ) {
+			$errors['user_email'] = __( 'Please enter an email address.', 'paid-memberships-pro' );
+		} elseif ( ! is_email( $user->user_email ) ) {
+			$errors['user_email'] = __( 'The email address is not correct.', 'paid-memberships-pro' );
 		} else {
-			// Update/insert all good.
+			$owner_id = email_exists( $user->user_email );
+			if ( $owner_id && ( ! $update || ( $owner_id !== $user->ID ) ) ) {
+				$errors['user_found'] = sprintf(
+					__('A user with email address %1$s already exists. <a href="%2$s">Click here to edit this member</a>.', 'paid-memberships-pro'),
+					esc_html( $user->user_email ),
+					esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => email_exists( $user->user_email ) ), admin_url( 'admin.php' ) ) )
+				);
+			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			// Set error fields.
+			// TO DO: These aren't being set correctly. Do we want to support this here?
+			//$pmpro_error_fields = array_keys( $errors );
+
+			// Set error messages.
+			$error_messages = '<p>' . __( 'There were errors in the form.', 'paid-memberships-pro' ) . '</p>';
+			$error_messages .= '<ul>';
+			foreach ( $errors as $error ) {
+				$error_messages .= '<li>' . $error . '</li>';
+			}
+			$error_messages .= '</ul>';
+
+			// Set the message.
+			// TO DO: Should we escape/sanitize anything here? It is also handled in the pmpro_setMessage function.
+			pmpro_setMessage( $error_messages, 'pmpro_error' );
+		} else {
+
+			if ( $update ) {
+				// Update the user.
+				$user_id = wp_update_user( $user );
+			} else {
+				// Insert the user.
+				$user_id = wp_insert_user( $user );
+
+				// Notify users if needed.
+				if ( isset( $_POST['send_user_notification'] ) ) {
+					wp_new_user_notification( $user_id, null, 'user' );
+				}
+			}
 
 			// Add other user meta
-			update_user_meta( $updated_id, 'user_notes', $user_notes );
+			$user_notes = ! empty( $_POST['user_notes'] ) ? stripslashes( sanitize_textarea_field( $_POST['user_notes'] ) ) : '';
+			update_user_meta( $user_id, 'user_notes', $user_notes );
 
-			// Notify users if needed.
-			if ( ! $user->ID && ! empty( $_REQUEST['send_password'] ) ) {
-				wp_new_user_notification( $updated_id, null, 'user' );
-			}
-			
 			// Set message and redirect if this is a new user.		
-			if ( empty( $_REQUEST['user_id'] ) ) {
-				// User inserted.
-				wp_redirect( admin_url( 'admin.php?page=pmpro-member&pmpro_member_edit_panel=memberships&user_id=' . $updated_id ) );
+			if ( $update ) {
+				// User updated.
+				wp_redirect( admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id ) );
 				exit;
 			} else {
-				// User updated.
-				wp_redirect( admin_url( 'admin.php?page=pmpro-member&user_id=' . $updated_id ) );
+				// User inserted.
+				wp_redirect( admin_url( 'admin.php?page=pmpro-member&pmpro_member_edit_panel=memberships&user_id=' . $user_id ) );
 			}
 		}
 	}

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -33,24 +33,41 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 			$last_name = $user->last_name;
 			$role = $user->roles[0];
 			$user_notes = $user->user_notes;
+		} else {
+			// We are creating a new user.
+			// Enqueue core WordPress script for passwords: generate, visibility, and strength check.
+			wp_enqueue_script( 'user-profile' );
 		}
 
 		// Show the form.
 		?>
 		<table class="form-table">
-			<tr>
-				<th scope="row"><label for="user_login"><?php esc_html_e( 'Username (required)', 'paid-memberships-pro' ); ?></label></th>
-				<td><input type="text" name="user_login" id="user_login" autocapitalize="none" autocorrect="off" autocomplete="off" required <?php if ( ! empty( $_REQUEST['user_id'] ) ) { ?>readonly="true"<?php } ?> value="<?php echo esc_attr( $user_login ) ?>"></td>
+			<tr class="form-field form-required">
+				<th scope="row">
+					<label for="user_login">
+					<?php if ( $user->ID ) { ?>
+						<?php esc_html_e( 'Username', 'paid-memberships-pro' ); ?>
+					<?php } else { ?>
+						<?php esc_html_e( 'Username (required)', 'paid-memberships-pro' ); ?>
+					<?php } ?>
+					</label>
+				</th>
+				<td>
+					<input type="text" name="user_login" id="user_login" autocapitalize="none" autocorrect="off" autocomplete="off" required <?php if ( ! empty( $_REQUEST['user_id'] ) ) { ?>disabled="disabled"<?php } ?> value="<?php echo esc_attr( $user_login ) ?>">
+					<?php if ( $user->ID ) { ?>
+						<p class="description"><?php esc_html_e( 'Usernames cannot be changed.', 'paid-memberships-pro' ); ?></p>
+					<?php } ?>
+				</td>
 			</tr>
-			<tr>
+			<tr class="form-field form-required">
 				<th scope="row"><label for="email"><?php esc_html_e( 'Email (required)', 'paid-memberships-pro' ); ?></label></th>
 				<td><input type="email" name="email" id="email" autocomplete="new-password" spellcheck="false" required value="<?php echo esc_attr( $user_email ) ?>"></td>
 			</tr>
-			<tr>
+			<tr class="form-field">
 				<th scope="row"><label for="first_name"><?php esc_html_e( 'First Name', 'paid-memberships-pro' ); ?></label></th>
 				<td><input type="text" name="first_name" id="first_name" autocomplete="off" value="<?php echo esc_attr( $first_name ); ?>"></td>
 			</tr>
-			<tr>
+			<tr class="form-field">
 				<th scope="row"><label for="last_name"><?php esc_html_e( 'Last Name', 'paid-memberships-pro' ); ?></label></th>
 				<td><input type="text" name="last_name" id="last_name" autocomplete="off" value="<?php echo esc_attr( $last_name ); ?>"></td>
 			</tr>						
@@ -58,15 +75,39 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 			// Only show for new users.
 			if ( empty( $user->ID ) ) {
 				?>
-				<tr>
-					<th scope="row"><label for="password"><?php esc_html_e( 'Password', 'paid-memberships-pro' ); ?></label></th>
+				<tr class="form-field form-required user-pass1-wrap">
+					<th scope="row">
+						<label for="pass1">
+							<?php esc_html_e( 'Password', 'paid-memberships-pro' ); ?>
+							<span class="description hide-if-js"><?php esc_html_e( '(required)', 'paid-memberships-pro' ); ?></span>
+						</label>
+					</th>
 					<td>
-						<input type="password" name="password" id="password" autocomplete="off" value="">
-						<button class="toggle-pass-visibility" aria-controls="password" aria-expanded="false"><span class="dashicons dashicons-visibility toggle-pass-visibility"></span></button>
-						<p class="description"><?php esc_html_e( 'If left blank, a secure password will be generated automatically.', 'paid-memberships-pro' ); ?></p>
+						<input type="hidden" value=" " />
+						<button type="button" class="button wp-generate-pw hide-if-no-js"><?php esc_html_e( 'Generate password', 'paid-memberships-pro' ); ?></button>
+						<div class="wp-pwd">
+							<?php $initial_password = wp_generate_password( 24 ); ?>
+							<div class="password-input-wrapper">
+								<input type="password" name="pass1" id="pass1" class="regular-text" autocomplete="new-password" spellcheck="false" data-reveal="1" data-pw="<?php echo esc_attr( $initial_password ); ?>" aria-describedby="pass-strength-result" />
+								<div style="display:none" id="pass-strength-result" aria-live="polite"></div>
+							</div>
+							<button type="button" class="button wp-hide-pw hide-if-no-js" data-toggle="0" aria-label="<?php esc_attr_e( 'Hide password', 'paid-memberships-pro' ); ?>">
+								<span class="dashicons dashicons-hidden" aria-hidden="true"></span>
+								<span class="text"><?php esc_html_e( 'Hide', 'paid-memberships-pro' ); ?></span>
+							</button>
+						</div>
 					</td>
 				</tr>
-				<tr>
+				<tr class="pw-weak">
+					<th><?php esc_html_e( 'Confirm Password', 'paid-memberships-pro' ); ?></th>
+					<td>
+						<label>
+							<input type="checkbox" name="pw_weak" class="pw-checkbox" />
+							<?php esc_html_e( 'Confirm use of weak password', 'paid-memberships-pro' ); ?>
+						</label>
+					</td>
+				</tr>
+				<tr class="form-field">
 					<th scope="row"><label for="send_password"><?php esc_html_e( 'Send User Notification', 'paid-memberships-pro' ); ?></label></th>
 					<td>
 						<input type="checkbox" name="send_password" id="send_password">
@@ -77,22 +118,37 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 				<?php
 			}
 			?>
-			<?php if ( ! IS_PROFILE_PAGE && current_user_can( 'promote_user', $user->ID ) ) { ?>
-				<tr>
-					<th scope="row"><label for="role"><?php esc_html_e( 'Role', 'paid-memberships-pro' ); ?></label></th>
-					<td>
-						<select name="role" id="role" class="<?php echo pmpro_getClassForField( 'role' ); ?>">
-							<?php wp_dropdown_roles( $role ); ?>
-						</select>
-					</td>
-				</tr>
-			<?php } ?>
-			<tr>
+			<tr class="form-field">
 				<th scope="row" valign="top"><label for="user_notes"><?php esc_html_e( 'Member Notes', 'paid-memberships-pro' ); ?></label></th>
 				<td>
-					<textarea name="user_notes" id="user_notes" rows="5" cols="80" class="<?php echo pmpro_getClassForField( 'user_notes' ); ?>"><?php echo esc_textarea( $user_notes ); ?></textarea>
+					<textarea name="user_notes" id="user_notes" rows="5" class="<?php echo pmpro_getClassForField( 'user_notes' ); ?>"><?php echo esc_textarea( $user_notes ); ?></textarea>
 					<p class="description"><?php esc_html_e( 'Member notes are private and only visible to other users with membership management capabilities.', 'paid-memberships-pro' ); ?></p>
 				</td>
+			</tr>
+			<?php if ( ! IS_PROFILE_PAGE && current_user_can( 'promote_user', $user->ID ) ) {
+				?>
+				<tr>
+					<?php
+						// Set the role to subscriber if the default role is subscriber.
+						if ( empty( $user->ID ) && get_option( 'default_role' ) == 'subscriber' ) {
+							?>
+							<td colspan="2">
+								<input type="hidden" name="role" id="role" value="subscriber">
+							</td>
+							<?php
+						} else {
+							?>
+							<th scope="row"><label for="role"><?php esc_html_e( 'Role', 'paid-memberships-pro' ); ?></label></th>
+							<td>
+								<select name="role" id="role" class="<?php echo pmpro_getClassForField( 'role' ); ?>">
+									<?php wp_dropdown_roles( $role ); ?>
+								</select>
+							</td>
+						<?php
+						}
+					?>
+				</tr>
+			<?php } ?>
 		</table>
 		<?php
 	}
@@ -106,7 +162,7 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 		$user = self::get_user();
 
 		// Populate values from form.
-		$user_login = ! empty( $_POST['user_login'] ) ? sanitize_user( $_POST['user_login'] ) : '';
+		$user_login = ! empty( $_POST['user_login'] ) ? sanitize_user( $_POST['user_login'] ) : $user->user_login;
 		$user_email = ! empty( $_POST['email'] ) ? stripslashes( sanitize_email( $_POST['email'] ) ) : '';
 		$first_name = ! empty( $_POST['first_name'] ) ? stripslashes( sanitize_text_field( $_POST['first_name'] ) ): '';
 		$last_name = ! empty( $_POST['last_name'] ) ? stripslashes( sanitize_text_field( $_POST['last_name'] ) ) : '';	
@@ -183,8 +239,8 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 
 			// For new users, set the password.
 			if ( ! $user->ID ) {
-				$user_to_post['user_pass'] = empty( sanitize_text_field( $_REQUEST[ 'password' ] ) ) ? wp_generate_password() : sanitize_text_field( $_REQUEST[ 'password' ] );
-				unset( $_REQUEST[ 'password' ] );
+				$user_to_post['user_pass'] = empty( sanitize_text_field( $_REQUEST[ 'pass1' ] ) ) ? wp_generate_password() : sanitize_text_field( $_REQUEST[ 'pass1' ] );
+				unset( $_REQUEST[ 'pass1' ] );
 			}
 
 			// Update or insert user.

--- a/css/admin.css
+++ b/css/admin.css
@@ -1951,6 +1951,10 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	text-decoration: underline;
 }
 
+.pmpro_message ul {
+	list-style: disc;
+	margin-left: 20px;
+}
 .pmpro_success {
 	background-color: var(--pmpro--color--success-background);
 	border-color: var(--pmpro--color--success-border);

--- a/css/admin.css
+++ b/css/admin.css
@@ -50,7 +50,7 @@ p.pmpro_meta_notice {
 	font-family: "dashicons";
 }
 
-.pmpro_admin tr td .dashicons {
+.pmpro_admin tr td .dashicons:not(.button .dashicons) {
 	padding-top: 5px;
 }
 
@@ -727,12 +727,6 @@ body[class*="memberships_page_pmpro-"] {
 }
 
 /* General admin-area tables styles */
-.pmpro_admin table.wp-list-table thead th,
-.pmpro_admin table.wp-list-table tfoot th {
-	padding-left: calc( var(--pmpro--spacing--medium) / 2 );
-	padding-right: calc( var(--pmpro--spacing--medium) / 2 );
-}
-
 .pmpro_admin table.widefat {
 	border-color: var(--pmpro--border--color);
 	box-shadow: var(--pmpro--box-shadow);
@@ -1068,7 +1062,7 @@ body[class*="memberships_page_pmpro-"] {
 	border: none;
 }
 
-.pmpro_admin-pmpro-member td .dashicons {
+.pmpro_admin-pmpro-member td .dashicons:not(.button .dashicons) {
 	vertical-align: middle;
 }
 
@@ -1139,6 +1133,24 @@ body[class*="memberships_page_pmpro-"] {
 }
 
 /* Single Member - Memberships Panel */
+.pmpro_admin-pmpro-member input[type=text],
+.pmpro_admin-pmpro-member input[type=email] {
+	min-width: 25em;
+	width: auto;
+}
+
+.pmpro_admin-pmpro-member textarea {
+	width: 100%;
+}
+
+.pmpro_admin-pmpro-member .wp-pwd {
+	margin-top: 0;
+}
+
+.pmpro_admin-pmpro-member button.wp-generate-pw {
+	margin-bottom: var(--pmpro--spacing--small );
+}
+
 .pmpro_admin-pmpro-member #pmpro-member-edit-memberships-panel .pmpro_section .pmpro_section_inside {
 	padding: 0;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2674,7 +2674,7 @@ function pmpro_setMessage( $message, $type, $force = false ) {
 }
 
 /**
- * Show a a PMPro message set via pmpro_setMessage
+ * Show a PMPro message set via pmpro_setMessage
  *
  * @since 1.8.5
  */
@@ -2693,11 +2693,13 @@ function pmpro_showMessage() {
 			'class' => array(),
 		),
 		'strong' => array(),
+		'ul' => array(),
+		'li' => array(),
 	);
 
 	if ( ! empty( $pmpro_msg ) ) {		
 		?>
-		<div role="alert" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_msg ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">
+		<div role="alert" id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">
 			<p><?php echo wp_kses( $pmpro_msg, $allowed_html ); ?></p>
 		</div>
 		<?php

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -956,20 +956,6 @@ window.addEventListener("DOMContentLoaded", () => {
 		});
 	}
 
-	if ( togglePassVisibility ) {
-		togglePassVisibility.addEventListener('click', function(e) {
-			e.preventDefault();
-			const passInput = document.querySelector('#password');
-			const classToReplace = passInput.getAttribute('type') == 'password' ? 'dashicons-hidden' : 'dashicons-visibility';
-			const currentClass = passInput.getAttribute('type') == 'password' ? 'dashicons-visibility' : 'dashicons-hidden';
-
-			// Switch the input type.
-			passInput.getAttribute('type') == 'password' ? passInput.setAttribute('type', 'text') : passInput.setAttribute('type', 'password');
-
-			// Switch the icon.
-			e.currentTarget.firstChild.classList.replace(currentClass, classToReplace);
-		});
-	}
 });
 
 function pmpro_changeTabs( e, inputChanged ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Hiding the dropdown to choose user role from Add Member form if the site default is Subscriber.
2. Changed to use the matching core WP password generate code and confirmation of weak password.
3. Using a "disabled" field for username once set to match core user-edit.php view.
4. Removed unused password visibility toggle from pmpro-admin.js
5. Save function restructured to operate more like core WP, support for the illegal usernames filter in core WP.
6. Showing a link to edit membership for the found user if an existing member has the same username or email.
7. Update to messages set an array of errors if there are more than one.

Note: there are few TO DO: comments in here.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
