### PR TITLE
Fix admin_changed status not being applied on the Edit Member page

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1207,6 +1207,9 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 	 */
 	$pmpro_deactivate_old_levels = apply_filters( 'pmpro_deactivate_old_levels', true );
 
+	// If we are deactivating old levels, typically we will want to put the old level in 'changed status.
+	// The exception is if the level is being changed by an administrator, in which case 'admin_changed' would have been passed to this function.
+	$change_status = 'admin_changed' === $old_level_status ? 'admin_changed' : 'changed';
 	if ( ! empty( $level_group) && empty( $level_group->allow_multiple_selections ) && $pmpro_deactivate_old_levels ) {
 		// Get all levels in the group.
 		$levels_in_group = pmpro_get_levels_for_group( $level_group->id );
@@ -1217,12 +1220,12 @@ function pmpro_changeMembershipLevel( $level, $user_id = null, $old_level_status
 
 		// Cancel the levels.
 		foreach ( $levels_to_cancel as $level_to_cancel ) {
-			pmpro_cancelMembershipLevel( $level_to_cancel, $user_id, 'changed' );
+			pmpro_cancelMembershipLevel( $level_to_cancel, $user_id, $change_status );
 		}
 	} elseif ( $pmpro_deactivate_old_levels ) {
 		// If the user already has this membership level, we still want to cancel it.
 		if ( in_array( $level_id, $membership_ids ) ) {
-			pmpro_cancelMembershipLevel( $level_id, $user_id, 'changed' );
+			pmpro_cancelMembershipLevel( $level_id, $user_id, $change_status );
 		}
 	}
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Change level from Edit Member page
2. See that old level is put into changed status, not admin_changed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
