### PR TITLE
Adding message for user updated

### DIFF
--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -73,9 +73,12 @@ abstract class PMPro_Member_Edit_Panel {
 		>
 			<h2><?php echo esc_html( $this->title ); ?></h2>
 			<?php
-				echo wp_kses( $this->title_link, array( 'a' => array( 'href' => array(), 'target' => array(), 'class' => array() ) ) );
+			echo wp_kses( $this->title_link, array( 'a' => array( 'href' => array(), 'target' => array(), 'class' => array() ) ) );
+
+			// Get the URL to submit to.
+			$submit_url = add_query_arg( 'user_id', self::get_user()->ID, admin_url( 'admin.php?page=pmpro-member' ) );
 			?>
-			<form class="pmpro-members" action="" method="post">
+			<form class="pmpro-members" action="<?php echo esc_url( $submit_url ); ?>" method="post">
 				<input type="hidden" name="pmpro_member_edit_panel" value="<?php echo esc_attr( $this->slug ); ?>">
 				<?php
 				// Add a nonce.

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
@@ -32,6 +32,13 @@ class PMPro_Member_Edit_Panel_User_Fields extends PMPro_Member_Edit_Panel {
 	 * Save panel data.
 	 */
 	public function save() {
-		pmpro_save_user_fields_in_profile( self::get_user()->ID );
+		$saved = ( pmpro_save_user_fields_in_profile( self::get_user()->ID ) !== false ); // Function returns false on failed, null on saved.
+
+		// Show success message.
+		if ( $saved ) {
+			pmpro_setMessage( __( 'User fields updated successfully.', 'paid-memberships-pro' ), 'pmpro_success' );
+		} else {
+			pmpro_setMessage( __( 'You do not have permission to update these fields.', 'paid-memberships-pro' ), 'pmpro_error' );
+		}
 	}
 }

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -10,6 +10,15 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 		$this->title = empty( $user->ID ) ? __( 'Add New User', 'paid-memberships-pro' ) : __( 'User Info', 'paid-memberships-pro' );
 		$this->title_link = empty( $user->ID ) ? '' : '<a href="' . esc_url( add_query_arg( array( 'user_id' => intval( $user->ID ) ), admin_url( 'user-edit.php' ) ) ) . '" target="_blank" class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users">' . esc_html__( 'Edit User', 'paid-memberships-pro' ) . '</a>';
 		$this->submit_text = empty( $user->ID ) ? __( 'Create User ') : __( 'Update User Info', 'paid-memberships-pro' );
+
+		// Show user updated or user created message if necessary.
+		if ( ! empty( $_REQUEST['user_id'] && ! empty( $_REQUEST['user_info_action'] ) ) ) {
+			if ( 'updated' === $_REQUEST['user_info_action'] ) {
+				pmpro_setMessage( __( 'User updated.', 'paid-memberships-pro' ), 'pmpro_success' );
+			} elseif ( 'created' === $_REQUEST['user_info_action'] ) {
+				pmpro_setMessage( __( 'User created.', 'paid-memberships-pro' ), 'pmpro_success' );
+			}
+		}
 	}
 
 	/**
@@ -298,11 +307,11 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 			// Set message and redirect if this is a new user.		
 			if ( $update ) {
 				// User updated.
-				wp_redirect( admin_url( 'admin.php?page=pmpro-member&user_id=' . $user_id ) );
+				wp_redirect( admin_url( 'admin.php?page=pmpro-member&user_info_action=updated&user_id=' . $user_id ) );
 				exit;
 			} else {
 				// User inserted.
-				wp_redirect( admin_url( 'admin.php?page=pmpro-member&pmpro_member_edit_panel=memberships&user_id=' . $user_id ) );
+				wp_redirect( admin_url( 'admin.php?page=pmpro-member&user_info_action=created&pmpro_member_edit_panel=memberships&user_id=' . $user_id ) );
 			}
 		}
 	}

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -12,11 +12,11 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 		$this->submit_text = empty( $user->ID ) ? __( 'Create User ') : __( 'Update User Info', 'paid-memberships-pro' );
 
 		// Show user updated or user created message if necessary.
-		if ( ! empty( $_REQUEST['user_id'] && ! empty( $_REQUEST['user_info_action'] ) ) ) {
+		if ( isset( $_REQUEST['user_id'] ) && ! empty( $_REQUEST['user_id'] && ! empty( $_REQUEST['user_info_action'] ) ) ) {
 			if ( 'updated' === $_REQUEST['user_info_action'] ) {
 				pmpro_setMessage( __( 'User updated.', 'paid-memberships-pro' ), 'pmpro_success' );
 			} elseif ( 'created' === $_REQUEST['user_info_action'] ) {
-				pmpro_setMessage( __( 'User created.', 'paid-memberships-pro' ), 'pmpro_success' );
+				pmpro_setMessage( __( 'New user created.', 'paid-memberships-pro' ), 'pmpro_success' );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding a user updated/created message when the "user info" tab is saved on the single member dashboard and when user field panels are saved.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
