### PR TITLE
Sending payment descriptions to Stripe Checkout

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1613,12 +1613,13 @@ class PMProGateway_stripe extends PMProGateway {
 				'price'    => $initial_payment_price->id,
 				'quantity' => 1,
 			);
+			$payment_intent_data = array(
+				'description' => self::get_order_description( $morder ),
+			);
 			if ( ! empty( $application_fee_percentage ) ) {
 				$application_fee = floor( $initial_payment_price->unit_amount * $application_fee_percentage / 100 );
 				if ( ! empty( $application_fee ) ) {
-					$payment_intent_data = array(
-						'application_fee_amount' => $application_fee,
-					);
+					$payment_intent_data['application_fee_amount'] = $application_fee;
 				}
 			}
 		}
@@ -1638,7 +1639,9 @@ class PMProGateway_stripe extends PMProGateway {
 				'price'    => $recurring_payment_price->id,
 				'quantity' => 1,
 			);
-			$subscription_data = array();
+			$subscription_data = array(
+				'description' => self::get_order_description( $morder ),
+			);
 
 			// Check if we can combine initial and recurring payments.
 			$filtered_trial_period_days = $stripe->calculate_trial_period_days( $morder );
@@ -3858,7 +3861,7 @@ class PMProGateway_stripe extends PMProGateway {
 			'amount'                 => $this->convert_price_to_unit_amount( $amount ),
 			'currency'               => $pmpro_currency,
 			'confirmation_method'    => 'manual',
-			'description'            => apply_filters( 'pmpro_stripe_order_description', "Order #" . $order->code . ", " . trim( $order->FirstName . " " . $order->LastName ) . " (" . $order->Email . ")", $order ),
+			'description'            => self::get_order_description( $order ),
 			'setup_future_usage'     => 'off_session',
 		);
 		$params = $this->add_application_fee_amount( $params );
@@ -3972,5 +3975,17 @@ class PMProGateway_stripe extends PMProGateway {
 		$order->saveOrder();
 
 		return $success;
+	}
+
+	/**
+	 * Get the description to send to Stripe for an order.
+	 *
+	 * @since TBD
+	 *
+	 * @param MemberOrder $order The MemberOrder object to get the description for.
+	 * @return string The description to send to Stripe.
+	 */
+	private static function get_order_description( $order ) {
+		return apply_filters( 'pmpro_stripe_order_description', "Order #" . $order->code . ", " . trim( $order->FirstName . " " . $order->LastName ) . " (" . $order->Email . ")", $order );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Abstracting getting Stripe order descriptions into its own method and now using that method to add descriptions to payments made via Stripe Checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
