### PR TITLE
Pulling subscription data into Members List and Members CSV export.

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -98,7 +98,7 @@
 		$headers[] = 'Content-Disposition: attachment; filename="members_list.csv"';
 
 	//set default CSV file headers, using comma as delimiter
-	$csv_file_header = "id,username,firstname,lastname,email,billing firstname,billing lastname,address1,address2,city,state,zipcode,country,phone,membership,initial payment,fee,term,discount_code_id,discount_code,joined";
+	$csv_file_header = "id,username,firstname,lastname,email,billing firstname,billing lastname,address1,address2,city,state,zipcode,country,phone,membership,discount_code_id,discount_code,billing_amount,cycle_number,cycle_period,joined";
 
 	if($l == "oldmembers")
 		$csv_file_header .= ",ended";
@@ -122,9 +122,6 @@
 		array("metavalues", "pmpro_bcountry"),
 		array("metavalues", "pmpro_bphone"),
 		array("theuser", "membership"),
-		array("theuser", "initial_payment"),
-		array("theuser", "billing_amount"),
-		array("theuser", "cycle_period"),
 		array("discount_code", "id"),
 		array("discount_code", "code")
 		//joindate and enddate are handled specifically below
@@ -351,9 +348,6 @@
 				u.user_status,
 				u.display_name,
 				mu.membership_id,
-				mu.initial_payment,
-				mu.billing_amount,
-				mu.cycle_period,
 				UNIX_TIMESTAMP(CONVERT_TZ(max(mu.enddate), '+00:00', @@global.time_zone)) as enddate,
 				m.name as membership
 			FROM {$wpdb->users} u
@@ -436,6 +430,12 @@
 					array_push($csvoutput, pmpro_enclose($val));	//output the value
 				}
 			}
+
+			// Subscription billing amount, cycle number, and cycle period.
+			$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $theuser->ID, $theuser->membership_id );
+			array_push($csvoutput, pmpro_enclose( ( empty( $subscriptions  ) ? '' : $subscriptions[0]->get_billing_amount() ) ) );
+			array_push($csvoutput, pmpro_enclose( ( empty( $subscriptions  ) ? '' : $subscriptions[0]->get_cycle_number() ) ) );
+			array_push($csvoutput, pmpro_enclose( ( empty( $subscriptions  ) ? '' : $subscriptions[0]->get_cycle_period() ) ) );
 
 			//joindate and enddate
 			array_push($csvoutput, pmpro_enclose(date_i18n($dateformat, $theuser->joindate)));

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -139,7 +139,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			'address'       => __( 'Billing Address', 'paid-memberships-pro' ),
 			'membership'    => __( 'Level', 'paid-memberships-pro' ),
 			'membership_id' => __( 'Level ID', 'paid-memberships-pro' ),
-			'fee'           => __( 'Level Cost', 'paid-memberships-pro' ),
+			'subscription'  => __( 'Subscription', 'paid-memberships-pro' ),
 			'joindate'      => __( 'Registered', 'paid-memberships-pro' ),
 			'startdate'     => __( 'Start Date', 'paid-memberships-pro' ),
 			'enddate'       => __( 'End Date', 'paid-memberships-pro' ),
@@ -240,10 +240,6 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			),
 			'username'     => array(
 				'user_login',
-				false,
-			),
-			'fee' => array(
-				'fee',
 				false,
 			),
 			'display_name'   => array(
@@ -379,7 +375,7 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			$sqlQuery =
 				"
 				SELECT u.ID, u.user_login, u.user_email, u.display_name,
-				UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id, mu.initial_payment, mu.billing_amount, SUM(mu.initial_payment+ mu.billing_amount) as fee, mu.cycle_period, mu.cycle_number, mu.billing_limit, mu.trial_amount, mu.trial_limit,
+				UNIX_TIMESTAMP(CONVERT_TZ(u.user_registered, '+00:00', @@global.time_zone)) as joindate, mu.membership_id,
 				UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate,
 				UNIX_TIMESTAMP(CONVERT_TZ(max(mu.enddate), '+00:00', @@global.time_zone)) as enddate, m.name as membership
 				";
@@ -484,7 +480,6 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			'user_email' 		=> 'u.user_email',
 			'membership' 		=> 'mu.membership_id',
 			'membership_id' 	=> 'mu.membership_id',
-			'fee' 				=> 'fee',
 			'joindate' 			=> 'u.user_registered',
 			'startdate' 		=> 'mu.startdate',
 			'enddate' 			=> 'mu.enddate',
@@ -659,37 +654,69 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Get value for fee column.
+	 * Get value for subscription column.
 	 *
 	 * @param object $item A row's data.
 	 * @return string Text to be placed inside the column <td>.
 	 */
-	public function column_fee( $item ) {
-		$fee = '';
-		// If there is no payment for the level, show a dash.
-		if ( (float)$item['initial_payment'] <= 0 && (float)$item['billing_amount'] <= 0 ) {
-			$fee .= esc_html__( '&#8212;', 'paid-memberships-pro' );
+	public function column_subscription( $item ) {
+		// Check if we have subscriptions for this user.
+		$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $item['ID'], $item['membership_id'] );
+		if ( ! empty( $subscriptions ) ) {
+			// If the user has more than 1 subscription, show a warning message.
+			if ( count( $subscriptions ) > 1 ) {
+				?>
+				<div class="pmpro_message pmpro_error">
+					<p>
+						<?php
+						printf(
+							// translators: %1$d is the number of subscriptions and %2$s is the link to view subscriptions.
+							_n(
+								'This user has %1$d active subscription for this level. %2$s',
+								'This user has %1$d active subscriptions for this level. %2$s',
+								count( $subscriptions ),
+								'paid-memberships-pro'
+							),
+							count( $subscriptions ),
+							sprintf(
+								'<a href="%1$s">%2$s</a>',
+								esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => $item['ID'], 'pmpro_member_edit_panel' => 'subscriptions' ), admin_url( 'admin.php' ) ) ),
+								esc_html__( 'View Subscriptions', 'paid-memberships-pro' )
+							)
+						); ?>
+					</p>
+				</div>
+				<?php
+			}
+			$subscription = $subscriptions[0];
+			echo esc_html( $subscription->get_cost_text() );
+			$actions = [
+				'view'   => sprintf(
+					'<a href="%1$s">%2$s</a>',
+					esc_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $subscription->get_id() ), admin_url('admin.php' ) ) ),
+					esc_html__( 'View Details', 'paid-memberships-pro' )
+				)
+			];
+
+			$actions_html = [];
+
+			foreach ( $actions as $action => $link ) {
+				$actions_html[] = sprintf(
+					'<span class="%1$s">%2$s</span>',
+					esc_attr( $action ),
+					$link
+				);
+			}
+
+			if ( ! empty( $actions_html ) ) { ?>
+				<div class="row-actions">
+					<?php echo implode( ' | ', $actions_html ); ?>
+				</div>
+				<?php
+			}
 		} else {
-			// Display the member's initial payment.
-			if ( (float)$item['initial_payment'] > 0 ) {
-				$fee .= pmpro_escape_price( pmpro_formatPrice( $item['initial_payment'] ) );
-			}
-			// If there is a recurring payment, show a plus sign.
-			if ( (float)$item['initial_payment'] > 0 && (float)$item['billing_amount'] > 0 ) {
-				$fee .= esc_html__( ' + ', 'paid-memberships-pro' );
-			}
-			// If there is a recurring payment, show the recurring payment amount and cycle.
-			if ( (float)$item['billing_amount'] > 0 ) {
-				$fee .= pmpro_escape_price( pmpro_formatPrice( $item['billing_amount'] ) );
-				$fee .= esc_html__( ' per ', 'paid-memberships-pro' );
-				if ( $item['cycle_number'] > 1 ) {
-					$fee .= $item['cycle_number'] . " " . pmpro_translate_billing_period( $item['cycle_period'], $item['cycle_number'] );
-				} else {
-					$fee .= pmpro_translate_billing_period( $item['cycle_period'], 1 );
-				}
-			}
+			echo '&#8212;';
 		}
-		return $fee;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Changing "Fee" column to "Subscription" and letting subscription generate the cost text to show. A link will also be shown to view the subscription on hover.
![Screenshot 2024-02-08 at 3 37 51 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/3e5f8c81-3829-4c8d-b605-f705a5800888)

The main benefit of this PR is not relying on the payment data from the memberships_users table, which could be inaccurate. The tradeoff is not showing the initial payment price on the Members List anymore. Custom code could be used to add that information back.

Theoretically, we could also add other subscription info into the Members List (such as next payment date), but it feels right to have this information in a separate "subscriptions" list table.

The subscription billing amount, cycle number, and cycle period were also added to the CSV export along with the removal of the membership_user's initial payment field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
