### PR TITLE
LifterLMS streamline mode and the /membership/ CPT slug

### DIFF
--- a/includes/compatibility/lifterlms.php
+++ b/includes/compatibility/lifterlms.php
@@ -471,10 +471,13 @@ function pmpro_lifter_unregister_membership_post_type( $post_type, $args ) {
 		return;
 	}
 
-    if ( 'llms_membership' === $post_type ) {
-		unregister_post_type( 'llms_membership' );
-	}
 
+	add_filter( 'register_post_type_args', function( $args, $post_type ) {
+		if ( 'llms_membership' === $post_type ) {
+			$args['has_archive'] = false;
+		}
+		return $args;
+	}, 10, 2 );
 }
 
 add_action( 'registered_post_type', 'pmpro_lifter_unregister_membership_post_type', 10, 2 );

--- a/includes/compatibility/lifterlms.php
+++ b/includes/compatibility/lifterlms.php
@@ -461,26 +461,23 @@ add_filter( 'llms_install_create_pages', 'pmpro_lifter_install_get_pages' );	// 
 /**
  * If the streamline option is enabled, unregister the LifterLMS membership post type.
  *
- * @param string $post_type The post type name.
  * @param array $args The post type arguments.
+ * @param string $post_type The post type name.
  * @since TBD
  */
-function pmpro_lifter_unregister_membership_post_type( $post_type, $args ) {
+function pmpro_lifter_unregister_membership_post_type( $args, $post_type ) {
 	// Bail if streamline is not enabled.
 	if ( ! get_option( 'pmpro_lifter_streamline' ) ) {
-		return;
+		return $args;
 	}
 
-
-	add_filter( 'register_post_type_args', function( $args, $post_type ) {
-		if ( 'llms_membership' === $post_type ) {
-			$args['has_archive'] = false;
-		}
-		return $args;
-	}, 10, 2 );
+	if ( 'llms_membership' === $post_type ) {
+		$args['has_archive'] = false;
+	}
+	return $args;
 }
 
-add_action( 'registered_post_type', 'pmpro_lifter_unregister_membership_post_type', 10, 2 );
+add_action( 'register_post_type_args', 'pmpro_lifter_unregister_membership_post_type', 10, 2 );
 
 
 /**

--- a/includes/compatibility/lifterlms.php
+++ b/includes/compatibility/lifterlms.php
@@ -459,6 +459,28 @@ add_filter( 'llms_install_get_pages', 'pmpro_lifter_install_get_pages' );
 add_filter( 'llms_install_create_pages', 'pmpro_lifter_install_get_pages' );	// Old filter.
 
 /**
+ * If the streamline option is enabled, unregister the LifterLMS membership post type.
+ *
+ * @param string $post_type The post type name.
+ * @param array $args The post type arguments.
+ * @since TBD
+ */
+function pmpro_lifter_unregister_membership_post_type( $post_type, $args ) {
+	// Bail if streamline is not enabled.
+	if ( ! get_option( 'pmpro_lifter_streamline' ) ) {
+		return;
+	}
+
+    if ( 'llms_membership' === $post_type ) {
+		unregister_post_type( 'llms_membership' );
+	}
+
+}
+
+add_action( 'registered_post_type', 'pmpro_lifter_unregister_membership_post_type', 10, 2 );
+
+
+/**
  * If (1) we are in streamlined mode and (2) PMPro Courses was
  * only being used for the LifterLMS module, deactivate it
  * and show a notice.


### PR DESCRIPTION
 * Unregister the CPT that resevers the 'memberships' slug.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Unregister llms_membership if streamline version of lifterlms is enabled.

Resolves #2820

### How to test the changes in this Pull Request:

1. Create a page with 'memberships' slug
2. Check that it doesn't render appropriately
3. Apply this patch.
4. Flush cache saving permalinks.
5. Check again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
