### PR TITLE
Only cancel levels that the user has and fix cancellation call when expiring memberships.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -926,6 +926,13 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 		return false;
 	}
 
+	// If the user doesn't have the level, we don't need to do anything.
+	$user_levels = pmpro_getMembershipLevelsForUser( $user_id );
+	$user_level_ids = array_map( 'intval', wp_list_pluck( $user_levels, 'id' ) );
+	if ( ! in_array( (int)$level_id, $user_level_ids ) ) {
+		return false;
+	}
+
 	// Set old user levels to be used in the pmpro_do_action_after_all_membership_level_changes() function.
 	pmpro_set_old_user_levels( $user_id );
 
@@ -943,7 +950,7 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 
 	// Remove the membership level.	
 	$cols_set = array( 'status'=> $status, 'enddate' => current_time( 'mysql' ) );
-	$cols_where = array( 'user_id' => $user_id, 'membership_id' => $level_id );
+	$cols_where = array( 'user_id' => $user_id, 'membership_id' => $level_id, 'status' => 'active' );
 	$cols_format = array( '%s', '%s');
 	if ( $wpdb->update( $wpdb->pmpro_memberships_users, $cols_set, $cols_where, $cols_format ) === false ) {
 		$pmpro_error = __( 'Error interacting with database', 'paid-memberships-pro' ) . ': ' . ( $wpdb->last_error ? $wpdb->last_error : 'unavailable' );

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -29,7 +29,7 @@ function pmpro_cron_expire_memberships()
 		do_action("pmpro_membership_pre_membership_expiry", $e->user_id, $e->membership_id );		
 
 		//remove their membership
-		pmpro_changeMembershipLevel(false, $e->user_id, 'expired', $e->membership_id);
+		pmpro_cancelMembershipLevel( $e->membership_id, $e->user_id, 'expired' );
 
 		do_action("pmpro_membership_post_membership_expiry", $e->user_id, $e->membership_id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Now using `pmpro_cancelMembershipLevel()` when processing an expiration
2. Now only trying to cancel a level if the user has it
3. Fixes bug where inactive membership entries would be affected by cancellation status query

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
