### PR TITLE
Fixed always redirect to login page

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -501,11 +501,8 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 					<?php
 						$login_form_array = array(
 							'value_username' => esc_html( $username ),
-							'redirect' => false
+							'redirect' => empty( $redirect_to ) ? false : esc_url( $redirect_to ),
 						);
-						if ( ! empty( $redirect_to ) ) {
-							$login_form_array['redirect'] = esc_url( $redirect_to );
-						}
 						pmpro_login_form( $login_form_array );
 						pmpro_login_forms_handler_nav( 'login' );
 					?>

--- a/includes/login.php
+++ b/includes/login.php
@@ -501,7 +501,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 					<?php
 						$login_form_array = array(
 							'value_username' => esc_html( $username ),
-							'redirect' => $redirect_to // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped - This is escaped above already.
+							'redirect' => $redirect_to,
 						);
 						pmpro_login_form( $login_form_array );
 						pmpro_login_forms_handler_nav( 'login' );

--- a/includes/login.php
+++ b/includes/login.php
@@ -501,7 +501,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 					<?php
 						$login_form_array = array(
 							'value_username' => esc_html( $username ),
-							'redirect' => empty( $redirect_to ) ? false : esc_url( $redirect_to ),
+							'redirect' => empty( $redirect_to ) ? '' : esc_url( $redirect_to )
 						);
 						pmpro_login_form( $login_form_array );
 						pmpro_login_forms_handler_nav( 'login' );

--- a/includes/login.php
+++ b/includes/login.php
@@ -501,7 +501,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 					<?php
 						$login_form_array = array(
 							'value_username' => esc_html( $username ),
-							'redirect' => empty( $redirect_to ) ? '' : esc_url( $redirect_to )
+							'redirect' => empty( $redirect_to ) ? '' : $redirect_to // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped - This is escaped above already.
 						);
 						pmpro_login_form( $login_form_array );
 						pmpro_login_forms_handler_nav( 'login' );

--- a/includes/login.php
+++ b/includes/login.php
@@ -485,7 +485,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 			// Login form.
 			if ( empty( $_GET['login'] ) || empty( $_GET['key'] ) ) {
 				$username = isset( $_REQUEST['username'] ) ? sanitize_text_field( $_REQUEST['username'] ) : NULL;
-				$redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( $_REQUEST['redirect_to'] ) : NULL;
+				$redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( $_REQUEST['redirect_to'] ) : '';
 
 				// Redirect users back to their page that they logged-in from via the widget.
 				if( empty( $redirect_to ) && $location === 'widget' && apply_filters( 'pmpro_login_widget_redirect_back', true ) ) {
@@ -501,7 +501,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 					<?php
 						$login_form_array = array(
 							'value_username' => esc_html( $username ),
-							'redirect' => empty( $redirect_to ) ? '' : $redirect_to // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped - This is escaped above already.
+							'redirect' => $redirect_to // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped - This is escaped above already.
 						);
 						pmpro_login_form( $login_form_array );
 						pmpro_login_forms_handler_nav( 'login' );

--- a/includes/login.php
+++ b/includes/login.php
@@ -501,6 +501,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 					<?php
 						$login_form_array = array(
 							'value_username' => esc_html( $username ),
+							'redirect' => false
 						);
 						if ( ! empty( $redirect_to ) ) {
 							$login_form_array['redirect'] = esc_url( $redirect_to );


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the redirect would always redirect to the login page.

The issue here was we were ommitting the redirect value entirely from the $login_form_array which would then default to setting a $redirect_to value of the REQUEST URI and it would always redirect to that URL based on the wp_login_form defaults when that parameter was missing.

This fix, fixes issues for custom redirects (snippets) as well as the Member Homepages Add On.

Setting the `redirect` argument to false by default as Paid Memberships Pro handles it's own redirects during the login process and this returns the expected functionality.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?