### PR TITLE
Adjusting the wording and appearance of the View As toolbar feature for admins

### DIFF
--- a/css/frontend.css
+++ b/css/frontend.css
@@ -361,6 +361,74 @@ select.pmpro_error {
 }
 
 /*---------------------------------------
+	Admin Toolbar View As Feature
+---------------------------------------*/
+#wpadminbar .pmpro_admin-view {
+	display: inline-block;
+	padding: 0 5px;
+}
+
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view) + .ab-sub-wrapper {
+	border-bottom-right-radius: 6px;
+	border-bottom-left-radius: 6px;
+	padding: 10px;
+}
+
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view) + .ab-sub-wrapper ul li .ab-item {
+	height: auto;
+}
+
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view) + .ab-sub-wrapper p {
+	color: #FFF;
+	line-height: 1.5;
+	margin-bottom: 5px;
+	white-space: normal;
+}
+
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view) + .ab-sub-wrapper select {
+	border-radius: 6px;
+	line-height: 1.5;
+	padding: 5px 8px;
+}
+
+#wpadminbar .ab-item:has(.pmpro_admin-view-yes),
+#wpadminbar .ab-top-menu > li.hover > .ab-item:has(.pmpro_admin-view-yes),
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item:has(.pmpro_admin-view-yes),
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:has(.pmpro_admin-view-yes):focus,
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view-yes) + .ab-sub-wrapper {
+	background-color: #0F441C;
+	color: #FFF;
+}
+
+#wpadminbar .ab-item:has(.pmpro_admin-view-current),
+#wpadminbar .ab-top-menu > li.hover > .ab-item:has(.pmpro_admin-view-current),
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item:has(.pmpro_admin-view-current),
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:has(.pmpro_admin-view-current):focus,
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view-current) + .ab-sub-wrapper {
+	background-color: #245269;
+	color: #FFF;
+}
+
+#wpadminbar .ab-item:has(.pmpro_admin-view-no),
+#wpadminbar .ab-top-menu > li.hover > .ab-item:has(.pmpro_admin-view-no),
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item:has(.pmpro_admin-view-no),
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:has(.pmpro_admin-view-no):focus,
+#wpadminbar .menupop .ab-item:has(.pmpro_admin-view-no) + .ab-sub-wrapper {
+	background-color: #721c24;
+	color: #FFF;
+}
+
+#wpadminbar .pmpro_admin-view .ab-icon {
+	margin-right: 3px;
+}
+
+#wpadminbar .pmpro_admin-view .ab-icon:before,
+#wpadminbar li:hover .pmpro_admin-view .ab-icon:before,
+#wpadminbar li.hover .pmpro_admin-view .ab-icon:before {
+	color: #FFF;
+}
+
+/*---------------------------------------
 	Display Price Parts
 ---------------------------------------*/
 .pmpro_price_part_span {

--- a/css/frontend.css
+++ b/css/frontend.css
@@ -400,15 +400,6 @@ select.pmpro_error {
 	color: #FFF;
 }
 
-#wpadminbar .ab-item:has(.pmpro_admin-view-current),
-#wpadminbar .ab-top-menu > li.hover > .ab-item:has(.pmpro_admin-view-current),
-#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item:has(.pmpro_admin-view-current),
-#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:has(.pmpro_admin-view-current):focus,
-#wpadminbar .menupop .ab-item:has(.pmpro_admin-view-current) + .ab-sub-wrapper {
-	background-color: #245269;
-	color: #FFF;
-}
-
 #wpadminbar .ab-item:has(.pmpro_admin-view-no),
 #wpadminbar .ab-top-menu > li.hover > .ab-item:has(.pmpro_admin-view-no),
 #wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item:has(.pmpro_admin-view-no),
@@ -426,6 +417,12 @@ select.pmpro_error {
 #wpadminbar li:hover .pmpro_admin-view .ab-icon:before,
 #wpadminbar li.hover .pmpro_admin-view .ab-icon:before {
 	color: #FFF;
+}
+
+#wpadminbar .pmpro_admin-view-current .ab-icon:before,
+#wpadminbar li:hover .pmpro_admin-view-current .ab-icon:before,
+#wpadminbar li.hover .pmpro_admin-view-current .ab-icon:before {
+	color: inherit;
 }
 
 /*---------------------------------------

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -432,14 +432,16 @@ function pmpro_admin_membership_access_menu_bar() {
 	$admin_membership_access = get_user_meta( $current_user->ID, 'pmpro_admin_membership_access', true );
 
 	// Set the title and the option value.
+	$title = '<span class="pmpro_admin-view pmpro_admin-view-' . esc_attr( $admin_membership_access ) . '">';
 	if ( 'no' === $admin_membership_access ) {
-		$title = '<span class="ab-icon dashicons dashicons-hidden non-member-icon"></span>' . esc_html__( 'Viewing without membership access', 'paid-memberships-pro' );
+		$title .= '<span class="ab-icon dashicons dashicons-lock non-member-icon"></span>' . esc_html__( 'View: No Access', 'paid-memberships-pro' );
 	} elseif ( 'current' === $admin_membership_access ) {
-		$title = esc_html__( 'Viewing with current membership levels', 'paid-memberships-pro' );
+		$title .= '<span class="ab-icon dashicons dashicons-admin-users current-access-icon"></span>' . esc_html__( 'View: My Access', 'paid-memberships-pro' );
 	} else {
-		$title = '<span class="ab-icon dashicons dashicons-saved has-access-icon"></span>' . esc_html__( 'Viewing with membership access', 'paid-memberships-pro' );
+		$title .= '<span class="ab-icon dashicons dashicons-unlock has-access-icon"></span>' . esc_html__( 'View: With Access', 'paid-memberships-pro' );
 		$admin_membership_access = 'yes';
 	}
+	$title .= '</span>';
 
 	$wp_admin_bar->add_menu(
 		array(
@@ -453,6 +455,7 @@ function pmpro_admin_membership_access_menu_bar() {
 	ob_start();
 	?>
 	<form method="POST" id="pmpro-admin-membership-access-form" action="">
+		<p><?php esc_html_e( 'Preview your membership site by changing the selected view below.', 'paid-memberships-pro' ); ?></p>
 		<select name="pmpro-admin-membership-access" id="pmpro-admin-membership-access" onchange="this.form.submit()">
 			<option value="yes" <?php selected( $admin_membership_access, 'yes', true ); ?>><?php esc_html_e( 'View with membership access', 'paid-memberships-pro' ); ?></option>
 			<option value="current" <?php selected( $admin_membership_access, 'current', true ); ?>><?php esc_html_e( 'View with current membership levels', 'paid-memberships-pro' ); ?></option>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Styling the dropdown with color context and wording changes.

I think we should add a setting to hide this in advanced settings or usermeta somehow. Most plugins that add things to the WP Toolbar allow them to be disabled (https://yoast.com/help/remove-yoast-seo-admin-bar/).

This was also tested with the Kadence theme that Kim W. found inconsistency with. Looks good in any theme that I've tested with.

<img src="https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/fbde7ea2-0fa3-4322-9dd8-cb3f9bc8594e" width="350">

<img src="https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/c24a1051-6851-4d71-b2ed-8b72db417bbd" width="350">

<img src="https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/c133aa24-91af-4bef-a17e-f3f0fc646b4c" width="350">
