### PR TITLE
Updating checkout nonce via AJAX

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -272,3 +272,21 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 		return false;
 	}
 }
+
+/**
+ * AJAX method to get the checkout nonce.
+ *
+ * @since TBD
+ */
+function pmpro_get_checkout_nonce() {
+	// Get the checkout nonce.
+	$checkout_nonce = wp_create_nonce( 'pmpro_checkout_nonce' );
+
+	// Return the checkout nonce.
+	echo esc_html( $checkout_nonce );
+
+	// End the AJAX request.
+	wp_die();
+}
+add_action( 'wp_ajax_pmpro_get_checkout_nonce', 'pmpro_get_checkout_nonce' );
+add_action( 'wp_ajax_nopriv_pmpro_get_checkout_nonce', 'pmpro_get_checkout_nonce' );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -275,18 +275,16 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 
 /**
  * AJAX method to get the checkout nonce.
+ * Important for correcting the nonce value at checkout if the user is logged in during the same page load.
  *
  * @since TBD
  */
 function pmpro_get_checkout_nonce() {
-	// Get the checkout nonce.
-	$checkout_nonce = wp_create_nonce( 'pmpro_checkout_nonce' );
-
-	// Return the checkout nonce.
-	echo esc_html( $checkout_nonce );
+	// Output the checkout nonce.
+	echo esc_html( wp_create_nonce( 'pmpro_checkout_nonce' ) );
 
 	// End the AJAX request.
-	wp_die();
+	exit;
 }
 add_action( 'wp_ajax_pmpro_get_checkout_nonce', 'pmpro_get_checkout_nonce' );
 add_action( 'wp_ajax_nopriv_pmpro_get_checkout_nonce', 'pmpro_get_checkout_nonce' );

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -49,7 +49,7 @@ function pmpro_enqueue_scripts() {
             'show_discount_code' => pmpro_show_discount_code(),
 			'discount_code_passed_in' => !empty( $_REQUEST['pmpro_discount_code'] ) && !empty( $_REQUEST['discount_code'] ),
             'sensitiveCheckoutRequestVars' => pmpro_get_sensitive_checkout_request_vars(),
-            'update_nonces' => apply_filters( 'pmpro_update_nonces_at_checkout', false ),
+            'update_nonce' => apply_filters( 'pmpro_update_nonce_at_checkout', false ),
         ));
         wp_enqueue_script( 'pmpro_checkout' );
     }

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -49,6 +49,7 @@ function pmpro_enqueue_scripts() {
             'show_discount_code' => pmpro_show_discount_code(),
 			'discount_code_passed_in' => !empty( $_REQUEST['pmpro_discount_code'] ) && !empty( $_REQUEST['discount_code'] ),
             'sensitiveCheckoutRequestVars' => pmpro_get_sensitive_checkout_request_vars(),
+            'update_nonces' => apply_filters( 'pmpro_update_nonces_at_checkout', false ),
         ));
         wp_enqueue_script( 'pmpro_checkout' );
     }

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -222,7 +222,7 @@ jQuery(document).ready(function(){
 
 	// If a user was created during this page load, update the nonce to be valid.
 	// User is considered "created" if they were not logged in before the checkout preheader, and the username field is not present.
-	if ( pmpro.update_nonces ) {
+	if ( pmpro.update_nonce ) {
 		jQuery.ajax({
 			url: pmpro.ajaxurl,
 			type: 'POST',

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -221,6 +221,7 @@ jQuery(document).ready(function(){
 	}
 
 	// Call the pmpro_get_checkout_nonce AJAX function to get the updated nonce value.
+	// Important for correcting the nonce value at checkout if the user is logged in during the same page load.
 	jQuery.ajax({
 		url: pmpro.ajaxurl,
 		type: 'POST',

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -219,6 +219,17 @@ jQuery(document).ready(function(){
 			jQuery('#pmpro_message_bottom').hide();
 		}
 	}
+
+	// Call the pmpro_get_checkout_nonce AJAX function to get the updated nonce value.
+	jQuery.ajax({
+		url: pmpro.ajaxurl,
+		type: 'POST',
+		data: {
+			action: 'pmpro_get_checkout_nonce'
+		}
+	}).done(function(response) {
+		jQuery('input[name="pmpro_checkout_nonce"]').val(response);
+	});
 });
 
 // Get non-sensitive checkout form data to be sent to checkout_levels endpoint.

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -220,17 +220,19 @@ jQuery(document).ready(function(){
 		}
 	}
 
-	// Call the pmpro_get_checkout_nonce AJAX function to get the updated nonce value.
-	// Important for correcting the nonce value at checkout if the user is logged in during the same page load.
-	jQuery.ajax({
-		url: pmpro.ajaxurl,
-		type: 'POST',
-		data: {
-			action: 'pmpro_get_checkout_nonce'
-		}
-	}).done(function(response) {
-		jQuery('input[name="pmpro_checkout_nonce"]').val(response);
-	});
+	// If a user was created during this page load, update the nonce to be valid.
+	// User is considered "created" if they were not logged in before the checkout preheader, and the username field is not present.
+	if ( pmpro.update_nonces ) {
+		jQuery.ajax({
+			url: pmpro.ajaxurl,
+			type: 'POST',
+			data: {
+				action: 'pmpro_get_checkout_nonce'
+			}
+		}).done(function(response) {
+			jQuery('input[name="pmpro_checkout_nonce"]').val(response);
+		});
+	}
 });
 
 // Get non-sensitive checkout form data to be sent to checkout_levels endpoint.

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -221,7 +221,6 @@ jQuery(document).ready(function(){
 	}
 
 	// If a user was created during this page load, update the nonce to be valid.
-	// User is considered "created" if they were not logged in before the checkout preheader, and the username field is not present.
 	if ( pmpro.update_nonce ) {
 		jQuery.ajax({
 			url: pmpro.ajaxurl,

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -480,7 +480,7 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 					wp_set_current_user( $user_id, $username );
 					wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
 
-					// Update nonce value when we re-load the checkout page.
+					// Update nonce value to be for this new user when we load the checkout page.
 					add_filter( 'pmpro_update_nonce_at_checkout', '__return_true' );
 
 					// Skip the account fields since we just created an account.

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -481,7 +481,7 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 					wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
 
 					// Update nonce value when we re-load the checkout page.
-					add_filter( 'pmpro_update_nonces_at_checkout', '__return_true' );
+					add_filter( 'pmpro_update_nonce_at_checkout', '__return_true' );
 
 					// Skip the account fields since we just created an account.
 					$skip_account_fields = true;

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -480,6 +480,9 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 					wp_set_current_user( $user_id, $username );
 					wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
 
+					// Update nonce value when we re-load the checkout page.
+					add_filter( 'pmpro_update_nonces_at_checkout', '__return_true' );
+
 					// Skip the account fields since we just created an account.
 					$skip_account_fields = true;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When a user is created at checkout but the checkout fails (ex Stripe SCA) and the form is shown again, the nonce on that re-generated checkout form will not be specific to the newly created user object. This will cause nonce verification to fail when the form is then submitted again.

This PR adds JS to update the nonce value when the checkout form is displayed to ensure that we have the correct nonce value for the current user.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set up site with Stripe
2. Check out as new user using Stripe SCA test card
3. Choose to authenticate successfully
4. See that nonce fails before PR, but succeeds afterwards

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
