### PR TITLE
Removing unused msg logic from 9 years ago on account preheader

### DIFF
--- a/preheaders/account.php
+++ b/preheaders/account.php
@@ -10,18 +10,6 @@ if ( ! is_user_logged_in() ) {
 	}
 }
 
-// Process the msg param.
-if ( isset($_REQUEST['msg'] ) ) {
-    if ( $_REQUEST['msg'] == 1 ) {
-        $pmpro_msg = __( 'Your membership status has been updated - Thank you!', 'paid-memberships-pro' );
-    } else {
-        $pmpro_msg = __( 'Sorry, your request could not be completed - please try again in a few moments.', 'paid-memberships-pro' );
-        $pmpro_msgt = 'pmpro_error';
-    }
-} else {
-    $pmpro_msg = false;
-}
-
 /**
  * Check if the current logged in user has a membership level.
  * If not, and the site is using the pmpro_account_preheader_redirect


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Found some unused logic in the account page preheader. David and I confirmed its 9 years old and logic we don't use anymore. Removing here to clean up the code.
