### PR TITLE
Feature/register user fields on api

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -239,7 +239,17 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				)
 			)
 		);
-		}
+
+        register_rest_route( $pmpro_namespace, '/user_fields',
+            array(
+                array(
+                    'methods'   => WP_REST_Server::READABLE,
+                    'callback' => array( $this, 'pmpro_rest_api_user_fields' ),
+                    'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+                )
+            )
+        );
+        }
 		
 		/**
 		 * Get user's membership level.
@@ -1001,7 +1011,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$results[0]->timestamp = pmpro_format_date_iso8601( $results[0]->timestamp );
 
 			return new WP_REST_Response( $results, 200 );
-		}
+        }
 
 		/**
 		 * Default permissions check for endpoints/routes.
@@ -1083,7 +1093,40 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 */
 		function pmpro_rest_api_convert_to_array( $string ) {
 			return explode( ',', $string );
-		}
+        }
+
+        /**
+         * Handle request for the user fields.
+         *
+         * @since 2.12
+         *
+         * @param WP_REST_Request $request
+         *
+         * @return WP_REST_Response
+         */
+        public function pmpro_rest_api_user_fields( $request ) {
+			$params = $request->get_params();
+			$user_id = isset( $params['user_id'] ) ? intval( $params['user_id'] ) : null;
+
+			if ( empty( $user_id ) ) {
+                // see if they sent an email
+				if ( ! empty( $params['email'] ) ) {
+					$user = get_user_by( 'email', sanitize_email( $params['email'] ) );
+					$user_id = $user->ID;
+				} else {
+					return new WP_REST_Response( 'No user information passed through.', 404 );
+				}
+            }
+
+            global $pmpro_user_fields;
+            $profile_fields = pmpro_get_user_fields_for_profile( $user_id, false );
+
+            // return new WP_REST_Response( array_reduce( $profile_fields, function($carry, $field) {
+            //     $carry[ $field->id ] = get_user_meta( $user_id, $field->id, true );
+            //     return $carry;
+            // }, []), 200 );
+            return new WP_REST_Response( $pmpro_user_fields, 200 );
+        }
 	} // End of class
 
 	/**
@@ -1095,7 +1138,39 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		$pmpro_rest_api_routes->pmpro_rest_api_register_routes();
 	}
 
-	add_action( 'rest_api_init', 'pmpro_rest_api_register_custom_routes', 5 );
+    add_action( 'rest_api_init', 'pmpro_rest_api_register_custom_routes', 5 );
+
+    /**
+     * Add user meta fields to API.
+     * @since 2.12
+     */
+    function pmpro_rest_api_register_fields() {
+        global $pmpro_user_fields;
+
+        if ( !empty( $pmpro_user_fields ) ) {
+            foreach ( $pmpro_user_fields as $group => $fields ) {
+                foreach ( $fields as $field ) {
+                    if ( !pmpro_is_field( $field ) ) continue;
+                    if ( !pmpro_check_field_for_level( $field, "profile", $user_id ) ) continue;
+
+                    if ( !empty( $field->profile ) ) {
+                        if ( ( $field->profile === "admins" || $field->profile === "admin" || $field->profile === "only_admin" )
+                            && !( current_user_can( 'manage_options') || current_user_can( 'pmpro_membership_manager' ) ) )
+                                continue;
+                        
+                        register_rest_field( 'user', $field->meta_key, array(
+                            'get_callback' => function($user, $field_name, $request) {
+                                return get_user_meta( $user[ 'id' ], $field_name, true );
+                            },
+                        ));
+                    }
+                }
+
+            }
+        }
+    }
+
+    add_action( 'rest_api_init', 'pmpro_rest_api_register_fields', 5 );
 }
 
 

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -239,17 +239,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				)
 			)
 		);
-
-        register_rest_route( $pmpro_namespace, '/user_fields',
-            array(
-                array(
-                    'methods'   => WP_REST_Server::READABLE,
-                    'callback' => array( $this, 'pmpro_rest_api_user_fields' ),
-                    'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
-                )
-            )
-        );
-        }
+		}
 		
 		/**
 		 * Get user's membership level.
@@ -1011,7 +1001,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			$results[0]->timestamp = pmpro_format_date_iso8601( $results[0]->timestamp );
 
 			return new WP_REST_Response( $results, 200 );
-        }
+		}
 
 		/**
 		 * Default permissions check for endpoints/routes.
@@ -1093,40 +1083,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 */
 		function pmpro_rest_api_convert_to_array( $string ) {
 			return explode( ',', $string );
-        }
-
-        /**
-         * Handle request for the user fields.
-         *
-         * @since 2.12
-         *
-         * @param WP_REST_Request $request
-         *
-         * @return WP_REST_Response
-         */
-        public function pmpro_rest_api_user_fields( $request ) {
-			$params = $request->get_params();
-			$user_id = isset( $params['user_id'] ) ? intval( $params['user_id'] ) : null;
-
-			if ( empty( $user_id ) ) {
-                // see if they sent an email
-				if ( ! empty( $params['email'] ) ) {
-					$user = get_user_by( 'email', sanitize_email( $params['email'] ) );
-					$user_id = $user->ID;
-				} else {
-					return new WP_REST_Response( 'No user information passed through.', 404 );
-				}
-            }
-
-            global $pmpro_user_fields;
-            $profile_fields = pmpro_get_user_fields_for_profile( $user_id, false );
-
-            // return new WP_REST_Response( array_reduce( $profile_fields, function($carry, $field) {
-            //     $carry[ $field->id ] = get_user_meta( $user_id, $field->id, true );
-            //     return $carry;
-            // }, []), 200 );
-            return new WP_REST_Response( $pmpro_user_fields, 200 );
-        }
+		}
 	} // End of class
 
 	/**
@@ -1169,7 +1126,6 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
             }
         }
     }
-
     add_action( 'rest_api_init', 'pmpro_rest_api_register_fields', 5 );
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change adds profile custom fields to the `example.com/wp-json/wp/v2/users/1` REST API endpoint.

### How to test the changes in this Pull Request:

1. Create a custom field
2. Call the API `/wp-json/wp/v2/users/1`
3. Verify the custom field has been added to the response

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

These changes add the custom user fields to the REST API endpoint. This is needed to add automation after a new order comes in.

* [x] Have you successfully run tests with your changes locally?

I found the documentation for running tests but sadly it's outdated.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
