### PR TITLE
Fixed loading JS on Payment Settings Page

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -127,7 +127,7 @@
 								<option value="live" <?php selected( $gateway_environment, "live" ); ?>><?php esc_html_e('Live/Production', 'paid-memberships-pro' );?></option>
 							</select>
 							<script>
-							jQuery(document).ready(function(){;
+							jQuery(document).ready(function(){
 								function pmpro_changeGateway() {
 									const gateway = jQuery('#gateway').val();
 									const gateway_environment = jQuery('#gateway_environment').val();

--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -127,8 +127,8 @@
 								<option value="live" <?php selected( $gateway_environment, "live" ); ?>><?php esc_html_e('Live/Production', 'paid-memberships-pro' );?></option>
 							</select>
 							<script>
-								function pmpro_changeGateway()
-								{
+							jQuery(document).ready(function(){;
+								function pmpro_changeGateway() {
 									const gateway = jQuery('#gateway').val();
 									const gateway_environment = jQuery('#gateway_environment').val();
 
@@ -145,7 +145,7 @@
 										}
 									});							
 
-									if ( jQuery('#gateway').val() === '' ) {
+									if ( gateway === '' ) {
 										jQuery('#pmpro-default-gateway-message').show();
 									} else {
 										jQuery('#pmpro-default-gateway-message').hide();
@@ -155,6 +155,7 @@
 
 								// Handle change events.
 								jQuery('#gateway, #gateway_environment').on('change', pmpro_changeGateway);
+							});
 							</script>
 						</td>
 					</tr>


### PR DESCRIPTION
* BUG FIX: Fixed an issue where the Javascript for showing payment option fields on the Payment Settings Page was running too early for _some_ gateways (mainly external gateways).

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Install a plugin/Add On gateway like Paystack (https://wordpress.org/plugins/paystack-gateway-paid-memberships-pro/)
2. Before pulling this code into your environment, set your gateway to Paystack and reload the page without changing payment gateways and see that the "Currency & Tax Settings" don't display until you toggle the gateway dropdown.
3. Pull the code change and re-run the steps above to see that the settings show on page load.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
