### PR TITLE
Support users without a role

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -177,7 +177,15 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 							<th scope="row"><label for="role"><?php esc_html_e( 'Role', 'paid-memberships-pro' ); ?></label></th>
 							<td>
 								<select name="role" id="role" class="<?php echo esc_attr( pmpro_getClassForField( 'role' ) ); ?>" <?php echo esc_attr( $disable_fields ); ?>>
-									<?php wp_dropdown_roles( $role ); ?>
+									<?php
+									wp_dropdown_roles( $role );
+									// Print the 'no role' option. Make it selected if the user has no role yet.
+									if ( $role ) {
+										echo '<option value="">' . __( '&mdash; No role for this site &mdash;' ) . '</option>';
+									} else {
+										echo '<option value="" selected="selected">' . __( '&mdash; No role for this site &mdash;' ) . '</option>';
+									}
+									?>
 								</select>
 							</td>
 						<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
WordPress allows users to not have a role. In our Edit Member page, we don't support that option, so we default to the first value. This default could be a "powerful", like Membership Manager. If the page is then saved, the user will actually be given that role.

The fix is to have an option for "no role" and this PR is based on the core WP Edit User code here:
https://github.com/WordPress/wordpress-develop/blob/13fd2f829b01156174d1ca7ca2236eb9c7248e42/src/wp-admin/user-edit.php#L453-L461

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
