### PR TITLE
Reworked non-member message for logged-out

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2124,30 +2124,30 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			$newcontent .= stripslashes( get_option( 'pmpro_nonmembertext' ) );
 			$newcontent .= '</div>';
 
-			/**
-			 * Filter the content message for non-members.
-			 *
-			 * @param string $content The content message for non-members.
-			 * @return string $content The filtered content message for non-members.
-			 */
-			$newcontent = apply_filters( 'pmpro_non_member_text_filter', $newcontent );
 		} else {
 			// Use our generated smart default message.
 			$newcontent = '<h2 class="' . pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) . '">';
 			$newcontent .= '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-lock"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>';
+			
+			
 			if ( count( $level_ids ) > 1 ) {
 				$newcontent .= __( 'Membership Required', 'paid-memberships-pro' );
-			} else {
+			} elseif ( ! empty( $level_ids ) ) {
 				$newcontent .= __( '!!levels!! Membership Required', 'paid-memberships-pro' );
+			} else {
+				$newcontent .= __( 'Account Required', 'paid-memberships-pro' );
 			}
 			$newcontent .= '</h2>';
 			$newcontent .= '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">';
 			if ( count( $level_ids ) > 1 ) {
 				$newcontent .= '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
 				$newcontent .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
-			} else {
+			} elseif ( ! empty( $levels_ids ) ) {
 				$newcontent .= '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
 				$newcontent .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
+			} else {
+				$newcontent .= '<p>' . __(' You must be logged-in to access this content.', 'paid-memberships-pro') . '</p>';
+				$newcontent .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!login_url!!">' . __( 'Log in', 'paid-memberships-pro' ) . '</a></p>';
 			}
 			$newcontent .= '</div>';
 		}
@@ -2159,6 +2159,15 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			$newcontent .= esc_html__( 'Already a member?', 'paid-memberships-pro' ) . ' <a href="' . esc_url( wp_login_url( get_permalink() ) ) . '">' . esc_html__( 'Log in here', 'paid-memberships-pro' ) . '</a>';
 			$newcontent .= '</div>';
 		}
+		
+		/**
+		 * Filter the content message for non-members.
+		 *
+		 * @param string $content The content message for non-members.
+		 * @return string $content The filtered content message for non-members.
+		 */
+		$newcontent = apply_filters( 'pmpro_non_member_text_filter', $newcontent );
+
 		$content .= $pmpro_content_mesage_pre . str_replace( $sr_search, $sr_replace, $newcontent ) . $pmpro_content_message_post;
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2131,24 +2131,50 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			
 			
 			if ( count( $level_ids ) > 1 ) {
-				$newcontent .= __( 'Membership Required', 'paid-memberships-pro' );
+				$header = __( 'Membership Required', 'paid-memberships-pro' );
 			} elseif ( ! empty( $level_ids ) ) {
-				$newcontent .= __( '!!levels!! Membership Required', 'paid-memberships-pro' );
+				$header = __( '!!levels!! Membership Required', 'paid-memberships-pro' );
 			} else {
-				$newcontent .= __( 'Account Required', 'paid-memberships-pro' );
+				$header = __( 'Account Required', 'paid-memberships-pro' );
 			}
+			/**
+			 * Filter the header message for the no access message.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $header The header message for the no access message.
+			 * @param array $level_ids The array of level IDs this post is protected for.
+			 */
+			$newcontent .= apply_filters( 'pmpro_no_access_message_header', $header, $level_ids );
+
 			$newcontent .= '</h2>';
 			$newcontent .= '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">';
 			if ( count( $level_ids ) > 1 ) {
-				$newcontent .= '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
-				$newcontent .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
+				$body = '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
+				$body = '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
 			} elseif ( ! empty( $levels_ids ) ) {
-				$newcontent .= '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
-				$newcontent .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
+				$body = '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
+				$body = '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
 			} else {
-				$newcontent .= '<p>' . __(' You must be logged-in to access this content.', 'paid-memberships-pro') . '</p>';
-				$newcontent .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!login_url!!">' . __( 'Log in', 'paid-memberships-pro' ) . '</a></p>';
+				$body = '<p>' . __(' You must be logged-in to access this content.', 'paid-memberships-pro') . '</p>';
+				$body = '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!login_url!!">' . __( 'Log In', 'paid-memberships-pro' ) . '</a></p>';
 			}
+			/**
+			 * Filter the body message for the no access message.
+			 *
+			 * @since TBD
+			 *
+			 * @param string $body The body message for the no access message.
+			 * @param array $level_ids The array of level IDs this post is protected for.
+			 */
+			$body = apply_filters( 'pmpro_no_access_message_body', $body, $level_ids );
+			/**
+			 * Legacy filter for the body message for the no access message.
+			 *
+			 * @deprecated TBD
+			 */
+			$body = apply_filters_deprecated( 'pmpro_non_member_text_body', array( $body ), 'TBD', 'pmpro_no_access_message_body' );
+			$newcontent .= $body;
 			$newcontent .= '</div>';
 		}
 
@@ -2161,12 +2187,14 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 		}
 		
 		/**
-		 * Filter the content message for non-members.
+		 * Filter the HTML of the no access message.
 		 *
-		 * @param string $content The content message for non-members.
-		 * @return string $content The filtered content message for non-members.
+		 * @since TBD
+		 *
+		 * @param string $newcontent The HTML of the no access message.
+		 * @param array $level_ids The array of level IDs this post is protected for.
 		 */
-		$newcontent = apply_filters( 'pmpro_non_member_text_filter', $newcontent );
+		$newcontent = apply_filters( 'pmpro_no_access_message_html', $newcontent, $level_ids );
 
 		$content .= $pmpro_content_mesage_pre . str_replace( $sr_search, $sr_replace, $newcontent ) . $pmpro_content_message_post;
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2129,7 +2129,6 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			$newcontent = '<h2 class="' . pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) . '">';
 			$newcontent .= '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-lock"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>';
 			
-			
 			if ( count( $level_ids ) > 1 ) {
 				$header = __( 'Membership Required', 'paid-memberships-pro' );
 			} elseif ( ! empty( $level_ids ) ) {
@@ -2137,6 +2136,7 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			} else {
 				$header = __( 'Account Required', 'paid-memberships-pro' );
 			}
+
 			/**
 			 * Filter the header message for the no access message.
 			 *
@@ -2146,18 +2146,17 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			 * @param array $level_ids The array of level IDs this post is protected for.
 			 */
 			$newcontent .= apply_filters( 'pmpro_no_access_message_header', $header, $level_ids );
-
 			$newcontent .= '</h2>';
 			$newcontent .= '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">';
 			if ( count( $level_ids ) > 1 ) {
 				$body = '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
-				$body = '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
+				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
 			} elseif ( ! empty( $levels_ids ) ) {
 				$body = '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
-				$body = '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
+				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
 			} else {
-				$body = '<p>' . __(' You must be logged-in to access this content.', 'paid-memberships-pro') . '</p>';
-				$body = '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!login_url!!">' . __( 'Log In', 'paid-memberships-pro' ) . '</a></p>';
+				$body = '<p>' . __(' You must be logged in to access this content.', 'paid-memberships-pro') . '</p>';
+				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!login_url!!">' . __( 'Log In', 'paid-memberships-pro' ) . '</a></p>';
 			}
 			/**
 			 * Filter the body message for the no access message.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2064,6 +2064,7 @@ function pmpro_actions_nav_separator() {
 /**
  * pmpro_get_no_access_message to return the appropriate content message for the protected content.
  *
+ * @param string $content The content being shown before the no access message. Usually an excerpt.
  * @param array $level_ids The array of level IDs this post is protected for.
  * @param array $level_names The array of names for the levels this post is protected for.
  *
@@ -2071,8 +2072,6 @@ function pmpro_actions_nav_separator() {
  *
  */
 function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL ) {
-	global $current_user;
-
 	if ( empty( $level_ids ) ) {
 		$level_ids = array();
 	}
@@ -2120,23 +2119,22 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 		// Not a member. Show our default message or the site's custom message.
 		$nonmembertext_type = get_option( 'pmpro_nonmembertext_type' );
 		if ( $nonmembertext_type == 'custom' ) {
-			$newcontent = '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">';
-			$newcontent .= stripslashes( get_option( 'pmpro_nonmembertext' ) );
-			$newcontent .= '</div>';
+			$no_access_message_inner = '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">';
+			$no_access_message_inner .= stripslashes( get_option( 'pmpro_nonmembertext' ) );
+			$no_access_message_inner .= '</div>';
 
 		} else {
 			// Use our generated smart default message.
-			$newcontent = '<h2 class="' . pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) . '">';
-			$newcontent .= '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-lock"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>';
-			
-			if ( count( $level_ids ) > 1 ) {
+			// Build the dynamic message contents.
+			if ( count( $level_ids ) !== 1 ) {
 				$header = __( 'Membership Required', 'paid-memberships-pro' );
-			} elseif ( ! empty( $level_ids ) ) {
-				$header = __( '!!levels!! Membership Required', 'paid-memberships-pro' );
+				$body = '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
+				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
 			} else {
-				$header = __( 'Account Required', 'paid-memberships-pro' );
+				$header = __( '!!levels!! Membership Required', 'paid-memberships-pro' );
+				$body = '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
+				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
 			}
-
 			/**
 			 * Filter the header message for the no access message.
 			 *
@@ -2145,19 +2143,8 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			 * @param string $header The header message for the no access message.
 			 * @param array $level_ids The array of level IDs this post is protected for.
 			 */
-			$newcontent .= apply_filters( 'pmpro_no_access_message_header', $header, $level_ids );
-			$newcontent .= '</h2>';
-			$newcontent .= '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">';
-			if ( count( $level_ids ) > 1 ) {
-				$body = '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
-				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
-			} elseif ( ! empty( $level_ids ) ) {
-				$body = '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
-				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
-			} else {
-				$body = '<p>' . __(' You must be logged in to access this content.', 'paid-memberships-pro') . '</p>';
-				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!login_url!!">' . __( 'Log In', 'paid-memberships-pro' ) . '</a></p>';
-			}
+			$header = apply_filters( 'pmpro_no_access_message_header', $header, $level_ids );
+
 			/**
 			 * Filter the body message for the no access message.
 			 *
@@ -2167,35 +2154,43 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			 * @param array $level_ids The array of level IDs this post is protected for.
 			 */
 			$body = apply_filters( 'pmpro_no_access_message_body', $body, $level_ids );
+
 			/**
 			 * Legacy filter for the body message for the no access message.
 			 *
 			 * @deprecated TBD
 			 */
 			$body = apply_filters_deprecated( 'pmpro_non_member_text_body', array( $body ), 'TBD', 'pmpro_no_access_message_body' );
-			$newcontent .= $body;
-			$newcontent .= '</div>';
+
+			// Build the content message.
+			$no_access_message_inner = '<h2 class="' . pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) . '">';
+			$no_access_message_inner .= '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-lock"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>';
+			$no_access_message_inner .= $header;
+			$no_access_message_inner .= '</h2>';
+			$no_access_message_inner .= '<div class="' . pmpro_get_element_class( 'pmpro_card_content' ) . '">' . $body . '</div>';
 		}
 
 		// If the user is not logged in, show a link to log in if the message doesn't already have one.
-		if ( ! is_user_logged_in() && strpos( $newcontent, '!!login' ) === false ) {
-			$newcontent .= '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_card_actions pmpro_font-medium' ) ) . '">';
+		if ( ! is_user_logged_in() && strpos( $no_access_message_inner, '!!login' ) === false ) {
+			$no_access_message_inner .= '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_card_actions pmpro_font-medium' ) ) . '">';
 			// to do redirect back to content.
-			$newcontent .= esc_html__( 'Already a member?', 'paid-memberships-pro' ) . ' <a href="' . esc_url( wp_login_url( get_permalink() ) ) . '">' . esc_html__( 'Log in here', 'paid-memberships-pro' ) . '</a>';
-			$newcontent .= '</div>';
+			$no_access_message_inner .= esc_html__( 'Already a member?', 'paid-memberships-pro' ) . ' <a href="' . esc_url( wp_login_url( get_permalink() ) ) . '">' . esc_html__( 'Log in here', 'paid-memberships-pro' ) . '</a>';
+			$no_access_message_inner .= '</div>';
 		}
-		
+
+		// Add the pre and post content message.
+		$no_access_message_html = $pmpro_content_mesage_pre . str_replace( $sr_search, $sr_replace, $no_access_message_inner ) . $pmpro_content_message_post;
 		/**
 		 * Filter the HTML of the no access message.
 		 *
 		 * @since TBD
 		 *
-		 * @param string $newcontent The HTML of the no access message.
+		 * @param string $content_message The HTML of the no access message.
 		 * @param array $level_ids The array of level IDs this post is protected for.
 		 */
-		$newcontent = apply_filters( 'pmpro_no_access_message_html', $newcontent, $level_ids );
+		$no_access_message_html = apply_filters( 'pmpro_no_access_message_html', $no_access_message_html, $level_ids );
 
-		$content .= $pmpro_content_mesage_pre . str_replace( $sr_search, $sr_replace, $newcontent ) . $pmpro_content_message_post;
+		$content .= $no_access_message_html;
 	}
 
 	return $content;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2151,7 +2151,7 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			if ( count( $level_ids ) > 1 ) {
 				$body = '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
 				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
-			} elseif ( ! empty( $levels_ids ) ) {
+			} elseif ( ! empty( $level_ids ) ) {
 				$body = '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
 				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . $level_ids[0] ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
 			} else {


### PR DESCRIPTION
* BUG FIX: Fixes an issue for non-member text when no levels are found.

I.e. Show for logged-in users, show now access message in block settings.