### PR TITLE
Adding group attribute (accepts a group ID) to pmpro_member shortcode

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -20,6 +20,7 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 				'user_id' => $current_user->ID,
 				'field'   => null,
 				'levels'  => null,
+				'group'   => null,
 			),
 			$atts
 		)
@@ -102,14 +103,25 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		// Fields about the user's membership or subscription.
 		// Get the membership level to show.
 		$membership_level = null;
-		if ( empty( $levels ) ) {
+		if ( empty( $levels ) && empty( $group ) ) {
 			// Grab any one of the user's levels.
 			$membership_level = pmpro_getMembershipLevelForUser( $user_id );
-		} else {
-			// Grab the first level in the list.
+		} elseif ( ! empty( $levels ) ) {
+			// Grab the first level the user has from the list.
 			$levels = explode( ',', $levels );
 			foreach ( $levels as $level_id ) {
 				$membership_level = pmpro_getSpecificMembershipLevelForUser( $user_id, $level_id );
+				if ( ! empty( $membership_level ) ) {
+					break;
+				}
+			}
+		} elseif ( ! empty( $group ) ) {
+			// Get all the levels in this group.
+			$levels_in_group = pmpro_get_levels_for_group( intval( $group ) );
+
+			// Grab the first level the user has from the group.
+			foreach ( $levels_in_group as $level ) {
+				$membership_level = pmpro_getSpecificMembershipLevelForUser( $user_id, $level->id );
 				if ( ! empty( $membership_level ) ) {
 					break;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added the attribute "group" which accepts a single group ID value so that member info can be shown in the context of a single level group.

Note we still need to show group ID somewhere on the Settings > Levels admin list so that people know what group ID to use.

The logic in this now says:
- If the shortcode doesn't specify level IDs or a group, grab the first level we find for the user.
- If the shortcode has a levels attribute, grab the first level the user has in the that array otherwise return nothing.
- If the shortcode has a group attribute, grab the first level the user has in the that group otherwise return nothing.

### How to test the changes in this Pull Request:

1. Give yourself a level in a group with ID 1
2. Add a shortcode like [pmpro_member field="membership_name" group="1"] to a post or page
3. Check the frontend and see your level name.
4. Now, change the shortcode's group ID attribute to 2 or any other group you don't have a level.
5. The frontend should show nothing for your membership.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added attribute `group` to the `pmpro_member` shortcode to show specific member info in the context of a level group.
  
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
