### PR TITLE
Fixing inverted visibility logic

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -156,25 +156,10 @@ function pmpro_apply_block_visibility( $attributes, $content ) {
 				break;
 		}
 
-		if ( $attributes['invert_restrictions'] == '0' ) {
-			$should_show = pmpro_hasMembershipLevel( $levels_to_check );
-		} else {
-			// Make sure we have an array.
-			$levels_to_check = is_array( $levels_to_check ) ? $levels_to_check : array( $levels_to_check );
-
-			// Check if the user has any of the levels.
-			$should_show = true;
-			foreach ( $levels_to_check as $level ) {
-				if ( pmpro_hasMembershipLevel( $level ) ) {
-					$should_show = false;
-					break;
-				}
-			}
-		}
-
+		$should_show = empty( $attributes['invert_restrictions'] ) ? pmpro_hasMembershipLevel( $levels_to_check ) : ! pmpro_hasMembershipLevel( $levels_to_check );
 		if ( $should_show ) {
 			$output = do_blocks( $content );
-		} elseif ( ! empty( $attributes['show_noaccess'] ) && $attributes['invert_restrictions'] == '0' ) {
+		} elseif ( ! empty( $attributes['show_noaccess'] ) && empty( $attributes['invert_restrictions'] ) ) {
 			$output = pmpro_get_no_access_message( NULL, $attributes['levels'] );
 		}
 	}

--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -207,7 +207,7 @@ function pmpro_filter_core_blocks( $block_content, $block ) {
 		'segment' => 'all',
 		'levels' => array(),
 		'show_noaccess' => '0',
-		 'invert_restrictions' => '0',
+		'invert_restrictions' => '0',
 	) );
 	return pmpro_apply_block_visibility( $attributes, $block_content );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Issue:
I set up a content visibility block which is set to hide content from users with levels 1 and 2. Currently, if a user has both level 1 and level 2, the content is correctly hidden. If the user has neither level, the content is correctly shown. But if the user has level 1 but not level 2, the content is still shown which is not how we want the Content Visibility block to work

Fix:
Instead of passing negative levels to `pmpro_hasMembershipLevel()` which will be "or'd" together, this PR checks each inverted level one at a time so that if the user has any of the levels, we can hide the content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
