### PR TITLE
Fix localization loading incorrectly.

### DIFF
--- a/includes/localization.php
+++ b/includes/localization.php
@@ -1,28 +1,29 @@
 <?php
-function pmpro_load_textdomain()
-{
-    //get the locale
-	$locale = apply_filters("plugin_locale", get_user_locale(), "paid-memberships-pro");
-	$mofile = "paid-memberships-pro-" . $locale . ".mo";
+function pmpro_load_textdomain() {
+	$locale = apply_filters( 'plugin_locale', get_user_locale(), 'paid-memberships-pro' );
+	$mofile = esc_attr( 'paid-memberships-pro-' . $locale . '.mo' );
 
 	//paths to local (plugin) and global (WP) language files
-	$mofile_local  = dirname(__FILE__)."/../languages/" . $mofile;
+	$mofile_local  = dirname( __DIR__ ) . '/languages/' . $mofile;
 	$mofile_global = WP_LANG_DIR . '/pmpro/' . $mofile;
 	$mofile_global2 = WP_LANG_DIR . '/paid-memberships-pro/' . $mofile;
 
+	unload_textdomain( 'paid-memberships-pro' );
+
 	//load global first    
-	if(file_exists($mofile_global))
-		load_textdomain("paid-memberships-pro", $mofile_global);
-	elseif(file_exists($mofile_global2))
-		load_textdomain("paid-memberships-pro", $mofile_global2);
-	
+	if ( file_exists( $mofile_global ) ) {
+		load_textdomain( 'paid-memberships-pro', $mofile_global );
+	} elseif ( file_exists( $mofile_global2 ) ) {
+		load_textdomain( 'paid-memberships-pro', $mofile_global2 );
+	}
+
 	//load local second
-	load_textdomain("paid-memberships-pro", $mofile_local);
-	
+	load_textdomain( 'paid-memberships-pro', $mofile_local );
+
 	//load via plugin_textdomain/glotpress
-	load_plugin_textdomain( 'paid-memberships-pro', false, dirname(__FILE__)."/../languages/" );
+	load_plugin_textdomain( 'paid-memberships-pro', false, dirname( __DIR__) . '/languages/' );
 }
-add_action("init", "pmpro_load_textdomain", 1);
+add_action( 'init', 'pmpro_load_textdomain', 1 );
 
 function pmpro_translate_billing_period($period, $number = 1)
 {	


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the site locale was loading instead of the user locale (in the admin).

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:
_Don't apply the PR fix for steps 1-3._
1. Set your site locale to Portuguese Brasil.
2. Set your admin user locale to English (United States)
3. See that your Membership menu in the backend is loading the non-English text.
4. Apply the patch and view the dashboard. Your membership dashboard and PMPro page settings should be set to EN_US
5. The frontend of the site should still be PT_BR as it's set in the site settings.