### PR TITLE
Filterable dashboard widgets

### DIFF
--- a/adminpages/dashboard.php
+++ b/adminpages/dashboard.php
@@ -7,69 +7,70 @@
 /**
  * Add all the meta boxes for the dashboard.
  */
-add_action( 'add_meta_boxes', function() {
-	add_meta_box(
-		'pmpro_dashboard_welcome',
-		__( 'Welcome to Paid Memberships Pro', 'paid-memberships-pro' ),
-		'pmpro_dashboard_welcome_callback',
-		'toplevel_page_pmpro-dashboard',
-		'normal'
-	);
 
-	if ( current_user_can( 'pmpro_reports' ) ) {
+/**
+ * Filter the meta boxes to display on the Paid Memberships Pro dashboard.
+ * 
+ * @since TBD
+ * 
+ * @param array $pmpro_dashboard_meta_boxes Array of meta boxes to display on the dashboard. Hint: Use the associative array key as the meta box ID.
+ */
+$pmpro_dashboard_meta_boxes = apply_filters( 'pmpro_dashboard_meta_boxes', array(
+	'pmpro_dashboard_welcome' => array(
+		'title'    => esc_html__( 'Welcome to Paid Memberships Pro', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_dashboard_welcome_callback',
+		'context'  => 'normal',
+		'capability' => '',
+	),
+	'pmpro_dashboard_report_sales' => array(
+		'title'    => esc_html__( 'Sales and Revenue', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_report_sales_widget',
+		'context'  => 'advanced',
+		'capability' => 'pmpro_reports'
+	),
+	'pmpro_dashboard_report_membership_stats' => array(
+		'title'    => esc_html__( 'Membership Stats', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_report_memberships_widget',
+		'context'  => 'advanced',
+		'capability' => ''
+	),
+	'pmpro_dashboard_report_logins' => array(
+		'title'    => esc_html__( 'Visits, Views, and Logins', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_report_login_widget',
+		'context'  => 'advanced',
+		'capability' => ''
+	),
+	'pmpro_dashboard_report_recent_members' => array(
+		'title'    => esc_html__( 'Recent Members', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_dashboard_report_recent_members_callback',
+		'context'  => 'side',
+		'capability' => 'pmpro_memberslist'
+	),
+	'pmpro_dashboard_report_recent_orders' => array(
+		'title'    => esc_html__( 'Recent Orders', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_dashboard_report_recent_orders_callback',
+		'context'  => 'side',
+		'capability' => 'pmpro_orders'
+	),
+	'pmpro_dashboard_news_updates' => array(
+		'title'    => esc_html__( 'Paid Memberships Pro News and Updates', 'paid-memberships-pro' ),
+		'callback' => 'pmpro_dashboard_news_updates_callback',
+		'context'  => 'side',
+		'capability' => ''
+	),
+) );
+
+foreach ( $pmpro_dashboard_meta_boxes as $id => $meta_box ) {
+	if ( empty( $meta_box['capability'] ) || current_user_can( $meta_box['capability'] ) ) {
 		add_meta_box(
-			'pmpro_dashboard_report_sales',
-			__( 'Sales and Revenue', 'paid-memberships-pro' ),
-			'pmpro_report_sales_widget',
+			$id,
+			$meta_box['title'],
+			$meta_box['callback'],
 			'toplevel_page_pmpro-dashboard',
-			'advanced'
-		);
-		add_meta_box(
-			'pmpro_dashboard_report_membership_stats',
-			__( 'Membership Stats', 'paid-memberships-pro' ),
-			'pmpro_report_memberships_widget',
-			'toplevel_page_pmpro-dashboard',
-			'advanced'
-		);
-		add_meta_box(
-			'pmpro_dashboard_report_logins',
-			__( 'Visits, Views, and Logins', 'paid-memberships-pro' ),
-			'pmpro_report_login_widget',
-			'toplevel_page_pmpro-dashboard',
-			'advanced'
+			$meta_box['context']
 		);
 	}
-	
-	if ( current_user_can( 'pmpro_memberslist' ) ) {
-		add_meta_box(
-			'pmpro_dashboard_report_recent_members',
-			__( 'Recent Members', 'paid-memberships-pro' ),
-			'pmpro_dashboard_report_recent_members_callback',
-			'toplevel_page_pmpro-dashboard',
-			'side'
-		);
-	}
-	
-	if ( current_user_can( 'pmpro_orders' ) ) {
-		add_meta_box(
-			'pmpro_dashboard_report_recent_orders',
-			__( 'Recent Orders', 'paid-memberships-pro' ),
-			'pmpro_dashboard_report_recent_orders_callback',
-			'toplevel_page_pmpro-dashboard',
-			'side'
-		);
-	}
-
-	add_meta_box(
-		'pmpro_dashboard_news_updates',
-		__( 'Paid Memberships Pro News and Updates', 'paid-memberships-pro' ),
-		'pmpro_dashboard_news_updates_callback',
-		'toplevel_page_pmpro-dashboard',
-		'side'
-	);
-} );
-
-do_action( 'add_meta_boxes', 'toplevel_page_pmpro-dashboard' );
+}
 
 /**
  * Load the Paid Memberships Pro dashboard-area header


### PR DESCRIPTION
* ENHANCEMENT: Added new filter 'pmpro_dashboard_meta_boxes' which allows developers to hide dashboard widgets, as well as add their very own widgets to the dashboard area.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This resolves an issue where WooCommerce (and most likely other plugins) cause a fatal error when trying to view our dashboard page.

### How to test the changes in this Pull Request:

To test this, you can add the following code - this will remove the welcome dashboard from the PMPro dashboard:


```php
// Example to remove a meta box from the dashboard
function my_pmpro_remove_meta_box_from_dashboard( $meta_boxes_array ) {
	unset( $meta_boxes_array['pmpro_dashboard_welcome'] );
	return $meta_boxes_array;
}
add_filter( 'pmpro_dashboard_meta_boxes', 'my_pmpro_remove_meta_box_from_dashboard' );
``` 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->