### PR TITLE
Automatically select first edit member panel/tab

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -918,6 +918,15 @@ window.addEventListener("DOMContentLoaded", () => {
 	const tabList = document.querySelector('#pmpro-edit-user-div [role="tablist"]');
 	const inputs = document.querySelectorAll('#pmpro-edit-user-div input, #pmpro-edit-user-div textarea, #pmpro-edit-user-div select');
 
+    const firstTab = document.querySelector('[role="tab"]');
+    const firstPanel = document.querySelector(`#${firstTab.getAttribute("aria-controls")}`);
+
+    // Set the first tab as active
+    firstTab.setAttribute("aria-selected", true);
+
+    // Show the corresponding panel
+    firstPanel.removeAttribute("hidden");
+ 
 	if ( tabs && tabList ) {
 		// Track whether an input has been changed.
 		let inputChanged = false;

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -914,6 +914,8 @@ jQuery(document).ready(function () {
  * Add/Edit Member Page
  */
 window.addEventListener("DOMContentLoaded", () => {
+    if (window.location.search.includes('page=pmpro-member')) {
+
 	const tabs = document.querySelectorAll('#pmpro-edit-user-div [role="tab"]');
 	const tabList = document.querySelector('#pmpro-edit-user-div [role="tablist"]');
 	const inputs = document.querySelectorAll('#pmpro-edit-user-div input, #pmpro-edit-user-div textarea, #pmpro-edit-user-div select');
@@ -995,6 +997,7 @@ window.addEventListener("DOMContentLoaded", () => {
         }
 
     }
+}
 
 });
 


### PR DESCRIPTION
* ENHANCEMENT: Automatically select the first Edit member panel and tab that's available.

This helps improve UX when only certain tabs are shown to a specific user that may not have full capabilities or shown certain tabs only in the edit member screen.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Give a non-admin role the ability to all `pmpro_` prefixed capabilites, make sure they don't have `edit_users` capability.
2. Filter the `pmpro_edit_member_capability` to be `edit_users` (Note: The Membership Manager Add On does this automatically).
3. While logged-in as this manager/non-admin edit a member and see that the Orders panel shows by default due to the `pmpro_orders` capability given in step 1 and is automatically "active".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
