### PR TITLE
Logic update so we do not have to show an empty expires section on the my memberships area

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -595,6 +595,7 @@ function pmpro_getLevelsExpiration( &$levels ) {
  *
  * @param object|int  $level The level object or ID to get the expiration date for.
  * @param WP_User|int $user  The user object or ID to get the expiration date for.
+ * @param string|null $default The default text to show when there is no expiration date. If null, a dash is shown.
  *
  * @return string The expiration date text.
  */
@@ -632,7 +633,7 @@ function pmpro_get_membership_expiration_text( $level, $user, $default = null ) 
 	// Generate the expiration date text.
 	if ( empty( $level->enddate ) ) {
 		// If the level does not have an enddate, show a dash (&#8212;) or empty string.
-		$text = empty( $default ) ? '' : esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
+		$text = ( null === $default ) ? esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' ) : $default;
 	} elseif ( $show_time ) {
 		// Show the enddate with the time.
 		$text = sprintf(

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -598,7 +598,7 @@ function pmpro_getLevelsExpiration( &$levels ) {
  *
  * @return string The expiration date text.
  */
-function pmpro_get_membership_expiration_text( $level, $user ) {
+function pmpro_get_membership_expiration_text( $level, $user, $default = null ) {
 	// If a user ID was passed, get the user object.
 	if ( is_numeric( $user ) ) {
 		$user = get_userdata( $user );
@@ -631,8 +631,8 @@ function pmpro_get_membership_expiration_text( $level, $user ) {
 
 	// Generate the expiration date text.
 	if ( empty( $level->enddate ) ) {
-		// If the level does not have an enddate, show a dash (&#8212;).
-		$text = esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
+		// If the level does not have an enddate, show a dash (&#8212;) or empty string.
+		$text = empty( $default ) ? '' : esc_html_x( '&#8212;', 'A dash is shown when there is no expiration date.', 'paid-memberships-pro' );
 	} elseif ( $show_time ) {
 		// Show the enddate with the time.
 		$text = sprintf(

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -183,11 +183,17 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 											</li>
 											<?php
 										}
+
+										$expiration_text = pmpro_get_membership_expiration_text( $level, $current_user, '' );
+										if ( ! empty( $expiration_text ) ) {
+											?>
+											<li class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item' ) ); ?>">
+												<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item_label' ) ); ?>"><?php esc_html_e( 'Expires', 'paid-memberships-pro' ); ?></span>
+												<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item_value' ) ); ?>"><?php echo wp_kses_post( $expiration_text ); ?></span>
+											</li>
+											<?php
+										}
 										?>
-										<li class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item' ) ); ?>">
-											<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item_label' ) ); ?>"><?php esc_html_e( 'Expires', 'paid-memberships-pro' ); ?></span>
-											<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item_value' ) ); ?>"><?php echo wp_kses_post( pmpro_get_membership_expiration_text( $level, $current_user ) ); ?></span>
-										</li>
 									</ul> <!-- end pmpro_list -->
 								</div> <!-- end pmpro_card_content -->
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Supporting lots of cases here now on the My Memberships section whether the membership is:
- Free
- Recurring, no expiration / active
- Expiring

![Screenshot 2024-07-01 at 9 01 01 PM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/99035f17-f460-456c-b80d-24723656162d)
