### PR TITLE
Add Group ID to Level Settings page

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -342,7 +342,7 @@
 							<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
 								<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
 								<input type="hidden" class="pmpro-level-settings-group-id" value="<?php echo esc_attr( $level_group->id ); ?>" />
-								<?php echo esc_html( $level_group->name ) . '<small>'. sprintf( esc_html__( 'ID: %d', 'paid-memberships-pro' ), $level_group->id ) . '</small>'; ?>
+								<?php echo esc_html( $level_group->name ) . '<small>'. sprintf( esc_html__( 'ID: %d', 'paid-memberships-pro' ), esc_html( $level_group->id ) ) . '</small>'; ?>
 							</button>
 						</div>
 						<div class="pmpro_section_inside">

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -342,7 +342,7 @@
 							<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
 								<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
 								<input type="hidden" class="pmpro-level-settings-group-id" value="<?php echo esc_attr( $level_group->id ); ?>" />
-								<?php echo esc_html( $level_group->name ) . '<small>'. sprintf( esc_html( 'ID: %d', 'paid-memberships-pro' ), $level_group->id ) . '</small>'; ?>
+								<?php echo esc_html( $level_group->name ) . '<small>'. sprintf( esc_html__( 'ID: %d', 'paid-memberships-pro' ), $level_group->id ) . '</small>'; ?>
 							</button>
 						</div>
 						<div class="pmpro_section_inside">

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -342,7 +342,7 @@
 							<button class="pmpro_section-toggle-button" type="button" aria-expanded="<?php echo $section_visibility === 'hidden' ? 'false' : 'true'; ?>">
 								<span class="dashicons dashicons-arrow-<?php echo $section_visibility === 'hidden' ? 'down' : 'up'; ?>-alt2"></span>
 								<input type="hidden" class="pmpro-level-settings-group-id" value="<?php echo esc_attr( $level_group->id ); ?>" />
-								<?php echo esc_html( $level_group->name ) ?>
+								<?php echo esc_html( $level_group->name ) . '<small>'. sprintf( esc_html( 'ID: %d', 'paid-memberships-pro' ), $level_group->id ) . '</small>'; ?>
 							</button>
 						</div>
 						<div class="pmpro_section_inside">


### PR DESCRIPTION
* ENHANCEMENT: Added group ID value to the menu location within the Level Settings page. This makes it easier to identify the group's ID for developers and future features that may need this.

The idea of putting this to the right of the name is to try and not clutter up the group names and make it easily visible without clicking around to get this data.

**Screenshots**
![Screenshot 2024-04-26 at 13 15 05](https://github.com/strangerstudios/paid-memberships-pro/assets/12629136/f1fbddd6-94fe-4335-a115-c4ab6c6aa390)

![Screenshot 2024-04-26 at 13 15 15](https://github.com/strangerstudios/paid-memberships-pro/assets/12629136/e6566881-bc6a-4be5-b17b-926c7f26022e)

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?