### PR TITLE
Removing the restriction on setting visibility for nested blocks

### DIFF
--- a/blocks/src/component-content-visibility/content-visibility-controls.js
+++ b/blocks/src/component-content-visibility/content-visibility-controls.js
@@ -11,17 +11,9 @@ import { __ } from '@wordpress/i18n';
  */
 import { ToggleControl, CheckboxControl, PanelBody, SelectControl, Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import { select } from "@wordpress/data";
 
 export default function ContentVisibilityControls (props) {
 	const { attributes: { visibilityBlockEnabled, invert_restrictions, segment, levels, show_noaccess }, setAttributes } = props;
-	
-	// Get the root parent block id
-	const rootParentId = select( 'core/block-editor' ).getBlockHierarchyRootClientId( props.clientId );
-	// Get the root parent block
-	const rootParent = select('core/block-editor').getBlock( rootParentId );
-	// We don't want to render the visibility controls on the inner block.
-	const shouldRender = rootParent.name === props.name;
 
 	// Helper function to handle changes to the segment attribute.
 	const  handleSegmentChange = (newSegment) => {
@@ -60,7 +52,6 @@ export default function ContentVisibilityControls (props) {
 	});
 
 	return (
-		shouldRender &&
 		<InspectorControls>
 			<PanelBody
 				title={__( 'Content Visibility', 'paid-memberships-pro' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We previously thought it was problematic to allow people to nest blocks with visibility settings. We are changing our minds here early testers are confused why the setting isn't always shown.

This could mean people make weird logic and get confused, but the inverse is also true.

Visibility always cascades from the outermost block. We can make this clear in docs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
