### PR TITLE
i18n: Localize months shortnames for date fields

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1001,7 +1001,7 @@ class PMPro_Field {
                 if($i == $month)
                     $r .= 'selected="selected"';
 
-                $r .= '>' . esc_html( date("M", strtotime($i . "/15/" . $year, current_time("timestamp"))) ) . '</option>';
+                $r .= '>' . esc_html( date_i18n("M", strtotime($i . "/15/" . $year, current_time("timestamp"))) ) . '</option>';
             }
 
             $r .= '</select><input id="' . esc_attr( $this->id ) . '_d" name="' . esc_attr( $this->name ) . '[d]" type="text" size="2" value="' . esc_attr( $day ) . '" ';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Seems safe to use date_i18n in this context.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
