### PR TITLE
Adding background color to admin view as admin bar element.

### DIFF
--- a/css/frontend/base.css
+++ b/css/frontend/base.css
@@ -390,6 +390,10 @@ button[type="button"]#other_discount_code_toggle:focus {
 /**
  * Admin Toolbar View As Feature
  */
+#wpadminbar #wp-admin-bar-pmpro-admin-membership-access {
+	background-color: #1d2327;
+}
+
 #wpadminbar .pmpro_admin-view {
 	display: inline-block;
 	padding: 0 5px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
![Screenshot 2024-07-11 at 11 45 09 AM](https://github.com/strangerstudios/paid-memberships-pro/assets/5312875/7aae42a0-e949-4a46-a7eb-9526db94ad71)


Adds bg color to our view as menu item - when screens are smaller, this wraps outside the admin bar and is not visible. This PR could be closed and not merged - it's a problem with the admin bar overall and also present for the username "Howdy" part, so this only fixes "our" menu item, not any that wrap (which we should not do).

Resolves #3053 
