### PR TITLE
Use MemberOrder::get_orders on Edit Member page

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -18,7 +18,11 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 		global $wpdb, $pmpro_gateways;
 
 		// Show all orders for user
-		$orders = $wpdb->get_results( $wpdb->prepare( "SELECT mo.*, du.code_id as code_id FROM $wpdb->pmpro_membership_orders mo LEFT JOIN $wpdb->pmpro_discount_codes_uses du ON mo.id = du.order_id WHERE mo.user_id = %d ORDER BY mo.timestamp DESC", self::get_user()->ID ) );
+		$orders = MemberOrder::get_orders(
+			array(
+				'user_id' => self::get_user()->ID,
+			)
+		);
 
 		// Build the selectors for the orders history list based on history count.
 		$orders_classes = array();
@@ -96,11 +100,10 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 							<td>
 								<?php echo pmpro_escape_price( $order->get_formatted_total() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 								<?php
-									if ( ! empty( $order->code_id ) ) {
-										$discountQuery = $wpdb->prepare( "SELECT c.code FROM $wpdb->pmpro_discount_codes c WHERE c.id = %d LIMIT 1", $order->code_id );
-										$discount_code = $wpdb->get_row( $discountQuery );
+									if ( ! empty( $order->discount_code_id ) ) {
+										$discount_code = $order->getDiscountCode();
 										?>
-										<a class="pmpro_discount_code-tag" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $order->code_id, 'filter' => 'with-discount-code' ), admin_url( 'admin.php' ) ) ); ?>" title="<?php esc_attr_e( 'View all orders with this discount code', 'paid-memberships-pro' ); ?>"><?php echo esc_html( $discount_code->code ); ?></a>
+										<a class="pmpro_discount_code-tag" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'discount-code' => $order->discount_code_id, 'filter' => 'with-discount-code' ), admin_url( 'admin.php' ) ) ); ?>" title="<?php esc_attr_e( 'View all orders with this discount code', 'paid-memberships-pro' ); ?>"><?php echo esc_html( $discount_code->code ); ?></a>
 										<?php
 									}
 								?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Switched to using the `MemberOrder::get_orders()` method on the Edit Member orders page. Also fixes fatal error introduced by #3009 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Load the Edit Member orders page
2. See that there is no longer a fatal error in the "total" column

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
