### PR TITLE
Adding nonce to Lifter Streamline setup checkbox

### DIFF
--- a/includes/compatibility/lifterlms.php
+++ b/includes/compatibility/lifterlms.php
@@ -358,25 +358,32 @@ function pmpro_lifter_intro_html( $html, $wizard ) {
 	</label>
 	<script>
 		jQuery(document).ready(function(){
-			function pmpro_lifter_add_streamline_to_url() {
+			function pmpro_lifter_add_streamline_to_url( onload ) {
 				let $checkbox = jQuery('#lifter-streamline');
 				let $link = jQuery('.llms-setup-actions a.llms-button-primary');
 
+				// If we are running this on load, add a nonce to the URL.
+				if (onload) {
+					$link.attr('href', $link.attr('href') + '&pmpro_lifter_streamline_nonce=<?php echo wp_create_nonce( 'pmpro_lifter_streamline_nonce' ); ?>');
+				}
+
 				//If the checkbox is checked, add streamline to the url
+				$link.attr('href', $link.attr('href').replace('&pmpro_lifter_streamline=0', ''));
+				$link.attr('href', $link.attr('href').replace('&pmpro_lifter_streamline=1', ''));
 				if ($checkbox.is(':checked')) {
 					$link.attr('href', $link.attr('href') + '&pmpro_lifter_streamline=1');
 				} else {
-					$link.attr('href', $link.attr('href').replace('&pmpro_lifter_streamline=1', ''));
+					$link.attr('href', $link.attr('href') + '&pmpro_lifter_streamline=0');
 				}
 			}
 			
 			// Update the URL when the checkbox is changed.
 			jQuery('#lifter-streamline').on('change', function(){
-				pmpro_lifter_add_streamline_to_url();
+				pmpro_lifter_add_streamline_to_url( false );
 			});
 
 			// Run on load too.
-			pmpro_lifter_add_streamline_to_url();
+			pmpro_lifter_add_streamline_to_url( true );
 		});
 	</script>
 	<?php
@@ -404,6 +411,16 @@ function pmpro_lifter_save_streamline_option() {
 	// Bail if the current user doesn't have permission to manage LifterLMS.
 	if ( ! current_user_can( 'manage_lifterlms' ) ) {
 		return;
+	}
+
+	// Bail if a streamline option was not passed.
+	if ( ! isset( $_REQUEST['pmpro_lifter_streamline'] ) ) {
+		return;
+	}
+
+	// We are trying to set the streamline option. Check the nonce.
+	if ( ! isset( $_REQUEST['pmpro_lifter_streamline_nonce'] ) || ! wp_verify_nonce( $_REQUEST['pmpro_lifter_streamline_nonce'], 'pmpro_lifter_streamline_nonce' ) ) {
+		wp_die( __( 'Security check failed.', 'paid-memberships-pro' ), '', array( 'response' => 403 ) );
 	}
 
 	// Get the streamline value.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When a user has the option to enable the streamlined Lifter setup during the Lifter setup wizard, this checkbox was not nonced.

This PR adds a nonce to the checkbox and checks the nonce whenever the streamline value is passed to the next wizard page.

### How to test the changes in this Pull Request:

1. Install and set up PMPro
2. Activate Lifter
3. Navigate to `/wp-admin/?page=llms-setup&step=pages` and see that the page can be visited normally
4. Navigate to `/wp-admin/?page=llms-setup&step=pages&pmpro_lifter_streamline=1` and see that a nonce is now required
5. Navigate to `/wp-admin/admin.php?page=llms-setup` and use the link to proceed to the next step and see that the nonce is provided

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
