### PR TITLE
Edit customer in Stripe button is present in Edit Member page despite…

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
@@ -7,20 +7,6 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 	public function __construct() {
 		$this->slug = 'subscriptions';
 		$this->title = __( 'Subscriptions', 'paid-memberships-pro' );
-
-		// Get the user's Stripe Customer if they have one.
-		$user = self::get_user();
-		$stripe = new PMProGateway_Stripe();
-		$customer = $stripe->get_customer_for_user( $user->ID );
-		$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user->ID );
-		$user_has_active_stripe_subscription = array_reduce( $subscriptions, function ( $carry, $subscription ) {
-			return $carry || ( $subscription->get_status() === 'active' && $subscription->get_gateway() === 'stripe' );
-		}, false );
-		// Link to the Stripe Customer if they have one.
-		// TODO: Eventually make this a hook or filter so other gateways can add their own links.
-		if ( ! empty( $customer ) && $user_has_active_stripe_subscription ) {
-			$this->title_link = '<a target="_blank" class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users" href="' . esc_url( 'https://dashboard.stripe.com/' . ( get_option( 'pmpro_gateway_environment' ) == 'sandbox' ? 'test/' : '' ) . 'customers/' . $customer->id ) . '">' . esc_html__( 'Edit customer in Stripe', 'paid-memberships-pro' ) . '</a>';
-		}
 	}
 
 	/**

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
@@ -12,10 +12,13 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 		$user = self::get_user();
 		$stripe = new PMProGateway_Stripe();
 		$customer = $stripe->get_customer_for_user( $user->ID );
-
+		$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user->ID );
+		$user_has_active_stripe_subscription = array_reduce( $subscriptions, function ( $carry, $subscription ) {
+			return $carry || ( $subscription->get_status() === 'active' && $subscription->get_gateway() === 'stripe' );
+		}, false );
 		// Link to the Stripe Customer if they have one.
 		// TODO: Eventually make this a hook or filter so other gateways can add their own links.
-		if ( ! empty( $customer ) ) {
+		if ( ! empty( $customer ) && $user_has_active_stripe_subscription ) {
 			$this->title_link = '<a target="_blank" class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users" href="' . esc_url( 'https://dashboard.stripe.com/' . ( get_option( 'pmpro_gateway_environment' ) == 'sandbox' ? 'test/' : '' ) . 'customers/' . $customer->id ) . '">' . esc_html__( 'Edit customer in Stripe', 'paid-memberships-pro' ) . '</a>';
 		}
 	}

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -11,6 +11,13 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 		$this->title_link = empty( $user->ID ) ? '' : '<a href="' . esc_url( add_query_arg( array( 'user_id' => intval( $user->ID ) ), admin_url( 'user-edit.php' ) ) ) . '" target="_blank" class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users">' . esc_html__( 'Edit User', 'paid-memberships-pro' ) . '</a>';
 		$this->submit_text = empty( $user->ID ) ? __( 'Create User ') : __( 'Update User Info', 'paid-memberships-pro' );
 
+		// If this user has an associated Stripe Customer, add a link to edit that Stripe Customer as well.
+		$stripe = new PMProGateway_Stripe();
+ 		$customer = $stripe->get_customer_for_user( $user->ID );
+		 if ( ! empty( $customer ) ) {
+			$this->title_link .= '<a target="_blank" class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users" href="' . esc_url( 'https://dashboard.stripe.com/' . ( get_option( 'pmpro_gateway_environment' ) == 'sandbox' ? 'test/' : '' ) . 'customers/' . $customer->id ) . '">' . esc_html__( 'Edit Customer in Stripe', 'paid-memberships-pro' ) . '</a>';
+		}
+
 		// Show user updated or user created message if necessary.
 		if ( isset( $_REQUEST['user_id'] ) && ! empty( $_REQUEST['user_id'] && ! empty( $_REQUEST['user_info_action'] ) ) ) {
 			if ( 'updated' === $_REQUEST['user_info_action'] ) {

--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -72,6 +72,24 @@ if ( empty( $subscription ) ) {
 	</a>
 
 	<?php
+	// If this is a Stripe subscription and we have a customer for the user, show a link to edit the customer in Stripe.
+	if ( 'stripe' === $subscription->get_gateway() ) {
+		$stripe = new PMProGateway_Stripe();
+ 		$customer = $stripe->get_customer_for_user( $sub_user->ID );
+		 if ( ! empty( $customer ) ) {
+			?>
+			<a
+				target="_blank"
+				class="page-title-action pmpro-has-icon pmpro-has-icon-admin-users"
+				href="<?php echo esc_url( 'https://dashboard.stripe.com/' . ( get_option( 'pmpro_gateway_environment' ) == 'sandbox' ? 'test/' : '' ) . 'customers/' . $customer->id ) ?>">
+				<?php esc_html_e( 'Edit Customer in Stripe', 'paid-memberships-pro' ); ?>
+			</a>
+			<?php
+		}
+	}
+	?>
+
+	<?php
 		if ( $pmpro_msg ) {
 			?>
 			<div role="alert" id="pmpro_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">


### PR DESCRIPTION
… the active subscription belongs to a different gateway.

 * Check if there's an active Stripe subscription before render the button
<img width="1467" alt="Screenshot 2024-05-13 at 3 20 59 PM" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/64dc76f6-f6f7-4210-bf30-d13762a4e864">
<img width="1191" alt="Screenshot 2024-05-13 at 3 19 34 PM" src="https://github.com/strangerstudios/paid-memberships-pro/assets/1678457/e28b98d2-e302-4225-9b9b-2a9561c2fc76">


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Check if there's an active Stripe subscription before render the button

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #2986 

### How to test the changes in this Pull Request:

Follow steps from the linked issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
