### PR TITLE
Adjusting capability checks throughout to hide elements where the cap is not present

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -14,41 +14,51 @@ add_meta_box(
 	'toplevel_page_pmpro-dashboard',
 	'normal'
 );
-add_meta_box(
-	'pmpro_dashboard_report_sales',
-	__( 'Sales and Revenue', 'paid-memberships-pro' ),
-	'pmpro_report_sales_widget',
-	'toplevel_page_pmpro-dashboard',
-	'advanced'
-);
-add_meta_box(
-	'pmpro_dashboard_report_membership_stats',
-	__( 'Membership Stats', 'paid-memberships-pro' ),
-	'pmpro_report_memberships_widget',
-	'toplevel_page_pmpro-dashboard',
-	'advanced'
-);
-add_meta_box(
-	'pmpro_dashboard_report_logins',
-	__( 'Visits, Views, and Logins', 'paid-memberships-pro' ),
-	'pmpro_report_login_widget',
-	'toplevel_page_pmpro-dashboard',
-	'advanced'
-);
-add_meta_box(
-	'pmpro_dashboard_report_recent_members',
-	__( 'Recent Members', 'paid-memberships-pro' ),
-	'pmpro_dashboard_report_recent_members_callback',
-	'toplevel_page_pmpro-dashboard',
-	'side'
-);
-add_meta_box(
-	'pmpro_dashboard_report_recent_orders',
-	__( 'Recent Orders', 'paid-memberships-pro' ),
-	'pmpro_dashboard_report_recent_orders_callback',
-	'toplevel_page_pmpro-dashboard',
-	'side'
-);
+
+if ( current_user_can( 'pmpro_reports' ) ) {
+	add_meta_box(
+		'pmpro_dashboard_report_sales',
+		__( 'Sales and Revenue', 'paid-memberships-pro' ),
+		'pmpro_report_sales_widget',
+		'toplevel_page_pmpro-dashboard',
+		'advanced'
+	);
+	add_meta_box(
+		'pmpro_dashboard_report_membership_stats',
+		__( 'Membership Stats', 'paid-memberships-pro' ),
+		'pmpro_report_memberships_widget',
+		'toplevel_page_pmpro-dashboard',
+		'advanced'
+	);
+	add_meta_box(
+		'pmpro_dashboard_report_logins',
+		__( 'Visits, Views, and Logins', 'paid-memberships-pro' ),
+		'pmpro_report_login_widget',
+		'toplevel_page_pmpro-dashboard',
+		'advanced'
+	);
+}
+
+if ( current_user_can( 'pmpro_memberslist' ) ) {
+	add_meta_box(
+		'pmpro_dashboard_report_recent_members',
+		__( 'Recent Members', 'paid-memberships-pro' ),
+		'pmpro_dashboard_report_recent_members_callback',
+		'toplevel_page_pmpro-dashboard',
+		'side'
+	);
+}
+
+if ( current_user_can( 'pmpro_orders' ) ) {
+	add_meta_box(
+		'pmpro_dashboard_report_recent_orders',
+		__( 'Recent Orders', 'paid-memberships-pro' ),
+		'pmpro_dashboard_report_recent_orders_callback',
+		'toplevel_page_pmpro-dashboard',
+		'side'
+	);
+}
+
 add_meta_box(
 	'pmpro_dashboard_news_updates',
 	__( 'Paid Memberships Pro News and Updates', 'paid-memberships-pro' ),

--- a/adminpages/memberslist.php
+++ b/adminpages/memberslist.php
@@ -22,7 +22,9 @@ if ( isset( $_REQUEST['l'] ) ) {
 	<form id="member-list-form" method="get">		
 		<h1 class="wp-heading-inline"><?php esc_html_e( 'Members List', 'paid-memberships-pro' ); ?></h1>	
 		<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-member'), admin_url( 'admin.php' ) ) ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-plus"><?php esc_html_e( 'Add New Member', 'paid-memberships-pro' ); ?></a>
-		<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+		<?php if ( current_user_can( 'pmpro_memberslistcsv' ) ) { ?>
+			<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+		<?php } ?>
 		<?php do_action( 'pmpro_memberslist_before_table' ); ?>	
 		<input type="hidden" name="page" value="pmpro-memberslist" />
 		<?php

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -986,7 +986,10 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 		);
 		$export_url = add_query_arg( $url_params, $export_url );
 		?>
-		<a target="_blank" href="<?php echo esc_url( $export_url ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+
+		<?php if ( current_user_can( 'pmpro_orderscsv' ) ) { ?>
+			<a target="_blank" href="<?php echo esc_url( $export_url ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+		<?php } ?>
 
 		<?php if ( ! empty( $pmpro_msg ) ) { ?>
 			<div id="message" class="

--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -107,7 +107,9 @@ function pmpro_report_login_page()
 	<h1 class="wp-heading-inline">
 		<?php _e('Visits, Views, and Logins Report', 'paid-memberships-pro');?>
 	</h1>
-	<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+	<?php if ( current_user_can( 'pmpro_loginscsv' ) ) { ?>
+		<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+	<?php } ?>
 	<p class="search-box">
 		<label class="screen-reader-text" for="post-search-input"><?php echo esc_html_x( 'Search', 'Search form label', 'paid-memberships-pro')?> <?php if(empty($l)) esc_html_e( 'Users', 'paid-memberships-pro' ); else esc_html_e( 'Members', 'paid-memberships-pro' );?>:</label>
 		<input type="hidden" name="page" value="pmpro-reports" />

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -355,7 +355,9 @@ function pmpro_report_memberships_page() {
 	<h1 class="wp-heading-inline">
 		<?php _e( 'Membership Stats', 'paid-memberships-pro' ); ?>
 	</h1>
-	<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+	<?php if ( current_user_can( 'pmpro_reportscsv' ) ) { ?>
+		<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+	<?php } ?>
 	<div class="pmpro_report-filters">
 		<h3><?php esc_html_e( 'Customize Report', 'paid-memberships-pro' ); ?></h3>
 		<div class="tablenav top">

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -590,7 +590,9 @@ function pmpro_report_sales_page()
 	<h1 class="wp-heading-inline">
 		<?php _e('Sales and Revenue', 'paid-memberships-pro' );?>
 	</h1>
-	<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+	<?php if ( current_user_can( 'pmpro_sales_report_csv' ) ) { ?>
+		<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
+	<?php } ?>
 	<div class="pmpro_report-filters">
 		<h3><?php esc_html_e( 'Customize Report', 'paid-memberships-pro'); ?></h3>
 		<div class="tablenav top">

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -476,13 +476,29 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		$output   = $avatar . ' <strong>' . $userlink . '</strong><br />';
 
 		// Set up the hover actions for this user.
-		$actions      = array(
-			'editmember' => '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int)$item['ID'] ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Edit Member', 'paid-memberships-pro' ) . '</a>',
-			'edituser' => '<a href="' . esc_url( add_query_arg( array( 'user_id' => (int)$item['ID'] ), admin_url( 'user-edit.php' ) ) ) . '">' . __( 'Edit User', 'paid-memberships-pro' ) . '</a>'
-		);
-		$actions      = apply_filters( 'pmpro_memberslist_user_row_actions', $actions, (object) $item );
+		$actions = array();
+
+		/**
+		 * Filter the capability required to edit members.
+		 *
+		 * @since TBD
+		 * @param string $membership_level_capability The capability required to edit members. Default 'pmpro_edit_members'.
+		 */
+		$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'pmpro_edit_members' );
+		if ( current_user_can( $membership_level_capability ) ) {
+			// Add the "Edit Member" action.
+			$actions['editmember'] = '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int)$item['ID'] ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Edit Member', 'paid-memberships-pro' ) . '</a>';
+		}
+
+		if ( current_user_can( 'edit_users' ) ) {
+			// Add the "Edit User" action.
+			$actions['edituser'] = '<a href="' . esc_url( add_query_arg( array( 'user_id' => (int)$item['ID'] ), admin_url( 'user-edit.php' ) ) ) . '">' . __( 'Edit User', 'paid-memberships-pro' ) . '</a>';
+		}
+
+		$actions = apply_filters( 'pmpro_memberslist_user_row_actions', $actions, (object) $item );
+
 		$action_count = count( $actions );
-		$i            = 0;
+		$i = 0;
 		if ( $action_count ) {
 			$output .= '<div class="row-actions">';
 			foreach ( $actions as $action => $link ) {

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -344,9 +344,9 @@ function pmpro_admin_init_redirect_single_item_edit() {
 
 	// Edit Member redirect.
 	if ( $pmpro_admin_page == 'pmpro-member' ) {
-		// If the discount code they are trying to edit does not exist, redirect them to the discount codes page.
+		// If the user they are trying to edit does not exist, redirect them to the members list.
 		if ( ! empty( $_REQUEST['user_id'] ) && $_REQUEST['user_id'] > 0 && empty( PMPro_Member_Edit_Panel::get_user()->ID ) ) {
-			wp_redirect( add_query_arg( array( 'page' => 'pmpro-memberslist' ), 	admin_url( 'admin.php' ) ) );
+			wp_redirect( add_query_arg( array( 'page' => 'pmpro-memberslist' ), admin_url( 'admin.php' ) ) );
 			exit;
 		}
 	}
@@ -684,13 +684,27 @@ function pmpro_plugin_row_meta( $links, $file ) {
 add_filter( 'plugin_row_meta', 'pmpro_plugin_row_meta', 10, 2 );
 
 function pmpro_users_action_links( $actions, $user ) {
-	$cap = apply_filters( 'pmpro_add_member_cap', 'edit_users' );
+	/**
+	 * Filter the capability required to edit members.
+	 *
+	 * @since TBD
+	 * @param string $membership_level_capability The capability required to edit members. Default 'pmpro_edit_members'.
+	 */
+	$membership_level_capability = apply_filters( 'pmpro_edit_member_capability', 'pmpro_edit_members' );
 
-	if ( current_user_can( $cap ) && ! empty( $user->ID ) ) {
-		$actions['editmember'] = '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int) $user->ID ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Edit Member', 'paid-memberships-pro' ) . '</a>';
+	// If the user doesn't have the capability to edit members, return.
+	if ( ! current_user_can( $membership_level_capability ) ) {
+		return $actions;
 	}
+
+	// If the user doesn't have an ID, return.
+	if ( empty( $user->ID ) ) {
+		return $actions;
+	}
+
+	// Add the edit member link.
+	$actions['editmember'] = '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int) $user->ID ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Edit Member', 'paid-memberships-pro' ) . '</a>';
 
 	return $actions;
 }
-
 add_filter( 'user_row_actions', 'pmpro_users_action_links', 10, 2 );

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -68,6 +68,7 @@ function pmpro_get_capability_defs($role)
         'pmpro_reportscsv',
         'pmpro_orders',
         'pmpro_orderscsv',
+        'pmpro_sales_report_csv',
         'pmpro_subscriptions',
         'pmpro_discountcodes',
         'pmpro_userfields',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This is the start of better capability checks before we render buttons that do things.

On the adminpages/dashboard.php, we should do a bit more here to adjust who sees the "License" section. We need something else to replace it with or that entire "welcome" box could become separate boxes/collapse without that section (CSS fix).

The member-edit and panels have more specific capability checks we need to have a discussion for.