### PR TITLE
Marking some hooks as deprecated for 3.0

### DIFF
--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -23,9 +23,9 @@ global $pmpro_pages;
 $extra_pages = apply_filters('pmpro_extra_page_settings', array());
 
 /**
- * @deprecated replaced with pmpro_admin_pagesetting_post_type since 2.7.0
+ * @deprecated 3.0 replaced with pmpro_admin_pagesetting_post_type since 2.7.0
  */
-$post_types = apply_filters( 'pmpro_admin_pagesetting_post_type_array', array( 'page' ) );
+$post_types = apply_filters_deprecated( 'pmpro_admin_pagesetting_post_type_array', array( array( 'page' ) ), '3.0', 'pmpro_admin_pagesetting_post_type' );
 
 // For backward compatibility we extract the first element from the array
 if ( is_array( $post_types ) ) {

--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -41,7 +41,7 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 		 *
 		 * @param int $user_id The ID of the user associated with the subscription.
 		 */
-		do_action( 'pmpro_stripe_subscription_deleted', $user->ID );
+		do_action_deprecated( 'pmpro_stripe_subscription_deleted', array( $user->ID ), '3.0' );
 	}
 
 	// Check if we have already cancelled the subscription in PMPro.
@@ -68,7 +68,7 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 
 	// Legacy Braintree code to add action on subscription cancellation.
 	if ( 'braintree' === $gateway ) {
-		$newest_order = $this->get_orders( array( 'limit' => 1 ) );
+		$newest_order = $subscription->get_orders( array( 'limit' => 1 ) );
 		if ( ! empty( $newest_order ) ) {
 			/**
 			 * Action for when a subscription is cancelled at a payment gateway.
@@ -76,9 +76,9 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 			 *
 			 * @deprecated 3.0
 			 *
-			 * @param int $user_id The ID of the user associated with the subscription.
+			 * @param MemberOrder $newest_order The most recent order associated with the subscription.
 			 */
-			do_action( "pmpro_subscription_cancelled", current( $newest_order ) );
+			do_action_deprecated( 'pmpro_subscription_cancelled', array( current( $newest_order ) ), '3.0' );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Throwing warnings when deprecated actions/filters are used.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
