### PR TITLE
Show links and previews when viewing a file field as readonly

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -982,12 +982,12 @@ class PMPro_Field {
 
             //setup date vars
             if(is_array($value) && !empty($value)){
-	    $value = strtotime(implode("/", $value), current_time('timestamp'));
-	}elseif(!is_array($value) && !empty($value)){
-	    $value = strtotime($value, current_time('timestamp'));
-	}else{
-	    $value = strtotime(date('Y-m-d'), current_time('timestamp'));
-	}
+				$value = strtotime(implode("/", $value), current_time('timestamp'));
+			}elseif(!is_array($value) && !empty($value)){
+				$value = strtotime($value, current_time('timestamp'));
+			}else{
+				$value = strtotime(date('Y-m-d'), current_time('timestamp'));
+			}
 
             $year = date("Y", $value);
             $month = date("n", $value);
@@ -1310,9 +1310,10 @@ class PMPro_Field {
 	 * Echo the value of the field based on type
 	 * and taking into account fields with options.
 	 * @param mixed $value The value to be shown.
-	 * @since 3.0 Shows files as links.
+	 * @param bool $echo Whether to echo the value or return it.
+	 * @since 3.0 Shows files as links and added echo parameter.
 	 */
-	function displayValue( $value ) {
+	function displayValue( $value, $echo = true ) {
 		$output = '';
 		$allowed_html = array();
 		
@@ -1368,7 +1369,12 @@ class PMPro_Field {
 		// Enforce string as output.
 		$output = (string) $output;
 
-		echo wp_kses( $output, $allowed_html );
+		if ( $echo ) {
+			echo wp_kses( $output, $allowed_html );
+		} else {
+			return wp_kses( $output, $allowed_html );
+		}
+		
 	}
 	
 	/**

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -836,8 +836,7 @@ class PMPro_Field {
 			
 			$r .= sprintf( '</ul></div>' );
 			
-		}
-		
+		}	
 		elseif($this->type == "textarea")
 		{
 			$r = '<textarea id="' . $this->id . '" name="' . $this->name . '" rows="' . $this->rows . '" cols="' . $this->cols . '" ';
@@ -1273,9 +1272,9 @@ class PMPro_Field {
 			<td>
 				<?php 						
 					if(current_user_can("edit_users", $current_user->ID) && $edit !== false)
-						$this->display($value); 
+						$this->display($value);
 					else
-						echo "<div>" . $this->displayValue($value) . "</div>";						
+						echo "<div>" . $this->displayValue($value) . "</div>";
 				?>
 				<?php if(!empty($this->hint)) { ?>
 					<small class="lite"><?php echo wp_kses_post( $this->hint );?></small>
@@ -1288,28 +1287,24 @@ class PMPro_Field {
 	}		
 	
 	//checks for array values and values from fields with options
-	function displayValue($value)
-	{
-		if(is_array($value) && !empty($this->options))
-		{
+	function displayValue( $value ) {
+		if(is_array( $value ) && ! empty( $this->options ) ) {
 			$labels = array();
-			foreach($value as $item)
-			{
+			foreach( $value as $item ) {
 				$labels[] = $this->options[$item];
 			}
-
 			$output = implode( ', ', $labels);
-		}
-		elseif(is_array($value))
+		} elseif( is_array( $value ) ) {
 			$output = implode( ', ', $value );
-		elseif( ! empty( $this->options ) && isset( $this->options[$value] ) )
+		} elseif( ! empty( $this->options ) && isset( $this->options[$value] ) ) {
 			$output = $this->options[$value];
-		elseif ( $this->type == 'checkbox' )
+		} elseif ( $this->type == 'checkbox' ) {
 			$output = $value ? __( 'Yes', 'paid-memberships-pro' ) : __( 'No', 'paid-memberships-pro' );
-		elseif ( $this->type == 'date' )
+		} elseif ( $this->type == 'date' ) {
 			$output = date_i18n( get_option( 'date_format' ), strtotime( $value ) );
-		else
+		} else {
 			$output = $value;
+		}
 
 		// Enforce string as output.
 		$output = (string) $output;

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -901,15 +901,17 @@ class PMPro_Field {
 				if ( ( ! empty( $this->allow_delete ) ) && ! empty( $this->file['fullurl'] ) ) {
 					// Check whether the current user can delete the uploaded file based on the field attribute 'allow_delete'.
 					if ( $this->allow_delete === true || 
-						( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options', $current_user->ID ) )
+						( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options' ) )
 					) {
 						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
-						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
-						$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . esc_attr( $this->name ) . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
-						$r_beginning .= '<input id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_field" name="pmprorh_delete_file_' . esc_attr( $this->name ) . '_field" type="hidden" value="0" />';
-
 					}
 				}
+
+				if( empty( $this->readonly ) ) {
+					$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
+					$r_beginning .= '<button class="button button-secondary pmprorh_cancel_change_file" id="pmprorh_cancel_change_file_' . esc_attr( $this->name ) . '_button" style="display: none;" onclick="return false;">' . __( 'Cancel', 'paid-memberships-pro' ) . '</button>';
+					$r_beginning .= '<input id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_field" name="pmprorh_delete_file_' . esc_attr( $this->name ) . '_field" type="hidden" value="0" />';
+				}				
 			}
 			
 			//include script to change enctype of the form and allow deletion
@@ -1290,7 +1292,7 @@ class PMPro_Field {
 			<td>
 				<?php 						
 					if(current_user_can("edit_user", $current_user->ID) && $edit !== false)
-						$this->display($value); 
+						$this->display($value);
 					else
 						echo "<div>" . $this->displayValue($value) . "</div>";
 				?>

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1686,3 +1686,27 @@ function pmpro_get_label_for_user_field_value( $field_name, $field_value ) {
 	}
 	return $field_value;
 }
+
+/**
+ * Get a single field from the global $pmpro_user_fields array.
+ * @since 3.0
+ * @param string $field_name The name of the field to get.
+ * @return bool|object The field object if found, false otherwise.
+ */
+function pmpro_get_user_field( $field_name ) {
+	global $pmpro_user_fields;
+	
+	if ( empty( $pmpro_user_fields ) ) {
+		return false;
+	}
+
+	foreach ( $pmpro_user_fields as $group ) {
+		foreach ( $group as $field ) {
+			if ( $field->name === $field_name ) {
+				return $field;
+			}
+		}
+	}
+	
+	return false;
+}

--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -176,6 +176,18 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		}
 	}
 
+	// Check for files to reformat them.
+	if ( is_array( $r ) && ! empty( $r['fullurl'] ) ) {
+		$file_field = pmpro_get_user_field( $field );
+		if ( ! empty( $file_field ) ) {
+			$file_field->file = $r;
+			$file_field->readonly = true;
+			$r = $file_field->displayValue( $r['fullurl'], false ); // False to not echo.
+		} else {
+			$r = '<a href="' . esc_url( $r['fullurl'] ) . '">' . esc_html( basename($r['fullurl'] ) ) . '</a>';
+		}
+	}
+
 	// If this is a user field with an associative array of options, get the label(s) for the value(s).
 	$r = pmpro_get_label_for_user_field_value( $field, $r );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

PMPro 3.0 adds a read only view for the new edit member pages. When in this view, we noticed that file type user fields would only show the file name. In most scenarios, it makes sense for folks who are able to "edit_members" and otherwise view members to be able to view the files associated with that user. So we are updating the displayValue method to show previews and links for file type fields.

This should also make it so fields shown through the member shortcode are also shown in this way.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a user field of type file.
1. As an admin, edit a member to upload a file for them. Use an image to test previews.
2. Edit a user to have a role with the pmpro_edit_members cap but not the edit_users cap
3. Use that user to edit the membership for a member.
4. Go to the tab for the field group that has the file field. A preview and link should display if there is a file.

*Some other things to test:*
* A member shortcode that outputs a file field.
* Member Directory profiles for users with fields.
* Think of cases where file fields might have been output where we WOULDN'T want the link or preview to show.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> ENHANCEMENT: Now showing image previews and file links when file fields are viewed as readonly.
