### PR TITLE
Removing moved settings from Advanced Settings admin page

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -32,11 +32,6 @@
 
 		// Checkout settings.
 		pmpro_setOption("tospage");
-		pmpro_setOption("spamprotection");
-		pmpro_setOption("recaptcha");
-		pmpro_setOption("recaptcha_version");
-		pmpro_setOption("recaptcha_publickey");
-		pmpro_setOption("recaptcha_privatekey");
 
 		// Communication settings.
 		pmpro_setOption("maxnotificationpriority");
@@ -82,11 +77,6 @@
 
 	// Checkout settings.
 	$tospage = get_option( "pmpro_tospage");
-	$spamprotection = get_option( "pmpro_spamprotection");
-	$recaptcha = get_option( "pmpro_recaptcha");
-	$recaptcha_version = get_option( "pmpro_recaptcha_version");
-	$recaptcha_publickey = get_option( "pmpro_recaptcha_publickey");
-	$recaptcha_privatekey = get_option( "pmpro_recaptcha_privatekey");
 
 	// Communication settings.
 	$maxnotificationpriority = get_option( "pmpro_maxnotificationpriority");


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When the Security tab was created, the settings were moved from Advanced Settings. These should not still be here in the Advanced Settings admin page code.
