### PR TITLE
Fixing render for membership block

### DIFF
--- a/blocks/src/membership/render.php
+++ b/blocks/src/membership/render.php
@@ -1,2 +1,5 @@
 <?php
-echo wp_kses_post( pmpro_apply_block_visibility( $attributes, $content ) );
+/**
+ * Render the Content Visibility block on the frontend.
+ */
+echo pmpro_apply_block_visibility( $attributes, $content );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We added wp_kses_posts to this render but realizing now that the do_blocks applies content filters and is likely already escaped and sanitized safely so we do not need to do this. It was stripping the necessary HTML for the Log In Form block in PMPro.
