### PR TITLE
Show "Gateway" on Member Edit

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -15,7 +15,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 	 * Display the panel contents.
 	 */
 	protected function display_panel_contents() {
-		global $wpdb;
+		global $wpdb, $pmpro_gateways;
 
 		//Show all invoices for user
 		$invoices = $wpdb->get_results( $wpdb->prepare( "SELECT mo.*, du.code_id as code_id FROM $wpdb->pmpro_membership_orders mo LEFT JOIN $wpdb->pmpro_discount_codes_uses du ON mo.id = du.order_id WHERE mo.user_id = %d ORDER BY mo.timestamp DESC", self::get_user()->ID ) );
@@ -36,6 +36,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 						<th><?php esc_html_e( 'Code', 'paid-memberships-pro' ); ?></th>
 						<th><?php esc_html_e( 'Level', 'paid-memberships-pro' ); ?></th>
 						<th><?php esc_html_e( 'Total', 'paid-memberships-pro' ); ?></th>
+						<th><?php esc_html_e( 'Gateway', 'paid-memberships-pro' ); ?></th>
 						<th><?php esc_html_e( 'Subscription', 'paid-memberships-pro' ); ?></th>
 						<th><?php esc_html_e( 'Status', 'paid-memberships-pro' ); ?></th>
 						<?php do_action('pmpromh_orders_extra_cols_header');?>
@@ -101,6 +102,25 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 										?>
 										<a class="pmpro_discount_code-tag" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $invoice->code_id, 'filter' => 'with-discount-code' ), admin_url( 'admin.php' ) ) ); ?>" title="<?php esc_attr_e( 'View all orders with this discount code', 'paid-memberships-pro' ); ?>"><?php echo esc_html( $discount_code->code ); ?></a>
 										<?php
+									}
+								?>
+							</td>
+							<td>
+								<?php
+								// Logic to get the gateway name and output it neatly.
+									if ( ! empty( $invoice->gateway ) ) {
+										if ( ! empty( $pmpro_gateways[$invoice->gateway] ) ) {
+											$gateway = esc_html( $pmpro_gateways[$invoice->gateway] );
+										} else {
+											$gateway = esc_html( ucwords( $invoice->gateway ) );
+										}
+										if ( $invoice->gateway_environment == 'sandbox' ) {
+											$gateway .= ' (test)';
+										}
+
+										echo $gateway;
+									} else {
+										esc_html_e( '&#8212;', 'paid-memberships-pro' );
 									}
 								?>
 							</td>

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -120,7 +120,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 
 										echo $gateway;
 									} else {
-										esc_html_e( '&#8212;', 'paid-memberships-pro' );
+										echo  '&#8212;';
 									}
 								?>
 							</td>

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -115,7 +115,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 											$gateway = esc_html( ucwords( $invoice->gateway ) );
 										}
 										if ( $invoice->gateway_environment == 'sandbox' ) {
-											$gateway .= ' (test)';
+											$gateway .= ' (' . esc_html__( 'test', 'paid-memberships-pro' ) . ')';
 										}
 
 										echo $gateway;


### PR DESCRIPTION
* ENHANCEMENT: Show the payment gateway on the member edit orders panel to make it easier to differentiate where the payments are coming from when using more than one gateway.

Resolves: https://github.com/strangerstudios/paid-memberships-pro/issues/2958

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Navigate to the Member Edit Screen and choose "Orders"
2. See the gateway name included in the table.

![Screenshot 2024-04-22 at 11 27 09](https://github.com/strangerstudios/paid-memberships-pro/assets/12629136/5bdf745b-557a-49c8-976d-ced0c7817684)

