### PR TITLE
If a sub fails to migrate, throw an error and halt AJAX

### DIFF
--- a/includes/updates/upgrade_3_0.php
+++ b/includes/updates/upgrade_3_0.php
@@ -73,6 +73,7 @@ function pmpro_upgrade_3_0_ajax() {
 	// Check if the migration was successful.
 	$failed_migrations = array();
 	foreach ( $subscriptions as $subscription ) {
+		// This is the same check we used to get subs to update. We want to avoid infinite loops.
 		if ( empty( $subscription->get_billing_amount() ) && empty( $subscription->get_cycle_number() ) ) {
 			$failed_migrations[] = $subscription->get_id();
 		}

--- a/includes/updates/upgrade_3_0.php
+++ b/includes/updates/upgrade_3_0.php
@@ -70,6 +70,19 @@ function pmpro_upgrade_3_0_ajax() {
 	);
 	$subscriptions = PMPro_Subscription::get_subscriptions( $subscription_search_param );
 
+	// Check if the migration was successful.
+	$failed_migrations = array();
+	foreach ( $subscriptions as $subscription ) {
+		if ( empty( $subscription->get_billing_amount() ) && empty( $subscription->get_cycle_number() ) ) {
+			$failed_migrations[] = $subscription->get_id();
+		}
+	}
+	if ( ! empty( $failed_migrations ) ) {
+		// If we have failed migrations, echo the error.
+		echo '[error] Failed to migrate subscriptions: ' . implode( ', ', $failed_migrations );
+		return;
+	}
+
 	// Get the number of subs with a billing amount or cycle number.
 	$migrated = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->pmpro_subscriptions} WHERE billing_amount > 0 OR cycle_number > 0" );
 

--- a/js/updates.js
+++ b/js/updates.js
@@ -5,6 +5,7 @@ jQuery(document).ready(function() {
 	var $count = 0;
 	var $title = document.title;
 	var $cycles = ['|','/','-','\\'];
+	var $timeout = 30000;
 	
 	//start updates and update status
 	if($status && $status.length > 0)
@@ -14,11 +15,22 @@ jQuery(document).ready(function() {
 		function pmpro_updates()
 		{
 			jQuery.ajax({
-				url: ajaxurl,type:'GET', timeout: 30000,
+				url: ajaxurl,type:'GET', timeout: $timeout,
 				dataType: 'html',
 				data: 'action=pmpro_updates',
-				error: function(xml){
-					alert('Error with update. Try refreshing.');				
+				error: function( xml, status, error ) {
+					if ( status == 'timeout' ) {
+						if ( window.confirm( 'Timeout error. Would you like to try again with a longer timeout?' ) ) {
+							$timeout = $timeout * 2;
+							pmpro_updates();
+						}
+					} else if ( status == 'error' && error ) {
+						// Likely the case with a PHP error.
+						alert( error + '. Try refreshing. If this error occurs again, check your PHP error logs or seek help on the PMPro member forums.');
+					} else if ( status == 'error' ) {
+						// Likely the case if the user tries to nagivate away from the update page.
+						alert( 'This update could not complete. Try refreshing. If this error occurs again, seek help on the PMPro member forums.');
+					}
 				},
 				success: function(responseHTML){
 					if (responseHTML.indexOf('[error]') > -1)

--- a/js/updates.js
+++ b/js/updates.js
@@ -5,7 +5,8 @@ jQuery(document).ready(function() {
 	var $count = 0;
 	var $title = document.title;
 	var $cycles = ['|','/','-','\\'];
-	var $timeout = 30000;
+	var $timeout = 30; // 30 seconds
+	var $error_count = 0;
 	
 	//start updates and update status
 	if($status && $status.length > 0)
@@ -15,24 +16,34 @@ jQuery(document).ready(function() {
 		function pmpro_updates()
 		{
 			jQuery.ajax({
-				url: ajaxurl,type:'GET', timeout: $timeout,
+				url: ajaxurl,type:'GET', timeout: $timeout * 1000,
 				dataType: 'html',
 				data: 'action=pmpro_updates',
 				error: function( xml, status, error ) {
-					if ( status == 'timeout' ) {
-						if ( window.confirm( 'Timeout error. Would you like to try again with a longer timeout?' ) ) {
-							$timeout = $timeout * 2;
-							pmpro_updates();
+					$error_count++;
+					// If we haven't failed 3 times, try again.
+					if ( $error_count < 3 ) {
+						$status.html($status.html() + ( status == 'timeout' ? 't ' : 'x ') );
+						// Wait for a second to let things settle and then try again.
+						setTimeout(function() { pmpro_updates();}, 1000);
+					} else {
+						// We have failed 3 times. Alert the user and stop the updates.
+						if ( status == 'timeout' ) {
+							if ( window.confirm( 'Timeout error after ' + $timeout + ' seconds. Would you like to try again with a ' + ( $timeout + 30 ) + ' second timeout?' ) ) {
+								$timeout = $timeout + 30;
+								pmpro_updates();
+							}
+						} else if ( status == 'error' && error ) {
+							// Likely the case with a PHP error.
+							alert( error + '. Try refreshing. If this error occurs again, check your PHP error logs or seek help on the PMPro member forums.');
+						} else if ( status == 'error' ) {
+							// Likely the case if the user tries to nagivate away from the update page.
+							alert( 'This update could not complete. Try refreshing. If this error occurs again, seek help on the PMPro member forums.');
 						}
-					} else if ( status == 'error' && error ) {
-						// Likely the case with a PHP error.
-						alert( error + '. Try refreshing. If this error occurs again, check your PHP error logs or seek help on the PMPro member forums.');
-					} else if ( status == 'error' ) {
-						// Likely the case if the user tries to nagivate away from the update page.
-						alert( 'This update could not complete. Try refreshing. If this error occurs again, seek help on the PMPro member forums.');
 					}
 				},
 				success: function(responseHTML){
+					$error_count = 0;
 					if (responseHTML.indexOf('[error]') > -1)
 					{
 						alert('Error while running update: ' + responseHTML + ' Try refreshing. If this error occurs again, seek help on the PMPro member forums.');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
![Screenshot 2024-02-29 at 7 54 15 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/5dc8b3ca-b253-4493-941e-b6ed0d3e29cb)

If a subscription fails to have default migration data overwritten (in other words, does not have a billing amount or cycle number), throw an error during AJAX update and halt the AJAX.

### How to test the changes in this Pull Request:

1. Run AJAX to migrate subscriptions
2. Whenever you would like an error to occur, add a `return;` at the top of the `PMPro_Subscription->maybe_fix_default_migration_data()` method to break the migration

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
