### PR TITLE
Don't pass null to esc_url()

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -499,7 +499,13 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 						}
 					?>
 					<?php
-						pmpro_login_form( array( 'value_username' => esc_html( $username ), 'redirect' => esc_url( $redirect_to ) ) );
+						$login_form_array = array(
+							'value_username' => esc_html( $username ),
+						);
+						if ( ! empty( $redirect_to ) ) {
+							$login_form_array['redirect'] = esc_url( $redirect_to );
+						}
+						pmpro_login_form( $login_form_array );
 						pmpro_login_forms_handler_nav( 'login' );
 					?>
 				</div> <!-- end pmpro_login_wrap -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fix PHP error when passing `null` to `esc_url()`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
