### PR TITLE
Showing better progress during 3.0 migration

### DIFF
--- a/includes/updates/upgrade_3_0.php
+++ b/includes/updates/upgrade_3_0.php
@@ -60,7 +60,7 @@ function pmpro_upgrade_3_0( $rerunning_migration = false ) {
 function pmpro_upgrade_3_0_ajax() {
 	global $wpdb;
 
-	define ( 'PMPRO_UPGRADE_3_0_AJAX', true );
+	define( 'PMPRO_UPGRADE_3_0_AJAX', true );
 
 	// Migrated subscription data won't have a `cycle_number` or `billing_amount` set.
 	$subscription_search_param = array(

--- a/includes/updates/upgrade_3_0.php
+++ b/includes/updates/upgrade_3_0.php
@@ -58,6 +58,8 @@ function pmpro_upgrade_3_0( $rerunning_migration = false ) {
  * @since 3.0
  */
 function pmpro_upgrade_3_0_ajax() {
+	global $wpdb;
+
 	define ( 'PMPRO_UPGRADE_3_0_AJAX', true );
 
 	// Migrated subscription data won't have a `cycle_number` or `billing_amount` set.
@@ -67,6 +69,15 @@ function pmpro_upgrade_3_0_ajax() {
 		'limit' => 10,
 	);
 	$subscriptions = PMPro_Subscription::get_subscriptions( $subscription_search_param );
+
+	// Get the number of subs with a billing amount or cycle number.
+	$migrated = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->pmpro_subscriptions} WHERE billing_amount > 0 OR cycle_number > 0" );
+
+	// Get the total number of subscriptions.
+	$total = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->pmpro_subscriptions}" );
+
+	// Update the progress.
+	echo '[' . (int)$migrated . '/' . (int)$total . ']';
 
 	// If we have no subscriptions left to update, remove the update.
 	if ( empty( $subscriptions ) ) {

--- a/js/updates.js
+++ b/js/updates.js
@@ -36,11 +36,22 @@ jQuery(document).ready(function() {
 					else
 					{
 						$count++;
+						// Regex to find any string between square brackets.
 						re = /\[.*\]/;
+
+						// Get all strings between square brackets.
 						progress = re.exec(responseHTML);
-						if(progress && progress.length > 0)
-							jQuery('#pmpro_updates_progress').html(progress + ' ' + parseInt(eval(progress[0].replace(/\[|\]/ig, ''))*100) + '%');
-						$status.html($status.html() + responseHTML.replace(re, ''));						
+
+						// If there is a string between square brackets, update the progress bar.
+						if ( progress && progress.length > 0 ) {
+							// Assume progress is something like [1/10].
+							jQuery('#pmpro_updates_progress').html(progress[0] + ' ' + parseInt(eval(progress[0].replace(/\[|\]/ig, ''))*100) + '%');
+						}
+
+						// Update the status area.
+						$status.html($status.html() + responseHTML.replace(re, ''));
+
+						// Title bar animation.
 						document.title = $cycles[$count%4] + ' ' + $title;
 						$update_timer = setTimeout(function() { pmpro_updates();}, 200);
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Showing number of subs migrated/remaining while running AJAX update.
![Screenshot 2024-02-26 at 11 27 14 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/7c00c5e5-1a64-4700-9a83-39ce0a4f12c9)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
