### PR TITLE
Fixing removing all memberships on level delete

### DIFF
--- a/adminpages/levels/delete-level.php
+++ b/adminpages/levels/delete-level.php
@@ -29,12 +29,10 @@ if($ml_id > 0) {
     ) );
 
     foreach($user_ids as $user_id) {
-        //change there membership level to none. that will handle the cancel
-        if(pmpro_changeMembershipLevel(0, $user_id)) {
-            //okay
-        } else {
-            //couldn't delete the subscription
-            //we should probably notify the admin
+        // Cancel the membership level and subscription.
+        if ( ! pmpro_cancelMembershipLevel( $ml_id, $user_id, 'inactive' ) ) {
+            // Couldn't delete the subscription or the membership.
+            // We should probably notify the admin
             $pmproemail = new PMProEmail();
             $pmproemail->data = array("body"=>"<p>" . sprintf(__("There was an error canceling the subscription for user with ID=%d. You will want to check your payment gateway to see if their subscription is still active.", 'paid-memberships-pro' ), $user_id) . "</p>");
             $last_order = $wpdb->get_row( $wpdb->prepare( "


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing issue where if a user has multiple memberships and one of the corresponding levels is deleted, all memberships would be terminated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
