### PR TITLE
Reworked wp_mail_from and WPCS

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -25,21 +25,27 @@ function pmpro_wp_mail_from_name($from_name)
  * The default email address for WP emails is wordpress@sitename.
  * Use our setting instead.
  */
-function pmpro_wp_mail_from($from_email)
-{
+function pmpro_wp_mail_from( $from_email ) {
 	// default from email wordpress@sitename
-	$sitename = strtolower( sanitize_text_field( $_SERVER['SERVER_NAME'] ) );
+	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
+		$sitename = strtolower( sanitize_text_field( $_SERVER['SERVER_NAME'] ) );
+	} else {
+		$site_url = get_option( 'siteurl' );
+		$parsed_url = parse_url( $site_url );
+		$sitename = strtolower( $parsed_url['host'] );
+	}
+
 	if ( substr( $sitename, 0, 4 ) == 'www.' ) {
 		$sitename = substr( $sitename, 4 );
 	}
 	$default_from_email = 'wordpress@' . $sitename;
 
 	//make sure it's the default email address
-	if($from_email == $default_from_email)
-	{
-		$pmpro_from_email = get_option("pmpro_from_email");
-		if ($pmpro_from_email && is_email( $pmpro_from_email ) )
+	if( $from_email == $default_from_email ) {
+		$pmpro_from_email = get_option( 'pmpro_from_email' );
+		if ( $pmpro_from_email && is_email( $pmpro_from_email ) ) {
 			$from_email = $pmpro_from_email;
+		}
 	}
 
 	return $from_email;

--- a/includes/email.php
+++ b/includes/email.php
@@ -41,7 +41,7 @@ function pmpro_wp_mail_from( $from_email ) {
 	$default_from_email = 'wordpress@' . $sitename;
 
 	//make sure it's the default email address
-	if( $from_email == $default_from_email ) {
+	if ( $from_email == $default_from_email ) {
 		$pmpro_from_email = get_option( 'pmpro_from_email' );
 		if ( $pmpro_from_email && is_email( $pmpro_from_email ) ) {
 			$from_email = $pmpro_from_email;


### PR DESCRIPTION
* ENHANCEMENT: Added a fallback to get the site URL from the database should the SERVER_NAME parameter not be available in certain cases like using WPCLI and some other instances.

* REFACTOR: Applied WPCS to pmpro_wp_mail_from function

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
