### PR TITLE
Fix second params to current_user_can

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -902,7 +902,7 @@ class PMPro_Field {
 				if ( ( ! empty( $this->allow_delete ) ) && ! empty( $this->file['fullurl'] ) ) {
 					// Check whether the current user can delete the uploaded file based on the field attribute 'allow_delete'.
 					if ( $this->allow_delete === true || 
-						( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options', $current_user->ID ) )
+						( $this->allow_delete === 'admins' || $this->allow_delete === 'only_admin' && current_user_can( 'manage_options' ) )
 					) {
 						$r_beginning .= '<button class="button is-destructive pmprorh_delete_file" id="pmprorh_delete_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Delete', 'paid-memberships-pro' ) . '</button>';
 						$r_beginning .= '<button class="button button-secondary pmprorh_replace_file" id="pmprorh_replace_file_' . esc_attr( $this->name ) . '_button" onclick="return false;">' . __( 'Replace', 'paid-memberships-pro' ) . '</button>';
@@ -1290,7 +1290,7 @@ class PMPro_Field {
 			</th>
 			<td>
 				<?php 						
-					if(current_user_can("edit_user", $current_user->ID) && $edit !== false)
+					if(current_user_can("edit_user", $user_id) && $edit !== false)
 						$this->display($value); 
 					else
 						echo "<div>" . $this->displayValue($value) . "</div>";						


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The second parameter to `current_user_can()` should be blank unless a meta capability is passed as the first param, in which case the second param should be the object ID that the current user is trying to view/edit.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Steps to replicate:
1. Add this gist to your website, replacing `969` with the ID of an active member: https://gist.github.com/dparker1005/27eab6c0779f3dca9b51f6aa023ab48f
2. Add user fields that would be editable on the Edit Member page
3. Edit user 969 as an admin and see that the user fields cannot be edited. Edit any other user and see that they can.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
