### PR TITLE
PMProEmail class attributes created dynamically throw deprecated warn…

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -55,14 +55,14 @@
 		 *
 		 * @var array $headers
 		 */
-		public  $headers;
+		public $headers = array();
 
 		/**
 		 * Email attachments
 		 *
 		 * @var array $attachments
 		 */
-		 public $attachments;
+		 public $attachments = array();
 
 		/**
 		 * Send an email to a member or admin. Uses the wp_mail function.

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -49,7 +49,21 @@
 		 * @var string $body
 		 */
 		public $body = '';
-		
+
+		/**
+		 * Email headers
+		 *
+		 * @var array $headers
+		 */
+		public  $headers;
+
+		/**
+		 * Email attachments
+		 *
+		 * @var array $attachments
+		 */
+		 public $attachments;
+
 		/**
 		 * Send an email to a member or admin. Uses the wp_mail function.
 		 *


### PR DESCRIPTION
…ings in PHP 8.2

 * Declare $headers and $attachments as class attributes.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #2881

### How to test the changes in this Pull Request:

1. Switch PHP to 8.2 and enable wp_debug to true.
2. Try cancelling a membership without this patch and see the warning
3. Apply this patch and repeat steps above. Warning should have gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
