### PR TITLE
Fixing error message types to have the correct selectors; editing lan…

### DIFF
--- a/adminpages/groups/edit-group.php
+++ b/adminpages/groups/edit-group.php
@@ -35,16 +35,19 @@ $mmpu_incompatible_add_ons = pmpro_get_mmpu_incompatible_add_ons();
 <?php
 if ( ! empty( $mmpu_incompatible_add_ons ) ) {
 ?>
-	<div class="pmpro_error">
+	<div class="pmpro_message pmpro_error">
 		<p>
 			<?php
 			echo sprintf(
 				// translators: %s is the list of incompatible add ons.
-				esc_html__( 'The following add ons are not compatible with "Multiple Memberships Per User" setups: %s', 'paid-memberships-pro' ),
-				esc_html( implode( ', ', $mmpu_incompatible_add_ons ) )
+				esc_html__( 'The following active Add Ons are not compatible with your membership level setup: %s', 'paid-memberships-pro' ),
+				'<strong>' . esc_html( implode( ', ', $mmpu_incompatible_add_ons ) ) . '.</strong>'
 			);
-			echo '<br />';
-			esc_html_e( 'You should not have multiple level groups or a  group that allows users to have multiple levels from the group while those Add Ons are active.', 'paid-memberships-pro' );
+			?>
+		</p>
+		<p>
+			<?php
+			esc_html_e( 'This warning is shown because you have more than one level group or a level group that allows multiple selections. To continue using these Add Ons, you should move all levels to a single "one level per" group.', 'paid-memberships-pro' );
 			?>
 		</p>
 	</div>

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -294,16 +294,19 @@
 			<?php
 				if ( ! empty( $mmpu_incompatible_add_ons ) && $is_mmpu_setup ) {
 					?>
-					<div class="pmpro_error">
+					<div class="pmpro_message pmpro_error">
 						<p>
 							<?php
 							echo sprintf(
 								// translators: %s is the list of incompatible add ons.
-								esc_html__( 'The following add ons are not compatible with "Multiple Memberships Per User" setups: %s', 'paid-memberships-pro' ),
-								esc_html( implode( ', ', $mmpu_incompatible_add_ons ) )
+								esc_html__( 'The following active Add Ons are not compatible with your membership level setup: %s', 'paid-memberships-pro' ),
+								'<strong>' . esc_html( implode( ', ', $mmpu_incompatible_add_ons ) ) . '.</strong>'
 							);
-							echo '<br />';
-							esc_html_e( 'You should not have multiple level groups or a group that allows users to have multiple levels from the group while those Add Ons are active.', 'paid-memberships-pro' );
+							?>
+						</p>
+						<p>
+							<?php
+							esc_html_e( 'This warning is shown because you have more than one level group or a level group that allows multiple selections. To continue using these Add Ons, you should move all levels to a single "one level per" group.', 'paid-memberships-pro' );
 							?>
 						</p>
 					</div>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1450,7 +1450,9 @@ class PMProGateway_stripe extends PMProGateway {
 			$last_order->getLastMemberOrder( get_current_user_id(), null, null, 'stripe' );
 			if ( ! empty( $last_order->id ) && $last_order->status === 'pending' ) {
 				?>
-				<p class="pmpro_error"><?php _e( 'Your previous order has not yet been processed. Submitting your payment again will cause a separate charge to be initiated.', 'paid-memberships-pro' ); ?></p>
+				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_error' ) ); ?>">
+					<p><?php esc_html_e( 'Your previous order has not yet been processed. Submitting your payment again will cause a separate charge to be initiated.', 'paid-memberships-pro' ); ?></p>
+				</div>
 				<?php
 			}
 			


### PR DESCRIPTION
…guage of the MMPU-incomptible setup

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This fixes a display issue when something with just class="pmpro_error" also needs "pmpro_message" as a selector.

I also reworded the message shown when the site has active incompatible Add Ons.

Jason has a note to abstract some of these checks to a function.

![Screenshot 2024-01-30 at 8 58 33 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/eaf63f30-4d2d-4fea-93d9-fb19d255587a)

