### PR TITLE
Discount code error message strips single quotes

### DIFF
--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -32,10 +32,9 @@
 
 	//check that the code is valid
 	$codecheck = pmpro_checkDiscountCode($discount_code, $level_ids, true);
-	if($codecheck[0] == false)
-	{
+	if( $codecheck[0] == false ) {
 		//uh oh. show code error
-		echo esc_html( pmpro_no_quotes($codecheck[1]) );
+		echo esc_html( $codecheck[1] );
 		?>
 		<script>
 			jQuery('#<?php echo esc_attr( $msgfield ); ?>').show();


### PR DESCRIPTION
 * Remove unwanted strip quotes function, esc_html should strip all unwanted chars.
 
<img width="955" alt="Screenshot 2024-04-04 at 12 05 29 PM" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/6b9274fc-e501-4d3c-9d7a-a4719ac74ee9">

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #2882.

### How to test the changes in this Pull Request:

1. Reproduce bug with steps from linked issue.
2. Apply this patch
3. Check issue does not happen anymore 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
