### PR TITLE
Showing subscription sync errors

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
@@ -148,6 +148,16 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 								</span>
 								<?php
 							}
+
+							// Show warning if the subscription had an error when trying to sync.
+							$sync_error = get_pmpro_subscription_meta( $subscription->get_id(), 'sync_error', true );
+							if ( ! empty( $sync_error ) ) {
+								?>
+								<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
+									<?php echo esc_html( __( 'Sync Error', 'paid-memberships-pro' ) . ': ' . $sync_error ); ?>
+								</span>
+								<?php
+							}
 							?>
 							<div class="row-actions">
 								<?php

--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -208,6 +208,17 @@ if ( empty( $subscription ) ) {
 							<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-<?php echo esc_attr( $subscription->get_status() ); ?>">
 								<?php echo ucwords( esc_html( $subscription->get_status() ) ); ?>
 							</span>
+							<?php
+							// Show warning if the subscription had an error when trying to sync.
+							$sync_error = get_pmpro_subscription_meta( $subscription->get_id(), 'sync_error', true );
+							if ( ! empty( $sync_error ) ) {
+								?>
+								<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
+									<?php echo esc_html( __( 'Sync Error', 'paid-memberships-pro' ) . ': ' . $sync_error ); ?>
+								</span>
+								<?php
+							}
+							?>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If a subscription has a sync error, display the error when the subscription is viewed.
![Screenshot 2024-02-08 at 12 19 23 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/65256e29-bc9d-4dbd-8484-b33971f09cb5)
![Screenshot 2024-02-08 at 12 19 32 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/2c04f388-4f26-48b1-9769-bf6c8d996774)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
