### PR TITLE
Use MemberOrder->get_subscription() where we can

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -731,7 +731,7 @@ class PMPro_Subscription {
 	 * @param MemberOrder $order The order for the recurring payment that was just processed.
 	 */
 	public static function update_subscription_for_order( $order ) {
-		$subscription = self::get_subscription_from_subscription_transaction_id( $order->subscription_transaction_id, $order->gateway, $order->gateway_environment );
+		$subscription = $order->get_subscription();
 		if ( ! empty( $subscription ) ) {
 			$subscription->update();
 		}

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1510,15 +1510,14 @@
 		 * Call the cancel step of the order's subscription if needed.
 		 */
 		function cancel() {			
-			// Only need to cancel on the gateway if there is a subscription id.
-			if ( ! empty( $this->subscription_transaction_id ) ) {
-				$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $this->subscription_transaction_id, $this->gateway, $this->gateway_environment );
-				if ( ! empty( $subscription ) ) {
-					return $subscription->cancel_at_gateway();
-				}
+			// Only need to cancel on the gateway if there is a subscription.
+			$subscription = $this->get_subscription();
+			if ( empty( $subscription ) ) {
+				return true;
 			}
-				
-			return true;
+
+			// Cancel the subscription.
+			return $subscription->cancel_at_gateway();;
 		}
 
 		/**

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1517,7 +1517,7 @@
 			}
 
 			// Cancel the subscription.
-			return $subscription->cancel_at_gateway();;
+			return $subscription->cancel_at_gateway();
 		}
 
 		/**

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -34,7 +34,7 @@ if ( $pmpro_billing_order->status != 'success' ) {
 }
 
 // Get the subscription for this order and make sure that we can update its billing info.
-$pmpro_billing_subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $pmpro_billing_order->subscription_transaction_id, $pmpro_billing_order->gateway, $pmpro_billing_order->gateway_environment );
+$pmpro_billing_subscription = $pmpro_billing_order->get_subscription();
 $subscription_gateway_obj   = empty( $pmpro_billing_subscription ) ? null: $pmpro_billing_subscription->get_gateway_object();
 if ( empty( $pmpro_billing_subscription ) || $pmpro_billing_subscription->get_status() != 'active' || empty( $subscription_gateway_obj ) || empty( $subscription_gateway_obj->supports_payment_method_updates() ) ) {
     // We cannot update the billing info for this subscription. Redirect to the account page.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If we have a saved MemberOrder, use the `get_subscription()` method instead of searching for a subscription manually.
