### PR TITLE
Default to "View: My Access"

### DIFF
--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -432,17 +432,19 @@ function pmpro_admin_membership_access_menu_bar() {
 	}
 
 	// Let's get the option now so we can show it.
-	$admin_membership_access = get_user_meta( $current_user->ID, 'pmpro_admin_membership_access', true ) ?: 'current';
+	$admin_membership_access = get_user_meta( $current_user->ID, 'pmpro_admin_membership_access', true );
+	if ( ! in_array( $admin_membership_access, array( 'yes', 'no' ) ) ) {
+		$admin_membership_access = 'current';
+	}
 
 	// Set the title and the option value.
 	$title = '<span class="pmpro_admin-view pmpro_admin-view-' . esc_attr( $admin_membership_access ) . '">';
 	if ( 'no' === $admin_membership_access ) {
 		$title .= '<span class="ab-icon dashicons dashicons-lock non-member-icon"></span>' . esc_html__( 'View: No Access', 'paid-memberships-pro' );
-	} elseif ( 'current' === $admin_membership_access ) {
-		$title .= '<span class="ab-icon dashicons dashicons-admin-users current-access-icon"></span>' . esc_html__( 'View: My Access', 'paid-memberships-pro' );
-	} else {
+	} elseif ( 'yes' === $admin_membership_access ) {
 		$title .= '<span class="ab-icon dashicons dashicons-unlock has-access-icon"></span>' . esc_html__( 'View: With Access', 'paid-memberships-pro' );
-		$admin_membership_access = 'yes';
+	} else {
+		$title .= '<span class="ab-icon dashicons dashicons-admin-users current-access-icon"></span>' . esc_html__( 'View: My Access', 'paid-memberships-pro' );
 	}
 	$title .= '</span>';
 

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -432,7 +432,7 @@ function pmpro_admin_membership_access_menu_bar() {
 	}
 
 	// Let's get the option now so we can show it.
-	$admin_membership_access = get_user_meta( $current_user->ID, 'pmpro_admin_membership_access', true );
+	$admin_membership_access = get_user_meta( $current_user->ID, 'pmpro_admin_membership_access', true ) ?: 'current';
 
 	// Set the title and the option value.
 	$title = '<span class="pmpro_admin-view pmpro_admin-view-' . esc_attr( $admin_membership_access ) . '">';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2234,7 +2234,7 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 
 			if ( 'no' === $admin_membership_access ) {
 				return array();
-			} elseif ( 'current' !== $admin_membership_access ) {
+			} elseif ( 'yes' === $admin_membership_access ) {
 				$all_levels = pmpro_getAllLevels( true );
 
 				// Make sure that each level has all the necessary fields.


### PR DESCRIPTION
* ENHANCEMENT: Default to "View with my access" when no option is found. Fixes an issue where defaulting to View with access would confuse admins and not highlight the code green as the CSS class is missing.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
