### PR TITLE
Moving header end where notices are displayed so it doesn't break the edit code layout

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -356,7 +356,7 @@
 
 	require_once(dirname(__FILE__) . "/admin_header.php");
 ?>
-
+	<hr class="wp-header-end">
 	<?php if($edit) { ?>
 
 		<h1>
@@ -726,7 +726,6 @@
 		</form>
 
 	<?php } else { ?>
-		<hr class="wp-header-end">
 		<form id="discount-code-list-form" method="get">
 			<h1 class="wp-heading-inline"><?php esc_html_e( 'Discount Codes', 'paid-memberships-pro' ); ?></h1>
 			<a href="admin.php?page=pmpro-discountcodes&edit=-1" class="page-title-action"><?php esc_html_e( 'Add New Discount Code', 'paid-memberships-pro' ); ?></a>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes header / admin notices breaking on "Edit" single discount code view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

