### PR TITLE
Adding filter to skip fixing default migration data

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1224,7 +1224,7 @@ class PMPro_Subscription {
 		 *
 		 * @param bool $skip_fixing_default_migration_data True to skip fixing default migration data for a subscription, false to process it.
 		 */
-		$skip_fixing_default_migration_data = apply_filters( 'pmpro_skip_fixing_default_migration_data', false );
+		$skip_fixing_default_migration_data = apply_filters( 'pmpro_subscription_skip_fixing_default_migration_data', false );
 		if ( $skip_fixing_default_migration_data ) {
 			return;
 		}

--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1210,6 +1210,25 @@ class PMPro_Subscription {
 			return;
 		}
 
+		/**
+		 * Filter to skip fixing default migration data for a subscription.
+		 *
+		 * Useful in cases such as CSV imports where we need to be performant when creating subscriptions.
+		 * In such a use-case, the following steps should be taken:
+		 * 1. Use this hook to disable updating default migration data.
+		 * 2. Directly add the subscription data to the database with "default migration data".
+		 * 3. Create any orders for the subscription (this should only be done after the subscription is created in the db).
+		 * 4. After all entries are processed, add the `pmpro_upgrade_3_0_ajax` update so that admins can automatically sync the subscriptions after the import is complete.
+		 *
+		 * @since 3.0
+		 *
+		 * @param bool $skip_fixing_default_migration_data True to skip fixing default migration data for a subscription, false to process it.
+		 */
+		$skip_fixing_default_migration_data = apply_filters( 'pmpro_skip_fixing_default_migration_data', false );
+		if ( $skip_fixing_default_migration_data ) {
+			return;
+		}
+
 		/*
 		 * The following data should already be correct from the migration:
 		 * id, user_id, membership_level_id, gateway, gateway_environment, subscription_transaction_id, status.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add filter to subscriptions class to allow avoiding syncing subscriptions with gateway during CSV import.

This would be great to have for IUCSV, but maybe it's too late to squeeze into 3.0. We could add it in 3.1 if needed. We should build a proof-of-concept to make sure this filter is sufficient for speeding up IUCSV

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
