### PR TITLE
Removing the billing address from the members list

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -98,7 +98,7 @@
 		$headers[] = 'Content-Disposition: attachment; filename="members_list.csv"';
 
 	//set default CSV file headers, using comma as delimiter
-	$csv_file_header = "id,username,firstname,lastname,email,billing firstname,billing lastname,address1,address2,city,state,zipcode,country,phone,membership,discount_code_id,discount_code,subscription_transaction_id,billing_amount,cycle_number,cycle_period,next_payment_date,joined";
+	$csv_file_header = "id,username,firstname,lastname,email,membership,discount_code_id,discount_code,subscription_transaction_id,billing_amount,cycle_number,cycle_period,next_payment_date,joined";
 
 	if($l == "oldmembers")
 		$csv_file_header .= ",ended";
@@ -112,15 +112,6 @@
 		array("metavalues", "first_name"),
 		array("metavalues", "last_name"),
 		array("theuser", "user_email"),
-		array("metavalues", "pmpro_bfirstname"),
-		array("metavalues", "pmpro_blastname"),
-		array("metavalues", "pmpro_baddress1"),
-		array("metavalues", "pmpro_baddress2"),
-		array("metavalues", "pmpro_bcity"),
-		array("metavalues", "pmpro_bstate"),
-		array("metavalues", "pmpro_bzipcode"),
-		array("metavalues", "pmpro_bcountry"),
-		array("metavalues", "pmpro_bphone"),
 		array("theuser", "membership"),
 		array("discount_code", "id"),
 		array("discount_code", "code")

--- a/classes/class-pmpro-members-list-table.php
+++ b/classes/class-pmpro-members-list-table.php
@@ -136,7 +136,6 @@ class PMPro_Members_List_Table extends WP_List_Table {
 			'last_name'     => __( 'Last Name', 'paid-memberships-pro' ),
 			'display_name'  => __( 'Display Name', 'paid-memberships-pro' ),
 			'user_email'    => __( 'Email', 'paid-memberships-pro' ),
-			'address'       => __( 'Billing Address', 'paid-memberships-pro' ),
 			'membership'    => __( 'Level', 'paid-memberships-pro' ),
 			'membership_id' => __( 'Level ID', 'paid-memberships-pro' ),
 			'subscription'  => __( 'Subscription', 'paid-memberships-pro' ),
@@ -203,7 +202,6 @@ class PMPro_Members_List_Table extends WP_List_Table {
 				'ID',
 				'first_name',
 				'last_name',
-				'address',
 				'membership_id',
 				'joindate',
 			);
@@ -635,17 +633,6 @@ class PMPro_Members_List_Table extends WP_List_Table {
 	 */
 	public function column_user_email( $item ) {
 		return $item['user_email'];
-	}
-
-	/**
-	 * Get value for Address column.
-	 *
-	 * @param object $item A row's data.
-	 * @return string Text to be placed inside the column <td>.
-	 */
-	public function column_address( $item ) {
-		$user_object = get_userdata( $item['ID'] );
-		return pmpro_formatAddress( trim( $user_object->pmpro_bfirstname . ' ' . $user_object->pmpro_blastname ), $user_object->pmpro_baddress1, $user_object->pmpro_baddress2, $user_object->pmpro_bcity, $user_object->pmpro_bstate, $user_object->pmpro_bzipcode, $user_object->pmpro_bcountry, $user_object->pmpro_bphone );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We are moving away from storing billing addresses in user meta since this would not be MMPU-compatible. Instead, billing addresses should be stored per order.

This PR removes the MMPU-incompatible data from the Members List and CSV export.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
