### PR TITLE
Fixing creating PPE sandbox subscriptions

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -1280,7 +1280,7 @@
 					'httpversion' => '1.1',
 					'body' => $nvpreq,
 					'headers'     => array(
-						'content-type'      => 'application/json',
+						'content-type'      => 'application/x-www-form-urlencoded',
 						'PayPal-Request-Id' => $uuid,
 					),
 			    )
@@ -1326,7 +1326,7 @@
 			// But never sleep less than the base sleep seconds.
 			$sleepSeconds = \max( self::$initialNetworkRetryDelay, $sleepSeconds );
 
-			return $sleepSeconds;
+			return (int)$sleepSeconds;
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Sending a content type of `application/json` has started throwing "malformed JSON" errors when creating a PPE subscription in sandbox mode. This PR changes the content type to `application/x-www-form-urlencoded`, which should be the correct content type anyways.

Also fixes a PHP warning `PHP Deprecated:  Implicit conversion from float 1.1274959045124686 to int loses precision`


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
