### PR TITLE
Adjust style of Membership Account > My Memberships section when the user has no active level.

### DIFF
--- a/css/frontend/high_contrast.css
+++ b/css/frontend/high_contrast.css
@@ -597,6 +597,22 @@
 	}
 
 	/**
+	* Membership Account
+	*/
+	#pmpro_account-membership-none {
+
+		.pmpro_card_content {
+			padding-top: var(--pmpro--base--spacing--large);
+
+			p {
+				margin: 0;
+			}
+
+		}
+
+	}
+
+	/**
 	* Membership Orders
 	*/
 	.pmpro_table_orders .pmpro_tag {

--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -589,6 +589,22 @@
 	}
 
 	/**
+	* Membership Account
+	*/
+	#pmpro_account-membership-none {
+
+		.pmpro_card_content {
+			padding-top: var(--pmpro--base--spacing--large);
+
+			p {
+				margin: 0;
+			}
+
+		}
+
+	}
+
+	/**
 	 * Membership Levels
 	 */
 	.pmpro_levels_table {

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -148,7 +148,13 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_section_content' ) ); ?>">
 					<?php if ( empty( $mylevels ) ) {
 						$url = pmpro_url( 'levels' );
-						echo '<p>' . wp_kses( sprintf( __( "You do not have an active membership. <a href='%s'>Choose a membership level.</a>", 'paid-memberships-pro' ), $url ), array( 'a' => array( 'href' => array() ) ) ) . '</p>';
+						?>
+						<div id="pmpro_account-membership-none" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+								<p><?php echo wp_kses( sprintf( __( "You do not have an active membership. <a href='%s'>Choose a membership level.</a>", 'paid-memberships-pro' ), $url ), array( 'a' => array( 'href' => array() ) ) ); ?></p>
+							</div> <!-- end pmpro_card_content -->
+						</div> <!-- end pmpro_card -->
+						<?php
 					} else {
 						foreach ( $mylevels as $level ) {
 							?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Subtle adjustments so that the section shown on Membership Account when user has no memberships is more inline with other sections.
![Screenshot 2024-06-28 at 11 25 28 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/a4d896a5-62f5-4bd9-a47f-fa8957c1187d)

