### PR TITLE
Stripe/PPE: Ensure the credentials are set on each gateway before performing API requests

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -949,9 +949,16 @@
 		 * @return string|null Error message is returned if update fails.
 		 */
 		function update_subscription_info( $subscription ) {
+			$API_UserName	= get_option( "pmpro_apiusername" );
+			$API_Password	= get_option( "pmpro_apipassword" );
+			$API_Signature = get_option( "pmpro_apisignature" );
+			if ( empty( $API_UserName ) || empty( $API_Password ) || empty( $API_Signature ) ) {
+				return __( "PayPal login credentials are not set.", 'paid-memberships-pro' );
+			}
+
 			$subscription_transaction_id = $subscription->get_subscription_transaction_id();
 			if ( empty( $subscription_transaction_id ) ) {
-				return 'Subscription transaction ID is empty.';
+				return __( 'Subscription transaction ID is empty.', 'paid-memberships-pro' );
 			}
 
 			//paypal profile stuff

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2177,6 +2177,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return string|null Error message is returned if update fails.
 	 */
 	public function update_subscription_info( $subscription ) {
+		if( empty( $this->get_secretkey() ) ){
+			return __( "Stripe login credentials are not set.", 'paid-memberships-pro' );
+		}
+		
 		try {
 			$stripe_subscription = Stripe_Subscription::retrieve(
 				array(


### PR DESCRIPTION
…request

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Running the migration tool from 3.0 for the subs table makes a large number of requests.
Many of them can be avoided if you still have orders for a disabled gateway w/o the credentials set.

This was already implemented for some gateway.
The support is extended to Stripe (checking the secret key only) and to PPE (checking user/pass/signature keys).

### How to test the changes in this Pull Request:

1. Open an errored subscription, which has a message from the gateway after trying to connect w/o credentials
2. Apply this patch and update the subscription
3. The error will now be the message from this patch; this means no API request has been made bc there are no credentials set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
