### PR TITLE
Fixing meta boxes added too late or too early

### DIFF
--- a/includes/metaboxes.php
+++ b/includes/metaboxes.php
@@ -118,6 +118,7 @@ function pmpro_page_save( $post_id ) {
 
 	return $mydata;
 }
+add_action( 'save_post', 'pmpro_page_save' );
 
 /**
  * Wrapper to add meta boxes for classic editor.
@@ -128,12 +129,11 @@ function pmpro_page_meta_wrapper() {
 	if ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() ) {
 		return;
 	}
-	add_action( 'save_post', 'pmpro_page_save' );
-
+	
 	// Add meta box for each restrictable post type.
 	$restrictable_post_types = apply_filters( 'pmpro_restrictable_post_types', array( 'page', 'post' ) );
 	foreach( $restrictable_post_types as $post_type ) {
 		add_meta_box( 'pmpro_page_meta', __( 'Require Membership', 'paid-memberships-pro' ), 'pmpro_page_meta', $post_type, 'side', 'high' );
 	}
 }
-add_action( 'current_screen', 'pmpro_page_meta_wrapper' );
+add_action( 'add_meta_boxes', 'pmpro_page_meta_wrapper' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We have seen plugin conflicts where either our meta boxes aren't being loaded on "edit post" pages with some page builders including Avada, or where `add_meta_box()` is being called before the function is defined. The latter can cause a fatal error when updating to 3.0.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
