### PR TITLE
Adjusting the hierarchy and names of generated PMPro pages

### DIFF
--- a/adminpages/pagesettings.php
+++ b/adminpages/pagesettings.php
@@ -130,7 +130,7 @@ if (!empty($_REQUEST['createpages'])) {
         $pages['cancel'] = __('Membership Cancel', 'paid-memberships-pro' );
         $pages['checkout'] = __('Membership Checkout', 'paid-memberships-pro' );
         $pages['confirmation'] = __('Membership Confirmation', 'paid-memberships-pro' );
-        $pages['invoice'] = __('Membership Invoice', 'paid-memberships-pro' );
+        $pages['invoice'] = __('Membership Orders', 'paid-memberships-pro' );
         $pages['levels'] = __('Membership Levels', 'paid-memberships-pro' );
 		$pages['login'] = __('Log In', 'paid-memberships-pro' );
 		$pages['member_profile_edit'] = __('Your Profile', 'paid-memberships-pro' );

--- a/adminpages/wizard/save-steps.php
+++ b/adminpages/wizard/save-steps.php
@@ -62,7 +62,7 @@ function pmpro_init_save_wizard_data() {
 				$pages['cancel']              = __( 'Membership Cancel', 'paid-memberships-pro' );
 				$pages['checkout']            = __( 'Membership Checkout', 'paid-memberships-pro' );
 				$pages['confirmation']        = __( 'Membership Confirmation', 'paid-memberships-pro' );
-				$pages['invoice']             = __( 'Membership Invoice', 'paid-memberships-pro' );
+				$pages['invoice']             = __( 'Membership Orders', 'paid-memberships-pro' );
 				$pages['levels']              = __( 'Membership Levels', 'paid-memberships-pro' );
 				$pages['login']               = __( 'Log In', 'paid-memberships-pro' );
 				$pages['member_profile_edit'] = __( 'Your Profile', 'paid-memberships-pro' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3645,9 +3645,15 @@ function pmpro_generatePages( $pages ) {
 			);
 
 			// make some pages a subpage of account
-			$top_level_pages = array( 'account', 'login' );
-			if ( ! in_array( $name, $top_level_pages ) ) {
+			$post_parent_account_pages = array( 'billing', 'cancel', 'invoice', 'member_profile_edit' );
+			if ( in_array( $name, $post_parent_account_pages ) ) {
 				$insert['post_parent'] = $pmpro_pages['account'];
+			}
+
+			// make some pages a subpage of checkout
+			$post_parent_checkout_pages = array( 'confirmation' );
+			if ( in_array( $name, $post_parent_checkout_pages ) ) {
+				$insert['post_parent'] = $pmpro_pages['checkout'];
 			}
 
 			// tweak the login slug


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now generating pages as follows:

Membership Account page is parent of the: Billing, Cancel, Orders, and Profile Edit page.
Membership Checkout page is parent of the Confirmation page.
Membership Levels and Log In are top level pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Updated the hierarchy and names for generated PMPro pages as part of optional initial setup steps.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
