### PR TITLE
Updated cancel page to be a nonced form with new actions

### DIFF
--- a/js/pmpro-cancel.js
+++ b/js/pmpro-cancel.js
@@ -1,7 +1,7 @@
 jQuery( document ).ready( function() { 
-    // Prevent links from being clicked multiple times on PMPro cancel page.
-    jQuery( '#pmpro_cancel .pmpro_btn-submit' ).click( function() {
-        jQuery( '#pmpro_cancel a' ).unbind( 'click' );
-        jQuery( '#pmpro_cancel a' ).attr( 'disabled', 'disabled' );
-    });
+    // Prevent links and submit buttons from being clicked multiple times on PMPro cancel page.
+    jQuery('#pmpro_cancel #pmpro_form').submit( function(){
+		jQuery('#pmpro_cancel input[type=submit]').attr('disabled', 'disabled');
+        jQuery('#pmpro_cancel a').attr( 'disabled', 'disabled' );
+	});	
 });

--- a/pages/cancel.php
+++ b/pages/cancel.php
@@ -40,39 +40,53 @@ $user_levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
 	?>
 	<?php
 		if ( empty( $_REQUEST['confirm'] ) ) {
-			if($old_level_ids)
-			{
-				if(!is_array($old_level_ids) && $old_level_ids == "all")
-				{
-					?>
-					<p><?php esc_html_e('Are you sure you want to cancel your membership?', 'paid-memberships-pro' ); ?></p>
-					<?php
-				}
-				else
-				{
-					$level_names = $wpdb->get_col("SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode("','", array_map( 'intval', $old_level_ids ) ) . "')");
-					?>
-					<p><?php echo esc_html( sprintf( _n('Are you sure you want to cancel your %s membership?', 'Are you sure you want to cancel your %s memberships?', count($level_names), 'paid-memberships-pro'), pmpro_implodeToEnglish( $level_names) ) ); ?></p>
-					<?php
-				}
-			?>
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actionlinks' ) ); ?>">
-				<?php
-					if ( ! is_array( $old_level_ids ) && $old_level_ids == 'all' ) {
-						$cancel_memberships_text = __( 'Yes, cancel all of my memberships', 'paid-memberships-pro' );
-						$keep_memberships_text = __( 'No, keep my memberships', 'paid-memberships-pro' );
-					} elseif ( count( $old_level_ids ) > 1 ) {
-						$cancel_memberships_text = __( 'Yes, cancel these memberships', 'paid-memberships-pro' );
-						$keep_memberships_text = __( 'No, keep these memberships', 'paid-memberships-pro' );
-					} else {
-						$cancel_memberships_text = __( 'Yes, cancel this membership', 'paid-memberships-pro' );
-						$keep_memberships_text = __( 'No, keep this membership', 'paid-memberships-pro' );
-					}
+			if($old_level_ids) {
 				?>
-				<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit pmpro_yeslink yeslink', 'pmpro_btn-submit' ) ); ?>" href="<?php echo esc_url( pmpro_url( "cancel", "?levelstocancel=" . esc_attr( sanitize_text_field( $_REQUEST['levelstocancel'] ) ) . "&confirm=true" ) ) ?>" onclick="this.classList.add('disabled');"><?php echo esc_html( $cancel_memberships_text ); ?></a>
-				<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-cancel pmpro_nolink nolink', 'pmpro_btn-cancel' ) ); ?>" href="<?php echo esc_url( pmpro_url( "account" ) ) ?>"><?php echo esc_html( $keep_memberships_text ); ?></a>
-			</div>
-			<?php
+				<form id="pmpro_form" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form' ) ); ?>" action="<?php echo esc_url( pmpro_url( 'cancel', '', 'https') ) ?>" method="post">
+					<p>
+						<?php
+						if ( is_string( $old_level_ids ) && $old_level_ids == 'all' ) {
+							esc_html_e( 'Are you sure you want to cancel your membership?', 'paid-memberships-pro' );
+						} else {
+							$level_names = $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode( "','", array_map( 'intval', $old_level_ids ) ) . "')" );
+							echo esc_html( sprintf( _n( 'Are you sure you want to cancel your %s membership?', 'Are you sure you want to cancel your %s memberships?', count( $level_names ), 'paid-memberships-pro' ), pmpro_implodeToEnglish( $level_names ) ) );
+						}
+						?>
+					</p>
+
+					<?php
+					/**
+					 * Hook to add additional content to the cancel page.
+					 *
+					 * @since TBD
+					 *
+					 * @param WP_User $user The user cancelling their membership.
+					 * @param array|string   $old_level_ids The level IDs being cancelled or 'all'.
+					 */
+					do_action( 'pmpro_cancel_before_submit', $current_user, $old_level_ids );
+					?>
+
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_actionlinks' ) ); ?>">
+						<?php
+						if ( is_string( $old_level_ids ) && $old_level_ids == 'all' ) {
+							$cancel_memberships_text = __( 'Yes, cancel all of my memberships', 'paid-memberships-pro' );
+							$keep_memberships_text = __( 'No, keep my memberships', 'paid-memberships-pro' );
+						} elseif ( count( $old_level_ids ) > 1 ) {
+							$cancel_memberships_text = __( 'Yes, cancel these memberships', 'paid-memberships-pro' );
+							$keep_memberships_text = __( 'No, keep these memberships', 'paid-memberships-pro' );
+						} else {
+							$cancel_memberships_text = __( 'Yes, cancel this membership', 'paid-memberships-pro' );
+							$keep_memberships_text = __( 'No, keep this membership', 'paid-memberships-pro' );
+						}
+						?>
+						<input type="hidden" name="levelstocancel" value="<?php echo esc_attr( $_REQUEST['levelstocancel'] ); ?>" />
+						<input type="hidden" name="confirm" value="1" />
+						<?php wp_nonce_field( 'pmpro_cancel-nonce', 'pmpro_cancel-nonce' ); ?>
+						<input type="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit pmpro_yeslink yeslink', 'pmpro_btn-submit' ) ); ?>" value="<?php echo esc_attr( $cancel_memberships_text ); ?>" />
+						<a class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-cancel pmpro_nolink nolink', 'pmpro_btn-cancel' ) ); ?>" href="<?php echo esc_url( pmpro_url( "account" ) ) ?>"><?php echo esc_html( $keep_memberships_text ); ?></a>
+					</div>
+				</form>
+				<?php
 			}
 			else
 			{

--- a/preheaders/cancel.php
+++ b/preheaders/cancel.php
@@ -54,59 +54,74 @@
 
 	// Are we confirming a cancellation?
 	if ( ! empty( $_REQUEST['confirm'] ) ) {
-        if ( empty( $old_level_ids ) ) {
-        	$old_level_ids = wp_list_pluck( $user_levels, 'ID' );
-        }
+		// Check the nonce.
+		if ( ! wp_verify_nonce( $_REQUEST['pmpro_cancel-nonce'], 'pmpro_cancel-nonce' ) ) {
+			wp_die( __( 'Error: Invalid nonce.', 'paid-memberships-pro' ) );
+		}
 
-		$worked = true;
-		foreach($old_level_ids as $old_level_id) {
-			// If the user does have a subscription for this level (possibly multiple), get the furthest next payment date that is after today.
-			$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $current_user->ID, (int)$old_level_id );
-			$next_payment_date = false;
-			if ( ! empty( $subscriptions ) ) {
-				foreach ( $subscriptions as $sub ) {
-					$sub_next_payment_date = $sub->get_next_payment_date();
-					if ( ! empty( $sub_next_payment_date ) && $sub_next_payment_date > current_time( 'timestamp' ) && ( empty( $next_payment_date ) || $sub_next_payment_date > $next_payment_date ) ) {
-						$next_payment_date = $sub_next_payment_date;
-					}
-				}
+		/**
+		 * Check whether a cancellation should be able to process.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $process_cancellation Whether the cancellation should be processed.
+		 * @param WP_User $user The user cancelling their membership.
+		 */
+		$process_cancellation = apply_filters( 'pmpro_cancel_should_process', true, $current_user );
+		if ( $process_cancellation ) {
+			if ( empty( $old_level_ids ) ) {
+				$old_level_ids = wp_list_pluck( $user_levels, 'ID' );
 			}
 
-			// If we have a next payment date, we only want to set the enddate for the membership to the next payment date and cancel the subscription.
-			// Also add a filter in case a site wants to disable "cancel on next payment date" and cancel immediately.
-			if ( ! empty( $next_payment_date ) && apply_filters( 'pmpro_cancel_on_next_payment_date', true, $old_level_id, $current_user->ID ) ) {
-				// Set the enddate to the next payment date.
-				pmpro_set_expiration_date( $current_user->ID, $old_level_id, $next_payment_date );
-
-				// Cancel the subscriptions.
-				foreach ( $subscriptions as $sub ) {
-					$sub->cancel_at_gateway();
+			$worked = true;
+			foreach($old_level_ids as $old_level_id) {
+				// If the user does have a subscription for this level (possibly multiple), get the furthest next payment date that is after today.
+				$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $current_user->ID, (int)$old_level_id );
+				$next_payment_date = false;
+				if ( ! empty( $subscriptions ) ) {
+					foreach ( $subscriptions as $sub ) {
+						$sub_next_payment_date = $sub->get_next_payment_date();
+						if ( ! empty( $sub_next_payment_date ) && $sub_next_payment_date > current_time( 'timestamp' ) && ( empty( $next_payment_date ) || $sub_next_payment_date > $next_payment_date ) ) {
+							$next_payment_date = $sub_next_payment_date;
+						}
+					}
 				}
 
-				// Send an email to the member.
-				$myemail = new PMProEmail();
-				$myemail->sendCancelOnNextPaymentDateEmail( $current_user, $old_level_id );
+				// If we have a next payment date, we only want to set the enddate for the membership to the next payment date and cancel the subscription.
+				// Also add a filter in case a site wants to disable "cancel on next payment date" and cancel immediately.
+				if ( ! empty( $next_payment_date ) && apply_filters( 'pmpro_cancel_on_next_payment_date', true, $old_level_id, $current_user->ID ) ) {
+					// Set the enddate to the next payment date.
+					pmpro_set_expiration_date( $current_user->ID, $old_level_id, $next_payment_date );
 
-				// Send an email to the admin.
-				$myemail = new PMProEmail();
-				$myemail->sendCancelOnNextPaymentDateAdminEmail( $current_user, $old_level_id );
-			} else {
-				if ( pmpro_cancelMembershipLevel($old_level_id, $current_user->ID, 'cancelled') ) {
+					// Cancel the subscriptions.
+					foreach ( $subscriptions as $sub ) {
+						$sub->cancel_at_gateway();
+					}
+
 					// Send an email to the member.
 					$myemail = new PMProEmail();
-					$myemail->sendCancelEmail( $current_user, $old_level_id );
+					$myemail->sendCancelOnNextPaymentDateEmail( $current_user, $old_level_id );
 
 					// Send an email to the admin.
 					$myemail = new PMProEmail();
-					$myemail->sendCancelAdminEmail( $current_user, $old_level_id );
+					$myemail->sendCancelOnNextPaymentDateAdminEmail( $current_user, $old_level_id );
 				} else {
-					$worked = false;
+					if ( pmpro_cancelMembershipLevel($old_level_id, $current_user->ID, 'cancelled') ) {
+						// Send an email to the member.
+						$myemail = new PMProEmail();
+						$myemail->sendCancelEmail( $current_user, $old_level_id );
+
+						// Send an email to the admin.
+						$myemail = new PMProEmail();
+						$myemail->sendCancelAdminEmail( $current_user, $old_level_id );
+					} else {
+						$worked = false;
+					}
 				}
 			}
 		}
         
-		if($worked != false && empty($pmpro_error))
-		{
+		if ( $worked != false && empty( $pmpro_error ) ) {
 			if ( count( $old_level_ids ) > 1 ) {
 				// If cancelling multiple levels, show a generic message.
 				$pmpro_msg = __( 'Your memberships have been cancelled.', 'paid-memberships-pro' );
@@ -129,6 +144,15 @@
 				$pmpro_msg = __( 'Your membership has been cancelled.', 'paid-memberships-pro' );
 			}
 			$pmpro_msgt = "pmpro_success";
+
+			/**
+			 * Fires after a membership level is cancelled.
+			 *
+			 * @since TBD
+			 *
+			 * @param WP_User $user The user who cancelled their membership.
+			 */
+			do_action( 'pmpro_cancel_processed', $current_user );
 		} else {
 			global $pmpro_error;
 			$pmpro_msg = $pmpro_error;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The goal of these changes is to allow Add Ons (Such as the Reason For Cancelling Add On) and custom code to easily hook into the cancel page.

Added new actions:
- `pmpro_cancel_before_submit`
- `pmpro_cancel_should_process`
- `pmpro_cancel_processed`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
