### PR TITLE
Adding upgrade notice for 3.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1025,3 +1025,7 @@ BUG FIX: Fixed issue where PMPro would always try to add capabilities to the adm
 * ENHANCEMENT: Added links to the PMPro YouTube and Facebook profiles.
 * REFACTOR: Cleaned up some code in incldues/content.php, especially around the pmpro_search_filter() function.
 * REFACTOR: Removed the package-lock.json file from the repository.
+
+== Upgrade Notice ==
+= 3.0 =
+The PMPro v3.0 release will make irreversible changes to the structure of your membership site data. Please back up your database before upgrading. For more information, please visit https://www.paidmembershipspro.com/xyz.

--- a/readme.txt
+++ b/readme.txt
@@ -1028,4 +1028,4 @@ BUG FIX: Fixed issue where PMPro would always try to add capabilities to the adm
 
 == Upgrade Notice ==
 = 3.0 =
-The PMPro v3.0 release will make irreversible changes to the structure of your membership site data. Please back up your database before upgrading. For more information, please visit https://www.paidmembershipspro.com/xyz.
+The PMPro v3.0 release will make irreversible changes to the structure of your membership site data. Please back up your database before upgrading. For more information, please visit https://www.paidmembershipspro.com/pmpro-update-3-0/.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
A while back, we merged a PR which would theoretically allow us to show a notice on the Plugins page that users would see before upgrading to a particular version of PMPro:
https://github.com/strangerstudios/paid-memberships-pro/pull/2123

That PR was based off of the code in this article:
https://andidittrich.com/2015/05/howto-upgrade-notice-for-wordpress-plugins.html

This PR follows the recommended WP readme template here:
https://wordpress.org/plugins/readme.txt

According to that template, each update notice is limited to 300 characters. The current text in this PR is 222 characters. HTML will also be escaped when showing to the user on the Plugins page.

There is a chance that this will not work as we haven't ever actually been able to test this, but it is worth including in the hopes that everything does work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
