### PR TITLE
Fix undefined function error for 2.12.9

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -175,7 +175,7 @@ function pmpro_maybe_strip_member_shortcode( $content ) {
 	// If an array is passed in, filter all elements recursively.
 	if ( is_array( $content ) ) {
 		foreach ( $content as $key => $value ) {
-			$content[ $key ] = pmpro_strip_member_shortcode( $value );
+			$content[ $key ] = pmpro_maybe_strip_member_shortcode( $value );
 		}
 		return $content;
 	}


### PR DESCRIPTION
* BUG FIX: Fixed a minor typo causing a fatal error in certain cases where the we tried to strip the member shortcode.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?