### PR TITLE
Adding a "show more" button in the case that tabs on the edit member screen gets really long

### DIFF
--- a/adminpages/member-edit.php
+++ b/adminpages/member-edit.php
@@ -98,8 +98,36 @@ function pmpro_member_edit_display() {
 		<nav id="pmpro-edit-user-nav" role="tablist" aria-labelledby="pmpro-edit-user-menu">
 			<h2 id="pmpro-edit-user-menu" class="screen-reader-text"><?php esc_html_e( 'Edit Member Area Menu', 'paid-memberships-pro' ); ?></h2>
 			<?php
+				$count = 0;
 				foreach ( $panels as $panel_slug => $panel ) {
-					$panel->display_tab( $panel_slug === $default_panel_slug );
+					/**
+					 * Filter to limit the number of tabs that are visible on the member edit page.
+					 *
+					 * @since 3.0
+					 * @param int $num_visible_tabs The default number of tabs that are visible on the member edit page.
+					 * @return int
+					 */
+					$num_visible_tabs = apply_filters( 'pmpro_member_edit_num_visible_tabs', 6 );
+					$tab_visibility = $count < (int) $num_visible_tabs ? true : false;
+
+					// Show the tab.
+					$panel->display_tab( $panel_slug === $default_panel_slug, $tab_visibility );
+
+					// Increment the count.
+					$count++;
+				}
+
+				// Show a "More" tab if there are more than 4 panels.
+				if ( $count > (int) $num_visible_tabs ) {
+					?>
+					<div class="pmpro_relative">
+						<div class="pmpro_divider"></div>
+						<button role="showmore" class="pmpro-member-edit-show-more-tab">
+							<?php esc_html_e( 'Show More', 'paid-memberships-pro' ); ?>
+							<span class="dashicons dashicons-arrow-down-alt2"></span>
+						</button>
+					</div>
+					<?php
 				}
 			?>
 		</nav>
@@ -121,6 +149,9 @@ function pmpro_member_edit_display() {
 
 				// Display the panel.
 				$panel->display_panel( $panel_slug === $default_panel_slug );
+
+				// Increment the count.
+				$count++;
 			}
 			?>
 		</div>

--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -37,8 +37,9 @@ abstract class PMPro_Member_Edit_Panel {
 	 * @since 3.0
 	 *
 	 * @param bool $is_selected True if this is the selected panel, false otherwise.
+	 * @param string $tab_visibility True if  the tab is visible.
 	 */
-	final public function display_tab( $is_selected ) {
+	final public function display_tab( $is_selected, $tab_visibility = true ) {
 		// Check capabilities.
 		if ( ! $this->should_show() ) {
 			return;
@@ -52,6 +53,7 @@ abstract class PMPro_Member_Edit_Panel {
 			id="pmpro-member-edit-<?php echo esc_attr( $this->slug ) ?>-tab"
 			<?php echo ( empty( self::get_user()->ID ) && $this->slug != 'user_info'  ) ? 'disabled="disabled"' : ''; ?>
 			tabindex="<?php echo ( $is_selected ) ? '0' : '-1' ?>"
+			<?php echo empty( $tab_visibility ) ? 'style="display: none;"' : ''; ?>
 		>
 			<?php
 				echo esc_attr( ( strlen( $this->title ) > 40 ) ? substr( $this->title, 0, 40 ) . '...' : $this->title );

--- a/css/admin.css
+++ b/css/admin.css
@@ -283,7 +283,7 @@ body[class*="memberships_page_pmpro-"] {
 	gap: var(--pmpro--spacing--small);
 }
 
-.pmpro_admin .pmpro-nav-secondary a:not(.pmpro_admin .pmpro-nav-secondary li:first-child a) {
+.pmpro_admin .pmpro-nav-secondary li:not(.pmpro_admin .pmpro-nav-secondary li:first-child) {
 	border-left: 1px solid var(--pmpro--color--blue-darkest);
 	padding-left: var(--pmpro--spacing--small);
 }
@@ -972,7 +972,7 @@ body[class*="memberships_page_pmpro-"] {
 }
 
 /**
- * Single Member Page Styles
+ * Single Edit Member Page Styles
  */
 .pmpro_admin-pmpro-member h1.wp-heading-inline {
 	font-weight: 500;
@@ -1026,6 +1026,31 @@ body[class*="memberships_page_pmpro-"] {
 .pmpro_admin-pmpro-member nav button:disabled {	
 	color: #777;
 	cursor: not-allowed;	
+}
+
+.pmpro_admin-pmpro-member nav .pmpro_divider {
+	position: absolute;
+	top: 50%;
+	width: 100%;
+}
+
+.pmpro_admin-pmpro-member nav .pmpro_relative {
+	margin-top: calc( var(--pmpro--spacing--small) * 2 );
+}
+
+.pmpro_admin-pmpro-member nav button.pmpro-member-edit-show-more-tab {
+	background-color: #FFF;
+	border: 1px solid var(--pmpro--border--color);
+	border-radius: calc( var(--pmpro--border--radius) * 2 );
+	font-size: 12px;
+	font-weight: normal;
+	margin: 0 auto;
+	padding: calc( var(--pmpro--spacing--small) / 2 ) var(--pmpro--spacing--small);
+	width: auto;
+}
+
+.pmpro_admin-pmpro-member nav button.pmpro-member-edit-show-more-tab .dashicons {
+	color: var(--pmpro--color--blue-darkest);
 }
 
 .pmpro_admin-pmpro-member .pmpro_section:not(.pmpro_admin-pmpro-member .pmpro_section .pmpro_section) {
@@ -2837,6 +2862,17 @@ tr.pmpro_alert {
 /**
  * Misc
  */
+.pmpro_relative {
+	position: relative;
+}
+
+.pmpro_divider {
+	border-top: 1px solid var(--pmpro--border--color);
+    color: inherit;
+	height: 0;
+	margin: 0;
+}
+
 .pmpro_lite {
 	color: #777;
 }

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -962,7 +962,30 @@ window.addEventListener("DOMContentLoaded", () => {
 			tabs[tabFocus].focus();
 		}
 		});
-	}
+
+        // Enable the button to show more tabs.
+        document.addEventListener('click', function(e) {
+            const moreTabsToggle = e.target.closest('[role="showmore"]');
+            if (moreTabsToggle) {
+                e.preventDefault();
+                const parent = moreTabsToggle.parentNode;
+                const grandparent = parent.parentNode;
+                grandparent.querySelectorAll('[role="tab"]').forEach((t) => t.style.display = 'block');
+                parent.style.display = 'none';
+            }
+        });
+
+        // If the visible panel's corresponding tab is hidden, show all tabs.
+        const visiblePanel = document.querySelector('#pmpro-edit-user-div [role="tabpanel"]:not([hidden])');
+        if ( visiblePanel ) {
+            const visibleTab = document.querySelector(`[aria-controls="${visiblePanel.id}"]`);
+            if ( visibleTab.style.display === 'none' ) {
+                const moreTabsToggle = document.querySelector('[role="showmore"]');
+                moreTabsToggle.click();
+            }
+        }
+
+    }
 
 });
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding a "Show More" if the number of tabs is > 6. 6 is the number that includes all default tabs, the TOS tab if present and one additional user field group tab.

Added filter `pmpro_member_edit_num_visible_tabs` to change the default.

JS to handle the button click and also preserve the expanded tabs view if you make a change and save changes to a panel that would otherwise have the tab hidden.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

![Screenshot 2024-02-01 at 8 12 11 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/1766d3c2-4b8a-4bec-aff1-f7a93c921014)

