### PR TITLE
Sorting visits report to last, adding message about the data inconsistency

### DIFF
--- a/adminpages/reports.php
+++ b/adminpages/reports.php
@@ -19,12 +19,20 @@ if ( ! empty( $_REQUEST[ 'report' ] ) ) {
 	$report = sanitize_text_field( $_REQUEST[ 'report' ] ); ?>
 	<ul class="subsubsub">
 		<li><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-reports' ) ); ?>"><?php esc_html_e('All', 'paid-memberships-pro' ); ?></a></li>
-		<?php foreach ( $pmpro_reports as $report_menu_item => $report_menu_title ) {
-			if ( function_exists( 'pmpro_report_' . $report_menu_item . '_page' ) ) { ?>
-				<li>&nbsp;|&nbsp;<a class="<?php if ( $report === $report_menu_item ) { ?>current<?php } ?>"href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-reports&report=' . $report_menu_item ) ); ?>"><?php echo $report_menu_title; ?></a></li>
-				<?php
+		<?php
+			// If the Visits, Views, and Logins report is in the array, show it last.
+			if ( array_key_exists( 'login', $pmpro_reports ) ) {
+				$login = $pmpro_reports['login'];
+				unset( $pmpro_reports['login'] );
+				$pmpro_reports['login'] = $login;
 			}
-		} ?>
+			foreach ( $pmpro_reports as $report_menu_item => $report_menu_title ) {
+				if ( function_exists( 'pmpro_report_' . $report_menu_item . '_page' ) ) { ?>
+					<li>&nbsp;|&nbsp;<a class="<?php if ( $report === $report_menu_item ) { ?>current<?php } ?>"href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-reports&report=' . $report_menu_item ) ); ?>"><?php echo $report_menu_title; ?></a></li>
+					<?php
+				}
+			}
+		?>
 	</ul>
 	<br class="clear" />
 	<?php
@@ -36,32 +44,36 @@ if ( ! empty( $_REQUEST[ 'report' ] ) ) {
 	<?php
 } else { ?>
 	<h1><?php esc_html_e( 'Reports', 'paid-memberships-pro' ); ?></h1>
-    <?php if( ! empty( $pmpro_reports ) ) {
-        $pieces = array_chunk( $pmpro_reports, ceil( count( $pmpro_reports ) / 2 ), true );
-        foreach ( $pieces[0] as $report => $title ) {
-            add_meta_box(
-                'pmpro_report_' . $report,
-                $title,
-                'pmpro_report_' . $report . '_widget',
-                'memberships_page_pmpro-reports',
-                'advanced'
-            );
-        }
+    <?php if ( ! empty( $pmpro_reports ) ) {
+		// If the Visits, Views, and Logins report is in the array, show it last.
+		if ( array_key_exists( 'login', $pmpro_reports ) ) {
+			$login = $pmpro_reports['login'];
+			unset( $pmpro_reports['login'] );
+			$pmpro_reports['login'] = $login;
+		}
+		$pieces = array_chunk( $pmpro_reports, ceil( count( $pmpro_reports ) / 2 ), true );
+		foreach ( $pieces[0] as $report => $title ) {
+			add_meta_box(
+				'pmpro_report_' . $report,
+				$title,
+				'pmpro_report_' . $report . '_widget',
+				'memberships_page_pmpro-reports',
+				'advanced'
+			);
+		}
 
-        if( ! empty( $pieces[1] ) ) {
-	        foreach ( $pieces[1] as $report => $title ) {
-		        add_meta_box(
-			        'pmpro_report_' . $report,
-			        $title,
-			        'pmpro_report_' . $report . '_widget',
-			        'memberships_page_pmpro-reports',
-			        'side'
-		        );
-	        }
-        }
-    }
-
-	?>
+		if( ! empty( $pieces[1] ) ) {
+			foreach ( $pieces[1] as $report => $title ) {
+				add_meta_box(
+					'pmpro_report_' . $report,
+					$title,
+					'pmpro_report_' . $report . '_widget',
+					'memberships_page_pmpro-reports',
+					'side'
+				);
+			}
+		}
+    } ?>
 	<form id="pmpro-reports-form" method="post" action="admin-post.php">
 
 		<div class="dashboard-widgets-wrap">

--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -105,7 +105,7 @@ function pmpro_report_login_page()
 ?>
 	<form id="visits-views-logins-form" method="get" action="">
 	<h1 class="wp-heading-inline">
-		<?php _e('Visits, Views, and Logins Report', 'paid-memberships-pro');?>
+		<?php _e('Visits, Views, and Logins', 'paid-memberships-pro');?>
 	</h1>
 	<?php if ( current_user_can( 'pmpro_loginscsv' ) ) { ?>
 		<a target="_blank" href="<?php echo esc_url( $csv_export_link ); ?>" class="page-title-action pmpro-has-icon pmpro-has-icon-download"><?php esc_html_e( 'Export to CSV', 'paid-memberships-pro' ); ?></a>
@@ -160,6 +160,10 @@ function pmpro_report_login_page()
 		$theusers = $wpdb->get_results($sqlQuery);
 		$totalrows = $wpdb->get_var("SELECT FOUND_ROWS() as found_rows");
 	?>
+	<p>
+		<?php esc_html_e( 'This report offers a detailed view of data points by user and member. For various reasons, the numbers below will not perfectly match up to other tracking you might be doing (such as the data provided by an analytics plugin).', 'paid-memberships-pro' ); ?>
+		<a href="https://www.paidmembershipspro.com/documentation/admin/reports/?utm_source=plugin&utm_medium=pmpro-reports&utm_campaign=documentation&utm_content=visits-views-logins' ); ?>" target="_blank" rel="nofollow noopener"><?php esc_html_e( 'Click here to learn how these numbers are calculated.', 'paid-memberships-pro' ); ?></a>
+	</p>
 	<div class="pmpro_report-filters">
 		<h3><?php esc_html_e( 'Customize Report', 'paid-memberships-pro'); ?></h3>
 		<div class="tablenav top">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Moving the visits views and logins report to the end. added a note about the data.

![Screenshot 2024-02-01 at 10 39 47 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/44253191-d156-4066-8cc7-c66ae5944121)

