### PR TITLE
Fixing potentially ambiguous properties in get_orders()

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -502,10 +502,10 @@
 			// Filter by ID(s).
 			if ( isset( $args['id'] ) ) {
 				if ( ! is_array( $args['id'] ) ) {
-					$where[]    = 'id = %d';
+					$where[]    = '`o`.`id` = %d';
 					$prepared[] = $args['id'];
 				} else {
-					$where[]  = 'id IN ( ' . implode( ', ', array_fill( 0, count( $args['id'] ), '%d' ) ) . ' )';
+					$where[]  = '`o`.`id` IN ( ' . implode( ', ', array_fill( 0, count( $args['id'] ), '%d' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['id'] );
 				}
 			}
@@ -513,10 +513,10 @@
 			// Filter by user ID(s).
 			if ( isset( $args['user_id'] ) ) {
 				if ( ! is_array( $args['user_id'] ) ) {
-					$where[]    = 'user_id = %d';
+					$where[]    = '`o`.`user_id` = %d';
 					$prepared[] = $args['user_id'];
 				} else {
-					$where[]  = 'user_id IN ( ' . implode( ', ', array_fill( 0, count( $args['user_id'] ), '%d' ) ) . ' )';
+					$where[]  = '`o`.`user_id` IN ( ' . implode( ', ', array_fill( 0, count( $args['user_id'] ), '%d' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['user_id'] );
 				}
 			}
@@ -524,10 +524,10 @@
 			// Filter by membership level ID(s).
 			if ( isset( $args['membership_level_id'] ) ) {
 				if ( ! is_array( $args['membership_level_id'] ) ) {
-					$where[]    = 'membership_id = %d';
+					$where[]    = '`o`.`membership_id` = %d';
 					$prepared[] = $args['membership_level_id'];
 				} else {
-					$where[]  = 'membership_id IN ( ' . implode( ', ', array_fill( 0, count( $args['membership_level_id'] ), '%d' ) ) . ' )';
+					$where[]  = '`o`.`membership_id` IN ( ' . implode( ', ', array_fill( 0, count( $args['membership_level_id'] ), '%d' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['membership_level_id'] );
 				}
 			}
@@ -535,10 +535,10 @@
 			// Filter by status(es).
 			if ( isset( $args['status'] ) ) {
 				if ( ! is_array( $args['status'] ) ) {
-					$where[]    = 'status = %s';
+					$where[]    = '`o`.`status` = %s';
 					$prepared[] = $args['status'];
 				} else {
-					$where[]  = 'status IN ( ' . implode( ', ', array_fill( 0, count( $args['status'] ), '%s' ) ) . ' )';
+					$where[]  = '`o`.`status` IN ( ' . implode( ', ', array_fill( 0, count( $args['status'] ), '%s' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['status'] );
 				}
 			}
@@ -546,10 +546,10 @@
 			// Filter by subscription transaction ID(s).
 			if ( isset( $args['subscription_transaction_id'] ) ) {
 				if ( ! is_array( $args['subscription_transaction_id'] ) ) {
-					$where[]    = 'subscription_transaction_id = %s';
+					$where[]    = '`o`.`subscription_transaction_id` = %s';
 					$prepared[] = $args['subscription_transaction_id'];
 				} else {
-					$where[]  = 'subscription_transaction_id IN ( ' . implode( ', ', array_fill( 0, count( $args['subscription_transaction_id'] ), '%s' ) ) . ' )';
+					$where[]  = '`o`.`subscription_transaction_id` IN ( ' . implode( ', ', array_fill( 0, count( $args['subscription_transaction_id'] ), '%s' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['subscription_transaction_id'] );
 				}
 			}
@@ -557,10 +557,10 @@
 			// Filter by gateway(s).
 			if ( isset( $args['gateway'] ) ) {
 				if ( ! is_array( $args['gateway'] ) ) {
-					$where[]    = 'gateway = %s';
+					$where[]    = '`o`.`gateway` = %s';
 					$prepared[] = $args['gateway'];
 				} else {
-					$where[]  = 'gateway IN ( ' . implode( ', ', array_fill( 0, count( $args['gateway'] ), '%s' ) ) . ' )';
+					$where[]  = '`o`.`gateway` IN ( ' . implode( ', ', array_fill( 0, count( $args['gateway'] ), '%s' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['gateway'] );
 				}
 			}
@@ -568,10 +568,10 @@
 			// Filter by gateway environment(s).
 			if ( isset( $args['gateway_environment'] ) ) {
 				if ( ! is_array( $args['gateway_environment'] ) ) {
-					$where[]    = 'gateway_environment = %s';
+					$where[]    = '`o`.`gateway_environment` = %s';
 					$prepared[] = $args['gateway_environment'];
 				} else {
-					$where[]  = 'gateway_environment IN ( ' . implode( ', ', array_fill( 0, count( $args['gateway_environment'] ), '%s' ) ) . ' )';
+					$where[]  = '`o`.`gateway_environment` IN ( ' . implode( ', ', array_fill( 0, count( $args['gateway_environment'] ), '%s' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['gateway_environment'] );
 				}
 			}
@@ -579,10 +579,10 @@
 			// Filter by billing amount(s).
 			if ( isset( $args['total'] ) ) {
 				if ( ! is_array( $args['total'] ) ) {
-					$where[]    = 'total = %f';
+					$where[]    = '`o`.`total` = %f';
 					$prepared[] = $args['total'];
 				} else {
-					$where[]  = 'total IN ( ' . implode( ', ', array_fill( 0, count( $args['total'] ), '%f' ) ) . ' )';
+					$where[]  = '`o`.`total` IN ( ' . implode( ', ', array_fill( 0, count( $args['total'] ), '%f' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['total'] );
 				}
 			}
@@ -590,10 +590,10 @@
 			// Filter by payment transaction ID
 			if ( isset( $args['payment_transaction_id'] ) ) {
 				if ( ! is_array( $args['payment_transaction_id'] ) ) {
-					$where[]    = 'payment_transaction_id = %s';
+					$where[]    = '`o`.`payment_transaction_id` = %s';
 					$prepared[] = $args['payment_transaction_id'];
 				} else {
-					$where[]  = 'payment_transaction_id IN ( ' . implode( ', ', array_fill( 0, count( $args['payment_transaction_id'] ), '%f' ) ) . ' )';
+					$where[]  = '`o`.`payment_transaction_id` IN ( ' . implode( ', ', array_fill( 0, count( $args['payment_transaction_id'] ), '%f' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['payment_transaction_id'] );
 				}
 			}
@@ -611,20 +611,20 @@
 					$where[]    = '`dcu`.`code_id` = %d';
 					$prepared[] = $args['discount_code_id'];
 				} else {
-					$where[]  = 'dcu.code_id IN ( ' . implode( ', ', array_fill( 0, count( $args['discount_code_id'] ), '%d' ) ) . ' )';
+					$where[]  = '`dcu`.`code_id` IN ( ' . implode( ', ', array_fill( 0, count( $args['discount_code_id'] ), '%d' ) ) . ' )';
 					$prepared = array_merge( $prepared, $args['discount_code_id'] );
 				}
       }
 
 			// Filter by date range by start date. (YYYY-MM-DD HH:MM:SS UTC)
 			if ( isset( $args['start_date'] ) ) {
-				$where[]    = 'timestamp >= %s';
+				$where[]    = '`o`.`timestamp` >= %s';
 				$prepared[] = $args['start_date'];
 			}
 
 			// Filter by date range by end date. (YYYY-MM-DD HH:MM:SS UTC)
 			if ( isset( $args['end_date'] ) ) {
-				$where[]    = 'timestamp <= %s';
+				$where[]    = '`o`.`timestamp` <= %s';
 				$prepared[] = $args['end_date'];
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When both `id` and `discount_code_id` are used, the `id` column in the database is ambiguous.

This change defines the table for all search properties in get_orders().

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

> $order_args = array(
> 	'id' => '82',
> 	'discount_code_id' => '2',
> );
> var_dump( MemberOrder::get_orders( $order_args ) );

Returns empty array before the fix, even if there is a matching order. After the fix, returns matching orders.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
