### PR TITLE
Fixing PHP warning if entire site is HTTPS

### DIFF
--- a/adminpages/securitysettings.php
+++ b/adminpages/securitysettings.php
@@ -22,7 +22,10 @@
 		pmpro_setOption( "recaptcha_version", sanitize_text_field( $_POST['recaptcha_version'] ) );
 		pmpro_setOption( "recaptcha_publickey", sanitize_text_field( $_POST['recaptcha_publickey'] ) );
 		pmpro_setOption( "recaptcha_privatekey", sanitize_text_field( $_POST['recaptcha_privatekey'] ) );
-		pmpro_setOption( "use_ssl", intval( $_POST['use_ssl'] ) );
+		if ( isset( $_POST['use_ssl'] ) ) {
+			// REQUEST['use_ssl'] will not be set if the entire site is already over HTTPS.
+			pmpro_setOption( "use_ssl", intval( $_POST['use_ssl'] ) );
+		}
 		if( !empty( $_POST['nuclear_HTTPS'] ) ) {
 			$nuclear_HTTPS = 1;
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes warning: `Warning: Undefined array key “use_ssl” in /.../paid-memberships-pro/adminpages/securitysettings.php on line 25`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
