### PR TITLE
Link to levels page if group has no levels

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -64,6 +64,15 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 				<?php
 			}
 
+			// If this group does not have any levels, show a message to create a new level and move on to the next group.
+			if ( empty( $levels_in_group ) ) {
+				?>
+				<p><?php esc_html_e( 'There are no membership levels in this group.', 'paid-memberships-pro' ); ?></p>
+				<a class="button-primary" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-membershiplevels' ), admin_url( 'admin.php' ) ) ) ?>"><?php esc_html_e( 'Edit Membership Levels', 'paid-memberships-pro' ) ?></a>
+				<?php
+				continue;
+			}
+
 			// State whether users can have multiple levels from this group.
 			echo '<p>' . ( empty( $group->allow_multiple_selections ) ? __( 'Users can only hold one level from this group.', 'paid-memberships-pro' ) : __( 'Users can hold multiple levels from this group.', 'paid-memberships-pro' ) ) . '</p>';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x   ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When editing a member, if a level group has no levels in it, show a link to edit membership levels.
![Screenshot 2023-12-13 at 1 12 53 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/fbee5a9d-5571-4874-b7a7-1dfe7effe7fe)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
