### PR TITLE
Updating the jQuery to show the required asterisk logic on fields

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -137,10 +137,21 @@ jQuery(document).ready(function(){
 		jQuery('#pmpro_processing_message').css('visibility', 'visible');
 	});	
 
-	//add required to required fields
-	if ( ! jQuery( '.pmpro_required' ).next().hasClass( "pmpro_asterisk" ) ) {
-		jQuery( '.pmpro_required' ).closest( '.pmpro_checkout-field' ).append( '<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>' );
-	}
+	jQuery('.pmpro_checkout-field').each(function() {
+		// Check if this checkout field is marked as required (either by class or by containing a .pmpro_required element)
+		var isRequired = jQuery(this).hasClass('pmpro_checkout-field-required') || jQuery(this).find('.pmpro_required').length > 0;
+
+		if (isRequired) {
+			// Find the last input/select element within the .pmpro_checkout-field or .pmpro_display-field (if present)
+			var $lastInput = jQuery(this).find('.pmpro_display-field').length ? jQuery(this).find('.pmpro_display-field:last').find('input, select').last() : jQuery(this).find('input, select').last();
+
+			// Check if there's already an asterisk after the last input/select
+			if (!$lastInput.nextAll('.pmpro_asterisk').length) {
+				// If not, append the asterisk span after the last input/select
+				$lastInput.after('<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>');
+			}
+		}
+	});
 
 	//Loop through all radio type fields and move the asterisk.
 	jQuery('.pmpro_checkout-field-radio').each(function () {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Changes to how certain user fields were rendered broken the JS to attach our required red asterisk to certain fields at checkout. This PR improves the JS logic to locate where to put the asterisk.

Before:
![Screenshot 2024-02-23 at 3 46 27 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/ba2665a8-791c-4eaa-b8e1-f61d79923466)


After:
![Screenshot 2024-02-25 at 10 33 30 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/fc9716a3-d0a0-44a1-b629-f8b64f7784c8)

### How to test the changes in this Pull Request:

1. Create a variety of required user field types - text, checkbox, select, radio, date
2. Check your checkout page
3. Confirm the asterisks are in the right position.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
