### PR TITLE
Updating edit member tab in URL

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-tos.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-tos.php
@@ -5,7 +5,7 @@ class PMPro_Member_Edit_Panel_TOS extends PMPro_Member_Edit_Panel {
 	 * Set up the panel.
 	 */
 	public function __construct() {
-		$this->slug = 'other';
+		$this->slug = 'tos';
 		$this->title = __( 'Terms of Service', 'paid-memberships-pro' );
 	}
 

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -1021,6 +1021,14 @@ function pmpro_changeTabs( e, inputChanged ) {
 	.querySelector(`#${target.getAttribute("aria-controls")}`)
 	.removeAttribute("hidden");
 
+    // Update the URL to include the panel URL in the pmpro_member_edit_panel attribute.
+    const fullPanelName = target.getAttribute('aria-controls');
+    // Need to convert pmpro-member-edit-xyz-panel to xyz.
+    const panelSlug = fullPanelName.replace(/^pmpro-member-edit-/, '').replace(/-panel$/, '');
+    const url = new URL(window.location.href);
+    url.searchParams.set('pmpro_member_edit_panel', panelSlug);
+    window.history.pushState({}, '', url);
+
 	return true;
 }
 

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -1021,13 +1021,13 @@ function pmpro_changeTabs( e, inputChanged ) {
 	.querySelector(`#${target.getAttribute("aria-controls")}`)
 	.removeAttribute("hidden");
 
-    // Update the URL to include the panel URL in the pmpro_member_edit_panel attribute.
-    const fullPanelName = target.getAttribute('aria-controls');
-    // Need to convert pmpro-member-edit-xyz-panel to xyz.
-    const panelSlug = fullPanelName.replace(/^pmpro-member-edit-/, '').replace(/-panel$/, '');
-    const url = new URL(window.location.href);
-    url.searchParams.set('pmpro_member_edit_panel', panelSlug);
-    window.history.pushState({}, '', url);
+	// Update the URL to include the panel URL in the pmpro_member_edit_panel attribute.
+	const fullPanelName = target.getAttribute('aria-controls');
+	// Need to convert pmpro-member-edit-xyz-panel to xyz.
+	const panelSlug = fullPanelName.replace(/^pmpro-member-edit-/, '').replace(/-panel$/, '');
+	const url = new URL(window.location.href);
+	url.searchParams.set('pmpro_member_edit_panel', panelSlug);
+	window.history.pushState({}, '', url);
 
 	return true;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When switching tabs on the edit member page, update the URL accordingly. This means if the page is refreshed, it will go back to the previous tab.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
