### PR TITLE
Adding an Edit Member link inline with the h1 heading on the Edit User screen

### DIFF
--- a/includes/profile.php
+++ b/includes/profile.php
@@ -1308,3 +1308,18 @@ function pmpro_change_password_form() {
 	</div> <!-- end pmpro_change_password_wrap -->
 	<?php
 }
+
+/**
+ * Add a link to the Edit Member page in PMPro inline with the Edit User screen's page title.
+ */
+function pmpro_add_edit_member_link_on_profile( $user ) {
+	?>
+	<script>
+		jQuery(document).ready(function() {
+			jQuery('h1.wp-heading-inline').append(' <a class="page-title-action" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-member', 'user_id' => (int) $user->ID, 'pmpro_member_edit_panel' => 'memberships' ), admin_url( 'admin.php' ) ) ); ?>" target="_blank"><?php echo esc_html__( 'Edit Member', 'paid-memberships-pro' ); ?></a>');
+		});
+	</script>
+	<?php
+}
+add_action( 'show_user_profile', 'pmpro_add_edit_member_link_on_profile' );
+add_action( 'edit_user_profile', 'pmpro_add_edit_member_link_on_profile' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds a link to quickly navigate to the Edit Member screen from the Edit User screen. Without better hooks, this has to be done using JavaScript.

![Screenshot 2024-02-22 at 3 55 39 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/daa091cd-50bb-4e3c-8de1-c1df450db7fe)
![Screenshot 2024-02-22 at 3 55 34 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/a04b04a6-0483-4822-aa4d-5ecc992c1cf0)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
