### PR TITLE
Fixed slashes in From Name setting.

### DIFF
--- a/adminpages/emailsettings.php
+++ b/adminpages/emailsettings.php
@@ -107,7 +107,7 @@
 							<label for="from_name"><?php esc_html_e('From Name', 'paid-memberships-pro' );?>:</label>
 						</th>
 						<td>
-							<input type="text" name="from_name" value="<?php echo esc_attr($from_name);?>" class="regular-text" />
+							<input type="text" name="from_name" value="<?php echo esc_attr( wp_unslash($from_name) );?>" class="regular-text" />
 						</td>
 					</tr>
 					<tr>

--- a/includes/email.php
+++ b/includes/email.php
@@ -13,14 +13,14 @@ function pmpro_wp_mail_from_name( $from_name ) {
 	$default_from_name = 'WordPress';
 
 	//make sure it's the default from name
-	if($from_name == $default_from_name)
-	{
-		$pmpro_from_name = get_option("pmpro_from_name");
-		if ($pmpro_from_name)
-			$from_name = stripslashes($pmpro_from_name);
+	if( $from_name == $default_from_name ) {
+		$pmpro_from_name = get_option( 'pmpro_from_name' );
+		if ($pmpro_from_name) {
+			$from_name = $pmpro_from_name;
+		}
 	}
 
-	return $from_name;
+	return wp_unslash( $from_name );
 }
 
 /**


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the From Name email setting would escape apostrophe's but not remove the slash on the frontend (settings and email received).

Also WPCS was applied to the pmpro_wp_mail_from_name function.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Set the from name to something like: `PMPro's Test Site` and save your settings. You will see it changes `PMPro\'s Test Site`
2. After pulling this PR, it should set the values back to `PMPro's Test Site` on the settings page as well as the From name within the email browser.