### PR TITLE
Fix/early wp query

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3811,7 +3811,7 @@ function pmpro_cleanup_memberships_users_table() {
  * @return bool True if we are on the checkout page, false otherwise
  */
 function pmpro_is_checkout() {
-	global $pmpro_pages;
+	global $pmpro_pages, $wp_query;
 
 	// Try is_page first.
 	if ( ! empty( $pmpro_pages['checkout'] ) ) {
@@ -3821,7 +3821,11 @@ function pmpro_is_checkout() {
 	}
 
 	// Page might not be setup yet or a custom page.
-	$queried_object = get_queried_object();
+	if ( ! empty( $wp_query ) ) {
+		$queried_object = get_queried_object();
+	} else {
+		$queried_object = null;
+	}
 
 	if ( ! $is_checkout &&
 		! empty( $queried_object ) &&


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When you call pmpro_is_checkout(), it will call get_queried_object(), which tries to call $wp_query->get_queried_object().

If pmpro_is_checkout() is called before $wp_query is set up, there will be a fatal error.

This code checks first if the $wp_query global is non empty before trying to call get_queried_object().

### How to test the changes in this Pull Request:

1. Add code like the following into the root file of a plugin to run immediately. (Not in an init hook/etc.)

```
if ( pmpro_is_checkout() ) {
    echo "TESTING";
}
```

2. Note the fatal error on the unfixed version of PMPro.
3. No error with this fix.

### Other information:

Asking pmpro_is_checkout() so early will return false now instead of an error, which potentially gives you the wrong answer in certain contexts, but this was already a limitation of the function.

We could perhaps detect when the function is being called to early and throw a warning into the log so people can investigate. You can often fix the issue by adjusting custom code or add ons/etc to not call that function so early.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX/ENHANCEMENT: Fixed issue where `pmpro_is_checkout()` would throw a fatal error if called too early.
