### PR TITLE
Now reading cached values that are 0

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -581,7 +581,7 @@ function pmpro_report_memberships_page() {
 function pmpro_getSignups( $period = false, $levels = 'all' ) {
 	// check for a transient
 	$cache = get_transient( 'pmpro_report_memberships_signups' );
-	if ( ! empty( $cache ) && ! empty( $cache[ $period ] ) && ! empty( $cache[ $period ][ $levels ] ) ) {
+	if ( ! empty( $cache ) && isset( $cache[ $period ] ) && isset( $cache[ $period ][ $levels ] ) ) {
 		return $cache[ $period ][ $levels ];
 	}
 
@@ -649,7 +649,7 @@ function pmpro_getCancellations( $period = null, $levels = 'all', $status = arra
 		implode( ',', $status )
 	);
 
-	if ( ! empty( $cache ) && ! empty( $cache[ $hash ] ) ) {
+	if ( ! empty( $cache ) && isset( $cache[ $hash ] ) ) {
 		return $cache[ $hash ];
 	}
 
@@ -738,7 +738,7 @@ function pmpro_getCancellationRate( $period, $levels = 'all', $status = null ) {
 	// check for a transient
 	$cache = get_transient( 'pmpro_report_cancellation_rate' );
 	$hash  = md5( $period . $levels . implode( '', $status ) );
-	if ( ! empty( $cache ) && ! empty( $cache[ $hash ] ) ) {
+	if ( ! empty( $cache ) && isset( $cache[ $hash ] ) ) {
 		return $cache[ $hash ];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Using `isset()` instead of `empty()` so that we can read cached values that were set to `0` instead of trying to recalculate them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
