### PR TITLE
Updating level cost and fee statements; now showing subscription not level cost on account page

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -599,7 +599,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 									<td>
 										<?php 
 											if ( empty( $levelhistory->status ) ) {
-												echo '-';
+												esc_html_e( '&#8212;', 'paid-memberships-pro' );
 											} else {
 												echo esc_html( $levelhistory->status ); 
 											}

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -355,7 +355,7 @@
 									<tr>
 										<th><?php esc_html_e('ID', 'paid-memberships-pro' );?></th>
 										<th><?php esc_html_e('Name', 'paid-memberships-pro' );?></th>
-										<th><?php esc_html_e('Billing Details', 'paid-memberships-pro' );?></th>
+										<th><?php esc_html_e('Level Cost', 'paid-memberships-pro' );?></th>
 										<th><?php esc_html_e('Expiration', 'paid-memberships-pro' );?></th>
 										<th><?php esc_html_e('Allow Signups', 'paid-memberships-pro' );?></th>
 										<?php do_action( 'pmpro_membership_levels_table_extra_cols_header', $reordered_levels ); ?>
@@ -473,16 +473,16 @@
 										</td>
 										<td>
 											<?php if(pmpro_isLevelFree($level)) { ?>
-												<?php _e('FREE', 'paid-memberships-pro' );?>
+												<?php esc_html_e( 'Free', 'paid-memberships-pro' ); ?>
 											<?php } else { ?>
-												<?php echo str_replace( 'The price for membership is', '', pmpro_getLevelCost($level)); ?>
+												<?php echo str_replace( 'The price for membership is', '', pmpro_getLevelCost($level) ); ?>
 											<?php } ?>
 										</td>
 										<td>
-											<?php if(!pmpro_isLevelExpiring($level)) { ?>
-												--
-											<?php } else { ?>
-												<?php _e('After', 'paid-memberships-pro' );?> <?php echo $level->expiration_number?> <?php echo sornot($level->expiration_period,$level->expiration_number)?>
+											<?php if(!pmpro_isLevelExpiring($level)) {
+												esc_html_e( '&#8212;', 'paid-memberships-pro' );
+											} else { ?>
+												<?php esc_html_e('After', 'paid-memberships-pro' );?> <?php echo $level->expiration_number?> <?php echo sornot($level->expiration_period,$level->expiration_number)?>
 											<?php } ?>
 										</td>
 										<td><?php

--- a/adminpages/memberslist.php
+++ b/adminpages/memberslist.php
@@ -30,18 +30,6 @@ if ( isset( $_REQUEST['l'] ) ) {
 			$user_list_table->display();
 		?>
 	</form>
-
-	<?php if ( ! function_exists( 'pmprorh_add_registration_field' ) ) {
-		$allowed_pmprorh_html = array (
-			'a' => array (
-				'href' => array(),
-				'target' => array(),
-				'title' => array(),
-			),
-		);
-		echo '<p class="description">' . sprintf( wp_kses( __( 'Optional: Capture additional member profile fields using the <a href="%s" title="Paid Memberships Pro - Register Helper Add On" target="_blank">Register Helper Add On</a>.', 'paid-memberships-pro' ), $allowed_pmprorh_html ), 'https://www.paidmembershipspro.com/add-ons/pmpro-register-helper-add-checkout-and-profile-fields/?utm_source=plugin&utm_medium=pmpro-memberslist&utm_campaign=add-ons&utm_content=pmpro-register-helper-add-checkout-and-profile-fields' ) . '</p>';
-	} ?>
-	
 <?php
 	require_once dirname( __DIR__ ) . '/adminpages/admin_footer.php';
 ?>

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -81,7 +81,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			'address'       => __( 'Billing Address', 'paid-memberships-pro' ),
 			'membership'    => __( 'Level', 'paid-memberships-pro' ),
 			'membership_id' => __( 'Level ID', 'paid-memberships-pro' ),
-			'fee'           => __( 'Subscription', 'paid-memberships-pro' ),
+			'fee'           => __( 'Level Cost', 'paid-memberships-pro' ),
 			'joindate'      => __( 'Registered', 'paid-memberships-pro' ),
 			'startdate'     => __( 'Start Date', 'paid-memberships-pro' ),
 			'enddate'       => __( 'End Date', 'paid-memberships-pro' ),

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -140,7 +140,14 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 									</div> <!-- end pmpro_actionlinks -->
 								</td>
 								<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-levelfee' ) ); ?>">
-									<p><?php echo wp_kses_post( pmpro_getLevelCost($level, true, true) );?></p>
+									<p>
+										<?php
+											if ( ! empty( $subscriptions) ) {
+												$subscription = $subscriptions[0];
+												echo esc_html( $subscription->get_cost_text() );
+											}
+										?>
+									</p>
 								</td>
 								<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-expiration' ) ); ?>">
 									<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Establishing a naming structure for what is a Level Cost vs. what is a Fee.

If you get the data using this function: pmpro_getLevelCost, it’s Level Cost.

If you get the data using this function: $subscription->get_cost_text(), it’s Fee.

Exceptions to this right now include the levels page and checkout pages where we call the level's cost a "Price".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
