### PR TITLE
Revert "Now creating subscription when constructing orders"

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -293,11 +293,6 @@
 				} else {
 					$morder = $this->getMemberOrderByCode( $id );
 				}
-
-				// If we found an order, create a subscription if needed.
-				if ( ! empty( $this->id ) ) {
-					$this->get_subscription();
-				}
 			} else {
 				$morder = $this->getEmptyMemberOrder();	//blank constructor
 			}


### PR DESCRIPTION
Reverts strangerstudios/paid-memberships-pro#2746

This causes an infinite loop with PayPal Express checkout and any other case where subscription orders are being loaded as the subscription is being created.