### PR TITLE
Activity Email Discount Code Usage showing HTML

### DIFF
--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -229,6 +229,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										<?php
 										echo wp_kses_post(
 											sprintf(
+												// translators: %1$s is the attributes for the anchor tag, %2$s is the term being used.
 												__( 'No <a %1$s>Discount Codes</a> were used %2$s.', 'paid-memberships-pro' ),
 												'style="color:#1A688B;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"',
 												esc_html( $term )

--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -225,7 +225,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										}
 								} else {
 									?>
-									<p style="margin:0px;padding:0px;"><?php printf( esc_html__( 'No <a %1$s>Discount Codes</a> were used %2$s.', 'paid-memberships-pro' ), 'style="color:#1A688B;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"', esc_html( $term ) ); ?></p>
+									<p style="margin:0px;padding:0px;"><?php $url =  printf( __( 'No <a %1$s >Discount Codes were used %2$s.', 'paid-memberships-pro' ), 'style="color:#1A688B;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"', esc_html( $term ) ); ?></p>
 									<?php
 								}
 								?>

--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -225,7 +225,17 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 										}
 								} else {
 									?>
-									<p style="margin:0px;padding:0px;"><?php $url =  printf( __( 'No <a %1$s >Discount Codes were used %2$s.', 'paid-memberships-pro' ), 'style="color:#1A688B;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"', esc_html( $term ) ); ?></p>
+									<p style="margin:0px;padding:0px;">
+										<?php
+										echo wp_kses_post(
+											sprintf(
+												__( 'No <a %1$s>Discount Codes</a> were used %2$s.', 'paid-memberships-pro' ),
+												'style="color:#1A688B;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"',
+												esc_html( $term )
+											),
+										);
+										?>
+									</p>
 									<?php
 								}
 								?>


### PR DESCRIPTION
 * Cant escape link built and term is already escaped
<img width="1330" alt="image" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/104098e1-35a3-4c2b-8a4c-27bb1a7589fe">


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Stop escaping link

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves  #2973 .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
