### PR TITLE
Completely remove the admin notifications and ajax if prio=0

### DIFF
--- a/adminpages/admin_header.php
+++ b/adminpages/admin_header.php
@@ -165,24 +165,27 @@
 	<?php } ?>
 
 <div class="wrap pmpro_admin <?php echo 'pmpro_admin-' . esc_attr( $view ); ?>">
-	<div id="pmpro_notifications">
-	</div>
-	<?php
-		// To debug a specific notification.
-		if ( !empty( $_REQUEST['pmpro_notification'] ) ) {
-			$specific_notification = '&pmpro_notification=' . intval( $_REQUEST['pmpro_notification'] );
-		} else {	
-			$specific_notification = '';
-		}
-	?>
-	<script>
-		jQuery(document).ready(function() {
-			jQuery.get('<?php echo admin_url( "admin-ajax.php?action=pmpro_notifications" . $specific_notification ); ?>', function(data) {
-				if(data && data != 'NULL')
-					jQuery('#pmpro_notifications').html(data);
-			});
-		});
-	</script>
+    <?php if( pmpro_get_max_notification_priority() > 0 ) : ?>
+        <div id="pmpro_notifications">
+        </div>
+        <?php
+            // To debug a specific notification.
+            if ( !empty( $_REQUEST['pmpro_notification'] ) ) {
+                $specific_notification = '&pmpro_notification=' . intval( $_REQUEST['pmpro_notification'] );
+            } else {
+                $specific_notification = '';
+            }
+        ?>
+        <script>
+            jQuery(document).ready(function() {
+                jQuery.get('<?php echo admin_url( "admin-ajax.php?action=pmpro_notifications" . $specific_notification ); ?>', function(data) {
+                    if(data && data != 'NULL')
+                        jQuery('#pmpro_notifications').html(data);
+                });
+            });
+        </script>
+    <?php endif; ?>
+
 	<?php
 		$settings_tabs = array(
 			'pmpro-dashboard',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Useful to avoid an ajax call at every back-end page load, on high traffic websites.

Usage example: `add_filter( 'pmpro_max_notification_priority', '__return_zero' );`

### How to test the changes in this Pull Request:

1. add the snippet
2. load any pmpro admin page
3. the notifications ajax is not running anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
