### PR TITLE
Fixing cache of "empty prices paid" on sales/revenue dashboard report

### DIFF
--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -962,7 +962,7 @@ function pmpro_get_prices_paid( $period, $count = NULL ) {
 	// Check for a transient.
 	$cache = get_transient( 'pmpro_report_prices_paid' );
 	$param_hash = md5( $period . $count . PMPRO_VERSION );
-	if ( ! empty( $cache ) && ! empty( $cache[$param_hash] ) ) {
+	if ( ! empty( $cache ) && isset( $cache[$param_hash] ) ) {
 		return $cache[$param_hash];
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now reading empty "prices paid" data instead of always re-calculating.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
