### PR TITLE
Adding filters for formatted order total, subtotal, tax

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -370,7 +370,7 @@ function pmpro_dashboard_report_recent_orders_callback() {
 								<?php }
 							?>
 						</td>
-						<td><?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+						<td><?php echo pmpro_escape_price( $order->get_formatted_total() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 						<td>
 							<?php echo esc_html( $order->gateway ); ?>
 							<?php if ( $order->gateway_environment == 'test' ) {

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -308,7 +308,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 											<span class="pmpro-level_change-action-field">
 												<label>
 													<input type="checkbox" name="<?php echo esc_attr( $cancel_level_input_name_base ); ?>[refund]" value="<?php echo (int)$last_order->id; ?>" />
-													<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $last_order->total ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+													<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( $last_order->get_formatted_total() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 												</label>
 											</span>
 										</div>
@@ -436,7 +436,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 														<span class="pmpro-level_change-action-field">
 														<label>
 															<input type="checkbox" name="<?php echo esc_attr( $add_level_to_group_input_name_base ); ?>[refund]" value="<?php echo (int)$last_order->id; ?>" />
-															<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $last_order->total ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+															<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( $last_order->get_formatted_total() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 														</label>
 													</span>
 												</div>

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -94,7 +94,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 								?>
 							</td>
 							<td>
-								<?php echo pmpro_escape_price( pmpro_formatPrice( $order->total ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+								<?php echo pmpro_escape_price( $order->get_formatted_total() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								<?php
 									if ( ! empty( $order->code_id ) ) {
 										$discountQuery = $wpdb->prepare( "SELECT c.code FROM $wpdb->pmpro_discount_codes c WHERE c.id = %d LIMIT 1", $order->code_id );

--- a/adminpages/templates/orders-email.php
+++ b/adminpages/templates/orders-email.php
@@ -53,7 +53,7 @@
 				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
 					<td style="text-align:center;border-width:1px;border-style:solid;border-collapse:collapse;padding:4px;"><?php echo esc_html( $level->id ); ?></td>
 					<td style="border-width:1px;border-style:solid;border-collapse:collapse;padding:4px;"><?php echo esc_html( $level->name ); ?></td>
-					<td style="border-width:1px;border-style:solid;border-collapse:collapse;text-align:right;padding:4px;"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->subtotal ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+					<td style="border-width:1px;border-style:solid;border-collapse:collapse;text-align:right;padding:4px;"><?php echo pmpro_escape_price( $last_order->get_formatted_subtotal() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 				</tr>
 				<?php
 					if ( (float)$order->total > 0 ) {

--- a/adminpages/templates/orders-email.php
+++ b/adminpages/templates/orders-email.php
@@ -53,7 +53,7 @@
 				<tr style="border-width:1px;border-style:solid;border-collapse:collapse;">
 					<td style="text-align:center;border-width:1px;border-style:solid;border-collapse:collapse;padding:4px;"><?php echo esc_html( $level->id ); ?></td>
 					<td style="border-width:1px;border-style:solid;border-collapse:collapse;padding:4px;"><?php echo esc_html( $level->name ); ?></td>
-					<td style="border-width:1px;border-style:solid;border-collapse:collapse;text-align:right;padding:4px;"><?php echo pmpro_escape_price( $last_order->get_formatted_subtotal() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+					<td style="border-width:1px;border-style:solid;border-collapse:collapse;text-align:right;padding:4px;"><?php echo pmpro_escape_price( $order->get_formatted_subtotal() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 				</tr>
 				<?php
 					if ( (float)$order->total > 0 ) {

--- a/adminpages/templates/orders-print.php
+++ b/adminpages/templates/orders-print.php
@@ -82,7 +82,7 @@
 			<tr>
 				<td class="aligncenter"><?php echo esc_html( $level->id ); ?></td>
 				<td><?php echo esc_html( $level->name ); ?></td>
-				<td class="alignright"><?php echo pmpro_escape_price( pmpro_formatPrice( $order->subtotal ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+				<td class="alignright"><?php echo pmpro_escape_price( $last_order->get_formatted_subtotal() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 			</tr>
 			<?php
 				if ( (float)$order->total > 0 ) {

--- a/adminpages/templates/orders-print.php
+++ b/adminpages/templates/orders-print.php
@@ -82,7 +82,7 @@
 			<tr>
 				<td class="aligncenter"><?php echo esc_html( $level->id ); ?></td>
 				<td><?php echo esc_html( $level->name ); ?></td>
-				<td class="alignright"><?php echo pmpro_escape_price( $last_order->get_formatted_subtotal() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+				<td class="alignright"><?php echo pmpro_escape_price( $order->get_formatted_subtotal() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 			</tr>
 			<?php
 				if ( (float)$order->total > 0 ) {

--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -1087,7 +1087,7 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 	 */
 	public function column_total( $item ) {
 
-		echo pmpro_escape_price( pmpro_formatPrice( $item->total ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo pmpro_escape_price( $item->get_formatted_total() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		// If there is a discount code, show it.
 		if ( $item->getDiscountCode() ) {

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1860,4 +1860,67 @@
 		
 			return false;
 		}
+
+		/**
+		 * Get the formatted total for this order.
+		 *
+		 * @since TBD
+		 *
+		 * @return string
+		 */
+		public function get_formatted_total() {
+			$formatted_total = pmpro_formatPrice( $this->total );
+
+			/**
+			 * Filter the formatted total for this order.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $formatted_total The formatted total for this order.
+			 * @param MemberOrder $this The order object.
+			 */
+			return apply_filters( 'pmpro_order_formatted_total', $formatted_total, $this );
+		}
+
+		/**
+		 * Get the formatted subtotal for this order.
+		 *
+		 * @since TBD
+		 *
+		 * @return string
+		 */
+		public function get_formatted_subtotal() {
+			$formatted_subtotal = pmpro_formatPrice( $this->subtotal );
+
+			/**
+			 * Filter the formatted subtotal for this order.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $formatted_subtotal The formatted subtotal for this order.
+			 * @param MemberOrder $this The order object.
+			 */
+			return apply_filters( 'pmpro_order_formatted_subtotal', $formatted_subtotal, $this );
+		}
+
+		/**
+		 * Get the formatted tax for this order.
+		 *
+		 * @since TBD
+		 *
+		 * @return string
+		 */
+		public function get_formatted_tax() {
+			$formatted_tax = pmpro_formatPrice( $this->tax );
+
+			/**
+			 * Filter the formatted tax for this order.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $formatted_tax The formatted tax for this order.
+			 * @param MemberOrder $this The order object.
+			 */
+			return apply_filters( 'pmpro_order_formatted_tax', $formatted_tax, $this );
+		}
 	} // End of Class

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -507,7 +507,7 @@
 				'membership_id' => $membership_level_id,
 				'membership_level_name' => $membership_level_name,
 				'invoice_id' => $invoice->code,
-				'invoice_total' => pmpro_formatPrice($invoice->total),
+				'invoice_total' => $invoice->get_formatted_total(),
 				'invoice_date' => date_i18n(get_option('date_format'), $invoice->getTimestamp()),
 				'billing_name' => $invoice->billing->name,
 				'billing_street' => $invoice->billing->street,
@@ -579,7 +579,7 @@
 				'membership_id' => $membership_level_id,
 				'membership_level_name' => $membership_level_name,
 				'invoice_id' => $invoice->code,
-				'invoice_total' => pmpro_formatPrice($invoice->total),
+				'invoice_total' => $invoice->get_formatted_total(),
 				'invoice_date' => date_i18n(get_option('date_format'), $invoice->getTimestamp()),
 				'billing_name' => $invoice->billing->name,
 				'billing_street' => $invoice->billing->street,
@@ -690,7 +690,7 @@
 				}
 				
 				$this->data["invoice_id"] = $invoice->code;
-				$this->data["invoice_total"] = pmpro_formatPrice($invoice->total);
+				$this->data["invoice_total"] = $invoice->get_formatted_total();
 				$this->data["invoice_date"] = date_i18n( get_option( 'date_format' ), $invoice->getTimestamp() );
 				$this->data["billing_name"] = $invoice->billing->name;
 				$this->data["billing_street"] = $invoice->billing->street;
@@ -814,7 +814,7 @@
 			// Gather data depending on template being used.
 			if( in_array( $this->template, array( 'checkout_express_admin', 'checkout_check_admin', 'checkout_trial_admin', 'checkout_paid_admin' ) ) ) {
 				$this->data["invoice_id"] = $invoice->code;
-				$this->data["invoice_total"] = pmpro_formatPrice($invoice->total);
+				$this->data["invoice_total"] = $invoice->get_formatted_total();
 				$this->data["invoice_date"] = date_i18n(get_option('date_format'), $invoice->getTimestamp());
 				$this->data["billing_name"] = $invoice->billing->name;
 				$this->data["billing_street"] = $invoice->billing->street;
@@ -1206,7 +1206,7 @@
 								'display_name' => $user->display_name,
 								'user_email' => $user->user_email,	
 								'invoice_id' => $invoice->code,
-								'invoice_total' => pmpro_formatPrice( $invoice->total ),
+								'invoice_total' => $invoice->get_formatted_total(),
 								'invoice_date' => date_i18n( get_option( 'date_format' ), $invoice->getTimestamp() ),
 								'billing_name' => $invoice->billing->name,
 								'billing_street' => $invoice->billing->street,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3181,14 +3181,14 @@ function pmpro_get_price_parts( $pmpro_order, $format = 'array' ) {
 	if ( ! empty( $pmpro_order->subtotal ) && $pmpro_order->subtotal != $pmpro_order->total ) {
 		$pmpro_price_parts['subtotal'] = array(
 			'label' => __( 'Subtotal', 'paid-memberships-pro' ),
-			'value' => pmpro_escape_price( pmpro_formatPrice( $pmpro_order->subtotal ) ),
+			'value' => pmpro_escape_price( $pmpro_order->get_formatted_subtotal() ),
 		);
 	}
 
 	if ( ! empty( $pmpro_order->tax ) ) {
 		$pmpro_price_parts['tax'] = array(
 			'label' => __( 'Tax', 'paid-memberships-pro' ),
-			'value' => pmpro_escape_price( pmpro_formatPrice( $pmpro_order->tax ) ),
+			'value' => pmpro_escape_price( $pmpro_order->get_formatted_tax() ),
 		);
 	}
 
@@ -3209,7 +3209,7 @@ function pmpro_get_price_parts( $pmpro_order, $format = 'array' ) {
 	if ( ! empty( $pmpro_order->total ) ) {
 		$pmpro_price_parts_with_total['total'] = array(
 			'label' => __( 'Total', 'paid-memberships-pro' ),
-			'value' => pmpro_escape_price( pmpro_formatPrice( $pmpro_order->total ) ),
+			'value' => pmpro_escape_price( $pmpro_order->get_formatted_total() ),
 		);
 	}
 

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -276,7 +276,7 @@ function pmpro_membership_level_profile_fields($user)
 									?>
 									<label for="<?php echo esc_attr( $shown_level_name_prefix ); ?>[refund]" style="display: none">
 										<input type="checkbox" name="<?php echo esc_attr( $shown_level_name_prefix ); ?>[refund]" value="1" />
-										<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $last_order->total ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+										<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( $last_order->get_formatted_total() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 									</label>
 									<?php
 								}
@@ -382,7 +382,7 @@ function pmpro_membership_level_profile_fields($user)
 													?>
 													<label for="<?php echo esc_attr( $name_prefix ); ?>[refund]" style="display: none">
 														<input type="checkbox" name="<?php echo esc_attr( $name_prefix ); ?>[refund]" value="1" />
-														<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( pmpro_formatPrice( $last_order->total ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+														<?php printf( esc_html__( 'Refund the last payment (%s).', 'paid-memberships-pro' ), pmpro_escape_price( $last_order->get_formatted_total() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 													</label>
 													<?php
 												}
@@ -804,7 +804,7 @@ function pmpro_membership_history_profile_fields( $user ) {
 								}
 							?>
 						</td>
-						<td><?php echo pmpro_escape_price( pmpro_formatPrice( $invoice->total ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
+						<td><?php echo pmpro_escape_price( $invoice->get_formatted_total() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 						<td><?php 
 							if ( empty( $invoice->code_id ) ) {
 								esc_html_e( '&#8212;', 'paid-memberships-pro' );

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -219,7 +219,7 @@
 										<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_table_order-level' ) ); ?>" data-title="<?php esc_attr_e( 'Level', 'paid-memberships-pro' ); ?>"><?php if(!empty($order->membership_level)) echo esc_html( $order->membership_level->name ); else echo esc_html__("N/A", 'paid-memberships-pro' );?></td>
 										<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_table_order-amount' ) ); ?>" data-title="<?php esc_attr_e( 'Amount', 'paid-memberships-pro' ); ?>"><?php
 											//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-											echo pmpro_escape_price( pmpro_formatPrice($order->total) ); ?></td>
+											echo pmpro_escape_price( $order->get_formatted_total() ); ?></td>
 										<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_table_order-status' ) ); ?>" data-title="<?php esc_attr_e( 'Status', 'paid-memberships-pro' ); ?>">
 											<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_tag pmpro_tag-' . $tag_style ) ); ?>"><?php echo esc_html( $display_status ); ?></span>
 										</td>

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -354,7 +354,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 											<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_table_order-level' ) ); ?>" data-title="<?php esc_attr_e( 'Level', 'paid-memberships-pro' ); ?>"><?php if(!empty($order->membership_level)) echo esc_html( $order->membership_level->name ); else echo esc_html__("N/A", 'paid-memberships-pro' );?></td>
 											<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_table_order-amount' ) ); ?>" data-title="<?php esc_attr_e( 'Amount', 'paid-memberships-pro' ); ?>"><?php
 												//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-												echo pmpro_escape_price( pmpro_formatPrice($order->total) ); ?></td>
+												echo pmpro_escape_price( $order->get_formatted_total() ); ?></td>
 											<td class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_table_order-status' ) ); ?>" data-title="<?php esc_attr_e( 'Status', 'paid-memberships-pro' ); ?>">
 												<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_tag pmpro_tag-' . $tag_style ) ); ?>"><?php echo esc_html( $display_status ); ?></span>
 											</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds the following filters to adjust how an order's total, subtotal, and tax values are displayed across PMPro:
- pmpro_order_formatted_total
- pmpro_order_formatted_subtotal
- pmpro_order_formatted_tax

Opened as an alternative to #2988 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
