### PR TITLE
Avoid sensitive data in checkout_levels endpoint

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -813,6 +813,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'updatePaymentRequestButton' => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
 					'currency' => strtolower( $pmpro_currency ),
 					'accountCountry' => self::get_account_country(),
+					'sensitiveCheckoutRequestVars' => pmpro_get_sensitive_checkout_request_vars(),
 				);
 
 				if ( ! empty( $order ) ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -813,7 +813,6 @@ class PMProGateway_stripe extends PMProGateway {
 					'updatePaymentRequestButton' => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
 					'currency' => strtolower( $pmpro_currency ),
 					'accountCountry' => self::get_account_country(),
-					'sensitiveCheckoutRequestVars' => pmpro_get_sensitive_checkout_request_vars(),
 				);
 
 				if ( ! empty( $order ) ) {

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -51,18 +51,10 @@ function pmpro_calculate_profile_start_date( $order, $date_format, $filter = tru
 	// Save some checkout information in the order so that we can access it when the payment is complete.
 	// Save the request variables.
 	$request_vars = $_REQUEST;
-	// Unset restricted request variables.
-	$restricted_vars = array(
-		'password',
-		'password2',
-		'password2_copy',
-		'AccountNumber',
-		'CVV',
-		'ExpirationMonth',
-		'ExpirationYear',
-		'add_sub_accounts_password', // Creating users at checkout with Sponsored Members.
-	);
-	foreach ( $restricted_vars as $key ) {
+
+	// Unset sensitive request variables.
+	$sensitive_vars = pmpro_get_sensitive_checkout_request_vars();
+	foreach ( $sensitive_vars as $key ) {
 		if ( isset( $request_vars[ $key ] ) ) {
 			unset( $request_vars[ $key ] );
 		}
@@ -111,6 +103,36 @@ function pmpro_calculate_profile_start_date( $order, $date_format, $filter = tru
 		}
 		update_pmpro_membership_order_meta( $order->id, 'checkout_files', $files );
 	}
+}
+
+/**
+ * Get the list of sensitive request variables that should not be saved in the database.
+ *
+ * @since TBD
+ *
+ * @return array The list of sensitive request variables.
+ */
+function pmpro_get_sensitive_checkout_request_vars() {
+	// These are the request variables that we do not want to save in the database.
+	$sensitive_request_vars = array(
+		'password',
+		'password2',
+		'password2_copy',
+		'AccountNumber',
+		'CVV',
+		'ExpirationMonth',
+		'ExpirationYear',
+		'add_sub_accounts_password', // Creating users at checkout with Sponsored Members.
+	);
+
+	/**
+	 * Filter the list of sensitive request variables that should not be saved in the database.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $sensitive_request_vars The list of sensitive request variables.
+	 */
+	return apply_filters( 'pmpro_sensitive_checkout_request_vars', $sensitive_request_vars );
 }
 
 /**

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -48,6 +48,7 @@ function pmpro_enqueue_scripts() {
             'ajax_timeout' => apply_filters( 'pmpro_ajax_timeout', 5000, 'applydiscountcode' ),
             'show_discount_code' => pmpro_show_discount_code(),
 			'discount_code_passed_in' => !empty( $_REQUEST['discount_code'] ),
+            'sensitiveCheckoutRequestVars' => pmpro_get_sensitive_checkout_request_vars(),
         ));
         wp_enqueue_script( 'pmpro_checkout' );
     }

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -205,3 +205,24 @@ jQuery(document).ready(function(){
 		}
 	}
 });
+
+// Get non-sensitve checkout form data to be sent to checkout_levels endpoint.
+function pmpro_getNonSensitiveCheckoutFormData() {
+	// Get all form data.
+	const checkoutFormData = jQuery( "#pmpro_form" ).serializeArray();
+
+	// Get sensitive data fields.
+	const sensitiveCheckoutRequestVars = pmpro.sensitiveCheckoutRequestVars;
+
+	// Remove sensitive data from form data.
+	for ( var i = 0; i < checkoutFormData.length; i++ ) {
+		if ( sensitiveCheckoutRequestVars.includes( checkoutFormData[i].name ) ) {
+			// Remove sensitive data from form data and adjust index to account for removed item.
+			checkoutFormData.splice( i, 1 );
+			i--;
+		}
+	}
+
+	// Return form data as string.
+	return jQuery.param( checkoutFormData );
+}

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -127,11 +127,32 @@ jQuery( document ).ready( function( $ ) {
 	if ( $('#payment-request-button').length ) {
 		var paymentRequest = null;
 
+		// Get non-sensitve checkout form data to be sent to checkout_levels endpoint..
+		function pmproStripeGetNonSensitiveCheckoutFormData() {
+			// Get all form data.
+			const checkoutFormData = jQuery( "#pmpro_form" ).serializeArray();
+
+			// Get sensitive data fields.
+			const sensitiveCheckoutRequestVars = pmproStripe.sensitiveCheckoutRequestVars;
+
+			// Remove sensitive data from form data.
+			for ( var i = 0; i < checkoutFormData.length; i++ ) {
+				if ( sensitiveCheckoutRequestVars.includes( checkoutFormData[i].name ) ) {
+					// Remove sensitive data from form data and adjust index to account for removed item.
+					checkoutFormData.splice( i, 1 );
+					i--;
+				}
+			}
+
+			// Return form data as string.
+			return jQuery.param( checkoutFormData );
+		}
+
 		// Get the level price so that information can be shown in payment request popup
 		jQuery.noConflict().ajax({
 			url: pmproStripe.restUrl + 'pmpro/v1/checkout_levels',
 			dataType: 'json',
-			data: jQuery( "#pmpro_form" ).serialize(),
+			data: pmproStripeGetNonSensitiveCheckoutFormData(),
 			success: function(data) {
 				if ( data.hasOwnProperty('initial_payment') ) {
 					// Build payment request button.
@@ -185,7 +206,7 @@ jQuery( document ).ready( function( $ ) {
 			jQuery.noConflict().ajax({
 				url: pmproStripe.restUrl + 'pmpro/v1/checkout_levels',
 				dataType: 'json',
-				data: jQuery( "#pmpro_form" ).serialize(),
+				data: pmproStripeGetNonSensitiveCheckoutFormData(),
 				success: function(data) {
 					if ( data.hasOwnProperty('initial_payment') ) {
 						paymentRequest.update({

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -127,27 +127,6 @@ jQuery( document ).ready( function( $ ) {
 	if ( $('#payment-request-button').length ) {
 		var paymentRequest = null;
 
-		// Get non-sensitve checkout form data to be sent to checkout_levels endpoint..
-		function pmproStripeGetNonSensitiveCheckoutFormData() {
-			// Get all form data.
-			const checkoutFormData = jQuery( "#pmpro_form" ).serializeArray();
-
-			// Get sensitive data fields.
-			const sensitiveCheckoutRequestVars = pmproStripe.sensitiveCheckoutRequestVars;
-
-			// Remove sensitive data from form data.
-			for ( var i = 0; i < checkoutFormData.length; i++ ) {
-				if ( sensitiveCheckoutRequestVars.includes( checkoutFormData[i].name ) ) {
-					// Remove sensitive data from form data and adjust index to account for removed item.
-					checkoutFormData.splice( i, 1 );
-					i--;
-				}
-			}
-
-			// Return form data as string.
-			return jQuery.param( checkoutFormData );
-		}
-
 		// Get the level price so that information can be shown in payment request popup
 		jQuery.noConflict().ajax({
 			url: pmproStripe.restUrl + 'pmpro/v1/checkout_levels',

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -152,7 +152,7 @@ jQuery( document ).ready( function( $ ) {
 		jQuery.noConflict().ajax({
 			url: pmproStripe.restUrl + 'pmpro/v1/checkout_levels',
 			dataType: 'json',
-			data: pmproStripeGetNonSensitiveCheckoutFormData(),
+			data: pmpro_getNonSensitiveCheckoutFormData(),
 			success: function(data) {
 				if ( data.hasOwnProperty('initial_payment') ) {
 					// Build payment request button.
@@ -206,7 +206,7 @@ jQuery( document ).ready( function( $ ) {
 			jQuery.noConflict().ajax({
 				url: pmproStripe.restUrl + 'pmpro/v1/checkout_levels',
 				dataType: 'json',
-				data: pmproStripeGetNonSensitiveCheckoutFormData(),
+				data: pmpro_getNonSensitiveCheckoutFormData(),
 				success: function(data) {
 					if ( data.hasOwnProperty('initial_payment') ) {
 						paymentRequest.update({


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
No longer sending sensitive data to checkout_levels API endpoint when mounting/updating Stripe payment request button.

Also abstracts logic to get sensitive checkout fields and adds a new filter `pmpro_sensitive_checkout_request_vars` for Add Ons and custom code to hook into.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
