### PR TITLE
Member Order Property - $discount_code_id

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -479,16 +479,16 @@
 
 			global $wpdb;
 
-			$sql_query = "SELECT `id` FROM `$wpdb->pmpro_membership_orders`";
+			$sql_query = "SELECT `o`.`id` FROM `$wpdb->pmpro_membership_orders` `o`";
 
 			$prepared = array();
 			$where    = array();
 
-			$orderby  = isset( $args['orderby'] ) ? $args['orderby'] : '`timestamp` DESC';
+			$orderby  = isset( $args['orderby'] ) ? $args['orderby'] : '`o`.`timestamp` DESC';
 			$limit    = isset( $args['limit'] ) ? (int) $args['limit'] : 100;
 
 			// Detect unsupported orderby usage (in the future we may support better syntax).
-			if ( $orderby !== preg_replace( '/[^a-zA-Z0-9\s,`]/', ' ', $orderby ) ) {
+			if ( $orderby !== preg_replace( '/[^a-zA-Z0-9\s,.`]/', ' ', $orderby ) ) {
 				return array();
 			}
 
@@ -603,9 +603,9 @@
 			 * @DISCOUNT_CODE_ID_TODO
 			 */
 			if ( isset( $args['discount_code_id'] ) ) {
-				$sql_query .= " LEFT JOIN $wpdb->pmpro_discount_codes_uses dcu ON dcu.order_id = id";
+				$sql_query .= " LEFT JOIN `$wpdb->pmpro_discount_codes_uses` `dcu` ON `dcu`.`order_id` = `o`.`id`";
 				if ( ! is_array( $args['discount_code_id'] ) ) {
-					$where[]    = 'dcu.code_id = %d';
+					$where[]    = '`dcu`.`code_id` = %d';
 					$prepared[] = $args['discount_code_id'];
 				} else {
 					$where[]  = 'dcu.code_id IN ( ' . implode( ', ', array_fill( 0, count( $args['discount_code_id'] ), '%d' ) ) . ' )';

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -227,6 +227,33 @@
 		private $checkout_id = '';	
 
 		/**
+		 * The discount code ID that was used for this order.
+		 *
+		 * This property is being added in PMPro v3.0 with the intention
+		 * of adding a new column to the pmpro_membership_orders table duringe next
+		 * major release. For now, we need to have code to "fake" this property.
+		 * For now, this property will be initialized to `null` and will be set to an int
+		 * when this property is accessed.
+		 *
+		 * Step 1 (v3.0): Create abstracted function for modifying/searching the discount code ID.
+		 * Step 2 (At least 1 year later): Update Add Ons to use the new abstracted functions.
+		 * Step 3 (Next major release after all Add Ons updated): Add new column to the pmpro_membership_orders
+		 *        table for the discount code ID, update the abstracted functions to use the new column, create
+		 *        migration script to move the discount code ID from the pmpro_discount_codes_uses table to the
+		 *        new column in the pmpro_membership_orders table, and finally, drop the pmpro_discount_codes_uses table.
+		 *
+		 * Search "@DISCOUNT_CODE_ID_TODO" to find the places where we need to update
+		 * the code to use the new column when we add it.
+		 *
+		 * `0` means no discount code was used, any other int is the ID of the discount code used.
+		 *
+		 * @since 3.0
+		 *
+		 * @var int|null
+		 */
+		private $discount_code_id = null;
+
+		/**
 		 * Defines an array of optionally used properties
 		 *
 		 * @since 2.9
@@ -286,6 +313,20 @@
 		 * @return mixed|void
 		 */
 		public function __get( $property ) {
+			/**
+			 * Special case. We want to add `discount_code_id` as a property/db column in the future.
+			 * For now, we should support `discount_code_id` as a "property" by adding it here and
+			 * querying the pmpro_discount_codes_uses table for the discount code ID.
+			 *
+			 * @DISCOUNT_CODE_ID_TODO
+			 */
+			if ( $property == 'discount_code_id' ) {
+				if ( null === $this->discount_code_id ) {
+					// Get the discount code ID from the pmpro_discount_codes_uses table.
+					$this->getDiscountCode( true );
+				}
+				return $this->discount_code_id;
+			}
 
 			if ( $property == 'other_properties' ) {
 				return; //We don't want the actual other_properties array to be changed
@@ -315,6 +356,17 @@
 
 			if ( $property == 'other_properties' ) {
 				return; //We don't want the actual other_properties array to be changed
+			}
+
+			/**
+			 * Special case. We want to add `discount_code_id` as a property/db column in the future.
+			 * For now, `discount_code_id` may be null or an int. But if being updated, we always want it to be an int.
+			 *
+			 * @DISCOUNT_CODE_ID_TODO
+			 */
+			if ( $property == 'discount_code_id' ) {
+				$this->discount_code_id = (int) $value;
+				return;
 			}
 
 			if ( property_exists( $this, $property ) ) {
@@ -540,6 +592,24 @@
 				} else {
 					$where[]  = 'payment_transaction_id IN ( ' . implode( ', ', array_fill( 0, count( $args['payment_transaction_id'] ), '%f' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['payment_transaction_id'] );
+				}
+			}
+
+			// Filter by discount code ID
+			/**
+			 * Special case. Eventually, we want to add `discount_code_id` as a property/db column. But
+			 * for now, we need to query the pmpro_discount_codes_uses table for the discount code ID.
+			 *
+			 * @DISCOUNT_CODE_ID_TODO
+			 */
+			if ( isset( $args['discount_code_id'] ) ) {
+				$sql_query .= " LEFT JOIN $wpdb->pmpro_discount_codes_uses dcu ON dcu.order_id = id";
+				if ( ! is_array( $args['discount_code_id'] ) ) {
+					$where[]    = 'dcu.code_id = %d';
+					$prepared[] = $args['discount_code_id'];
+				} else {
+					$where[]  = 'dcu.code_id IN ( ' . implode( ', ', array_fill( 0, count( $args['discount_code_id'] ), '%d' ) ) . ' )';
+					$prepared = array_merge( $prepared, $args['discount_code_id'] );
 				}
 			}
 
@@ -946,7 +1016,13 @@
 			//filter @since v1.7.14
 			$this->discount_code = apply_filters("pmpro_order_discount_code", $this->discount_code, $this);
 
-			return $this->discount_code;
+			/**
+			 * Special case. We want to add `discount_code_id` as a property/db column in the future.
+			 * For now, save the discount code ID as a property on the order object.
+			 *
+			 * @DISCOUNT_CODE_ID_TODO
+			 */
+			$this->discount_code_id = ! empty( $this->discount_code ) ? $this->discount_code->id : 0;
 		}
 
 		/**
@@ -1345,6 +1421,18 @@
 			{
 				if(empty($this->id))
 					$this->id = $wpdb->insert_id;
+
+				/**
+				 * Special case. We want to add `discount_code_id` as a property/db column in the future.
+				 * For now, if we are saving an order with a non-null discount_code_id property,
+				 * call updateDiscountCode to save the discount code use in the current pmpro_discount_codes_uses table.
+				 *
+				 * @DISCOUNT_CODE_ID_TODO
+				 */
+				if ( null !== $this->discount_code_id ) {
+					$this->updateDiscountCode( $this->discount_code_id );
+				}
+
 				do_action($after_action, $this);
 
 				// Create a subscription if we need to.

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1046,6 +1046,7 @@
 			 * @DISCOUNT_CODE_ID_TODO
 			 */
 			$this->discount_code_id = ! empty( $this->discount_code ) ? $this->discount_code->id : 0;
+			return $this->discount_code;
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Creates a new property `$discount_code_id` in MemberOrder and allow searching orders by discount_code_id.

These changes work as proxies for querying the `pmpro_discount_codes_uses` table directly and, once Add Ons switch to interacting with discount codes through the MemberOrder object, will give us the option to cleanly deprecate the `pmpro_discount_codes_uses` table in the future in favor of storing this information directly in the `pmpro_orders` table.

If we did want to deprecate `pmpro_discount_codes_uses`, here are the necessary steps:
- Step 1 (v3.0): Create abstracted function for modifying/searching the discount code ID (this PR)
- Step 2 (At least 1 year later): Update Add Ons to use the new abstracted functions.
- Step 3 (Next major release after all Add Ons updated): Add new column to the `pmpro_membership_orders` table for the discount code ID, update the abstracted functions to use the new column, create migration script to move the discount code ID from the `pmpro_discount_codes_uses` table to the new column in the `pmpro_membership_orders` table, and finally, drop the `pmpro_discount_codes_uses table`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
