### PR TITLE
Formatting for file-type fields on Edit Member and Edit User screen

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -905,7 +905,7 @@ class PMPro_Field {
 						( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options', $current_user->ID ) )
 					) {
 						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
-						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . $this->name . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
+						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . $this->name . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<input id="pmprorh_delete_file_' . $this->name . '_field" name="pmprorh_delete_file_' . $this->name . '_field" type="hidden" value="0" />';
 

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -906,7 +906,7 @@ class PMPro_Field {
 					) {
 						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
-						$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . $this->name . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
+						$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . esc_attr( $this->name ) . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<input id="pmprorh_delete_file_' . $this->name . '_field" name="pmprorh_delete_file_' . $this->name . '_field" type="hidden" value="0" />';
 
 					}

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -907,7 +907,7 @@ class PMPro_Field {
 						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . esc_attr( $this->name ) . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
-						$r_beginning .= '<input id="pmprorh_delete_file_' . $this->name . '_field" name="pmprorh_delete_file_' . $this->name . '_field" type="hidden" value="0" />';
+						$r_beginning .= '<input id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_field" name="pmprorh_delete_file_' . esc_attr( $this->name ) . '_field" type="hidden" value="0" />';
 
 					}
 				}

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -888,7 +888,7 @@ class PMPro_Field {
 				if ( ( ! empty( $this->preview ) ) && ! empty( $this->file['previewurl'] ) ) {
 					$filetype = wp_check_filetype( basename( $this->file['previewurl'] ), null );
 					if ( $filetype && 0 === strpos( $filetype['type'], 'image/' ) ) {
-						$r_beginning .= '<div class="pmprorh_file_preview"><img src="' . $this->file['previewurl'] . '" alt="' . basename($value) . '" /></div>';
+						$r_beginning .= '<div class="pmprorh_file_preview"><img src="' . esc_url( $this->file['previewurl'] ) . '" alt="' . esc_attr( basename($value) ) . '" /></div>';
 					}
 				}
 

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -904,7 +904,7 @@ class PMPro_Field {
 					if ( $this->allow_delete === true || 
 						( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options', $current_user->ID ) )
 					) {
-						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . $this->name . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
+						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . $this->name . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . $this->name . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<input id="pmprorh_delete_file_' . $this->name . '_field" name="pmprorh_delete_file_' . $this->name . '_field" type="hidden" value="0" />';

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -893,7 +893,7 @@ class PMPro_Field {
 				}
 
 				if( ! empty( $this->file['fullurl'] ) ) {										
-					$r_beginning .= '<div class="pmprorh_file_' . $this->name . '_name">' . sprintf(__('Current File: %s', 'paid-memberships-pro' ), '<a target="_blank" href="' . $this->file['fullurl'] . '">' . basename($value) . '</a>' ) . '</div>';
+					$r_beginning .= '<div class="pmprorh_file_' . esc_attr( $this->name ) . '_name">' . sprintf(__('Current File: %s', 'paid-memberships-pro' ), '<a target="_blank" href="' . esc_url( $this->file['fullurl'] ) . '">' . esc_html( basename($value) ) . '</a>' ) . '</div>';
 				} else {
 					$r_beginning .= sprintf(__('Current File: %s', 'paid-memberships-pro' ), basename($value) );
 				}

--- a/css/admin.css
+++ b/css/admin.css
@@ -1171,6 +1171,10 @@ body[class*="memberships_page_pmpro-"] {
 	width: 100%;
 }
 
+.pmpro_admin-pmpro-member .pmpro_display-field-file .pmprorh_file_upload {
+	margin-top: var(--pmpro--spacing--medium);
+}
+
 .pmpro_admin-pmpro-member .wp-pwd {
 	margin-top: 0;
 }
@@ -1938,6 +1942,30 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	.pmpro_admin-pmpro-userfields .pmpro_userfield-field-setting {
 		flex: 50%;
 	}
+}
+
+/* Display-style User Fields on Edit Member or Edit User screen */
+.pmpro_display-field-file .pmprorh_file_preview {
+	border: 1px solid var(--pmpro--border--color);
+	border-radius: var(--pmpro--border--radius);
+	box-shadow: var(--pmpro--box-shadow);
+	display: inline-block;
+	margin-bottom: var(--pmpro--spacing--small);
+	overflow: hidden;
+}
+
+.pmpro_display-field-file .pmprorh_file_file_field_name {
+	margin-bottom: var(--pmpro--spacing--small);
+}
+
+.pmpro_display-field-file .button {
+	margin-right: calc( var(--pmpro--spacing--small) / 2 );
+}
+
+.pmpro_display-field-file .pmprorh_file_upload {
+	border: 3px dashed var(--pmpro--border--color);
+	border-radius: var(--pmpro--border--radius);
+	padding: var(--pmpro--spacing--medium);
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Improved the UI for displaying a file type field. When a file exists, the preview and actions to delete or replace are present. Without an existing file, the input form is shown.

New buttons to handle replace / delete and cancelling that action.
![Screenshot 2024-01-30 at 8 28 51 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/8aa75c74-6007-45ba-a2f4-8f0e3da465e8)

![Screenshot 2024-01-30 at 8 28 46 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/bc62ded1-1a9e-452b-b330-6dd31a0a334a)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?