### PR TITLE
Calculating the last day of month instead of assuming 31

### DIFF
--- a/adminpages/memberships-csv.php
+++ b/adminpages/memberships-csv.php
@@ -74,7 +74,7 @@ if ( isset( $_REQUEST[ 'discount_code' ] ) ) {
 if($period == "daily")
 {
 	$startdate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-01';
-	$enddate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-31';
+	$enddate = $year . '-' . substr("0" . $month, strlen($month) - 1, 2) . '-' . date_i18n( 't', strtotime( $startdate ) );
 	$date_function = 'DAY';
 }
 elseif($period == "monthly")

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -170,7 +170,7 @@ function pmpro_report_memberships_page() {
 	// calculate start date and how to group dates returned from DB
 	if ( $period == 'daily' ) {
 		$startdate     = $year . '-' . substr( '0' . $month, strlen( $month ) - 1, 2 ) . '-01';
-		$enddate       = $year . '-' . substr( '0' . $month, strlen( $month ) - 1, 2 ) . '-31';
+		$enddate       = $year . '-' . substr( '0' . $month, strlen( $month ) - 1, 2 ) . '-' . date_i18n( 't', strtotime( $startdate ) );
 		$date_function = 'DAY';
 	} elseif ( $period == 'monthly' ) {
 		$startdate     = $year . '-01-01';
@@ -665,7 +665,7 @@ function pmpro_getCancellations( $period = null, $levels = 'all', $status = arra
 		$enddate   = "CONCAT(LAST_DAY('" . date_i18n( 'Y-m', $now ) . '-01' . "'), ' 23:59:59')";
 	} elseif ( $period == 'this year' ) {
 		$startdate = date( 'Y', $now ) . '-01-01 00:00:00';
-		$enddate   = "'" . date( 'Y', $now ) . "-12-31 23:59:59'";
+		$enddate   = "'" . date( 'Y', $now ) . "-12-" . date_i18n( 't', strtotime( $startdate ) ) . " 23:59:59'";
 	} else {
 		// all time
 		$startdate = '1970-01-01';  // all time (no point in using a value prior to the start of the UNIX epoch)

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -253,7 +253,7 @@ function pmpro_report_sales_page()
 
 		// Set up the start and end dates.
 		$startdate = $year . '-01-01';
-		$enddate = $year . '-12-31';
+		$enddate = $year . '-12-' . date_i18n( 't', strtotime( $startdate ) );
 		
 		// Set up the compare period.
 		$compare_startdate = date( 'Y-m-d', strtotime( $startdate . ' -1 year' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Invalid dates have caused SQL errors on some websites.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
