### PR TITLE
Adds Screen Options for orders and discount codes list tables

### DIFF
--- a/classes/class-pmpro-discount-code-list-table.php
+++ b/classes/class-pmpro-discount-code-list-table.php
@@ -167,9 +167,22 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 	 * @return Array
 	 */
 	public function get_hidden_columns() {
-		
-		return array();
-		
+		$user = wp_get_current_user();
+ 		if ( ! $user ) {
+ 			return array();
+ 		}
+
+ 		// Check whether the current user has changed screen options or not.
+ 		$hidden = get_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', true );
+
+ 		// If user meta is not found, add the default hidden columns.
+ 		// Right now, we don't have any default hidden columns.
+ 		if ( ! $hidden ) {
+ 			$hidden = array();
+ 			update_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', $hidden );
+ 		}
+
+ 		return $hidden;
 	}
 
 	/**

--- a/classes/class-pmpro-discount-code-list-table.php
+++ b/classes/class-pmpro-discount-code-list-table.php
@@ -39,6 +39,58 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Sets up screen options for the discount codes list table.
+	 *
+	 * @since 3.0
+	 */
+	public static function hook_screen_options() {
+		$list_table = new PMPro_Discount_Code_List_Table();
+		add_screen_option(
+			'per_page',
+			array(
+				'default' => 20,
+				'label'   => __( 'Discount codes per page', 'paid-memberships-pro' ),
+				'option'  => 'pmpro_discount_codes_per_page',
+			)
+		);
+		add_filter(
+			'screen_settings',
+			array(
+				$list_table,
+				'screen_controls',
+			),
+			10,
+			2
+		);
+		add_filter(
+			'set-screen-option',
+			array(
+				$list_table,
+				'set_screen_option',
+			),
+			10,
+			3
+		);
+		set_screen_options();
+	}
+
+	/**
+	 * Sets the screen options.
+	 *
+	 * @param string $dummy   Unused.
+	 * @param string $option  Screen option name.
+	 * @param string $value   Screen option value.
+	 * @return string
+	 */
+	public function set_screen_option( $dummy, $option, $value ) {
+		if ( 'pmpro_discount_codes_per_page' === $option ) {
+			return $value;
+		} else {
+			return $dummy;
+		}
+	}
+
+	/**
 	 * Prepares the list of items for displaying.
 	 *
 	 * Query, filter data, handle sorting, and pagination, and any other data-manipulation required prior to rendering
@@ -55,7 +107,7 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 
 		$this->items = $this->sql_table_data();
 
-		$items_per_page = $this->get_items_per_page( 'discount_codes_per_page' );
+		$items_per_page = $this->get_items_per_page( 'pmpro_discount_codes_per_page' );
 		$total_items = $this->sql_table_data( true );
 		$this->set_pagination_args(
 			array(
@@ -186,7 +238,7 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 			$pn = 1;
 		}
 		
-		$limit = $this->get_items_per_page( 'discount_codes_per_page' );
+		$limit = $this->get_items_per_page( 'pmpro_discount_codes_per_page' );
 
 		$end = $pn * $limit;
 		$start = $end - $limit;

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -75,6 +75,22 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Sets the screen options.
+	 *
+	 * @param string $dummy   Unused.
+	 * @param string $option  Screen option name.
+	 * @param string $value   Screen option value.
+	 * @return string
+	 */
+	public function set_screen_option( $dummy, $option, $value ) {
+		if ( 'pmpro_members_per_page' === $option ) {
+			return $value;
+		} else {
+			return $dummy;
+		}
+	}
+
+	/**
 	 * Prepares the list of items for displaying.
 	 *
 	 * Query, filter data, handle sorting, and pagination, and any other data-manipulation required prior to rendering
@@ -294,22 +310,6 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			<li><a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-memberslist', 'l' => 'oldmembers', 's' => $s ) ) ); ?>"><?php esc_html_e( 'Old Members', 'paid-memberships-pro' ); ?></a></li>
 		</ul>
 		<?php
-	}
-
-	/**
-	 * Sets the screen options.
-	 *
-	 * @param string $dummy   Unused.
-	 * @param string $option  Screen option name.
-	 * @param string $value   Screen option value.
-	 * @return string
-	 */
-	public function set_screen_option( $dummy, $option, $value ) {
-		if ( 'pmpro_members_per_page' === $option ) {
-			return $value;
-		} else {
-			return $dummy;
-		}
 	}
 
 	/**

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -36,17 +36,41 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				// If true, the parent class will call the _js_vars() method in the footer
 			)
 		);
+	}
 
+	/**
+	 * Sets up screen options for the members list table.
+	 *
+	 * @since 3.0
+	 */
+	public static function hook_screen_options() {
+		$list_table = new PMPro_Members_List_Table();
+		add_screen_option(
+			'per_page',
+			array(
+				'default' => 20,
+				'label'   => __( 'Members per page', 'paid-memberships-pro' ),
+				'option'  => 'pmpro_members_per_page',
+			)
+		);
 		add_filter(
 			'screen_settings',
 			array(
-				$this,
+				$list_table,
 				'screen_controls',
 			),
 			10,
 			2
 		);
-
+		add_filter(
+			'set-screen-option',
+			array(
+				$list_table,
+				'set_screen_option',
+			),
+			10,
+			3
+		);
 		set_screen_options();
 	}
 
@@ -68,7 +92,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		$this->items = $this->sql_table_data();
 
 		// Set the pagination arguments.
-		$items_per_page = $this->get_items_per_page( 'users_per_page' );
+		$items_per_page = $this->get_items_per_page( 'pmpro_members_per_page' );
 		$total_items = $this->sql_table_data( true );
 		$this->set_pagination_args(
 			array(
@@ -273,6 +297,22 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Sets the screen options.
+	 *
+	 * @param string $dummy   Unused.
+	 * @param string $option  Screen option name.
+	 * @param string $value   Screen option value.
+	 * @return string
+	 */
+	public function set_screen_option( $dummy, $option, $value ) {
+		if ( 'pmpro_members_per_page' === $option ) {
+			return $value;
+		} else {
+			return $dummy;
+		}
+	}
+
+	/**
 	 * Get the table data
 	 *
 	 * @return Array|integer if $count parameter = true
@@ -328,7 +368,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 		else
 			$pn = 1;
 
-		$limit = $this->get_items_per_page( 'users_per_page' );
+		$limit = $this->get_items_per_page( 'pmpro_members_per_page' );
 
 		$end = $pn * $limit;
 		$start = $end - $limit;

--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -75,6 +75,22 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Sets the screen options.
+	 *
+	 * @param string $dummy   Unused.
+	 * @param string $option  Screen option name.
+	 * @param string $value   Screen option value.
+	 * @return string
+	 */
+	public function set_screen_option( $dummy, $option, $value ) {
+		if ( 'pmpro_orders_per_page' === $option ) {
+			return $value;
+		} else {
+			return $dummy;
+		}
+	}
+
+	/**
 	 * Prepares the list of items for displaying.
 	 *
 	 * Query, filter data, handle sorting, and pagination, and any other data-manipulation required prior to rendering
@@ -225,22 +241,6 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 
 		esc_html_e( 'No orders found.', 'paid-memberships-pro' );
 
-	}
-
-	/**
-	 * Sets the screen options.
-	 *
-	 * @param string $dummy   Unused.
-	 * @param string $option  Screen option name.
-	 * @param string $value   Screen option value.
-	 * @return string
-	 */
-	public function set_screen_option( $dummy, $option, $value ) {
-		if ( 'pmpro_orders_per_page' === $option ) {
-			return $value;
-		} else {
-			return $dummy;
-		}
 	}
 
 	/**

--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -39,6 +39,42 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Sets up screen options for the orders list table.
+	 *
+	 * @since 3.0
+	 */
+	public static function hook_screen_options() {
+		$list_table = new PMPro_Orders_List_Table();
+		add_screen_option(
+			'per_page',
+			array(
+				'default' => 20,
+				'label'   => __( 'Orders per page', 'paid-memberships-pro' ),
+				'option'  => 'pmpro_orders_per_page',
+			)
+		);
+		add_filter(
+			'screen_settings',
+			array(
+				$list_table,
+				'screen_controls',
+			),
+			10,
+			2
+		);
+		add_filter(
+			'set-screen-option',
+			array(
+				$list_table,
+				'set_screen_option',
+			),
+			10,
+			3
+		);
+		set_screen_options();
+	}
+
+	/**
 	 * Prepares the list of items for displaying.
 	 *
 	 * Query, filter data, handle sorting, and pagination, and any other data-manipulation required prior to rendering
@@ -53,7 +89,7 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 
 		$this->_column_headers = array($columns, $hidden, $sortable);
 
-		$items_per_page = $this->get_items_per_page( 'orders_per_page' );
+		$items_per_page = $this->get_items_per_page( 'pmpro_orders_per_page' );
 		/**
 		 * Filter to set the default number of items to show per page
 		 * on the Orders page in the admin.
@@ -130,9 +166,22 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 	 * @return Array
 	 */
 	public function get_hidden_columns() {
-		
-		return array();
-		
+		$user = wp_get_current_user();
+		if ( ! $user ) {
+			return array();
+		}
+
+		// Check whether the current user has changed screen options or not.
+		$hidden = get_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', true );
+
+		// If user meta is not found, add the default hidden columns.
+		// Right now, we don't have any default hidden columns.
+		if ( ! $hidden ) {
+			$hidden = array();
+			update_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', $hidden );
+		}
+
+		return $hidden;
 	}
 
 	/**
@@ -179,6 +228,22 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Sets the screen options.
+	 *
+	 * @param string $dummy   Unused.
+	 * @param string $option  Screen option name.
+	 * @param string $value   Screen option value.
+	 * @return string
+	 */
+	public function set_screen_option( $dummy, $option, $value ) {
+		if ( 'pmpro_orders_per_page' === $option ) {
+			return $value;
+		} else {
+			return $dummy;
+		}
+	}
+
+	/**
 	 * Get the table data
 	 *
 	 * @return Array|integer if $count parameter = true
@@ -202,7 +267,7 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 		$filter = isset( $_REQUEST['filter'] ) ? sanitize_text_field( $_REQUEST['filter'] ) : 'all';
 		$pn = isset( $_REQUEST['paged'] ) ? intval( $_REQUEST['paged'] ) : 1;
 
-		$items_per_page = $this->get_items_per_page( 'orders_per_page' );
+		$items_per_page = $this->get_items_per_page( 'pmpro_orders_per_page' );
 		/**
 		 * Filter to set the default number of items to show per page
 		 * on the Orders page in the admin.

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -69,7 +69,7 @@ function pmpro_add_pages() {
 	add_submenu_page( 'pmpro-dashboard', __( 'License', 'paid-memberships-pro' ), __( '<span style="color: ' . $span_color . '">License</span>', 'paid-memberships-pro' ), 'manage_options', 'pmpro-license', 'pmpro_license_settings_page' );
 
 	// Settings tabs
-	add_submenu_page( 'admin.php', __( 'Discount Codes', 'paid-memberships-pro' ), __( 'Discount Codes', 'paid-memberships-pro' ), 'pmpro_discountcodes', 'pmpro-discountcodes', 'pmpro_discountcodes' );
+	$discount_codes_list_table_hook = add_submenu_page( 'admin.php', __( 'Discount Codes', 'paid-memberships-pro' ), __( 'Discount Codes', 'paid-memberships-pro' ), 'pmpro_discountcodes', 'pmpro-discountcodes', 'pmpro_discountcodes' );
 	add_submenu_page( 'admin.php', __( 'Page Settings', 'paid-memberships-pro' ), __( 'Page Settings', 'paid-memberships-pro' ), 'pmpro_pagesettings', 'pmpro-pagesettings', 'pmpro_pagesettings' );
 	add_submenu_page( 'admin.php', __( 'Payment Settings', 'paid-memberships-pro' ), __( 'Payment Settings', 'paid-memberships-pro' ), 'pmpro_paymentsettings', 'pmpro-paymentsettings', 'pmpro_paymentsettings' );
 	add_submenu_page( 'admin.php', __( 'Email Settings', 'paid-memberships-pro' ), __( 'Email Settings', 'paid-memberships-pro' ), 'pmpro_emailsettings', 'pmpro-emailsettings', 'pmpro_emailsettings' );
@@ -80,6 +80,7 @@ function pmpro_add_pages() {
 	// Set up screen settings for list tables.
 	add_action( 'load-' . $members_list_table_hook, 'PMPro_Members_List_Table::hook_screen_options' );
 	add_action( 'load-' . $orders_list_table_hook, 'PMPro_Orders_List_Table::hook_screen_options' );
+	add_action( 'load-' . $discount_codes_list_table_hook, 'PMPro_Discount_Code_List_Table::hook_screen_options' );
 
 	//updates page only if needed
 	if ( pmpro_isUpdateRequired() ) {

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -53,8 +53,8 @@ function pmpro_add_pages() {
 	
 	// Main submenus
 	add_submenu_page( 'pmpro-dashboard', __( 'Dashboard', 'paid-memberships-pro' ), __( 'Dashboard', 'paid-memberships-pro' ), 'pmpro_dashboard', 'pmpro-dashboard', 'pmpro_dashboard' );
-	$list_table_hook = add_submenu_page( 'pmpro-dashboard', __( 'Members', 'paid-memberships-pro' ), __( 'Members', 'paid-memberships-pro' ), 'pmpro_memberslist', 'pmpro-memberslist', 'pmpro_memberslist' );
-	add_submenu_page( 'pmpro-dashboard', __( 'Orders', 'paid-memberships-pro' ), __( 'Orders', 'paid-memberships-pro' ), 'pmpro_orders', 'pmpro-orders', 'pmpro_orders' );
+	$members_list_table_hook = add_submenu_page( 'pmpro-dashboard', __( 'Members', 'paid-memberships-pro' ), __( 'Members', 'paid-memberships-pro' ), 'pmpro_memberslist', 'pmpro-memberslist', 'pmpro_memberslist' );
+	$orders_list_table_hook = add_submenu_page( 'pmpro-dashboard', __( 'Orders', 'paid-memberships-pro' ), __( 'Orders', 'paid-memberships-pro' ), 'pmpro_orders', 'pmpro-orders', 'pmpro_orders' );
 	add_submenu_page( 'pmpro-dashboard', __( 'Reports', 'paid-memberships-pro' ), __( 'Reports', 'paid-memberships-pro' ), 'pmpro_reports', 'pmpro-reports', 'pmpro_reports' );
 	add_submenu_page( 'pmpro-dashboard', __( 'Settings', 'paid-memberships-pro' ), __( 'Settings', 'paid-memberships-pro' ), 'pmpro_membershiplevels', 'pmpro-membershiplevels', 'pmpro_membershiplevels' );
 	add_submenu_page( 'pmpro-dashboard', __( 'Add Ons', 'paid-memberships-pro' ), __( 'Add Ons', 'paid-memberships-pro' ), 'pmpro_addons', 'pmpro-addons', 'pmpro_addons' );
@@ -77,7 +77,9 @@ function pmpro_add_pages() {
 	add_submenu_page( 'admin.php', __( 'User Fields', 'paid-memberships-pro' ), __( 'User Fields', 'paid-memberships-pro' ), 'pmpro_userfields', 'pmpro-userfields', 'pmpro_userfields' );
 	add_submenu_page( 'admin.php', __( 'Advanced Settings', 'paid-memberships-pro' ), __( 'Advanced Settings', 'paid-memberships-pro' ), 'pmpro_advancedsettings', 'pmpro-advancedsettings', 'pmpro_advancedsettings' );
 
-	add_action( 'load-' . $list_table_hook, 'pmpro_list_table_screen_options' );
+	// Set up screen settings for list tables.
+	add_action( 'load-' . $members_list_table_hook, 'PMPro_Members_List_Table::hook_screen_options' );
+	add_action( 'load-' . $orders_list_table_hook, 'PMPro_Orders_List_Table::hook_screen_options' );
 
 	//updates page only if needed
 	if ( pmpro_isUpdateRequired() ) {
@@ -631,9 +633,11 @@ add_filter( 'display_post_states', 'pmpro_display_post_states', 10, 2 );
  * Called when the plugin page is loaded
  *
  * @since    2.0.0
+ * @deprecated 3.0
  */
 function pmpro_list_table_screen_options() {
-	global $user_list_table;
+	_deprecated_function( __FUNCTION__, '3.0' );
+
 	$arguments = array(
 		'label'   => __( 'Members Per Page', 'paid-memberships-pro' ),
 		'default' => 13,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves #2497 

In addition to allowing showing/hiding columns and setting "per page" settings on the orders and discount code list tables, this PR also fixes a bug where changing the "per page" setting on the members list changes the corresponding setting on the users list and vice versa.


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
