### PR TITLE
Check transaction IDs before sending to Stripe Checkout

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1479,6 +1479,11 @@ class PMProGateway_stripe extends PMProGateway {
 			return;
 		}
 
+		// Only continue if the order's payment_transaction_id and subscription_transaction_id are empty, meaning that a payment hasn't been made yet.
+		if ( ! empty( $morder->payment_transaction_id ) || ! empty( $morder->subscription_transaction_id ) ) {
+			return;
+		}
+
 		$morder->user_id = $user_id;
 		$morder->status  = 'token';
 		$morder->saveOrder();

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -667,9 +667,6 @@
  * @return bool
  */
 function pmpro_stripe_webhook_change_membership_level( $morder ) {
-	// Make sure that we don't redirect back to Stripe Checkout.
-	remove_action(  'pmpro_checkout_before_change_membership_level', array('PMProGateway_stripe', 'pmpro_checkout_before_change_membership_level'), 10, 2 );
-
 	pmpro_pull_checkout_data_from_order( $morder );
  	return pmpro_complete_async_checkout( $morder );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Moving check to avoid sending users to Stripe Checkout multiple times to inside the `pmpro_checkout_before_change_membership_level()` method of the Stripe gateway class.

This is helpful to avoid infinite loops where there are multiple hooks on `pmpro_checkout_before_change_membership_level`. We only want users sent to Stripe Checkout when they need to pay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
