### PR TITLE
Switching the new content admin menu item to respect the same capability as Members List

### DIFF
--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -273,7 +273,7 @@ function pmpro_admin_bar_menu() {
 	}
 
 	// Add menu item for adding a new member.
-	if ( current_user_can( 'manage_options' ) ) {
+	if ( current_user_can( pmpro_get_edit_member_capability() ) ) {
 		$wp_admin_bar->add_menu(
 			array(
 				'id' => 'pmpro-new-member',

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -273,7 +273,7 @@ function pmpro_admin_bar_menu() {
 	}
 
 	// Add menu item for adding a new member.
-	if ( current_user_can( pmpro_get_edit_member_capability() ) ) {
+	if ( current_user_can( 'edit_users' ) ) {
 		$wp_admin_bar->add_menu(
 			array(
 				'id' => 'pmpro-new-member',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adjusted the capability for the admin + New > Member menu item to respect the same capability we use to check for this on the Members List: edit_users.
