### PR TITLE
Setting max index length when needed

### DIFF
--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -383,6 +383,15 @@ function pmpro_db_delta() {
 		$collate = $wpdb->get_charset_collate();
 	}
 
+	/*
+	 * Indexes have a maximum size of 767 bytes. Historically, we haven't need to be concerned about that.
+	 * As of 4.2, however, we moved to utf8mb4, which uses 4 bytes per character. This means that an index which
+	 * used to have room for floor(767/3) = 255 characters, now only has room for floor(767/4) = 191 characters.
+	 *
+	 * Copied from Core WP.
+	 */
+	$max_index_length = 191;
+
 	//wp_pmpro_membership_levels
 	$sqlQuery = "
 		CREATE TABLE `" . $wpdb->pmpro_membership_levels . "` (
@@ -403,7 +412,7 @@ function pmpro_db_delta() {
 		  PRIMARY KEY  (`id`),
 		  KEY `allow_signups` (`allow_signups`),
 		  KEY `initial_payment` (`initial_payment`),
-		  KEY `name` (`name`)
+		  KEY `name` (`name`(" . $max_index_length . "))
 		) $collate;
 	";
 	dbDelta($sqlQuery);
@@ -573,7 +582,7 @@ function pmpro_db_delta() {
 		  `meta_value` longtext,
 		  PRIMARY KEY (`meta_id`),
 		  KEY `pmpro_membership_level_id` (`pmpro_membership_level_id`),
-		  KEY `meta_key` (`meta_key`)
+		  KEY `meta_key` (`meta_key`(" . $max_index_length . "))
 		) $collate;
 	";
 	dbDelta($sqlQuery);
@@ -615,7 +624,7 @@ function pmpro_db_delta() {
 		  `meta_value` longtext,
 		  PRIMARY KEY (`meta_id`),
 		  KEY `pmpro_membership_order_id` (`pmpro_membership_order_id`),
-		  KEY `meta_key` (`meta_key`)
+		  KEY `meta_key` (`meta_key`(" . $max_index_length . "))
 		) $collate;
 	";
 	dbDelta($sqlQuery);
@@ -629,7 +638,7 @@ function pmpro_db_delta() {
 		  `meta_value` longtext,
 		  PRIMARY KEY (`meta_id`),
 		  KEY `pmpro_subscription_id` (`pmpro_subscription_id`),
-		  KEY `meta_key` (`meta_key`)
+		  KEY `meta_key` (`meta_key`(" . $max_index_length . "))
 		) $collate;
 	";
 	dbDelta($sqlQuery);
@@ -642,7 +651,7 @@ function pmpro_db_delta() {
 		 `allow_multiple_selections` tinyint NOT NULL DEFAULT '1',
 		 `displayorder` int,
 		 PRIMARY KEY (`id`),
-		 KEY `name` (`name`)
+		 KEY `name` (`name`(" . $max_index_length . "))
 		) $collate;
 	";
 	dbDelta($sqlQuery);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Sets the max index length on indexed `varchar` columns with length greater than 191. The addresses the SQL error `WordPress database error Index column size too large. The maximum column size is 767 bytes. for query...`

This is based off the logic in core WP here: https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/includes/schema.php

Note: This will only fix column indexes on new installs, though this SQL error is only an issue since 3.0 where we started setting table collates based on the site's settings.

To test, you can set up a new site and run the following SQL to check if there are "max sizes" set up: `SHOW INDEX FROM wp_pmpro_membership_levelmeta`

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
