### PR TITLE
Fix/sub sync

### DIFF
--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -53,12 +53,14 @@ if ( empty( $subscription ) ) {
 		: $sub_membership_level->name;
 	?>
 
-	<a
-		href="<?php echo ( esc_url( wp_nonce_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $subscription->get_id(), 'update' => '1' ), admin_url('admin.php' ) ), 'update', 'pmpro_subscriptions_nonce'  ) ) ); ?>"
-		title="<?php esc_attr_e( 'Sync With Gateway', 'paid-memberships-pro' ); ?>" 
-		class="page-title-action pmpro-has-icon pmpro-has-icon-update">
-		<?php esc_html_e( 'Sync With Gateway', 'paid-memberships-pro' ); ?>
-	</a>
+	<?php if ( $subscription->get_gateway_object()->supports( 'subscription_sync' ) ) { ?>
+		<a
+			href="<?php echo ( esc_url( wp_nonce_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $subscription->get_id(), 'update' => '1' ), admin_url('admin.php' ) ), 'update', 'pmpro_subscriptions_nonce'  ) ) ); ?>"
+			title="<?php esc_attr_e( 'Sync With Gateway', 'paid-memberships-pro' ); ?>" 
+			class="page-title-action pmpro-has-icon pmpro-has-icon-update">
+			<?php esc_html_e( 'Sync With Gateway', 'paid-memberships-pro' ); ?>
+		</a>
+	<?php } ?>
 
 	<a
 		href="javascript:void(0);"

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -1,7 +1,7 @@
 <?php	
 	//require_once(dirname(__FILE__) . "/class.pmprogateway.php");
 	class PMProGateway
-	{
+	{	
 		function __construct($gateway = NULL)
 		{
 			$this->gateway = $gateway;
@@ -215,17 +215,18 @@
 		{			
 			//this looks different for each gateway, but generally an array of some sort
 			return array();
-		}
+		}		
 
 		/**
-		 * Returns whether the gateway allows for payment method updates.
-		 *
+		 * Check if the gateway supports a certain feature.
+		 * 
 		 * @since 3.0
-		 *
-		 * @return string|false 'individual' if the gateway allows for payment method updates for individual subscriptions, 
-		 *                      'all' if the gateway updates all subscriptions, or false if the gateway does not support payment method updates.
+		 * 
+		 * @param string $feature The feature to check for.
+		 * @return bool		 
 		 */
-		function supports_payment_method_updates() {
+		public static function supports( $feature ) {
+			// The base gateway doesn't support anything.			
 			return false;
 		}
 

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -223,7 +223,7 @@
 		 * @since 3.0
 		 * 
 		 * @param string $feature The feature to check for.
-		 * @return bool		 
+		 * @return bool|string Whether the gateway supports the requested. A string may be returned in cases where a feature has different variations of support.
 		 */
 		public static function supports( $feature ) {
 			// The base gateway doesn't support anything.			

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -69,6 +69,25 @@ class PMProGateway_stripe extends PMProGateway {
 	 ************ STATIC METHODS ************
 	 ****************************************/
 	/**
+	 * Does this gateway support this feature?
+	 * 
+	 * @since 3.0
+	 * 
+	 * @return array
+	 */
+	public static function supports( $feature ) {
+		$supports = array(
+			'subscription_sync' => true,
+		);
+
+		if ( empty( $supports[$feature] ) ) {
+			return false;
+		}
+
+		return $supports[$feature];
+	}
+	
+	 /**
 	 * Load the Stripe API library.
 	 *
 	 * @since 1.8


### PR DESCRIPTION
Adding a supports() method to the base gateway class and stripe class that we can use on the subscriptions tab to figure out if we should show the sync button on subscriptions.

This method is nice because we can extend it in the future for other similar things to detect difference between the gateways.

If we like this approach:

1. We need to update the other gateways that support sub sync to have their own methods like Stripe does. (Braintree, Authorize.net, PayPal Express, others in core?, other gateways added through plugins? PayFast? PayStack?)
2. We should probably recode this similar check for payment method updates: https://github.com/strangerstudios/paid-memberships-pro/blob/v3.0/classes/gateways/class.pmprogateway_stripe.php#L2227-L2237 