### PR TITLE
Better subs table migration defaults

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1247,16 +1247,18 @@ class PMPro_Subscription {
 		 *        created for.
 		 * 4. If we do not find a membership level that matches the subscription level and is recurring,
 		 *       then let's use the default membership level settings if it is recurring.
-		*/
-		$all_user_levels = pmpro_getMembershipLevelsForUser( $this->user_id, true ); // True to include old memberships.
-		// Looping through $all_user_levels backwards to get the most recent first.
-		for ( end( $all_user_levels ); key( $all_user_levels ) !== null; prev( $all_user_levels ) ) {
-			$level_check = current( $all_user_levels );
+		 */
+		if ( 'active' === $this->status ) { // Only guess for active subscriptions. For cancelled subscriptions, we would rather show $0/month than a potentially wrong amount.
+			$all_user_levels = pmpro_getMembershipLevelsForUser( $this->user_id, true ); // True to include old memberships.
+			// Looping through $all_user_levels backwards to get the most recent first.
+			for ( end( $all_user_levels ); key( $all_user_levels ) !== null; prev( $all_user_levels ) ) {
+				$level_check = current( $all_user_levels );
 
-			// Let's check if level the same level as this subscription and if it's a recurring level.
-			if ( $level_check->id == $this->membership_level_id && ! empty( $level_check->billing_amount ) && ! empty( $level_check->cycle_number ) ) {
-				$subscription_level = $level_check;
-				break;
+				// Let's check if level the same level as this subscription and if it's a recurring level.
+				if ( $level_check->id == $this->membership_level_id && ! empty( $level_check->billing_amount ) && ! empty( $level_check->cycle_number ) ) {
+					$subscription_level = $level_check;
+					break;
+				}
 			}
 		}
 

--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1306,7 +1306,7 @@ class PMPro_Subscription {
 		// Let's also take a guess at the next payment date or end date.
 		$newest_orders = $this->get_orders(
 			[
-				'limit'   => 5,
+				'limit'   => 1,
 				'orderby' => '`timestamp` DESC, `id` DESC',
 			]
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Only pull default subscription data from current level settings if the subscription is active. This is to prevent old subscriptions from being updated with current pricing data when the old subscription could have been charged at a different price. If we have the old memberships_users entry, we will use that, but otherwise, we should just 0 out the billing amount and try to sync with the gateway if we can.

- If we are migrating a cancelled subscription, we are now defaulting the "enddate" to the date of the most recent subscription order instead of the current date. This is far more accurate. The other option would be to try to pull the enddate from the memberships users table, but this is potentially problematic since the user could have multiple terminated entries for the same level. Pulling the most recent subscription order and then trying to sync feels the most "true" to the subscription.

### How to test the changes in this Pull Request:

- If you have not migrated your site to 3.0 yet, just update and migrate.

- If the site has already been updated to 3.0, use the following query to reset your subscriptions table to before the "migration AJAX", run `pmpro_addUpdate( 'pmpro_upgrade_3_0_ajax' );` to set up the AJAX again, and run the AJAX:
`UPDATE wp_pmpro_subscriptions SET startdate = NULL, enddate = NULL, next_payment_date = NULL, billing_amount = 0, cycle_number = 0, cycle_period = '', billing_limit = 0, trial_amount = 0, trial_limit = 0, modified = CURRENT_TIMESTAMP;`

It is important to not delete the entire subs table on a live site to avoid losing the data of which unsyncable subscriptions are cancelled and which are not. If you delete the entire table, all orders will now be in `success` status and corresponding created subscriptions will all default to `active` status. If the subscription can't sync, it will stay in `active` status until manually cancelled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
