### PR TITLE
remove PMPRO_BENCHMARK define by default

### DIFF
--- a/adminpages/login-csv.php
+++ b/adminpages/login-csv.php
@@ -5,8 +5,6 @@ if ( ! function_exists( 'current_user_can' ) || ( ! current_user_can( 'manage_op
 	die( __( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 }
 
-define( 'PMPRO_BENCHMARK', true );
-
 if ( ! defined( 'PMPRO_BENCHMARK' ) ) {
 	define( 'PMPRO_BENCHMARK', false );
 }

--- a/adminpages/memberships-csv.php
+++ b/adminpages/memberships-csv.php
@@ -5,8 +5,6 @@ if ( ! function_exists( 'current_user_can' ) || ( ! current_user_can( 'manage_op
 	die( __( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 }
 
-define( 'PMPRO_BENCHMARK', true );
-
 if ( ! defined( 'PMPRO_BENCHMARK' ) ) {
 	define( 'PMPRO_BENCHMARK', false );
 }

--- a/adminpages/orders-csv.php
+++ b/adminpages/orders-csv.php
@@ -4,8 +4,6 @@ if ( ! function_exists( "current_user_can" ) || ( ! current_user_can( "manage_op
 	die( __( "You do not have permissions to perform this action.", 'paid-memberships-pro' ) );
 }
 
-define('PMPRO_BENCHMARK', true);
-
 if (!defined('PMPRO_BENCHMARK'))
 	define('PMPRO_BENCHMARK', false);
 


### PR DESCRIPTION
* Remove "PMPRO_BENCHMARK" that defaulted to true. This was most likely defined during testing and we didn't remove it.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Removed predefined "PMPRO_BENCHMARK" that was writing to the PHP error_log file by default whenever exporting to CSV for some reports.