### PR TITLE
Fix issue of field not hiding

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1226,8 +1226,10 @@ class PMPro_Field {
 			$this->divclass .= " ";
 		}
 
-		// Add a class to the field based on the type.
-		$this->divclass .= "pmpro_form_field pmpro_form_field-" . $this->type;
+		// Add a class to the field based on the type and skip if we're trying to hide it with pmpro_hidden
+		if ( strpos( $this->divclass, 'pmpro_hidden' ) === false ) {
+			$this->divclass .= "pmpro_form_field pmpro_form_field-" . $this->type;
+		}
 		$this->class .= " pmpro_form_input-" . $this->type;
 
 		// Add the required class to field.


### PR DESCRIPTION
* BUG FIX: Fixed an issue where classes would override the pmpro_hidden styling, so this honors pmpro_hidden classes always.

Using strpos instead of identical conditonal as there may be more than one added custom class. This will always give a priority to `pmpro_hidden` class to hide the field.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?