### PR TITLE
Fix/cap tweaks

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -547,7 +547,13 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function column_username( $item ) {
 		$avatar   = get_avatar( $item['ID'], 32 );
-		$userlink = '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int)$item['ID'] ), admin_url( 'admin.php' ) ) ) . '">' . $item['user_login'] . '</a>';
+		
+		if ( current_user_can( pmpro_get_edit_member_capability() ) ) {
+			$userlink = '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int)$item['ID'] ), admin_url( 'admin.php' ) ) ) . '">' . $item['user_login'] . '</a>';
+		} else {
+			// If the user can't edit members, don't link to the edit page.
+			$userlink = $item['user_login'];
+		}
 		$userlink = apply_filters( 'pmpro_members_list_user_link', $userlink, get_userdata( $item['ID'] ) );
 		$output   = $avatar . ' <strong>' . $userlink . '</strong><br />';
 

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -97,8 +97,8 @@ function pmpro_add_pages() {
 	add_submenu_page( $wizard_location, __( 'Setup Wizard', 'paid-memberships-pro' ), __( 'Setup Wizard', 'paid-memberships-pro' ), 'pmpro_wizard', 'pmpro-wizard', 'pmpro_wizard' );
 
 	// Hidden pages
-	add_submenu_page( 'admin.php', __( 'Subscriptions', 'paid-memberships-pro' ), __( 'Subscriptions', 'paid-memberships-pro' ), 'pmpro_edit_members', 'pmpro-subscriptions', 'pmpro_subscriptions' );
-	add_submenu_page( 'admin.php', __( 'Add Member', 'paid-memberships-pro' ), __( 'Add Member', 'paid-memberships-pro' ), 'pmpro_edit_members', 'pmpro-member', 'pmpro_member_edit_display' );
+	add_submenu_page( 'admin.php', __( 'Subscriptions', 'paid-memberships-pro' ), __( 'Subscriptions', 'paid-memberships-pro' ), pmpro_get_edit_member_capability(), 'pmpro-subscriptions', 'pmpro_subscriptions' );
+	add_submenu_page( 'admin.php', __( 'Add Member', 'paid-memberships-pro' ), __( 'Add Member', 'paid-memberships-pro' ), pmpro_get_edit_member_capability(), 'pmpro-member', 'pmpro_member_edit_display' );
 }
 add_action( 'admin_menu', 'pmpro_add_pages' );
 

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -69,7 +69,6 @@ function pmpro_get_capability_defs($role)
         'pmpro_orders',
         'pmpro_orderscsv',
         'pmpro_sales_report_csv',
-        'pmpro_subscriptions',
         'pmpro_discountcodes',
         'pmpro_userfields',
         'pmpro_updates',


### PR DESCRIPTION
Some fixes and tweaks to caps and permissions for 3.0.

1. Using the pmpro_get_edit_member_capability() method when setting up the hidden admin menu items, which avoids the issue where folks can get to the page without permission to view/use it.

2. Checking for permission before building the username link to edit the member in the members list table.

3. Removed the pmpro_subscriptions cap which we aren't using anymore. Because of how memberships, orders, and subs are interrelated, we thought to just use the pmpro_edit_members cap. We still have the pmpro_orders cap for adding/editing orders. Folks with pmpro_edit_members but no pmpro_orders cap can only edit the order table/etc through editing a member or clicking refund.