### PR TITLE
Allowing dynamic properties in gateways and fields to avoid PHP warnings

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1,4 +1,5 @@
 <?php
+#[AllowDynamicProperties]
 class PMPro_Field {
 	/**
 	 * The name of the field.

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -1,5 +1,6 @@
 <?php	
 	//require_once(dirname(__FILE__) . "/class.pmprogateway.php");
+	#[AllowDynamicProperties]
 	class PMProGateway
 	{	
 		function __construct($gateway = NULL)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ideally, we would comb through our gateway and field code and stop using dynamic properties altogether, but it is important to address this PHP warning ASAP. So this PR adds the `#[AllowDynamicProperties]` attribute to all gateway classes for now, and we will address this issue fully down the road.

Using `#[AllowDynamicProperties]` is the path that core WP is using to address these PHP warnings as well.

### How to test the changes in this Pull Request:
Test using PHP v8.2+

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
