### PR TITLE
Adding filter `pmpro_member_edit_memberships_panel_memberships_enddate_text`

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -138,7 +138,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 								<?php
 									// Get the expiration date to show for this level.
 									$enddate_to_show = $shown_level->enddate;
-									$enddate_text = __( 'Never', 'paid-memberships-pro' );
+									$enddate_text = esc_html__( 'Never', 'paid-memberships-pro' );
 									if ( ! empty( $enddate_to_show ) ) {
 										$enddate_text = sprintf(
 											// translators: %1$s is the date and %2$s is the time.

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -138,16 +138,26 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 								<?php
 									// Get the expiration date to show for this level.
 									$enddate_to_show = $shown_level->enddate;
-									if ( empty( $enddate_to_show ) ) {
-										esc_html_e( 'Never', 'paid-memberships-pro' );
-									} else {
-										echo esc_html( sprintf(
+									$enddate_text = __( 'Never', 'paid-memberships-pro' );
+									if ( ! empty( $enddate_to_show ) ) {
+										$enddate_text = sprintf(
 											// translators: %1$s is the date and %2$s is the time.
 											__( '%1$s at %2$s', 'paid-memberships-pro' ),
-											esc_html( date_i18n( get_option( 'date_format'), $enddate_to_show ) ),
-											esc_html( date_i18n( get_option( 'time_format'), $enddate_to_show ) )
-										) );
+											date_i18n( get_option( 'date_format'), $enddate_to_show ),
+											date_i18n( get_option( 'time_format'), $enddate_to_show )
+										);
 									}
+									/**
+									 * Filter the expiration date text to show for this level.
+									 *
+									 * @since 3.0
+									 *
+									 * @param string $enddate_text The expiration date text to show for this level.
+									 * @param WP_User $user The user object.
+									 * @param object $shown_level The level object.
+									 */
+									$enddate_text = apply_filters( 'pmpro_member_edit_memberships_panel_memberships_enddate_text', $enddate_text, $user, $shown_level );
+									echo esc_html( $enddate_text );
 								?>
 							</td>
 							<td class="pmpro_levels_subscription_data has-row-actions">

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -142,7 +142,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 									if ( ! empty( $enddate_to_show ) ) {
 										$enddate_text = sprintf(
 											// translators: %1$s is the date and %2$s is the time.
-											__( '%1$s at %2$s', 'paid-memberships-pro' ),
+											esc_html__( '%1$s at %2$s', 'paid-memberships-pro' ),
 											date_i18n( get_option( 'date_format'), $enddate_to_show ),
 											date_i18n( get_option( 'time_format'), $enddate_to_show )
 										);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding filter `pmpro_member_edit_memberships_panel_memberships_enddate_text` to allow filtering expiration date shown on edit member memberships page.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
