### PR TITLE
Fixing levels table for accessibility

### DIFF
--- a/css/frontend-rtl.css
+++ b/css/frontend-rtl.css
@@ -42,6 +42,10 @@ li.pmpro_more {
 /*---------------------------------------
 	Membership Levels
 ---------------------------------------*/
+#pmpro_levels_table thead th,
+#pmpro_levels_table tbody th {
+	text-align: right;
+}
 
 /*---------------------------------------
 	Misc

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -671,7 +671,14 @@ li.pmpro_more {
 /*---------------------------------------
 	Membership Levels
 ---------------------------------------*/
-#pmpro_levels_table { }
+#pmpro_levels_table {
+	table-layout: fixed;
+	width: 100%;
+}
+#pmpro_levels_table thead th,
+#pmpro_levels_table tbody th {
+	text-align: left;
+}
 #pmpro_levels_table td:nth-child(1) {
 	min-width: 200px;
 }

--- a/pages/levels.php
+++ b/pages/levels.php
@@ -41,7 +41,7 @@ if($pmpro_msg)
 		$has_any_level = $has_level ?: $has_any_level;
 	?>
 	<tr class="<?php if($count++ % 2 == 0) { ?>odd<?php } ?><?php if( $has_level ) { ?> active<?php } ?>">
-		<td><?php echo $has_level ? "<strong>" . esc_html( $level->name ) . "</strong>" : esc_html( $level->name );?></td>
+		<th><?php echo $has_level ? "<strong>" . esc_html( $level->name ) . "</strong>" : esc_html( $level->name );?></th>
 		<td>
 			<?php
 				$cost_text = pmpro_getLevelCost($level, true, true); 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
A user brought it to our attention that the default levels page wasn't passing an Lighthouse Accessibility check related to tables rows in the body having a <th> element to identify the row.

This PR updates the levels table so the level name column uses the <th> markup and passes Lighthouse Accessibility tests 100%.

Accessibility will always be a two-part issue, where we can do our best in the core product and then the site's chosen WP theme on the site also needs to pass.

This test was done on the latest WordPress Twenty Twenty-Four theme.
![Screenshot 2023-11-27 at 8 39 11 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/89a3ab08-51b1-4be6-98eb-48e976fe0bf4)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
* BUG FIX/ENHANCEMENT: Improved accessibility for the frontend membership levels page default table.
