### PR TITLE
Fixing assumption that all months are 30 days

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -28,22 +28,12 @@ function pmpro_checkout_level_extend_memberships( $level ) {
 
 		// time left?
 		if ( $time_left > 0 ) {
-			// convert to days and add to the expiration date (assumes expiration was 1 year)
-			$days_left = floor( $time_left / ( 60 * 60 * 24 ) );
+			// Calculate when the new expiration date should be.
+			$new_expiration_date = strtotime( '+' . $level->expiration_number . ' ' . $level->expiration_period, $expiration_date);
 
-			// figure out days based on period
-			if ( $level->expiration_period == 'Day' ) {
-				$total_days = $days_left + $level->expiration_number;
-			} elseif ( $level->expiration_period == 'Week' ) {
-				$total_days = $days_left + $level->expiration_number * 7;
-			} elseif ( $level->expiration_period == 'Month' ) {
-				$total_days = $days_left + $level->expiration_number * 30;
-			} elseif ( $level->expiration_period == 'Year' ) {
-				$total_days = $days_left + $level->expiration_number * 365;
-			}
-
-			// update number and period
-			$level->expiration_number = $total_days;
+			// Set the level to expire in that many days.
+			$days_until_new_expiration = floor( ( $new_expiration_date - $todays_date ) / ( 60 * 60 * 24 ) );
+			$level->expiration_number = $days_until_new_expiration;
 			$level->expiration_period = 'Day';
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Alternative to #1864.
Resolves #1617

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a level that expires in a month
2. Check out repeatedly
3. See that day of month stays the same each time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
