### PR TITLE
Cannot test "Cancel On Next Payment Date" email templates

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -363,7 +363,7 @@
 		}
 
 		/**
-		 * Semnd the "cancel on next payment date" email to the member.
+		 * Send the "cancel on next payment date" email to the member.
 		 *
 		 * @param WP_User $user The WordPress user object.
 		 * @param int $level_id The level ID of the level that was cancelled.
@@ -383,7 +383,7 @@
 			$level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $level_id );
 
 			// Make sure that the level is now set to expire.
-			if ( empty( $level ) || empty( $level->enddate) ) {
+				if ( empty( $level ) || empty( $level->enddate) ) {
 				return false;
 			}
 
@@ -415,6 +415,8 @@
 		 *
 		 * @param WP_User $user The WordPress user object.
 		 * @param int $level_id The level ID of the level that was cancelled.
+		 * @return bool True if the email was sent, false otherwise.
+		 * @since TBD
 		 */
 		function sendCancelOnNextPaymentDateAdminEmail( $user, $level_id ) {
 			// If an array is passed for $level_id, throw doing it wrong warning.

--- a/includes/email.php
+++ b/includes/email.php
@@ -318,11 +318,27 @@ function pmpro_email_templates_send_test() {
 			break;
 		case 'cancel_on_next_payment_date':
 			$send_email = 'sendCancelOnNextPaymentDateEmail';
-			$params = array( $test_user, $test_user->membership_level->id );
+			//Ensure mock level has enddate set
+			add_filter( 'pmpro_get_membership_levels_for_user', function() {
+				//get the first level
+				$levels = pmpro_getAllLevels( true );
+				$level = $levels[1];
+				$level->enddate = date( 'Y-m-d', strtotime( '+1 month' ) );
+				return array( 1 => $level );
+			} );
+			$params = array( $test_user, "1" );
 			break;
 		case 'cancel_on_next_payment_date_admin':
 			$send_email = 'sendCancelOnNextPaymentDateAdminEmail';
-			$params = array( $test_user, $test_user->membership_level->id );
+			// //Ensure mock level has enddate set
+			add_filter( 'pmpro_get_membership_levels_for_user', function() {
+				//get the first level
+				$levels = pmpro_getAllLevels( true );
+				$level = $levels[1];
+				$level->enddate = date( 'Y-m-d', strtotime( '+1 month' ) );
+				return array( 1 => $level );
+			} );
+			$params = array( $test_user, "1" );
 			break;
 		case 'checkout_check':
 		case 'checkout_express':

--- a/includes/email.php
+++ b/includes/email.php
@@ -317,28 +317,19 @@ function pmpro_email_templates_send_test() {
 			$params = array($current_user, $current_user->membership_level->id);
 			break;
 		case 'cancel_on_next_payment_date':
-			$send_email = 'sendCancelOnNextPaymentDateEmail';
+		case 'cancel_on_next_payment_date_admin':
+			$send_email = 'cancel_on_next_payment_date' == $test_email->template ? 'sendCancelOnNextPaymentDateEmail' :
+				'sendCancelOnNextPaymentDateAdminEmail';
+			$levels = pmpro_getAllLevels( true );
+			global $pmpro_conpd_email_test_level;
+			$pmpro_conpd_email_test_level = current( $levels );
 			//Ensure mock level has enddate set
 			add_filter( 'pmpro_get_membership_levels_for_user', function() {
-				//get the first level
-				$levels = pmpro_getAllLevels( true );
-				$level = $levels[1];
-				$level->enddate = date( 'Y-m-d', strtotime( '+1 month' ) );
-				return array( 1 => $level );
+				global $pmpro_conpd_email_test_level;
+				$pmpro_conpd_email_test_level->enddate = date( 'Y-m-d', strtotime( '+1 month' ) );
+				return array( $pmpro_conpd_email_test_level->id => $pmpro_conpd_email_test_level );
 			} );
-			$params = array( $test_user, "1" );
-			break;
-		case 'cancel_on_next_payment_date_admin':
-			$send_email = 'sendCancelOnNextPaymentDateAdminEmail';
-			// //Ensure mock level has enddate set
-			add_filter( 'pmpro_get_membership_levels_for_user', function() {
-				//get the first level
-				$levels = pmpro_getAllLevels( true );
-				$level = $levels[1];
-				$level->enddate = date( 'Y-m-d', strtotime( '+1 month' ) );
-				return array( 1 => $level );
-			} );
-			$params = array( $test_user, "1" );
+			$params = array( $test_user, $pmpro_conpd_email_test_level->id );
 			break;
 		case 'checkout_check':
 		case 'checkout_express':


### PR DESCRIPTION
 * Hook into pmpro_get_membership_levels_for_user filter to "mock" level to send a test email

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Hook into pmpro_get_membership_levels_for_user filter to "mock" level to send a test email

Resolves #2980
.

### How to test the changes in this Pull Request:

Follow steps described in the issue above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
