### PR TITLE
Fix applying discount codes for outdated checkout templates

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -29,6 +29,10 @@ jQuery(document).ready(function(){
         jQuery('#other_discount_code_button').click(function() {
             var code = jQuery('#pmpro_other_discount_code').val();
             var level_id = jQuery('#pmpro_level').val();
+            if ( ! level_id ) {
+                // If the level ID is not set, try to get it from the #level field for outdated checkout templates.
+                level_id = jQuery('#level').val();
+            }
 
             if(code)
             {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed an issue where discount codes would not be applied if using an outdated checkout page template.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
