### PR TITLE
Now creating subscription when constructing orders

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -293,6 +293,11 @@
 				} else {
 					$morder = $this->getMemberOrderByCode( $id );
 				}
+
+				// If we found an order, create a subscription if needed.
+				if ( ! empty( $this->id ) ) {
+					$this->get_subscription();
+				}
 			} else {
 				$morder = $this->getEmptyMemberOrder();	//blank constructor
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, subscriptions were only created when an order is saved. This works fine in most cases, but not in a scenario like this:
1. Site upgrades to 3.0
2. Site downgrades to 2.x for whatever reason
3. User checks out for recurring membership on 2.x
4. Site switches back to 3.0

In this case, the upgrade script would not create a subscription for this user since the upgrade script won't run twice. Without this PR, that means that a subscription object wouldn't be created for this user until an order for the subscription is saved, which likely wouldn't happen until the next renewal. But with this PR, a subscription order only needs to be loaded in order for the subscription to be created, which is much more common and may just happen over time by chance.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
