### PR TITLE
Fixing password toggle if there are multiple login forms on page

### DIFF
--- a/css/frontend/high_contrast.css
+++ b/css/frontend/high_contrast.css
@@ -386,6 +386,11 @@
 		width: 20px;
 	}
 
+	.pmpro_form_field-password-toggle button:focus .pmpro_icon-eye svg,
+	.pmpro_form_field-password-toggle button:active .pmpro_icon-eye svg {
+		stroke: var(--pmpro--color--accent--variation);
+	}
+
 	.pmpro_form_field-select2 {
 		display: block;
 	}
@@ -553,6 +558,33 @@
 
 	#pass-strength-result {
 		border-radius: 0;
+	}
+
+	/* Move password toggle before field visually but structurally after */
+	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle),
+	.pmpro_section #loginform .login-password {
+		align-items: center;
+		display: grid;
+		grid-template-areas:
+			"label toggle"
+			"input input";
+		grid-template-columns: 1fr auto;
+	}
+
+	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) label,
+	.pmpro_section #loginform .login-password label {
+		grid-area: label;
+	}
+
+	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) input,
+	.pmpro_section #loginform .login-password input {
+		grid-area: input;
+	}
+
+	#pmpro_user_fields .pmpro_form_field-password .pmpro_form_field-password-toggle,
+	.pmpro_section #loginform .login-password .pmpro_form_field-password-toggle {
+		grid-area: toggle;
+		justify-self: end;
 	}
 
 	/**

--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -394,6 +394,11 @@
 		width: 20px;
 	}
 
+	.pmpro_form_field-password-toggle button:focus .pmpro_icon-eye svg,
+	.pmpro_form_field-password-toggle button:active .pmpro_icon-eye svg {
+		stroke: var(--pmpro--color--accent--variation);
+	}
+
 	.pmpro_form_field-select2 {
 		display: block;
 	}
@@ -563,6 +568,33 @@
 
 	.pmpro_section #loginform .login-submit .button:active {
 		opacity: .7;
+	}
+
+	/* Move password toggle before field visually but structurally after */
+	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle),
+	.pmpro_section #loginform .login-password {
+		align-items: center;
+		display: grid;
+		grid-template-areas:
+			"label toggle"
+			"input input";
+		grid-template-columns: 1fr auto;
+	}
+
+	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) label,
+	.pmpro_section #loginform .login-password label {
+		grid-area: label;
+	}
+
+	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) input,
+	.pmpro_section #loginform .login-password input {
+		grid-area: input;
+	}
+
+	#pmpro_user_fields .pmpro_form_field-password .pmpro_form_field-password-toggle,
+	.pmpro_section #loginform .login-password .pmpro_form_field-password-toggle {
+		grid-area: toggle;
+		justify-self: end;
 	}
 
 	/**

--- a/includes/login.php
+++ b/includes/login.php
@@ -613,6 +613,7 @@ function pmpro_login_form( $args = array() ) {
 			const toggleWrapper = toggleButton.closest('.pmpro_form_field-password-toggle');
 			const loginForm = toggleWrapper.previousElementSibling;
 			const passwordParagraph = loginForm.querySelector('.login-password');
+			const passwordInput = loginForm.querySelector('#user_pass');
 
 			passwordParagraph.appendChild(toggleWrapper);
 			toggleButton.classList.remove('hide-if-no-js');

--- a/includes/login.php
+++ b/includes/login.php
@@ -612,21 +612,9 @@ function pmpro_login_form( $args = array() ) {
 			const toggleButton = document.querySelectorAll('#pmpro_btn-password-toggle-<?php echo esc_attr( $pmpro_login_form_counter ); ?>')[0];
 			const toggleWrapper = toggleButton.closest('.pmpro_form_field-password-toggle');
 			const loginForm = toggleWrapper.previousElementSibling;
-			const userloginInput = loginForm.querySelector('#user_login');
-			const passwordLabel = loginForm.querySelector('label[for="user_pass"]');
-			const passwordInput = loginForm.querySelector('#user_pass');
-			const remembermeInput = loginForm.querySelector('#rememberme');
-			const submitInput = loginForm.querySelector('#wp-submit');
+			const passwordParagraph = loginForm.querySelector('.login-password');
 
-			// Set tabindex values on form fields.
-			const tabIndexStart = 5 * <?php echo intval( $pmpro_login_form_counter - 1 ); ?>; // Start at 0.
-			userloginInput.setAttribute('tabindex', tabIndexStart + 1);
-			passwordInput.setAttribute('tabindex', tabIndexStart + 2);
-			toggleButton.setAttribute('tabindex', tabIndexStart + 3);
-			remembermeInput.setAttribute('tabindex', tabIndexStart + 4);
-			submitInput.setAttribute('tabindex', tabIndexStart + 5);
-
-			passwordLabel.appendChild(toggleWrapper);
+			passwordParagraph.appendChild(toggleWrapper);
 			toggleButton.classList.remove('hide-if-no-js');
 			toggleButton.addEventListener('click', togglePassword);
 

--- a/includes/login.php
+++ b/includes/login.php
@@ -596,11 +596,12 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
  * @since 2.3
  */
 function pmpro_login_form( $args = array() ) {
+	static $pmpro_login_form_counter = 1;
 	add_filter( 'login_form_top', 'pmpro_login_form_hidden_field' );
 	wp_login_form( $args );
 	?>
 	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle' ) ); ?>">
-		<button type="button" class="pmpro_btn pmpro_btn-plain pmpro_btn-password-toggle-alt hide-if-no-js" data-toggle="0" tabindex="3">
+		<button type="button" id="pmpro_btn-password-toggle-<?php echo esc_attr( $pmpro_login_form_counter ); ?>" class="pmpro_btn pmpro_btn-plain hide-if-no-js" data-toggle="0">
 			<span class="pmpro_icon pmpro_icon-eye" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>
 			<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle-state' ) ); ?>"><?php esc_html_e( 'Show Password', 'paid-memberships-pro' ); ?></span>
 		</button>
@@ -608,25 +609,26 @@ function pmpro_login_form( $args = array() ) {
 	<script>
 		// Password visibility toggle (wp_login_form instance).
 		(function() {
-			const toggleButton = document.querySelectorAll('.pmpro_btn-password-toggle-alt');
-			const toggleWrapper = document.querySelector('.pmpro_form_field-password-toggle');
-			const userloginInput = document.querySelector('#user_login');
-			const passwordLabel = document.querySelector('label[for="user_pass"]');
-			const passwordInput = document.querySelector('#user_pass');
-			const remembermeInput = document.querySelector('#rememberme');
-			const submitInput = document.querySelector('#wp-submit');
+			const toggleButton = document.querySelectorAll('#pmpro_btn-password-toggle-<?php echo esc_attr( $pmpro_login_form_counter ); ?>')[0];
+			const toggleWrapper = toggleButton.closest('.pmpro_form_field-password-toggle');
+			const loginForm = toggleWrapper.previousElementSibling;
+			const userloginInput = loginForm.querySelector('#user_login');
+			const passwordLabel = loginForm.querySelector('label[for="user_pass"]');
+			const passwordInput = loginForm.querySelector('#user_pass');
+			const remembermeInput = loginForm.querySelector('#rememberme');
+			const submitInput = loginForm.querySelector('#wp-submit');
 
 			// Set tabindex values on form fields.
-			userloginInput.setAttribute('tabindex', '1');
-			passwordInput.setAttribute('tabindex', '2');
-			remembermeInput.setAttribute('tabindex', '4');
-			submitInput.setAttribute('tabindex', '5');
+			const tabIndexStart = 5 * <?php echo intval( $pmpro_login_form_counter - 1 ); ?>; // Start at 0.
+			userloginInput.setAttribute('tabindex', tabIndexStart + 1);
+			passwordInput.setAttribute('tabindex', tabIndexStart + 2);
+			toggleButton.setAttribute('tabindex', tabIndexStart + 3);
+			remembermeInput.setAttribute('tabindex', tabIndexStart + 4);
+			submitInput.setAttribute('tabindex', tabIndexStart + 5);
 
-			toggleButton.forEach(toggle => {
-				passwordLabel.appendChild(toggleWrapper);
-				toggle.classList.remove('hide-if-no-js');
-				toggle.addEventListener('click', togglePassword);
-			});
+			passwordLabel.appendChild(toggleWrapper);
+			toggleButton.classList.remove('hide-if-no-js');
+			toggleButton.addEventListener('click', togglePassword);
 
 			function togglePassword() {
 				const status = this.getAttribute('data-toggle');
@@ -636,7 +638,7 @@ function pmpro_login_form( $args = array() ) {
 
 				if (parseInt(status, 10) === 0) {
 					this.setAttribute('data-toggle', 1);
-					passwordInputs.forEach(input => input.setAttribute('type', 'text'));
+					passwordInput.setAttribute( 'type', 'text' );
 					icon.innerHTML = `
 						<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye-off">
 							<path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
@@ -645,7 +647,7 @@ function pmpro_login_form( $args = array() ) {
 					state.textContent = '<?php esc_html_e( 'Hide Password', 'paid-memberships-pro' ); ?>';
 				} else {
 					this.setAttribute('data-toggle', 0);
-					passwordInputs.forEach(input => input.setAttribute('type', 'password'));
+					passwordInput.setAttribute( 'type', 'password' );
 					icon.innerHTML = `
 						<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye">
 							<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
@@ -658,6 +660,7 @@ function pmpro_login_form( $args = array() ) {
 	</script>
 	<?php
 	remove_filter( 'login_form_top', 'pmpro_login_form_hidden_field' );
+	$pmpro_login_form_counter++;
 }
 
 /**

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -223,7 +223,7 @@ if ( empty( $default_gateway ) ) {
 							</div> <!-- end pmpro_form_field-password -->
 
 							<?php
-								if ( $pmpro_checkout_confirm_password || true) {
+								if ( $pmpro_checkout_confirm_password ) {
 									?>
 									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-password pmpro_form_field-required', 'pmpro_form_field-password2' ) ); ?>">
 										<label for="password2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Confirm Password', 'paid-memberships-pro' );?></label>

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -210,20 +210,20 @@ if ( empty( $default_gateway ) ) {
 							?>
 
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-password pmpro_form_field-required' ) ); ?>">
+								<label for="password" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+									<?php esc_html_e( 'Password', 'paid-memberships-pro' );?>
+								</label>
+								<input type="password" name="password" id="password" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-password pmpro_form_input-required', 'password' ) ); ?>" autocomplete="new-password" spellcheck="false" value="<?php echo esc_attr($password); ?>" />
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle' ) ); ?>">
-									<label for="password" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-										<?php esc_html_e( 'Password', 'paid-memberships-pro' );?>
-									</label>
-									<button type="button" class="pmpro_btn pmpro_btn-plain pmpro_btn-password-toggle hide-if-no-js" data-toggle="0" tabindex="-1">
+									<button type="button" class="pmpro_btn pmpro_btn-plain pmpro_btn-password-toggle hide-if-no-js" data-toggle="0">
 										<span class="pmpro_icon pmpro_icon-eye" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>
-										<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle-state' ) ); ?>"><?php esc_html_e( 'Show Password', 'paid-memberships-pro' ); ?></span>
+											<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle-state' ) ); ?>"><?php esc_html_e( 'Show Password', 'paid-memberships-pro' ); ?></span>
 									</button>
 								</div> <!-- end pmpro_form_field-password-toggle -->
-								<input type="password" name="password" id="password" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-password pmpro_form_input-required', 'password' ) ); ?>" autocomplete="new-password" spellcheck="false" value="<?php echo esc_attr($password); ?>" />
 							</div> <!-- end pmpro_form_field-password -->
 
 							<?php
-								if ( $pmpro_checkout_confirm_password ) {
+								if ( $pmpro_checkout_confirm_password || true) {
 									?>
 									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-password pmpro_form_field-required', 'pmpro_form_field-password2' ) ); ?>">
 										<label for="password2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Confirm Password', 'paid-memberships-pro' );?></label>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing bug where "toggle password" buttons would be linked if there were multiple login pages on a single page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
