### PR TITLE
Moving default behavior for updating sub info

### DIFF
--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -228,4 +228,49 @@
 		function supports_payment_method_updates() {
 			return false;
 		}
+
+		/**
+		 * Synchronizes a subscription with this payment gateway.
+		 *
+		 * @since TBD
+		 *
+		 * @param PMPro_Subscription $subscription The subscription to synchronize.
+		 * @return string|null Error message is returned if update fails.
+		 */
+		public function update_subscription_info( $subscription ) {
+			// Track the fields that need to be updated.
+			$update_array = array();
+
+			// Update the start date to the date of the first order for this subscription if it
+			// it is earlier than the current start date.
+			$oldest_orders = $subscription->get_orders( [
+				'limit'   => 1,
+				'orderby' => '`timestamp` ASC, `id` ASC',
+			] );
+			if ( ! empty( $oldest_orders ) ) {
+				$oldest_order = current( $oldest_orders );
+				if ( empty( $subscription->get_startdate() ) || $oldest_order->getTimestamp( true ) < strtotime( $subscription->get_startdate() ) ) {
+					$update_array['startdate'] = date_i18n( 'Y-m-d H:i:s', $oldest_order->getTimestamp( true ) );
+				}
+			}
+
+			// If the next payment date has passed, update the next payment date based on the most recent order.
+			if ( strtotime( $subscription->get_next_payment_date() ) < time() && ! empty( $subscription->get_cycle_number() ) ) {
+				// Only update the next payment date if we are not at checkout or if we don't have a next payment date yet.
+				// We don't want to update profile start dates set at checkout.
+				if ( ! pmpro_is_checkout() || empty( $subscription->get_next_payment_date() ) ) {
+					$newest_orders = $subscription->get_orders( array( 'limit' => 1 ) );
+					if ( ! empty( $newest_orders ) ) {
+						// Get the most recent order.
+						$newest_order = current( $newest_orders );
+
+						// Calculate the next payment date.
+						$update_array['next_payment_date'] = date_i18n( 'Y-m-d H:i:s', strtotime( '+ ' . $subscription->get_cycle_number() . ' ' . $subscription->get_cycle_period(), $newest_order->getTimestamp( true ) ) );
+					}
+				}
+			}
+
+			// Update the subscription.
+			$subscription->set( $update_array );
+		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Moving the default behavior for updating subscription info to the abstract PMProGateway class.

This code that we thought was "universal" may not actually be. The PMPro Pay By Check Add On is one instance where we would not like to have "next payment dates" be automatically updated when they are in the past. Moving this update code to the abstract gateway class allow individual gateways to override this kind of functionality based on their requirements.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
