### PR TITLE
Fatal error after updating to 3.0.1 on PHP 7.2.

### DIFF
--- a/includes/level-groups.php
+++ b/includes/level-groups.php
@@ -124,7 +124,7 @@ function pmpro_edit_level_group( $id, $name, $allow_multiple_levels = true, $dis
 			'displayorder' => (int) $displayorder,
 		),
 		array( 'id' => $id ),
-		array( '%s', '%d', '%d', '%d' ),
+		array( '%s', '%d', '%d', '%d' )
 	);
 
 	return ! empty( $result );


### PR DESCRIPTION
 * remove extra comma that breaks PHP lt 7.3

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://wordpress.org/support/topic/fatal-error-after-updating-to-3-0-1/



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
