### PR TITLE
Cast level_id to be integer in the pmpro_getLevelAtCheckout

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2427,8 +2427,11 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 		$level_id = apply_filters( 'pmpro_default_level', intval( $default_level ) );
 	}
 
+	// Cast level ID to int to be safe.
+	$level_id = (int) $level_id;
+
 	// If we still don't have a level, bail.
-	if ( empty( $level_id ) || $level_id < 1 || ! is_int( $level_id ) ) {
+	if ( empty( $level_id ) || $level_id < 1 ) {
 		return;
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2427,11 +2427,8 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 		$level_id = apply_filters( 'pmpro_default_level', intval( $default_level ) );
 	}
 
-	// Cast level ID to int to be safe.
-	$level_id = (int) $level_id;
-
 	// If we still don't have a level, bail.
-	if ( empty( $level_id ) || $level_id < 1 ) {
+	if ( empty( $level_id ) || intval( $level_id ) < 1 ) {
 		return;
 	}
 


### PR DESCRIPTION
* BUG FIX: Fixes cases where passing a string, but valid, level_id to the `pmpro_getLevelAtCheckout` would return NULL.

The proposed fix is to case the level ID to integer as late as possible. This only occurs when you pass through the level ID as a string, a good example of this is the Advanced Levels Page Add On using this function and passing through a string.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?