### PR TITLE
Moving pmpro_after_membership_level_profile_fields to user_info panel

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-tos.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-tos.php
@@ -41,8 +41,6 @@ class PMPro_Member_Edit_Panel_TOS extends PMPro_Member_Edit_Panel {
 		} else {
 			echo '<p>' . __( 'No TOS consent history found.', 'paid-memberships-pro' ) . '</p>';
 		}
-
-		do_action( 'pmpro_after_membership_level_profile_fields', self::get_user() );
 	}
 
 	/**

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -187,6 +187,7 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 			<?php } ?>
 		</table>
 		<?php
+		do_action( 'pmpro_after_membership_level_profile_fields', self::get_user() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
