### PR TITLE
Fixing warnings on User Fields settings page

### DIFF
--- a/adminpages/userfields.php
+++ b/adminpages/userfields.php
@@ -121,7 +121,7 @@
 
 					<?php						
 						foreach( $user_fields_settings as $group ) {
-							echo wp_kses_post( pmpro_get_field_group_html( $group ) );
+							pmpro_get_field_group_html( $group );
 						}
 					?>
 

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1298,7 +1298,7 @@ function pmpro_get_field_group_html( $group = null ) {
 				<?php
 					if ( ! empty( $group->fields ) ) {
 						foreach ( $group->fields as $field ) {
-							echo wp_kses_post( pmpro_get_field_html( $field ) );
+							pmpro_get_field_html( $field );
 						}
 					}
                 ?>

--- a/includes/services.php
+++ b/includes/services.php
@@ -198,7 +198,7 @@ add_action('wp_ajax_pmpro_update_level_group_order', 'pmpro_update_level_group_o
  * Callback to draw a field group.
  */
 function pmpro_userfields_get_group_ajax() {	
-	echo pmpro_get_field_group_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	pmpro_get_field_group_html();
     exit;
 }
 add_action( 'wp_ajax_pmpro_userfields_get_group', 'pmpro_userfields_get_group_ajax' );
@@ -207,7 +207,7 @@ add_action( 'wp_ajax_pmpro_userfields_get_group', 'pmpro_userfields_get_group_aj
  * Callback to draw a field.
  */
 function pmpro_userfields_get_field_ajax() {
- 	echo pmpro_get_field_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+ 	pmpro_get_field_html();
 	exit;
 }
 add_action( 'wp_ajax_pmpro_userfields_get_field', 'pmpro_userfields_get_field_ajax' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
`pmpro_get_field_html()` and `pmpro_get_field_group_html()` echo their contents immediately. Those functions do not return their contents.

This PR fixes warnings with code that expects the contents to be returned instead of already being echoed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
