### PR TITLE
Fix button text when adding a membership to a one per group when member has no levels in group

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -327,9 +327,10 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 							<tfoot>
 								<tr>
 									<?php
-									$link_icon = empty( $group->allow_multiple_selections ) ? 'image-rotate' : 'plus';
 									$js_target_class = empty( $group->allow_multiple_selections ) ? 'pmpro-member-change-level' : 'pmpro-member-add-level';
-									$link_text = empty( $group->allow_multiple_selections ) ? __( 'Change Membership', 'paid-memberships-pro' ) : __( 'Add Membership', 'paid-memberships-pro' );
+									$is_single_membership = count( $user_level_ids_in_group ) === 0;
+									$link_icon = ( $group->allow_multiple_selections || $is_single_membership ) ? 'plus' : 'image-rotate';
+									$link_text = $group->allow_multiple_selections || $is_single_membership ? __( 'Add Membership', 'paid-memberships-pro' ) : __( 'Change Membership', 'paid-memberships-pro' );
 									?>
 									<td colspan="3"><a class="button-secondary pmpro-has-icon pmpro-has-icon-<?php echo esc_attr( $link_icon ) . ' ' . esc_attr( $js_target_class ); ?>" href="#"><?php echo esc_html( $link_text ); ?></a></td>
 								</tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When the member has no levels in a "one per" level group, the button was showing as "Change Membership".

This update accounts for the case where the user doesn't have anything in the group and rather shows "Add Membership".

![Screenshot 2023-11-25 at 8 34 26 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/4b61597a-7a42-471e-adfe-d03361d0a9c8)

![Screenshot 2023-11-25 at 8 34 13 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/f74c94e6-6e60-4f86-8ed5-e5a61c544943)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
