### PR TITLE
Listing coded user fields instead of showing a generic notice

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1623,12 +1623,7 @@ add_action( 'init', 'pmpro_load_user_fields_from_settings', 1 );
  * @return bool True if user is adding custom user fields with code.
  */
 function pmpro_has_coded_user_fields() {
-	global $pmpro_user_fields, $pmprorh_registration_fields;
-
-	// Check if coded fields are being added using the PMPro Register Helper Add On active.
-	if ( ! empty( $pmprorh_registration_fields ) ) {
-		return true;
-	}
+	global $pmpro_user_fields;
 
 	// Check if coded fields are being added using the PMPro Register Helper Add On inactive.
 	$num_db_fields = array_sum( array_map( function ($group) { return count( $group->fields ); }, pmpro_get_user_fields_settings() ) ); // Fields from UI settings page.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

![Screenshot 2024-04-25 at 9 42 20 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/24977505/1d278ecf-b7c5-43b6-8577-7fc91031c368)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Install and activate the PMPro Shipping Add On (v1.2+)
2. Edit your user fields
3. See that the shipping fields are listed in the sidebar

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
