### PR TITLE
Removing unneccessary global $pmpro_giving_level

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -930,7 +930,7 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 	pmpro_set_old_user_levels( $user_id );
 
 	// If we are not giving the user a new level, run the before change membership action.
-	if ( 'changed' === $status ) {
+	if ( ! in_array( $status, array( 'changed', 'admin_changed' ) ) ) {
 		/**
 		 * Action to run before the membership level changes.
 		 *
@@ -962,7 +962,7 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 	}
 
 	// If we are not giving the user a new level, clear the level cache for this user and run the change membership action.
-	if ( 'changed' !== $status ) {
+	if ( ! in_array( $status, array( 'changed', 'admin_changed' ) ) ) {
 		// Clear the level cache for this user.
 		pmpro_clear_level_cache_for_user( $user_id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `$pmpro_giving_level` global is not needed and adds unnecessary confusion to the code. Instead, we should just check whether `$status` is `changed`, which should only be the case if the user is being assigned a membership level at the same time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
