### PR TITLE
* Make checkout form submit event handler specific enough to match on…

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -130,7 +130,7 @@ jQuery(document).ready(function(){
     }
 	
 	// Find ALL <form> tags on your page
-	jQuery('form').submit(function(){
+	jQuery('form#pmpro_form').submit(function(){
 		// On submit disable its submit button
 		jQuery('input[type=submit]', this).attr('disabled', 'disabled');
 		jQuery('input[type=image]', this).attr('disabled', 'disabled');


### PR DESCRIPTION
…ly checkout form and not others.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?




### Changes proposed in this Pull Request:

Make checkout submit event handler selector more specific to match only the checkout form and not others.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves conflicts with gravity forms in checkout form for example

### How to test the changes in this Pull Request:

1. Add a gravity form to checkout page.
2. Submit the gravity form
3. Try to checkout the level.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
