### PR TITLE
PMPro_Discount_Code class attributes created dynamically throw deprec…

### DIFF
--- a/classes/class-pmpro-discount-codes.php
+++ b/classes/class-pmpro-discount-codes.php
@@ -9,12 +9,12 @@ class PMPro_Discount_Code {
 	 */
 	public $id = 0;
 
-    /**
-     * Discount code
-     *
-     * @var string $code
-     */
-    public $code = '';
+	/**
+	 * Discount code
+	 *
+	 * @var string $code
+	 */
+	public $code = '';
 
 	/**
 	 * When the discount code starts (YYYY-MM-DD format)

--- a/classes/class-pmpro-discount-codes.php
+++ b/classes/class-pmpro-discount-codes.php
@@ -7,28 +7,35 @@ class PMPro_Discount_Code {
 	 *
 	 * @var int $id
 	 */
-	public $id;
+	public $id = 0;
+
+    /**
+     * Discount code
+     *
+     * @var string $code
+     */
+    public $code = '';
 
 	/**
-	 * When the discount code starts
+	 * When the discount code starts (YYYY-MM-DD format)
 	 *
-	 * @var date $starts
+	 * @var string $starts
 	 */
-	public $starts;
+	public $starts = '';
 
 	/**
-	 * When the discount code expires
+	 * When the discount code expires (YYYY-MM-DD format)
 	 *
-	 * @var date $expires
+	 * @var string $expires
 	 */
-	public $expires;
+	public $expires = '';
 
 	/**
 	 * how many times the discount code has been used. 0 means unlimited.
 	 *
 	 * @var int $uses
 	 */
-	public $uses;
+	public $uses = 0;
 
 
 	/**
@@ -36,7 +43,7 @@ class PMPro_Discount_Code {
 	 *
 	 * @var array $levels
 	 */
-	public $levels;
+	public $levels = array();
 
     function __construct( $code = NULL ) {
 
@@ -140,6 +147,7 @@ class PMPro_Discount_Code {
         if ( ! empty( $dcobj ) ) {
             // Setup the discount code object.
             $this->id = $dcobj->id;
+            $this->code = $dcobj->code;
             $this->starts = $dcobj->starts;
             $this->expires = $dcobj->expires;
             $this->uses = $dcobj->uses;

--- a/classes/class-pmpro-discount-codes.php
+++ b/classes/class-pmpro-discount-codes.php
@@ -1,6 +1,42 @@
 <?php
 
-class PMPro_Discount_Code{
+class PMPro_Discount_Code {
+
+	/**
+	 * Discount code id
+	 *
+	 * @var int $id
+	 */
+	public $id;
+
+	/**
+	 * When the discount code starts
+	 *
+	 * @var date $starts
+	 */
+	public $starts;
+
+	/**
+	 * When the discount code expires
+	 *
+	 * @var date $expires
+	 */
+	public $expires;
+
+	/**
+	 * how many times the discount code has been used. 0 means unlimited.
+	 *
+	 * @var int $uses
+	 */
+	public $uses;
+
+
+	/**
+	 * Levels and billing settings tied to the discount code.
+	 *
+	 * @var array $levels
+	 */
+	public $levels;
 
     function __construct( $code = NULL ) {
 


### PR DESCRIPTION
…ated warnings in PHP 8.2

 Declare dynamic created props as class attributes.

<img width="1698" alt="Screenshot 2024-04-04 at 3 16 22 PM" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/0fed939a-1560-4564-a4e9-b3a8e9f03cca">


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
