### PR TITLE
Cancel all subs on level removal

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -951,12 +951,13 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 	}
 
 	// Check if we should cancel the user's subscription.
+	$subscriptions_cancelled_successfully = true;
 	if ( apply_filters( 'pmpro_cancel_previous_subscriptions', true ) ) {
 		$active_subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user_id, $level_id );
 		foreach ( $active_subscriptions as $subscription ) {
 			if ( ! $subscription->cancel_at_gateway() ) {
 				$pmpro_error = __( 'Error cancelling subscription at gateway.', 'paid-memberships-pro' );
-				return false;
+				$subscriptions_cancelled_successfully = false;
 			}
 		}
 	}
@@ -976,7 +977,7 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 		do_action( 'pmpro_after_change_membership_level', 0, $user_id, $level_id );
 	}
 
-	return true;
+	return $subscriptions_cancelled_successfully;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If a user has multiple subscriptions for a single level for whatever reason, this change avoids issues where only some of the subscriptions get canceled when the level is lost if one of the subscriptions has an error while canceling.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
