### PR TITLE
Fixing menu UI when the design tab is selected

### DIFF
--- a/adminpages/admin_header.php
+++ b/adminpages/admin_header.php
@@ -243,7 +243,7 @@
 			<?php } ?>
 
 			<?php if(current_user_can('pmpro_membershiplevels')) { ?>
-				<li><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) );?>"<?php if( in_array( $view, array( 'pmpro-membershiplevels', 'pmpro-discountcodes', 'pmpro-pagesettings', 'pmpro-paymentsettings', 'pmpro-emailsettings', 'pmpro-emailtemplates', 'pmpro-advancedsettings' ) ) ) { ?> class="current"<?php } ?>"><?php esc_html_e('Settings', 'paid-memberships-pro' );?></a></li>
+				<li><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-membershiplevels' ) );?>"<?php if( in_array( $view, array( 'pmpro-membershiplevels', 'pmpro-discountcodes', 'pmpro-pagesettings', 'pmpro-paymentsettings', 'pmpro-emailsettings', 'pmpro-emailtemplates', 'pmpro-designsettings', 'pmpro-advancedsettings' ) ) ) { ?> class="current"<?php } ?>"><?php esc_html_e('Settings', 'paid-memberships-pro' );?></a></li>
 			<?php } ?>
 
 			<?php if(current_user_can('pmpro_addons')) { ?>

--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -118,6 +118,7 @@ function pmpro_parent_file( $parent_file ) {
 		'pmpro-emailsettings' => 'pmpro-membershiplevels',
 		'pmpro-emailtemplates' => 'pmpro-membershiplevels',
 		'pmpro-userfields' => 'pmpro-membershiplevels',
+		'pmpro-designsettings' => 'pmpro-membershiplevels',
 		'pmpro-advancedsettings' => 'pmpro-membershiplevels',
 		'pmpro-subscriptions' => '',
 		'pmpro-member' => 'pmpro-memberslist',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixing "Memberships" menu not being open in sidebar when on the Design Settings tab and fixing the "Settings" header menu not being highlighted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
