### PR TITLE
Re-run migration script after RC 1

### DIFF
--- a/includes/updates/upgrade_3_0.php
+++ b/includes/updates/upgrade_3_0.php
@@ -7,9 +7,21 @@
  * subscription for each unique subscription_transaction_id in the orders table.
  *
  * @since 3.0
+ *
+ * @param bool $rerunning_migration True if we are rerunning the migration. In this case, we want to clear out subscription data and always rerun the migration AJAX.
  */
-function pmpro_upgrade_3_0() {
+function pmpro_upgrade_3_0( $rerunning_migration = false ) {
 	global $wpdb;
+
+	// If we are rerunning the migration, clear out subscription data.
+	if ( $rerunning_migration ) {
+		// We need to reset billing_amount, cycle_number, cycle_period, startdate, enddate, next_payment_date, billing_limit, and trial_amount, and trial_limit.
+		$sqlQuery = "
+			UPDATE {$wpdb->pmpro_subscriptions}
+			SET billing_amount = 0, cycle_number = 0, cycle_period = 'Month', startdate = NULL, enddate = NULL, next_payment_date = NULL, billing_limit = 0, trial_amount = 0, trial_limit = 0
+		";
+		$wpdb->query( $sqlQuery );
+	}
 
 	// Create a subscription for each unique `subscription_transaction_id` in the orders table.
 	$sqlQuery = "
@@ -23,8 +35,8 @@ function pmpro_upgrade_3_0() {
 		";
 	$wpdb->query( $sqlQuery );
 
-	// If we added any subscriptions, create an update to fill out the data.
-	if ( $wpdb->rows_affected ) {
+	// If we added any subscriptions or rerunning the migration script, create an update to fill out the data.
+	if ( $wpdb->rows_affected || $rerunning_migration ) {
 		pmpro_addUpdate( 'pmpro_upgrade_3_0_ajax' );
 	}
 

--- a/includes/updates/upgrade_3_0.php
+++ b/includes/updates/upgrade_3_0.php
@@ -35,7 +35,7 @@ function pmpro_upgrade_3_0( $rerunning_migration = false ) {
 		";
 	$wpdb->query( $sqlQuery );
 
-	// If we added any subscriptions or rerunning the migration script, create an update to fill out the data.
+	// If we added any subscriptions or are rerunning the migration script, create an update to fill out the data.
 	if ( $wpdb->rows_affected || $rerunning_migration ) {
 		pmpro_addUpdate( 'pmpro_upgrade_3_0_ajax' );
 	}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -337,16 +337,24 @@ function pmpro_checkForUpgrades() {
 	}
 
 	/**
-	 * Version 3.0
+	 * Version 3.0 (db v3.0-3.009 for RC's)
 	 * Running `pmpro_db_delta` to add subscription and subscription meta tables.
 	 * Populate subscription and subscription meta tables based on this site's order data.
 	 * Updates all orders in `cancelled` status to `success` so that we can remove cancelled status.
 	 */
 	require_once( PMPRO_DIR . "/includes/updates/upgrade_3_0.php" );
-	if ( $pmpro_db_version < 3.0 ) {
+	if ( $pmpro_db_version < 3.001 ) {
+		// Run the dbDelta function to add new tables.
 		pmpro_db_delta();
-		$pmpro_db_version = pmpro_upgrade_3_0();
-		update_option( 'pmpro_db_version', '3.0' );
+
+		// Determine if the migration script has already ran ($pmpro_db_version >= 3.0).
+		$rerunning_migration = $pmpro_db_version >= 3.0;
+
+		// Run the migration script.
+		$pmpro_db_version = pmpro_upgrade_3_0( $rerunning_migration );
+
+		// If the migration script has already ran, we need to update the db version to the latest version.
+		update_option( 'pmpro_db_version', '3.001' );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When updating from 3.0 RC 1 to a future RC or the full release, wipe the subscriptions table data and re-run the migration script.

### How to test the changes in this Pull Request:

Check out PR and see that subs table data is wiped and the site is prompted to run the AJAX update again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
