### PR TITLE
Showing a message on user field groups that are part of custom code for checkout field location hooks

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
@@ -20,6 +20,12 @@ class PMPro_Member_Edit_Panel_User_Fields extends PMPro_Member_Edit_Panel {
 			echo wp_kses_post( $field_group->description );
 		}
 
+		// Check if this is a checkout field location and show a message about custom code.
+		$checkout_field_locations = pmpro_get_checkout_field_location_names();
+		if ( array_key_exists( $this->title, $checkout_field_locations ) ) {
+			esc_html_e( 'These user fields were added via custom code to hook into a location on the membership checkout page.', 'paid-memberships-pro' );
+		}
+
 		// Print the fields.
 		$profile_user_fields = pmpro_get_user_fields_for_profile( self::get_user()->ID, true );
 		?>

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
@@ -23,7 +23,7 @@ class PMPro_Member_Edit_Panel_User_Fields extends PMPro_Member_Edit_Panel {
 		// Check if this is a checkout field location and show a message about custom code.
 		$checkout_field_locations = pmpro_get_checkout_field_location_names();
 		if ( array_key_exists( $this->title, $checkout_field_locations ) ) {
-			esc_html_e( 'These user fields were added via custom code to hook into the following location on the membership checkout page:', 'paid-memberships-pro' );
+			esc_html_e( 'These user fields were added via custom code to hook into the following location:', 'paid-memberships-pro' );
 			echo ' <code>' . esc_html( $checkout_field_locations[ $this->title ] ) . '</code>';
 		}
 

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
@@ -23,7 +23,8 @@ class PMPro_Member_Edit_Panel_User_Fields extends PMPro_Member_Edit_Panel {
 		// Check if this is a checkout field location and show a message about custom code.
 		$checkout_field_locations = pmpro_get_checkout_field_location_names();
 		if ( array_key_exists( $this->title, $checkout_field_locations ) ) {
-			esc_html_e( 'These user fields were added via custom code to hook into a location on the membership checkout page.', 'paid-memberships-pro' );
+			esc_html_e( 'These user fields were added via custom code to hook into the following location on the membership checkout page:', 'paid-memberships-pro' );
+			echo ' <code>' . esc_html( $checkout_field_locations[ $this->title ] ) . '</code>';
 		}
 
 		// Print the fields.

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php
@@ -21,10 +21,19 @@ class PMPro_Member_Edit_Panel_User_Fields extends PMPro_Member_Edit_Panel {
 		}
 
 		// Check if this is a checkout field location and show a message about custom code.
-		$checkout_field_locations = pmpro_get_checkout_field_location_names();
-		if ( array_key_exists( $this->title, $checkout_field_locations ) ) {
+		$checkout_field_locations = array(
+			'after_username',
+			'after_password',
+			'after_email',
+			'after_captcha',
+			'checkout_boxes',
+			'after_billing_fields',
+			'before_submit_button',
+			'just_profile'
+		);
+		if ( in_array( $this->title, $checkout_field_locations ) ) {
 			esc_html_e( 'These user fields were added via custom code to hook into the following location:', 'paid-memberships-pro' );
-			echo ' <code>' . esc_html( $checkout_field_locations[ $this->title ] ) . '</code>';
+			echo ' <code>' . esc_html( $this->title ) . '</code>';
 		}
 
 		// Print the fields.

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -37,6 +37,7 @@ function pmpro_get_checkout_field_location_names() {
 		'checkout_boxes' => __( 'Checkout Boxes', 'paid-memberships-pro' ),
 		'after_billing_fields' => __( 'Checkout: After Billing Fields', 'paid-memberships-pro' ),
 		'before_submit_button' => __( 'Checkout: Before Submit Button', 'paid-memberships-pro' ),
+		'just_profile' => __( 'User Profile Only', 'paid-memberships-pro' ),
 	);
 }
 

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -23,6 +23,24 @@ function pmpro_is_field( $var ) {
 }
 
 /**
+ * Get checkout page field location nice names.
+ *
+ * @since TBD
+ * @return array
+ */
+function pmpro_get_checkout_field_location_names() {
+	return array(
+		'after_username' => __( 'Checkout: After Username', 'paid-memberships-pro' ),
+		'after_password' => __( 'Checkout: After Password', 'paid-memberships-pro' ),
+		'after_email' => __( 'Checkout: After Email', 'paid-memberships-pro' ),
+		'after_captcha' => __( 'Checkout: After Captcha', 'paid-memberships-pro' ),
+		'checkout_boxes' => __( 'Checkout Boxes', 'paid-memberships-pro' ),
+		'after_billing_fields' => __( 'Checkout: After Billing Fields', 'paid-memberships-pro' ),
+		'before_submit_button' => __( 'Checkout: Before Submit Button', 'paid-memberships-pro' ),
+	);
+}
+
+/**
  * Add a field to the PMProRH regisration fields global
  *
  *	$where refers to various hooks in the PMPro checkout page and can be:

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -23,25 +23,6 @@ function pmpro_is_field( $var ) {
 }
 
 /**
- * Get checkout page field location nice names.
- *
- * @since TBD
- * @return array
- */
-function pmpro_get_checkout_field_location_names() {
-	return array(
-		'after_username' => __( 'Checkout: After Username', 'paid-memberships-pro' ),
-		'after_password' => __( 'Checkout: After Password', 'paid-memberships-pro' ),
-		'after_email' => __( 'Checkout: After Email', 'paid-memberships-pro' ),
-		'after_captcha' => __( 'Checkout: After Captcha', 'paid-memberships-pro' ),
-		'checkout_boxes' => __( 'Checkout Boxes', 'paid-memberships-pro' ),
-		'after_billing_fields' => __( 'Checkout: After Billing Fields', 'paid-memberships-pro' ),
-		'before_submit_button' => __( 'Checkout: Before Submit Button', 'paid-memberships-pro' ),
-		'just_profile' => __( 'User Profile Only', 'paid-memberships-pro' ),
-	);
-}
-
-/**
  * Add a field to the PMProRH regisration fields global
  *
  *	$where refers to various hooks in the PMPro checkout page and can be:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When user field are added via custom code, there are a few locations we support to hook into the Membership Checkout page or on profiles only. These groups of fields do not have a nice field group name, so they look somewhat off on the Edit Member screen. Additionally, these fields settings won't be editable in the Settings > User Fields GUI. Is it helpful to show a message about where these fields are coming from?

I'm not 100% sold on the message here.

Note: I also looked into changing the panel's title and the navigation link but it would require more extensive changes to how the fields are architected that didn't feel right at this time.

![Screenshot 2024-02-21 at 8 09 37 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/3290ce43-3ed7-4f54-9633-61ed104cb06a)

