### PR TITLE
Add 'pmpro_edit_members' capability

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -628,7 +628,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 		global $wpdb;
 
 		// Check if the current user can manage memberships.
-		$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'manage_options' );
+		$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'pmpro_edit_members' );
 		if ( ! current_user_can( $membership_level_capability ) ) {
 			pmpro_setMessage( __( "You do not have permission to update this user's membership levels.", 'paid-memberships-pro' ), 'pmpro_error' );
 			return;

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -96,7 +96,7 @@ function pmpro_add_pages() {
 
 	// Hidden pages
 	add_submenu_page( 'admin.php', __( 'Subscriptions', 'paid-memberships-pro' ), __( 'Subscriptions', 'paid-memberships-pro' ), 'pmpro_subscriptions', 'pmpro-subscriptions', 'pmpro_subscriptions' );
-	add_submenu_page( 'admin.php', __( 'Add Member', 'paid-memberships-pro' ), __( 'Add Member', 'paid-memberships-pro' ), 'manage_options', 'pmpro-member', 'pmpro_member_edit_display' );
+	add_submenu_page( 'admin.php', __( 'Add Member', 'paid-memberships-pro' ), __( 'Add Member', 'paid-memberships-pro' ), 'pmpro_edit_members', 'pmpro-member', 'pmpro_member_edit_display' );
 
 	// For the subscriptions page, if there is not an ID or the ID does not exist, redirect to the members page.
 	if ( isset( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-subscriptions' ) {

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -55,6 +55,7 @@ function pmpro_get_capability_defs($role)
         'pmpro_wizard',
         'pmpro_membershiplevels',
         'pmpro_edit_memberships',
+        'pmpro_edit_members',
         'pmpro_pagesettings',
         'pmpro_paymentsettings',
         'pmpro_emailsettings',

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -54,7 +54,6 @@ function pmpro_get_capability_defs($role)
         'pmpro_dashboard',
         'pmpro_wizard',
         'pmpro_membershiplevels',
-        'pmpro_edit_memberships',
         'pmpro_edit_members',
         'pmpro_pagesettings',
         'pmpro_paymentsettings',

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -7,7 +7,7 @@
 function pmpro_membership_levels_table_on_profile( $user ) {
 	global $current_user;
 
-	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'manage_options' );
+	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'pmpro_edit_members' );
 
 	// If the user doesn't have the capability to edit members, don't show the table.
 	if ( ! current_user_can( $membership_level_capability ) )
@@ -564,7 +564,7 @@ function pmpro_membership_level_profile_fields_update() {
 
 	$user_id = empty( $_REQUEST['user_id'] ) ? intval( $current_user->ID ) : intval( $_REQUEST['user_id'] );
 
-	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'manage_options' );
+	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'pmpro_edit_members' );
 	if ( ! current_user_can( $membership_level_capability ) ) {
 		return false;
 	}
@@ -704,7 +704,7 @@ function pmpro_membership_history_profile_fields( $user ) {
 
 	_deprecated_function( __FUNCTION__, 'TBD' );
 
-	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'manage_options' );
+	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'pmpro_edit_members' );
 
 	if ( ! current_user_can( $membership_level_capability ) ) {
 		return false;

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -552,12 +552,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$level = new PMPro_Membership_Level( $id );
-			
+
 			// Hide confirmation message if not an admin or member.
 			if ( ! empty( $level->confirmation ) 
 				 && ! pmpro_hasMembershipLevel( $id )
-				 && ! current_user_can( 'pmpro_edit_memberships' ) ) {				
-					 $level->confirmation = '';					
+				 && ! current_user_can( 'pmpro_edit_members' ) ) {
+					 $level->confirmation = '';
 			}
 
 			if ( 'json' === $response_type ) {
@@ -879,14 +879,14 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$checkout_level = pmpro_getLevelAtCheckout( $level_id, $discount_code );
-			
+
 			// Hide confirmation message if not an admin or member.
 			if ( ! empty( $checkout_level->confirmation ) 
 				 && ! pmpro_hasMembershipLevel( $level_id )
-				 && ! current_user_can( 'pmpro_edit_memberships' ) ) {				
-					 $checkout_level->confirmation = '';					
+				 && ! current_user_can( 'pmpro_edit_members' ) ) {
+					 $checkout_level->confirmation = '';
 			}
-			
+
 			return new WP_REST_Response( $checkout_level );
 		}
 
@@ -1149,16 +1149,16 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$method = $request->get_method();
 			$route = $request->get_route();
 
-			// Default to requiring pmpro_edit_memberships capability.
-			$permission = current_user_can( 'pmpro_edit_memberships' );
+			// Default to requiring pmpro_edit_members capability.
+			$permission = current_user_can( 'pmpro_edit_members' );
 
 			// Check other caps for some routes.
 			$route_caps = array(
-				'/pmpro/v1/has_membership_access' => 'pmpro_edit_memberships',
-				'/pmpro/v1/get_membership_level_for_user' => 'pmpro_edit_memberships',
-				'/pmpro/v1/get_membership_levels_for_user' => 'pmpro_edit_memberships',
-				'/pmpro/v1/change_membership_level' => 'pmpro_edit_memberships',
-				'/pmpro/v1/cancel_membership_level' => 'pmpro_edit_memberships',
+				'/pmpro/v1/has_membership_access' => 'pmpro_edit_members',
+				'/pmpro/v1/get_membership_level_for_user' => 'pmpro_edit_members',
+				'/pmpro/v1/get_membership_levels_for_user' => 'pmpro_edit_members',
+				'/pmpro/v1/change_membership_level' => 'pmpro_edit_members',
+				'/pmpro/v1/cancel_membership_level' => 'pmpro_edit_members',
 				'/pmpro/v1/membership_level' => true,
 				'/pmpro/v1/membership_levels' => true,
 				'/pmpro/v1/discount_code' => 'pmpro_discountcodes',
@@ -1166,9 +1166,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				'/pmpro/v1/checkout_level' => true,
 				'/pmpro/v1/checkout_levels' => true,
 				'/pmpro/v1/me' => true,
-				'/pmpro/v1/recent_memberships' => 'pmpro_edit_memberships',
+				'/pmpro/v1/recent_memberships' => 'pmpro_edit_members',
 				'/pmpro/v1/recent_orders' => 'pmpro_orders',
-				'/pmpro/v1/post_restrictions' => 'pmpro_edit_memberships',
+				'/pmpro/v1/post_restrictions' => 'pmpro_edit_members',
 			);
 			$route_caps = apply_filters( 'pmpro_rest_api_route_capabilities', $route_caps, $request );			
 			


### PR DESCRIPTION
* ENHANCEMENT: Added pmpro_edit_members capability for editing membership information for users, or creating new members with the "Edit Member" screen.

Note: The Membership Manager Add On also needs to be updated and will reference this PR shortly.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
