### PR TITLE
Adjust REST API capability

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -925,7 +925,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				// Hide confirmation message if not an admin or member.
 				if ( ! empty( $r[ $level_id ]->confirmation ) 
 						&& ! pmpro_hasMembershipLevel( $level_id )
-						&& ! current_user_can( 'pmpro_edit_memberships' ) ) {				
+						&& ! current_user_can( 'pmpro_membershiplevels' ) ) {				
 					$r[ $level_id ]->confirmation = '';					
 				}
 			}


### PR DESCRIPTION
* BUG FIX: The REST API was using the wrong capability during the get_checkout_levels and hide the confirmation message. This would be hidden more times than not due to this incorrect permission.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?
