### PR TITLE
Removing references to $pmpro_level in MemberOrder

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1114,20 +1114,10 @@
 		 * @param bool $force If true, it will reset the property.
 		 *
 		 */
-		function getMembershipLevelAtCheckout($force = false) {
-			global $pmpro_level;
-
-			if( ! empty( $this->membership_level ) && empty( $force ) ) {
-				return $this->membership_level;
+		function getMembershipLevelAtCheckout($force = false) {			
+			if ( empty( $this->membership_level ) || $force ) {
+				$this->membership_level = pmpro_getLevelAtCheckout();
 			}
-			
-			// If for some reason, we haven't setup pmpro_level yet, do that.
-			if ( empty( $pmpro_level ) ) {
-				$pmpro_level = pmpro_getLevelAtCheckout();
-			}
-			
-			// Set the level to the checkout level global.
-			$this->membership_level = $pmpro_level;
 			
 			// Fix the membership level id.
 			if(!empty( $this->membership_level) && !empty($this->membership_level->level_id)) {
@@ -1695,8 +1685,6 @@
 		 * @return PMPro_Subscription|null The subscription object or null if the order is not a subscription.
 		 */
 		public function get_subscription() {
-			global $pmpro_level;
-
 			// Make sure that this order is a part of a subscription.
 			if ( empty( $this->subscription_transaction_id ) ) {
 				// No subscription transaction ID, so we don't need to create a subscription.
@@ -1720,7 +1708,7 @@
 				return null;
 			}
 
-			if ( isset( $pmpro_level ) ) {
+			if ( pmpro_is_checkout() ) {
 				// We are processing a checkout. Get the level from the checkout.
 				$subscription_level = $this->getMembershipLevelAtCheckout();
 			} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Removing references to $pmpro_level in MemberOrder

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
