### PR TITLE
Cancel to close; adjusting some CSS

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -221,7 +221,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 									?>
 									<div class="pmpro-level_change-action-header">
 										<h4><?php esc_html_e( 'Edit Membership', 'paid-memberships-pro' ); ?></h4>
-										<p><?php printf( esc_html( 'You are editing the following membership level: %s.', 'paid-memberships-pro' ),  esc_html( $shown_level->name ) ); ?></p>
+										<p><?php printf( esc_html( 'You are editing the following membership level: %s.', 'paid-memberships-pro' ), '<strong>' . esc_html( $shown_level->name ) . '</strong>' ); ?></p>
 									</div>
 
 									<div class="pmpro-level_change-action">
@@ -296,7 +296,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 
 									<div class="pmpro-level_change-action-footer">
 										<button type="submit" name="pmpro-member-edit-memberships-panel-edit_level" class="button button-primary" value="<?php echo (int)$shown_level->id; ?>"><?php esc_html_e( 'Edit Membership', 'paid-memberships-pro' ) ?></button>
-										<input type="button" name="cancel-edit-level" value="Cancel" class="button button-secondary">
+										<input type="button" name="cancel-edit-level" value="<?php esc_attr_e( 'Close', 'paid-memberships-pro' ); ?>" class="button button-secondary">
 									</div>
 								</div> <!-- end pmpro-level_change-actions -->
 							</td>
@@ -309,7 +309,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 									?>
 									<div class="pmpro-level_change-action-header">
 										<h4><?php esc_html_e( 'Cancel Membership', 'paid-memberships-pro' ); ?></h4>
-										<p><?php printf( esc_html( 'This change will permanently cancel the following membership level: %s.', 'paid-memberships-pro' ),  esc_html( $shown_level->name ) ); ?></p>
+										<p><?php printf( esc_html( 'This change will permanently cancel the following membership level: %s.', 'paid-memberships-pro' ),  '<strong>' . esc_html( $shown_level->name ) . '</strong>' ); ?></p>
 									</div>
 
 									<?php
@@ -362,7 +362,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 
 									<div class="pmpro-level_change-action-footer">
 										<button type="submit" name="pmpro-member-edit-memberships-panel-cancel_level" class="button button-primary" value="<?php echo (int)$shown_level->id; ?>"><?php esc_html_e( 'Cancel Membership', 'paid-memberships-pro' ) ?></button>
-										<input type="button" name="cancel-cancel-level" value="Cancel" class="button button-secondary">
+										<input type="button" name="cancel-cancel-level" value="<?php esc_attr_e( 'Close', 'paid-memberships-pro' ); ?>" class="button button-secondary">
 									</div>
 								</div> <!-- end pmpro-level_change-actions -->
 							</td>
@@ -397,7 +397,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 											// If the group only allows a single level and the user already has a level, note the level that will be removed.
 											if ( empty( $group->allow_multiple_selections ) && ! empty( $shown_level ) ) {
 												?>
-												<p><?php printf( esc_html( 'This change will remove the following membership level: %s.', 'paid-memberships-pro' ), esc_html( $shown_level->name ) ); ?></p>
+												<p><?php printf( esc_html( 'This change will remove the following membership level: %s.', 'paid-memberships-pro' ), '<strong>' . esc_html( $shown_level->name ) . '</strong>' ); ?></p>
 												<?php
 											}
 											?>
@@ -491,7 +491,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 
 										<div class="pmpro-level_change-action-footer">
 											<button type="submit" name="pmpro-member-edit-memberships-panel-add_level_to_group" class="button button-primary" value="<?php echo (int)$group->id; ?>"><?php echo esc_html( $link_text ) ?></button>
-											<input type="button" name="cancel-add-level" value="Cancel" class="button button-secondary">
+											<input type="button" name="cancel-add-level" value="<?php esc_attr_e( 'Close', 'paid-memberships-pro' ); ?>" class="button button-secondary">
 										</div>
 
 									</div> <!-- end pmpro-level_change-actions -->

--- a/css/admin.css
+++ b/css/admin.css
@@ -1126,6 +1126,18 @@ body[class*="memberships_page_pmpro-"] {
 	margin: 0;
 }
 
+.pmpro_admin-pmpro-member [id^="pmpro-level-"][id$="-edit"] .pmpro-level_change-action-header strong {
+	color: var(--pmpro--color--info-link);
+}
+
+.pmpro_admin-pmpro-member [id^="pmpro-level-"][id$="-cancel"] .pmpro-level_change-action-header strong {
+	color: var(--pmpro--color--error-text);
+}
+
+.pmpro_admin-pmpro-member [id^="pmpro-level-"][id$="-change"] .pmpro-level_change-action-header strong {
+	color: var(--pmpro--color--alert-text);
+}
+
 .pmpro_admin-pmpro-member .pmpro-level_change-action-footer {
 	display: flex;
 	flex-direction: row;
@@ -1153,6 +1165,10 @@ body[class*="memberships_page_pmpro-"] {
 
 .pmpro_admin-pmpro-member #pmpro-member-edit-memberships-panel .pmpro_section .pmpro_section_inside {
 	padding: 0;
+}
+
+.pmpro_admin-pmpro-member #pmpro-member-edit-memberships-panel .row-actions {
+	position: static;
 }
 
 .pmpro_admin-pmpro-member #member-history-memberships table.widefat {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We're planning user stories + testing to do more with the membership cancel/change/edit stuff. For now, this PR does a few minor things:

- Row Actions for the Memberships tab of the Member Edit screen are now always visible (not just on hover).
- Level name that's being changed / cancelled / edited is now bold and a color for what the change is. We could do more with this. I tried a pill-style tag but it wasn't my favorite.
- Changed the button to "cancel" the action you started to say "Close". This helps a small bit with the confusion over "Cancel Membership" being a button right next to "Cancel" (cancel your change).
