### PR TITLE
Avoid user meta joins in member searches on big sites.

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -174,6 +174,9 @@
 				}
 				$search = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 			}
+		} elseif( function_exists( 'wp_is_large_user_count' ) && wp_is_large_user_count() ) {
+			// Don't check user meta at all on big sites.
+			$search_query = " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";
 		} else {
 			// Default search checks a few fields.
 			$sqlQuery .= "LEFT JOIN {$wpdb->usermeta} um ON u.ID = um.user_id ";

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -339,6 +339,9 @@ class PMPro_Members_List_Table extends WP_List_Table {
 					}
 					$search_query = " AND u.ID IN(" . implode( ",", $user_ids ) . ") ";
 				}
+			} elseif( function_exists( 'wp_is_large_user_count' ) && wp_is_large_user_count() ) {
+				// Don't check user meta at all on big sites.
+				$search_query = " AND ( u.user_login LIKE '%" . esc_sql($s) . "%' OR u.user_email LIKE '%" . esc_sql($s) . "%' OR u.display_name LIKE '%" . esc_sql($s) . "%' ) ";
 			} else {
 				// Default search checks a few fields.
 				$sqlQuery .= " LEFT JOIN $wpdb->usermeta um ON u.ID = um.user_id ";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

On sites with a large numbers of users and/or user meta, members list searches could take a LONG time. The culprit is the join on the user meta table and the checks against user meta in the where clause.

To help with this, we already detect when there is a colon in the search query, and in those cases presearch for a specific user field or meta key. However "non-colon" searches could take a long time or even cause resource issues on the server.

This PR adds a check using the new `wp_is_large_user_count()` added in WP 6.0.0. If this value is true, then a simpler version of the search is done that doesn't join on the user meta table or search any user meta fields.

By default, sites with over 10k users are considered large. This can be adjusted using the `wp_is_large_user_count ` filter. https://developer.wordpress.org/reference/functions/wp_is_large_user_count/

We could consider adding a notice in these cases where the member search query is altered... or even perhaps just suggesting searching with colons, since the colon searches are a hidden feature as is.

### How to test the changes in this Pull Request:

1. Create a site with > 10k users.
2. User a tool like the query monitor plugin to track how long it takes to do a search on the members list table (without a colon in it).
3. Note that the search is faster (and doesn't search user meta) once this code is enabled.
4. Sites with < 4k users or with a : in them are unaffected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: If `wp_is_large_user_count()` is true, searches on the members list table will use a simpler query that does not search user meta. You can still search user meta by using a query with a colon in it, e.g. meta_key:term or first_name: jason. By default WP considers a site with > 10k users "large". You can adjust this using the `wp_is_large_user_count` filter.
