### PR TITLE
Add `#pmpro_btn-submit` to offsite gateways

### DIFF
--- a/js/pmpro-recaptcha-v3.js
+++ b/js/pmpro-recaptcha-v3.js
@@ -36,21 +36,19 @@ var pmpro_recaptcha_onSubmit = function(token) {
     }						
 };
 
-var pmpro_recaptcha_onloadCallback = function() {
-    // Render on main submit button.
-    grecaptcha.render('pmpro_btn-submit', {
-    'sitekey' : pmpro_recaptcha_v3.public_key,
-    'callback' : pmpro_recaptcha_onSubmit
-        });
-    
-    // Update other submit buttons.
+var pmpro_recaptcha_onloadCallback = function () {
+
+    // If we're using a custom button, let's add the button ID to the custom button.
     var submit_buttons = jQuery('.pmpro_btn-submit-checkout');
-    submit_buttons.each(function() {
-        if(jQuery(this).attr('id') != 'pmpro_btn-submit') {
-            jQuery(this).click(function(event) {
-                event.preventDefault();
-                grecaptcha.execute();
-            });
+    if (jQuery('#pmpro_btn-submit').length === 0) {
+        if (submit_buttons.length > 0) {
+            jQuery(submit_buttons[0]).attr('id', 'pmpro_btn-submit');
         }
+    }
+    
+    // Render on submit button.
+    grecaptcha.render('pmpro_btn-submit', {
+        'sitekey': pmpro_recaptcha_v3.public_key,
+        'callback': pmpro_recaptcha_onSubmit
     });
 };

--- a/js/pmpro-recaptcha-v3.js
+++ b/js/pmpro-recaptcha-v3.js
@@ -51,4 +51,14 @@ var pmpro_recaptcha_onloadCallback = function () {
         'sitekey': pmpro_recaptcha_v3.public_key,
         'callback': pmpro_recaptcha_onSubmit
     });
+
+    // Fallback if there still are buttons without the #pmpro_btn-submit ID.
+    submit_buttons.each(function () {
+        if (jQuery(this).attr('id') != 'pmpro_btn-submit') {
+            jQuery(this).click(function (event) {
+                event.preventDefault();
+                grecaptcha.execute();
+            });
+        }
+    });
 };


### PR DESCRIPTION
* BUG FIX: Added `#pmpro_btn-submit` to offsite gateways that replace the default submit button and had this ID missing. This fixes an issue where reCAPTCHA wouldn't show the badge for v3 and offsite gateways.

Doing it this way will always ensure that reCAPTCHA works, however it has to be an input type of "submit" and any other input type for a button won't work. However even though it may not display the reCAPTCHA badge but that is only cosmetic - I don't think this would negatively affect checkouts and spam.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
