### PR TITLE
Make sure user ID exists

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -258,7 +258,13 @@ function pmpro_dashboard_report_recent_members_callback() {
     			foreach ( $theusers as $auser ) {
     				$auser = apply_filters( 'pmpro_members_list_user', $auser );
     				//get meta
-    				$theuser = get_userdata( $auser->ID ); ?>
+    				$theuser = get_userdata( $auser->ID ); 
+					
+					// Lets check again if the user exists as it may be pulling "old data" from the transient.
+					if ( ! isset( $theuser->ID ) ) {
+						continue;
+					}
+					?>
     				<tr>
     					<td class="username column-username">
     						<?php echo get_avatar($theuser->ID, 32)?>


### PR DESCRIPTION
* BUG FIX: Fixes an issue where "Recent Members" dashboard widget would throw a warning for a recently deleted user as the code is cached and not cleared on user deletion.

This adds a final check before outputting the data to ensure that the user exists.

Another option would be to cache this for a shorter period in time or clear cache on user deletion.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Ensure `WP_DEBUG` is enabled.
2. Delete a member from the Users Table (but it has to be a recent member)
3. Navigate to the dashboard widget "Recent Members" and see the error.
4. Implement this code
5. Re-view the Recent Member widget and see the user is gone. This is same functionality as once the transient is cleared.

See ticket #562793 for reference.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
