### PR TITLE
Hide non-PMPro notices on PMPro settings pages.

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -328,39 +328,39 @@ add_filter( 'admin_footer_text', 'pmpro_admin_footer_text' );
 function pmpro_hide_non_pmpro_notices() {
     global $wp_filter;
 
-	// Only filter on PMPro pages in the admin.
+	// Make sure we're on a PMPro page.
 	if ( ! isset( $_REQUEST['page'] )
 			|| substr( sanitize_text_field( $_REQUEST['page'] ), 0, 6 ) !== 'pmpro-' ) {
 		return;
 	}
 
+	// Handle notices added through these hooks.
     $hooks = ['admin_notices', 'all_admin_notices'];
 
     foreach ($hooks as $hook) {
-        if ( ! isset( $wp_filter[$hook] ) ) {
+        // If no callbacks are registered, skip.
+		if ( ! isset( $wp_filter[$hook] ) ) {
 			continue;
 		}
-				
+
+		// Loop through the callbacks and remove any that aren't PMPro.
 		foreach ($wp_filter[$hook]->callbacks as $priority => $callbacks) {
-			foreach ($callbacks as $key => $callback) {
-				// Check if the callback is a method of a class
-				if (is_array($callback['function'])) {
-					$class = is_object($callback['function'][0]) ? get_class($callback['function'][0]) : $callback['function'][0];
-					$method = $callback['function'][1];
-
+			foreach ($callbacks as $key => $callback) {				
+				if ( is_array( $callback['function'] ) ) {					
 					// Skip if the class starts with pmpro_.
-					if (strpos(strtolower($class), 'pmpro_') === 0 ) {
+					$class = get_class( $callback['function'][0] );
+					if ( strpos( strtolower( $class ), 'pmpro_' ) === 0 ) {
 						continue;
 					}
-
-					// Skip if the method starts with pmpro_.
-					if (strpos(strtolower($method), 'pmpro_') === 0 ) {
+				} else {
+					// Skip if the callback function starts with pmpro_.				
+					if ( strpos( strtolower( $callback['function'] ), 'pmpro_') === 0 ) {
 						continue;
 					}
-					
-					// Probably not a PMPro notice, remove it.
-					unset($wp_filter[$hook]->callbacks[$priority][$key]);
 				}
+
+				// Probably not a PMPro notice, remove it.
+				unset($wp_filter[$hook]->callbacks[$priority][$key]);
 			}
 		}
     }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -328,6 +328,12 @@ add_filter( 'admin_footer_text', 'pmpro_admin_footer_text' );
 function pmpro_hide_non_pmpro_notices() {
     global $wp_filter;
 
+	// Only filter on PMPro pages in the admin.
+	if ( ! isset( $_REQUEST['page'] )
+			|| substr( sanitize_text_field( $_REQUEST['page'] ), 0, 6 ) !== 'pmpro-' ) {
+		return;
+	}
+
     $hooks = ['admin_notices', 'all_admin_notices'];
 
     foreach ($hooks as $hook) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Inspired by [this tweet](https://twitter.com/verygoodplugins/status/1751228984065446001) and other discussions, this PR removes non-PMPro notices from PMPro settings pages.

This PR needs some discussion.

1. Do we really want to do this?
2. Are we sure we aren't filtering out PMPro callbacks that might not start with pmpro_ or be part of a class that starts with PMPro_?
3. Should we only do this on certain pages?
4. Should we even hide some of our notices?
5. We had some stricter code already running on the wizard that could be merged with this new code: https://github.com/strangerstudios/paid-memberships-pro/blob/74d80891d63a3b65fccb448b52461e7c525b6132/includes/admin.php#L217-L226

> ENHANCEMENT: Hiding non-PMPro notices from PMPro settings pages.
