### PR TITLE
Fix a small content warning when trying to add the CSS body class dynamically.

### DIFF
--- a/includes/content.php
+++ b/includes/content.php
@@ -568,7 +568,9 @@ function pmpro_body_classes( $classes ) {
 		if( ! empty( $post_levels[1] ) ) {
 			$classes[] = 'pmpro-body-level-required';
 			foreach( $post_levels[1] as $post_level ) {
-				$classes[] = 'pmpro-body-level-' . $post_level[0];
+				if ( ! empty( $post_level[0] ) ) {
+					$classes[] = 'pmpro-body-level-' . $post_level[0];
+				}
 			}
 		}
 		if( ! empty( $post_levels[0] ) && $post_levels[0] == true) {


### PR DESCRIPTION
* BUG FIX: Fixed an issue in some cases where a warning would be shown when trying to dynamically add the membership level body CSS class.

NOTE: I cannot replicate this but I assume there is some sort of missing data/stray data in the database that's adding to the array. A customer was facing this issue on a specific page on their site.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?