### PR TITLE
Fixing error handling on cancel page

### DIFF
--- a/adminpages/levels/delete-level.php
+++ b/adminpages/levels/delete-level.php
@@ -34,7 +34,7 @@ if($ml_id > 0) {
             // Couldn't delete the subscription or the membership.
             // We should probably notify the admin
             $pmproemail = new PMProEmail();
-            $pmproemail->data = array("body"=>"<p>" . sprintf(__("There was an error canceling the subscription for user with ID=%d. You will want to check your payment gateway to see if their subscription is still active.", 'paid-memberships-pro' ), $user_id) . "</p>");
+            $pmproemail->data = array("body"=>"<p>" . sprintf(__("There was an error removing the membership level for user with ID=%d. You will want to check your payment gateway to see if their subscription is still active.", 'paid-memberships-pro' ), $user_id) . "</p>");
             $last_order = $wpdb->get_row( $wpdb->prepare( "
                 SELECT * FROM $wpdb->pmpro_membership_orders
                 WHERE user_id = %d

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1065,14 +1065,10 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 	}
 
 	// Check if we should cancel the user's subscription.
-	$subscriptions_cancelled_successfully = true;
 	if ( apply_filters( 'pmpro_cancel_previous_subscriptions', true ) ) {
 		$active_subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user_id, $level_id );
 		foreach ( $active_subscriptions as $subscription ) {
-			if ( ! $subscription->cancel_at_gateway() ) {
-				$pmpro_error = __( 'Error cancelling subscription at gateway.', 'paid-memberships-pro' );
-				$subscriptions_cancelled_successfully = false;
-			}
+			$subscription->cancel_at_gateway();
 		}
 	}
 
@@ -1091,7 +1087,7 @@ function pmpro_cancelMembershipLevel( $level_id, $user_id = null, $status = 'ina
 		do_action( 'pmpro_after_change_membership_level', 0, $user_id, $level_id );
 	}
 
-	return $subscriptions_cancelled_successfully;
+	return true;
 }
 
 /**

--- a/preheaders/cancel.php
+++ b/preheaders/cancel.php
@@ -121,7 +121,7 @@
 			}
 		}
         
-		if ( $worked != false && empty( $pmpro_error ) ) {
+		if ( ! empty( $worked ) && empty( $pmpro_error ) ) {
 			if ( count( $old_level_ids ) > 1 ) {
 				// If cancelling multiple levels, show a generic message.
 				$pmpro_msg = __( 'Your memberships have been cancelled.', 'paid-memberships-pro' );
@@ -154,9 +154,10 @@
 			 */
 			do_action( 'pmpro_cancel_processed', $current_user );
 		} else {
-			global $pmpro_error;
-			$pmpro_msg = $pmpro_error;
-			$pmpro_msgt = "pmpro_error";
+			if ( ! empty( $pmpro_error ) ) {
+				pmpro_setMessage( $pmpro_error, 'pmpro_error' );
+			}
+			$_REQUEST['confirm'] = false; // Show the form again.
 		}
 	}
 

--- a/preheaders/cancel.php
+++ b/preheaders/cancel.php
@@ -121,7 +121,7 @@
 			}
 		}
         
-		if ( ! empty( $worked ) && empty( $pmpro_error ) ) {
+		if ( ! empty( $worked ) ) {
 			if ( count( $old_level_ids ) > 1 ) {
 				// If cancelling multiple levels, show a generic message.
 				$pmpro_msg = __( 'Your memberships have been cancelled.', 'paid-memberships-pro' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
`! empty()` fixed warning when `$worked` is not defined.

`$pmpro_error` change avoids overwritting any error messages that may already be set.

`$_REQUEST['confirm']` change is needed to re-show the cancellation form on error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
