### PR TITLE
Show level ID when editing a subscription with a deleted level

### DIFF
--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -44,7 +44,7 @@ if ( empty( $subscription ) ) {
 
 	$sub_membership_level_id   = $subscription->get_membership_level_id();
 	$sub_membership_level      = pmpro_getLevel( $sub_membership_level_id );
-	$sub_membership_level_name = empty( $sub_membership_level ) ? '' : $sub_membership_level->name;
+	$sub_membership_level_name = empty( $sub_membership_level ) ? '[' . sprintf( esc_html( 'deleted level #%d', 'paid-memberships-pro' ), (int)$subscription->get_membership_level_id() ) . ']' : $sub_membership_level->name;
 	?>
 
 	<a

--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -44,7 +44,13 @@ if ( empty( $subscription ) ) {
 
 	$sub_membership_level_id   = $subscription->get_membership_level_id();
 	$sub_membership_level      = pmpro_getLevel( $sub_membership_level_id );
-	$sub_membership_level_name = empty( $sub_membership_level ) ? '[' . sprintf( esc_html( 'deleted level #%d', 'paid-memberships-pro' ), (int)$subscription->get_membership_level_id() ) . ']' : $sub_membership_level->name;
+	$sub_membership_level_name = empty( $sub_membership_level )
+		? sprintf(
+			/* translators: %d is the level ID. */
+			esc_html__( 'Level ID: %d [deleted]', 'paid-memberships-pro' ),
+			(int) $subscription->get_membership_level_id()
+		)
+		: $sub_membership_level->name;
 	?>
 
 	<a


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Show level ID when editing a subscription with a deleted level

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
