### PR TITLE
Example of how to integrate TrustedLogin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ package-lock.json
 
 # composer
 vendor
+vendor-namespaced
+strauss.phar
 composer.js
 composer.lock
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   ],
   "require": {
     "composer/installers": "1.9.*",
-    "php": ">=5.6"
+    "php": ">=5.6",
+    "trustedlogin/client": "dev-main"
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.0",
@@ -52,15 +53,51 @@
     "lucatume/function-mocker-le": "^1.0.1",
     "lucatume/wp-browser": "^3.0.11",
     "lucatume/wp-snaphot-assertions": "^1.0",
-    "the-events-calendar/tribalscents": "dev-master",
     "phpunit/phpunit": "^6.5.14",
     "spatie/phpunit-snapshot-assertions": "^1.4.2",
     "wp-cli/wp-cli": "2.*",
-    "wp-coding-standards/wpcs": "^2.1"
+    "wp-coding-standards/wpcs": "^2.1",
+    "scssphp/scssphp": "^1.12"
   },
   "minimum-stability": "stable",
   "prefer-stable": true,
+  "autoload": {
+    "classmap": [
+      "vendor"
+    ]
+  },
   "extra": {
-    "installer-name": "paid-memberships-pro"
+    "installer-name": "paid-memberships-pro",
+    "strauss": {
+      "target_directory": "vendor-namespaced",
+      "namespace_prefix": "PMPro\\",
+      "classmap_prefix": "PMPro_",
+      "classmap_output": true,
+      "packages": [
+        "trustedlogin/client"
+      ]
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "composer/installers": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  },
+  "scripts": {
+    "strauss": [
+      "@php strauss.phar"
+    ],
+    "trustedlogin": [
+      "@php vendor/bin/build-sass --namespace=PMPro"
+    ],
+    "post-install-cmd": [
+      "@strauss",
+      "@trustedlogin"
+    ],
+    "post-update-cmd": [
+      "@strauss",
+      "@trustedlogin"
+    ]
   }
 }

--- a/includes/trustedlogin.php
+++ b/includes/trustedlogin.php
@@ -1,0 +1,58 @@
+<?php
+
+
+// For a plugin or theme:
+include_once trailingslashit( PMPRO_DIR ) . 'vendor-namespaced/autoload.php';
+
+/**
+ * Configuration for TrustedLogin Client
+ *
+ *
+ * @see https://docs.trustedlogin.com/Client/configuration
+ */
+$public_key = '7a21b4f6e7eb0914';
+$config = [
+	'auth' => [
+		'api_key' => $public_key,
+	],
+	'vendor' => [
+		'namespace' => 'pmpro',
+		'title' => 'Paid Memberships Pro',
+		'email' => 'support@paidmembershipspro.com',
+		'website' => 'https://embarrassed-elk-ewa3s.test.trustedlogin.dev',
+		'support_url' => 'https://www.paidmembershipspro.com/support/',
+        'logo_url' => plugins_url( 'images/Paid-Memberships-Pro.png', PMPRO_BASE_FILE ),
+	],
+	'role' => 'administrator',
+    'menu' => [
+		'slug' => 'pmpro-dashboard',
+		'title' => 'Grant Support Access',
+	],
+	'webhook' => [
+		'url' => 'https://example.com/webhook',
+		'create_ticket' => true,
+		'debug_data' => true,
+	],
+];
+
+$config = new PMPro\TrustedLogin\Config( $config );
+try {
+	new PMPro\TrustedLogin\Client(
+		$config
+	);
+} catch ( \Exception $exception ) {
+	error_log( $exception->getMessage() );
+
+	add_action( 'admin_notices', function() use ( $exception ) {
+
+		if( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		?>
+		<div class="notice notice-error">
+			<p><?php echo $exception->getMessage(); ?></p>
+		</div>
+		<?php
+	} );
+}

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -95,6 +95,7 @@ require_once( PMPRO_DIR . '/includes/checkout.php' );		        // Common functio
 require_once( PMPRO_DIR . '/includes/xmlrpc.php' );                 // xmlrpc methods
 require_once( PMPRO_DIR . '/includes/rest-api.php' );               // rest API endpoints
 require_once( PMPRO_DIR . '/includes/widgets.php' );                // widgets for PMPro
+require_once( PMPRO_DIR . '/includes/trustedlogin.php' );           // TrustedLogin!
 
 require_once( PMPRO_DIR . '/classes/class-pmpro-site-health.php' ); // Site Health information.
 


### PR DESCRIPTION
Integrates TrustedLogin into PMPro.

Note, @ideadude — `the-events-calendar/tribalscents` was throwing errors. It seems to no longer exist, since it's under Stellar now.