### PR TITLE
Passing $item to get level ID being shown

### DIFF
--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -525,7 +525,16 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			}
 		} else {
 			// The preferred ways of doing things.
-			do_action( 'pmpro_manage_memberslist_custom_column', $column_name, $item['ID'] );
+			/**
+			 * Fill in columns that don't have a built-in method.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $column_name The name of the column.
+			 * @param int    $user_id     The ID of the user.
+			 * @param array  $item        The membership data being shown.
+			 */
+			do_action( 'pmpro_manage_memberslist_custom_column', $column_name, $item['ID'], $item );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, the `pmpro_manage_memberslist_custom_column` did not pass the full `$item`. This means that Add Ons that use that filter will know the user being shown in the members list, but not other information like the specific level being shown. This is an issue for MMPU compatibility.

This PR passes the entire `$item` being shown so that Add Ons can accurately add data to the Members List.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
