### PR TITLE
pmpro_no_quotes - Add null coalescing operator

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1978,7 +1978,7 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 }
 
 function pmpro_no_quotes( $s, $quotes = array( "'", '"' ) ) {
-	return str_replace( $quotes, '', $s );
+	return str_replace( $quotes, '', $s ?? '' );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1978,7 +1978,11 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 }
 
 function pmpro_no_quotes( $s, $quotes = array( "'", '"' ) ) {
-	return str_replace( $quotes, '', $s ?? '' );
+	if ( empty( $s ) ) {
+		$s = '';
+	}
+
+	return str_replace( $quotes, '', $s );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When null is passed to the `str_replace` arguments used in `pmpro_no_quotes` the follow error got logged in debug:
```
PHP Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
Resolves XXX.
```

Adding a null coalescing operator to the search string third argument returns an empty string which resolves this issue.

### How to test the changes in this Pull Request:

1. Activate the Custom Level Cost Text Add On, navigate to Memberships > Settings > Advanced and check the debug log for the deprecated warning.
2. Apply the patch, reload the page, and confirm that no new log entries were added.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


