### PR TITLE
Discount codes with unsupported billing details are not highlighted

### DIFF
--- a/adminpages/functions.php
+++ b/adminpages/functions.php
@@ -187,7 +187,7 @@ function pmpro_check_discount_code_for_gateway_compatibility( $discount_code = N
 			}
 		}
 	} else {
-		if ( ! is_numeric( $discount_code ) ) {
+		if (  $discount_code instanceof stdClass ) {
 			// Convert the code array into a single id.
 			$discount_code = $discount_code->id;
 		}

--- a/classes/class-pmpro-discount-code-list-table.php
+++ b/classes/class-pmpro-discount-code-list-table.php
@@ -571,7 +571,7 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 	 */
 	public function single_row( $item ) {
 		$cssClass = ( ! pmpro_check_discount_code_for_gateway_compatibility( $item ) ) ? 'pmpro_error' : '';
-		echo '<tr class="' . $cssClass . '">';
+		echo '<tr class="' . esc_attr( $cssClass ) . '">';
 		$this->single_row_columns( $item );
 		echo '</tr>';
 	}

--- a/classes/class-pmpro-discount-code-list-table.php
+++ b/classes/class-pmpro-discount-code-list-table.php
@@ -561,5 +561,19 @@ class PMPro_Discount_Code_List_Table extends WP_List_Table {
 			esc_html_e( 'None', 'paid-memberships-pro' );
 		}
 	}
+
+	/**
+	 * Override single_row function to add error class if the discount code row need to be higlighted due miscounfiguration
+	 *
+	 * @param StdClass $item The current row item.
+	 * @return void
+	 * @since TBD
+	 */
+	public function single_row( $item ) {
+		$cssClass = ( ! pmpro_check_discount_code_for_gateway_compatibility( $item ) ) ? 'pmpro_error' : '';
+		echo '<tr class="' . $cssClass . '">';
+		$this->single_row_columns( $item );
+		echo '</tr>';
+	}
 	
 }


### PR DESCRIPTION
* Override single_row function to add error class if the discount code row need to be higlighted due miscounfiguration

<img width="1529" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/fbc645d1-4d6b-416a-a9af-b2e3d6e3cb92">


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Override single_row function to add error class if the discount code row need to be higlighted due miscounfiguration

Resolves #2823

### How to test the changes in this Pull Request:

Steps in the linked issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
