### PR TITLE
Removing unused JS for password (using core WP password JS now)

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -915,7 +915,6 @@ jQuery(document).ready(function () {
 window.addEventListener("DOMContentLoaded", () => {
 	const tabs = document.querySelectorAll('#pmpro-edit-user-div [role="tab"]');
 	const tabList = document.querySelector('#pmpro-edit-user-div [role="tablist"]');
-	const togglePassVisibility = document.querySelector('#pmpro-edit-user-div .toggle-pass-visibility');
 	const inputs = document.querySelectorAll('#pmpro-edit-user-div input, #pmpro-edit-user-div textarea, #pmpro-edit-user-div select');
 
 	if ( tabs && tabList ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We had originally coded our own password visibility toggle, but I adjusted this to rather use core WP's add new user / generate password logic. This is unused JS to clean up.

