### PR TITLE
Adding notice if we detect a custom frontend.css loaded via theme files

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1024,40 +1024,46 @@ function pmpro_get_plugin_duplicates() {
  *
  * @since TBD
  */
-function pmpro_was_loading_frontend_css_override_notice() {
+function pmpro_was_loading_frontend_css_notice() {
 	global $current_user;
 
-	// Only show on PMPro admin pages.
-	if ( empty( $_REQUEST['page'] ) || strpos( $_REQUEST['page'], 'pmpro' ) === false ) {
+	// If we are not on a PMPro admin page, don't show the notice.
+	if ( ! isset( $_REQUEST['page'] ) || ( isset( $_REQUEST['page'] ) && 'pmpro-' !== substr( $_REQUEST['page'], 0, 6 ) ) ) {
 		return;
 	}
 
 	// Determine if this site was loading a custom frontend.css override file.
 	if ( ! file_exists( get_stylesheet_directory() . '/paid-memberships-pro/css/frontend.css' ) && ! file_exists( get_template_directory() . '/paid-memberships-pro/frontend.css' ) ) {
-		// No custom frontend.css override file was found.
+		// No custom frontend.css override file was found. Don't show the notice.
 		return;
 	}
 
-	// Hide if the notice has been dismissed.
+	// Get notifications that have been archived.
 	$archived_notifications = get_user_meta( $current_user->ID, 'pmpro_archived_notifications', true );
-	if ( ! empty( $archived_notifications ) && in_array( 'pmpro_was_loading_frontend_css_notice', array_keys( $archived_notifications ) ) ) {
-		return;
-	}
 
-	// Show a dismissable notice to the user.
-	?>
-	<div id="pmpro_was_loading_frontend_css_notice" class="notice notice-warning is-dismissible pmpro-notice">
-		<p>
-			<?php
-			printf(
-				wp_kses_post(
-					__( 'Paid Memberships Pro detected that you were using a custom override for the frontend stylesheet. As of v3.1 and later, we no longer load your custom stylesheet. For more information, read our <a href="%s">v3.1 release notes post here</a>.', 'paid-memberships-pro' )
-				),
-				esc_url( 'https://www.paidmembershipspro.com/pmpro-update-3-1/' )
-			);
-			?>
-		</p>
-	</div>
-	<?php
+	// If the user hasn't dismissed the notice, show it.
+	if ( ! is_array( $archived_notifications ) || ! array_key_exists( 'was_loading_frontend_css_notice', $archived_notifications ) ) {
+		?>
+		<div id="was_loading_frontend_css_notice" class="notice notice-error pmpro_notification pmpro_notification-error">
+			<button type="button" class="pmpro-notice-button notice-dismiss" value="was_loading_frontend_css_notice"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></span></button>
+			<div class="pmpro_notification-icon">
+				<span class="dashicons dashicons-warning"></span>
+			</div>
+			<div class="pmpro_notification-content">
+				<h3><?php esc_html_e( 'Custom Frontend Stylesheet Detected', 'paid-memberships-pro' ); ?></h3>
+				<p>
+					<?php
+					printf(
+						wp_kses_post(
+							__( 'Paid Memberships Pro detected that you were using a custom override for the frontend stylesheet. As of v3.1 and later, we no longer load your custom stylesheet. For more information, read our <a href="%s">v3.1 release notes post here</a>.', 'paid-memberships-pro' )
+						),
+						esc_url( 'https://www.paidmembershipspro.com/pmpro-update-3-1/' )
+					);
+					?>
+				</p>
+			</div>
+		</div>
+		<?php
+	}
 }
-add_action( 'admin_notices', 'pmpro_was_loading_frontend_css_override_notice' );
+add_action( 'admin_notices', 'pmpro_was_loading_frontend_css_notice' );

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1017,3 +1017,47 @@ function pmpro_get_plugin_duplicates() {
 
 	return $multiple_installations;
 }
+
+/**
+ * Show admin notice if site was using a custom-loaded frontend.css file.
+ * We no longer enqueue the frontend.css override file by default.
+ *
+ * @since TBD
+ */
+function pmpro_was_loading_frontend_css_override_notice() {
+	global $current_user;
+
+	// Only show on PMPro admin pages.
+	if ( empty( $_REQUEST['page'] ) || strpos( $_REQUEST['page'], 'pmpro' ) === false ) {
+		return;
+	}
+
+	// Determine if this site was loading a custom frontend.css override file.
+	if ( ! file_exists( get_stylesheet_directory() . '/paid-memberships-pro/css/frontend.css' ) && ! file_exists( get_template_directory() . '/paid-memberships-pro/frontend.css' ) ) {
+		// No custom frontend.css override file was found.
+		return;
+	}
+
+	// Hide if the notice has been dismissed.
+	$archived_notifications = get_user_meta( $current_user->ID, 'pmpro_archived_notifications', true );
+	if ( ! empty( $archived_notifications ) && in_array( 'pmpro_was_loading_frontend_css_notice', array_keys( $archived_notifications ) ) ) {
+		return;
+	}
+
+	// Show a dismissable notice to the user.
+	?>
+	<div id="pmpro_was_loading_frontend_css_notice" class="notice notice-warning is-dismissible pmpro-notice">
+		<p>
+			<?php
+			printf(
+				wp_kses_post(
+					__( 'Paid Memberships Pro detected that you were using a custom override for the frontend stylesheet. As of v3.1 and later, we no longer load your custom stylesheet. For more information, read our <a href="%s">v3.1 release notes post here</a>.', 'paid-memberships-pro' )
+				),
+				esc_url( 'https://www.paidmembershipspro.com/pmpro-update-3-1/' )
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'pmpro_was_loading_frontend_css_override_notice' );

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -97,8 +97,12 @@ jQuery(document).on('click', function (e) {
 
 /** JQuery to hide the notifications. */
 jQuery(document).ready(function () {
-	jQuery(document).on('click', '.pmpro-notice-button.notice-dismiss', function () {
-		var notification_id = jQuery(this).val();
+	jQuery(document).on('click', '.pmpro-notice-button.notice-dismiss,.pmpro-notice button', function () {
+		if ( jQuery(this).val().length > 0 ) {
+			var notification_id = jQuery(this).val();
+		} else {
+			var notification_id = jQuery(this).parent().attr('id');
+		}
 
 		var postData = {
 			action: 'pmpro_hide_notice',

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -97,12 +97,8 @@ jQuery(document).on('click', function (e) {
 
 /** JQuery to hide the notifications. */
 jQuery(document).ready(function () {
-	jQuery(document).on('click', '.pmpro-notice-button.notice-dismiss,.pmpro-notice button', function () {
-		if ( jQuery(this).val().length > 0 ) {
-			var notification_id = jQuery(this).val();
-		} else {
-			var notification_id = jQuery(this).parent().attr('id');
-		}
+	jQuery(document).on('click', '.pmpro-notice-button.notice-dismiss', function () {
+		var notification_id = jQuery(this).val();
 
 		var postData = {
 			action: 'pmpro_hide_notice',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Check if the site's theme or child theme is loading a frontend.css override and show an admin notice.

![Screenshot 2024-07-02 at 7 41 39 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/dca21d0f-df47-4028-badd-f057260d44af)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
