### PR TITLE
Added pmpro_get_membership_expiration_text() function

### DIFF
--- a/adminpages/member-edit.php
+++ b/adminpages/member-edit.php
@@ -178,3 +178,24 @@ function pmpro_member_edit_save() {
 	}
 }
 add_action( 'admin_init', 'pmpro_member_edit_save' );
+
+/**
+ * We always want to show the time of expiration on the edit member page of the dashboard.
+ * Fires on priority 5 so sites filtering run later by default.
+ * @param bool $show Whether to show the time of expiration
+ * @since 3.0
+ */
+function pmpro_member_edit_show_time_on_expiration( $show ) {
+	// Ignore on frontend.
+	if ( ! is_admin() ) {
+		return $show;
+	}
+
+	// Make sure we are on the edit member page.
+	if ( empty( $_REQUEST['page'] ) || $_REQUEST['page'] !== 'pmpro-member' ) {
+		return $show;
+	}
+
+	return true;
+}
+add_filter( 'pmpro_show_time_on_expiration_date', 'pmpro_member_edit_show_time_on_expiration', 5 );

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -135,20 +135,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 								</div>
 							</td>
 							<td>
-								<?php
-									// Get the expiration date to show for this level.
-									$enddate_to_show = $shown_level->enddate;
-									if ( empty( $enddate_to_show ) ) {
-										esc_html_e( 'Never', 'paid-memberships-pro' );
-									} else {
-										echo esc_html( sprintf(
-											// translators: %1$s is the date and %2$s is the time.
-											__( '%1$s at %2$s', 'paid-memberships-pro' ),
-											esc_html( date_i18n( get_option( 'date_format'), $enddate_to_show ) ),
-											esc_html( date_i18n( get_option( 'time_format'), $enddate_to_show ) )
-										) );
-									}
-								?>
+								<?php echo pmpro_get_membership_expiration_text( $shown_level->enddate, $shown_level, $user ); ?>
 							</td>
 							<td class="pmpro_levels_subscription_data has-row-actions">
 								<?php

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -135,7 +135,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 								</div>
 							</td>
 							<td>
-								<?php echo pmpro_get_membership_expiration_text( $shown_level->enddate, $shown_level, $user ); ?>
+								<?php echo pmpro_get_membership_expiration_text( $shown_level, $user ); ?>
 							</td>
 							<td class="pmpro_levels_subscription_data has-row-actions">
 								<?php

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -438,11 +438,8 @@
 			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));
 
 			if($theuser->membership_id)
-			{
-				if($theuser->enddate)
-					array_push($csvoutput, pmpro_enclose(apply_filters("pmpro_memberslist_expires_column", date_i18n($dateformat, $theuser->enddate), $theuser)));
-				else
-					array_push($csvoutput, pmpro_enclose(apply_filters("pmpro_memberslist_expires_column", __('Never', 'paid-memberships-pro'), $theuser)));
+			{				
+				array_push($csvoutput, pmpro_enclose(pmpro_get_membership_expiration_text( $theuser->enddate, null, $theuser)));			
 			}
 			elseif($l == "oldmembers" && $theuser->enddate) {
 				array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->enddate)));

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -437,11 +437,14 @@
 			//joindate and enddate
 			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));
 
-			if($theuser->membership_id)
-			{				
-				array_push($csvoutput, pmpro_enclose(pmpro_get_membership_expiration_text( $theuser->enddate, null, $theuser)));
-			}
-			elseif($l == "oldmembers" && $theuser->enddate) {
+			if ( $theuser->membership_id ) {
+				// We are no longer filtering the expiration date text for performance reasons.
+				if ( $theuser->enddate ) {
+					array_push( $csvoutput, pmpro_enclose( date_i18n( $dateformat, $theuser->enddate ) ) );
+				} else {
+					array_push( $csvoutput, pmpro_enclose( __( 'N/A', 'paid-memberships-pro' ) ) );
+				}
+			} elseif($l == "oldmembers" && $theuser->enddate) {
 				array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->enddate)));
 			} else {
 				array_push($csvoutput, __('N/A', 'paid-memberships-pro'));

--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -439,7 +439,7 @@
 
 			if($theuser->membership_id)
 			{				
-				array_push($csvoutput, pmpro_enclose(pmpro_get_membership_expiration_text( $theuser->enddate, null, $theuser)));			
+				array_push($csvoutput, pmpro_enclose(pmpro_get_membership_expiration_text( $theuser->enddate, null, $theuser)));
 			}
 			elseif($l == "oldmembers" && $theuser->enddate) {
 				array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->enddate)));

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -681,11 +681,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function column_enddate( $item ) {
 		$user_object = get_userdata( $item['ID'] );
-		if ( 0 == $item['enddate'] ) {
-			return apply_filters( 'pmpro_memberslist_expires_column', __( 'Never', 'paid-memberships-pro' ), $user_object );
-		} else {
-			return apply_filters( 'pmpro_memberslist_expires_column', date_i18n( get_option( 'date_format' ), $item['enddate'] ), $user_object );
-		}
+		return pmpro_get_membership_expiration_text( $item['enddate'], null, $user_object );		
 	}
 
 	/**

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -680,8 +680,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 * @return string Text to be placed inside the column <td>.
 	 */
 	public function column_enddate( $item ) {
-		$user_object = get_userdata( $item['ID'] );
-		return pmpro_get_membership_expiration_text( $item['enddate'], null, $user_object );
+		return pmpro_get_membership_expiration_text( $item['membership_id'], $item['ID'] );
 	}
 
 	/**

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -681,7 +681,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function column_enddate( $item ) {
 		$user_object = get_userdata( $item['ID'] );
-		return pmpro_get_membership_expiration_text( $item['enddate'], null, $user_object );		
+		return pmpro_get_membership_expiration_text( $item['enddate'], null, $user_object );
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -590,54 +590,93 @@ function pmpro_getLevelsExpiration( &$levels ) {
 
 /**
  * Get the text to display a membership's expiration date.
+ *
  * @since 3.0
- * @param int|string $enddate The expiration date timestamp or string to show. 
- * @param mixed $level A level object or id (optional) to pass to filters.
- * @param mixed $user A user object or id (optional) to pass to filters.
+ *
+ * @param object|int  $level The level object or ID to get the expiration date for.
+ * @param WP_User|int $user  The user object or ID to get the expiration date for.
+ *
  * @return string The expiration date text.
  */
-function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = null ) {
-	/**
-	 * Filter to include the expiration time with expiration date
-	 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date
-	 * @param int $enddate The expiration date timestamp.
-	 * @param mixed $level A level object or id passed into this function.
-	 * @param mixed $user A user object or id passed into this function.
-	 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
-	 * @since 3.0 Now passes the $enddate, $level, and $user.
-	 *
-	 * Used in adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
-	 */
-	$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false, $enddate, $level, $user );
+function pmpro_get_membership_expiration_text( $level, $user ) {
+	// If a user ID was passed, get the user object.
+	if ( is_numeric( $user ) ) {
+		$user = get_userdata( $user );
+	}
 
-	if ( empty( $enddate ) ) {
-		// N/A on the backend. &#8212; dash on the frontend.
+	// Make sure that we have a user object.
+	if ( empty( $user ) || ! is_a( $user, 'WP_User' ) ) {
+		return '';
+	}
+
+	// If a level ID was passed, get the level object.
+	if ( is_numeric( $level ) ) {
+		pmpro_getSpecificMembershipLevelForUser( $user->ID, (int)$level );
+	}
+
+	// Make sure that we have a level object with an enddate property, even if it's empty.
+	if ( empty( $level ) || ! is_object( $level ) || ! isset( $level->enddate ) ) {
+		return '';
+	}
+
+	/**
+	 * Filter to include the expiration time with expiration date.
+	 * Used in adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php.
+	 *
+	 * @param bool $show_time Whether to show the expiration time with expiration date.
+	 *
+	 * @return bool Whether to show the expiration time with expiration date.
+	 */
+	$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false );
+
+	// Generate the expiration date text.
+	if ( empty( $level->enddate ) ) {
+		// If the level does not have an enddate, show a dash (&#8212;).
 		$text = esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
-	} elseif( is_numeric( $enddate ) ) {
+	} else {
 		// Convert enddate timestamp to a date string.
 		if ( $show_time ) {
 			$text = sprintf(
 				// translators: %1$s is the date and %2$s is the time.
 				esc_html__( '%1$s at %2$s', 'paid-memberships-pro' ),
-				date_i18n( get_option( 'date_format'), $enddate ),
-				date_i18n( get_option( 'time_format'), $enddate )
+				date_i18n( get_option( 'date_format'), $level->enddate ),
+				date_i18n( get_option( 'time_format'), $level->enddate )
 			);
 		} else {
-			$text = date_i18n( get_option( 'date_format' ), $enddate );
+			$text = date_i18n( get_option( 'date_format' ), $level->enddate );
 		}		
-	} else {
-		// A non-timestamp string was passed in. Let's use that.
-		$text = $enddate;
 	}
 
-	// Apply the pmpro_account_membership_expiration_text filter on frontend for backwards compatibility.
-	if ( ! is_admin() ) {
-		$text = apply_filters( 'pmpro_account_membership_expiration_text', $text, $level );
+	// Apply legacy filter pmpro_memberslist_expires_column.
+	if ( is_admin() && has_filter( 'pmpro_memberslist_expires_column' ) ) {
+		/**
+		 * Legacy filter for showing the expiration date in the WP Dashboard.
+		 *
+		 * Note: Since level data is not passed, this filter is not MMPU-compatible.
+		 *
+		 * @deprecated 3.0 Use the pmpro_membership_expiration_text filter instead.
+		 *
+		 * @param string  $text The expiration date text to show for this level.
+		 * @param WP_User $user The user that the expiration date is for.
+		 *
+		 * @return string $text The expiration date text to show for this level.
+		 */
+		$text = apply_filters_deprecated( 'pmpro_memberslist_expires_column', array( $text, $user ), '3.0', 'pmpro_membership_expiration_text' );
 	}
-	
-	// Apply the pmpro_memberslist_expires_column filter on backend for backwards compatibility.
-	if ( is_admin() ) {		
-		$text = apply_filters( 'pmpro_memberslist_expires_column', $text, $user );
+
+	// Apply legacy filter pmpro_account_membership_expiration_text.
+	if ( is_admin() && has_filter( 'pmpro_account_membership_expiration_text' ) ) {
+		/**
+		 * Legacy filter for showing the expiration date on the frontend.
+		 *
+		 * @deprecated 3.0 Use the pmpro_membership_expiration_text filter instead.
+		 *
+		 * @param string $text  The expiration date text to show for this level.
+		 * @param object $level The level that the expiration date is for.
+		 *
+		 * @return string $text The expiration date text to show for this level.
+		 */
+		$text = apply_filters_deprecated( 'pmpro_account_membership_expiration_text', array( $text, $level ), '3.0', 'pmpro_membership_expiration_text' );
 	}
 
 	/**
@@ -645,13 +684,15 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 	 *
 	 * @since 3.0
 	 *
-	 * @param string $text The expiration date text to show for this level.	
-	 * @param mixed $level A level object or id passed into this function.
-	 * @param mixed $user A user object or id passed into this function.
-	 * @param bool $show_time Whether to show the expiration time with expiration date.
+	 * @param string  $text The expiration date text to show for this level.	
+	 * @param object  $level The level that the expiration date is for.
+	 * @param WP_User $user The user that the expiration date is for.
+	 * @param bool    $show_time Whether to show the expiration time with expiration date.
+	 *
+	 * @return string $text The expiration date text to show for this level.
 	 */
 	$text = apply_filters( 'pmpro_membership_expiration_text', $text, $level, $user, $show_time );
-	
+
 	return $text;
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -589,6 +589,65 @@ function pmpro_getLevelsExpiration( &$levels ) {
 }
 
 /**
+ * Get the text to display a membership's expiration date.
+ * @since 3.0
+ * @param int $enddate The expiration date timestamp. 
+ * @param mixed $level A level object or id (optional) to pass to filters.
+ * @param mixed $user A user object or id (optional) to pass to filters.
+ * @return string The expiration date text.
+ */
+function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = null ) {	
+	if ( empty( $enddate ) ) {
+		$text = esc_html__( 'Never', 'paid-memberships-pro' );
+	} elseif( is_numeric( $enddate ) ) {		
+		/**
+		 * Filter to include the expiration time with expiration date
+		 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date
+		 * @param int $enddate The expiration date timestamp.
+		 * @param mixed $level A level object or id passed into this function.
+		 * @param mixed $user A user object or id passed into this function.
+		 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
+		 * @since 3.0 Now passes the $enddate, $level, and $user.
+		 */
+		$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false, $enddate, $level, $user );
+		
+		// Convert enddate timestamp to a date string.
+		if ( $show_time ) {
+			$text = sprintf(
+				// translators: %1$s is the date and %2$s is the time.
+				esc_html__( '%1$s at %2$s', 'paid-memberships-pro' ),
+				date_i18n( get_option( 'date_format'), $enddate ),
+				date_i18n( get_option( 'time_format'), $enddate )
+			);
+		} else {
+			$text = date_i18n( get_option( 'date_format' ), $enddate );
+		}		
+	}
+
+	// Apply the pmpro_account_membership_expiration_text filter on frontend for backwards compatibility.
+	if ( ! is_admin() ) {
+		$text = '<p>' . $text . '</p>';	// The account shortcode expects this in a p tag.
+		$text = apply_filters( 'pmpro_account_membership_expiration_text', $text, $level );
+	}
+	
+	// Apply the pmpro_memberslist_expires_column filter on backend for backwards compatibility.
+	if ( is_admin() ) {		
+		$text = apply_filters( 'pmpro_memberslist_expires_column', $text, $user );
+	}
+
+	/**
+	 * Filter the expiration date text to show for this level.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $text The expiration date text to show for this level.	
+	 */
+	$text = apply_filters( 'pmpro_member_edit_memberships_panel_memberships_enddate_text', $text, $level, $user );
+	
+	return $text;
+}
+
+/**
  * pmpro_membership_level Meta Functions
  *
  * @ssince 1.8.6.5

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -608,6 +608,8 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 		 * @param mixed $user A user object or id passed into this function.
 		 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
 		 * @since 3.0 Now passes the $enddate, $level, and $user.
+		 * 
+		 * Used in adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
 		 */
 		$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false, $enddate, $level, $user );
 		

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -591,7 +591,7 @@ function pmpro_getLevelsExpiration( &$levels ) {
 /**
  * Get the text to display a membership's expiration date.
  * @since 3.0
- * @param int $enddate The expiration date timestamp. 
+ * @param int|string $enddate The expiration date timestamp or string to show. 
  * @param mixed $level A level object or id (optional) to pass to filters.
  * @param mixed $user A user object or id (optional) to pass to filters.
  * @return string The expiration date text.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -597,22 +597,22 @@ function pmpro_getLevelsExpiration( &$levels ) {
  * @return string The expiration date text.
  */
 function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = null ) {	
+	/**
+	 * Filter to include the expiration time with expiration date
+	 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date
+	 * @param int $enddate The expiration date timestamp.
+	 * @param mixed $level A level object or id passed into this function.
+	 * @param mixed $user A user object or id passed into this function.
+	 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
+	 * @since 3.0 Now passes the $enddate, $level, and $user.
+	 *
+	 * Used in adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+	 */
+	$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false, $enddate, $level, $user );
+
 	if ( empty( $enddate ) ) {
 		$text = esc_html__( 'Never', 'paid-memberships-pro' );
-	} elseif( is_numeric( $enddate ) ) {		
-		/**
-		 * Filter to include the expiration time with expiration date
-		 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date
-		 * @param int $enddate The expiration date timestamp.
-		 * @param mixed $level A level object or id passed into this function.
-		 * @param mixed $user A user object or id passed into this function.
-		 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
-		 * @since 3.0 Now passes the $enddate, $level, and $user.
-		 * 
-		 * Used in adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
-		 */
-		$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false, $enddate, $level, $user );
-		
+	} elseif( is_numeric( $enddate ) ) {
 		// Convert enddate timestamp to a date string.
 		if ( $show_time ) {
 			$text = sprintf(
@@ -643,8 +643,11 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 	 * @since 3.0
 	 *
 	 * @param string $text The expiration date text to show for this level.	
+	 * @param mixed $level A level object or id passed into this function.
+	 * @param mixed $user A user object or id passed into this function.
+	 * @param bool $show_time Whether to show the expiration time with expiration date.
 	 */
-	$text = apply_filters( 'pmpro_member_edit_memberships_panel_memberships_enddate_text', $text, $level, $user );
+	$text = apply_filters( 'pmpro_member_edit_memberships_panel_memberships_enddate_text', $text, $level, $user, $show_time );
 	
 	return $text;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -628,7 +628,6 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 
 	// Apply the pmpro_account_membership_expiration_text filter on frontend for backwards compatibility.
 	if ( ! is_admin() ) {
-		$text = '<p>' . $text . '</p>';	// The account shortcode expects this in a p tag.
 		$text = apply_filters( 'pmpro_account_membership_expiration_text', $text, $level );
 	}
 	

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -646,7 +646,7 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 	 * @param mixed $user A user object or id passed into this function.
 	 * @param bool $show_time Whether to show the expiration time with expiration date.
 	 */
-	$text = apply_filters( 'pmpro_member_edit_memberships_panel_memberships_enddate_text', $text, $level, $user, $show_time );
+	$text = apply_filters( 'pmpro_membership_expiration_text', $text, $level, $user, $show_time );
 	
 	return $text;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -612,11 +612,7 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 
 	if ( empty( $enddate ) ) {
 		// N/A on the backend. &#8212; dash on the frontend.
-		if ( is_admin() ) {
-			$text = esc_html_x( 'N/A', 'N/A is shown when there is no expiration date.', 'paid-memberships-pro' );
-		} else {
-			$text = esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
-		}		
+		$text = esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
 	} elseif( is_numeric( $enddate ) ) {
 		// Convert enddate timestamp to a date string.
 		if ( $show_time ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -596,7 +596,7 @@ function pmpro_getLevelsExpiration( &$levels ) {
  * @param mixed $user A user object or id (optional) to pass to filters.
  * @return string The expiration date text.
  */
-function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = null ) {	
+function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = null ) {
 	/**
 	 * Filter to include the expiration time with expiration date
 	 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date
@@ -611,7 +611,12 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 	$show_time = apply_filters( 'pmpro_show_time_on_expiration_date', false, $enddate, $level, $user );
 
 	if ( empty( $enddate ) ) {
-		$text = esc_html__( 'Never', 'paid-memberships-pro' );
+		// N/A on the backend. &#8212; dash on the frontend.
+		if ( is_admin() ) {
+			$text = esc_html_x( 'N/A', 'N/A is shown when there is no expiration date.', 'paid-memberships-pro' );
+		} else {
+			$text = esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
+		}		
 	} elseif( is_numeric( $enddate ) ) {
 		// Convert enddate timestamp to a date string.
 		if ( $show_time ) {
@@ -624,6 +629,9 @@ function pmpro_get_membership_expiration_text( $enddate, $level = null, $user = 
 		} else {
 			$text = date_i18n( get_option( 'date_format' ), $enddate );
 		}		
+	} else {
+		// A non-timestamp string was passed in. Let's use that.
+		$text = $enddate;
 	}
 
 	// Apply the pmpro_account_membership_expiration_text filter on frontend for backwards compatibility.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -611,11 +611,11 @@ function pmpro_get_membership_expiration_text( $level, $user ) {
 
 	// If a level ID was passed, get the level object.
 	if ( is_numeric( $level ) ) {
-		pmpro_getSpecificMembershipLevelForUser( $user->ID, (int)$level );
+		$level = pmpro_getSpecificMembershipLevelForUser( $user->ID, (int)$level );
 	}
 
-	// Make sure that we have a level object with an enddate property, even if it's empty.
-	if ( empty( $level ) || ! is_object( $level ) || ! isset( $level->enddate ) ) {
+	// Make sure that we have a level object.
+	if ( empty( $level ) || ! is_object( $level ) ) {
 		return '';
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -633,18 +633,17 @@ function pmpro_get_membership_expiration_text( $level, $user ) {
 	if ( empty( $level->enddate ) ) {
 		// If the level does not have an enddate, show a dash (&#8212;).
 		$text = esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
+	} elseif ( $show_time ) {
+		// Show the enddate with the time.
+		$text = sprintf(
+			// translators: %1$s is the date and %2$s is the time.
+			esc_html__( '%1$s at %2$s', 'paid-memberships-pro' ),
+			date_i18n( get_option( 'date_format'), $level->enddate ),
+			date_i18n( get_option( 'time_format'), $level->enddate )
+		);
 	} else {
-		// Convert enddate timestamp to a date string.
-		if ( $show_time ) {
-			$text = sprintf(
-				// translators: %1$s is the date and %2$s is the time.
-				esc_html__( '%1$s at %2$s', 'paid-memberships-pro' ),
-				date_i18n( get_option( 'date_format'), $level->enddate ),
-				date_i18n( get_option( 'time_format'), $level->enddate )
-			);
-		} else {
-			$text = date_i18n( get_option( 'date_format' ), $level->enddate );
-		}		
+		// Show the enddate without the time.
+		$text = date_i18n( get_option( 'date_format' ), $level->enddate );
 	}
 
 	// Apply legacy filter pmpro_memberslist_expires_column.

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -154,12 +154,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 								<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-expiration' ) ); ?>">
 									<p>
 										<?php
-											if ( $level->enddate ) {
-												$expiration_text = pmpro_get_membership_expiration_text( $level->enddate, $level, $current_user );
-											} else {
-												$expiration_text = pmpro_get_membership_expiration_text( null, $level, $current_user );
-											}
-											echo wp_kses_post( $expiration_text );
+										echo wp_kses_post( pmpro_get_membership_expiration_text( $level, $current_user ) );
 										?>
 									</p>
 								</td>

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -157,7 +157,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 											if ( $level->enddate ) {
 												$expiration_text = pmpro_get_membership_expiration_text( $level->enddate, $level, $current_user );
 											} else {
-												$expiration_text = pmpro_get_membership_expiration_text( esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' ), $level, $current_user );
+												$expiration_text = pmpro_get_membership_expiration_text( null, $level, $current_user );
 											}
 											echo wp_kses_post( $expiration_text );
 										?>

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -152,14 +152,16 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 									</p>
 								</td>
 								<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-expiration' ) ); ?>">
-									<?php
-										if ( $level->enddate ) {
-											$expiration_text = pmpro_get_membership_expiration_text( $level->enddate, $level, $current_user );
-										} else {
-											$expiration_text = pmpro_get_membership_expiration_text( esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' ), $level, $current_user );											
-										}
-										echo wp_kses_post( $expiration_text );
-									?>
+									<p>
+										<?php
+											if ( $level->enddate ) {
+												$expiration_text = pmpro_get_membership_expiration_text( $level->enddate, $level, $current_user );
+											} else {
+												$expiration_text = pmpro_get_membership_expiration_text( esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' ), $level, $current_user );
+											}
+											echo wp_kses_post( $expiration_text );
+										?>
+									</p>
 								</td>
 							</tr>
 							<?php } ?>

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -153,25 +153,12 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 								</td>
 								<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-expiration' ) ); ?>">
 									<?php
-										$expiration_text = '<p>';
 										if ( $level->enddate ) {
-											$expiration_text .= date_i18n( get_option( 'date_format' ), $level->enddate );
-											/**
-											 * Filter to include the expiration time with expiration date
-											 *
-											 * @param bool $pmpro_show_time_on_expiration_date Show the expiration time with expiration date (default: false).
-											 *
-											 * @return bool $pmpro_show_time_on_expiration_date Whether to show the expiration time with expiration date.
-											 *
-											 */
-											if ( apply_filters( 'pmpro_show_time_on_expiration_date', false ) ) {
-												$expiration_text .= ' ' . date_i18n( get_option( 'time_format', __( 'g:i a' ) ), $level->enddate );
-											}
+											$expiration_text = pmpro_get_membership_expiration_text( $level->enddate, $level, $current_user );
 										} else {
-											$expiration_text .= esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
+											$expiration_text = pmpro_get_membership_expiration_text( esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' ), $level, $current_user );											
 										}
-										$expiration_text .= '</p>';
-										echo wp_kses_post( apply_filters( 'pmpro_account_membership_expiration_text', $expiration_text, $level ) );
+										echo wp_kses_post( $expiration_text );
 									?>
 								</td>
 							</tr>


### PR DESCRIPTION
This is an alternative to the PR here: https://github.com/strangerstudios/paid-memberships-pro/pull/2767

We are trying to allow new folks to filter the expiration date wherever it is shown using just one filter, while still supporting older versions of this filter which were used in a few different pages/scenarios.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

> ENHANCEMENT: Added `pmpro_get_membership_expiration_text()` function and using it whenever an expiration date is shown. This can be filtered by the `pmpro_member_edit_memberships_panel_memberships_enddate_text` and also supports the old `pmpro_account_membership_expiration_text` and `pmpro_memberslist_expires_column` filters from older versions of PMPro.
