### PR TITLE
Showing an error when order refund fails

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -738,7 +738,13 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 
 				// Process the refund.
 				if ( ! pmpro_refund_order( $refund_order ) ) {
-					pmpro_setMessage( __( 'Error refunding order. Please check the order notes for more information.', 'paid-memberships-pro' ), 'pmpro_error' );
+					pmpro_setMessage(
+						sprintf(
+							/* translators: %s is the order code. */
+							__( 'These was an error refunding order #%s. None of the submitted changes to this membership have been made. Please check the order notes for more information.', 'paid-memberships-pro' ),
+							$refund_order->code
+						) . ' <a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $refund_order->id ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View Order', 'paid-memberships-pro' ) . '</a>', 'pmpro_error'
+					);
 					return;
 				}
 			}
@@ -869,7 +875,13 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 
 				// Process the refund.
 				if ( ! pmpro_refund_order( $refund_order ) ) {
-					pmpro_setMessage( __( 'Error refunding order. Please check the order notes for more information.', 'paid-memberships-pro' ), 'pmpro_error' );
+					pmpro_setMessage(
+						sprintf(
+							/* translators: %s is the order code. */
+							__( 'These was an error refunding order #%s. None of the submitted changes to this membership have been made. Please check the order notes for more information.', 'paid-memberships-pro' ),
+							$refund_order->code
+						) . ' <a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $refund_order->id ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View Order', 'paid-memberships-pro' ) . '</a>', 'pmpro_error'
+					);
 					return;
 				}
 			}

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -741,7 +741,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 					pmpro_setMessage(
 						sprintf(
 							/* translators: %s is the order code. */
-							__( 'These was an error refunding order #%s. None of the submitted changes to this membership have been made. Please check the order notes for more information.', 'paid-memberships-pro' ),
+							__( 'There was an error refunding order #%s. None of the submitted changes to this membership have been made. Please check the order notes for more information.', 'paid-memberships-pro' ),
 							$refund_order->code
 						) . ' <a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $refund_order->id ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View Order', 'paid-memberships-pro' ) . '</a>', 'pmpro_error'
 					);
@@ -878,7 +878,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 					pmpro_setMessage(
 						sprintf(
 							/* translators: %s is the order code. */
-							__( 'These was an error refunding order #%s. None of the submitted changes to this membership have been made. Please check the order notes for more information.', 'paid-memberships-pro' ),
+							__( 'There was an error refunding order #%s. None of the submitted changes to this membership have been made. Please check the order notes for more information.', 'paid-memberships-pro' ),
 							$refund_order->code
 						) . ' <a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $refund_order->id ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'View Order', 'paid-memberships-pro' ) . '</a>', 'pmpro_error'
 					);

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -737,7 +737,10 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 				}
 
 				// Process the refund.
-				pmpro_refund_order( $refund_order );
+				if ( ! pmpro_refund_order( $refund_order ) ) {
+					pmpro_setMessage( __( 'Error refunding order. Please check the order notes for more information.', 'paid-memberships-pro' ), 'pmpro_error' );
+					return;
+				}
 			}
 
 			// If we need to keep the subscription, add the filter.
@@ -865,7 +868,10 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 				}
 
 				// Process the refund.
-				pmpro_refund_order( $refund_order );
+				if ( ! pmpro_refund_order( $refund_order ) ) {
+					pmpro_setMessage( __( 'Error refunding order. Please check the order notes for more information.', 'paid-memberships-pro' ), 'pmpro_error' );
+					return;
+				}
 			}
 
 			// Check if we should keep the subscription active.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When an order refund fails on the Edit Member "memberships" tab, show an error message and halt any other changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
