### PR TITLE
Fix compat with auto-close popup on click-outside

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -826,6 +826,7 @@ jQuery(document).ready(function () {
             document.getElementById('addon-license').innerHTML = button.siblings('input[name="pmproAddOnAdminLicense"]').val();
             jQuery('.pmpro-popup-overlay').show();
             button.removeClass('disabled');
+            return false;
         } else {
             // Remove checkmark if there.
             button.removeClass('checkmarked');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves a bug caused by https://github.com/strangerstudios/paid-memberships-pro/blob/b82164df98dc1be3cd905f1815e898dd1f6cf46b/js/pmpro-admin.js#L90-L96.

**If not returning false when opening a modal, then the current click action event is still propagating causing the modal immediately close after opening (not even seeing this, because it's happening too fast).**

To reproduce the issue, install the v3.0 affected by the bug. Go through the wizard NOT setting up a license.
Then try to install an addon from the addons panel. Nothing happens.
Well, the modal is opening and closing, but again: too fast to be seen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
