### PR TITLE
Showing notice if order/sub data may be linked to incorrect users

### DIFF
--- a/includes/updates/upgrade_3_1.php
+++ b/includes/updates/upgrade_3_1.php
@@ -8,6 +8,8 @@
  * @since 3.1
  */
 function pmpro_upgrade_3_1() {
+	global $wpdb;
+
     delete_option( 'pmpro_sslseal' );
     delete_option( 'pmpro_accepted_credit_cards' );
 
@@ -24,4 +26,58 @@ function pmpro_upgrade_3_1() {
 
 	// Delete the pmpro_stripe_update_billing_flow option. The update billing flow now matches the payment flow.
 	delete_option( 'pmpro_stripe_update_billing_flow' );
+
+	// In this update, we updated some user_id columns from int(11) to bigint(20). We want to detect sites that may have run into issues with int(11) previously.
+	// The plan is to check if there is a PMPro order with a user ID greater than 4294967295. If so, we will show a notice on the PMPro dashboard.
+	// We are checking orders because on the vast majority of sites, users will always have an order created if they have a subscription associated with them.
+	global $wpdb;
+	$high_user_id_order_exists = $wpdb->get_var( "SELECT user_id FROM $wpdb->pmpro_membership_orders WHERE user_id > 4294967295 LIMIT 1" );
+	if ( $high_user_id_order_exists ) {
+		update_option( 'pmpro_upgrade_3_1_notice', true );
+	}
 }
+
+/**
+ * Show a notice on the PMPro dashboard if there are orders with user IDs greater than 4294967295.
+ * This is to alert users that they may have run into issues with user IDs being too large for the int(11) column.
+ *
+ * @since 3.1
+ */
+function pmpro_show_upgrade_3_1_notice() {
+	// Check if we need to show the notice.
+	if ( ! get_option( 'pmpro_upgrade_3_1_notice' ) ) {
+		return;
+	}
+
+	// Only show on PMPro admin pages.
+	if ( empty( $_REQUEST['page'] ) || strpos( $_REQUEST['page'], 'pmpro' ) === false ) {
+		return;
+	}
+
+	// Check if the user has dismissed the notice.
+	if ( ! empty( $_REQUEST['pmpro-hide-upgrade_3_1-notice'] ) ) {
+		delete_option( 'pmpro_upgrade_3_1_notice' );
+		return;
+	}
+
+	// Show a dismissable notice. Do not show a link to scrub data.
+	?>
+	<div class="notice notice-warning" id="pmpro-upgrade-3-1-notice">
+		<p>
+			<?php
+			printf(
+				wp_kses_post(
+					__( 'Paid Memberships Pro has detected data that may not be linked to the correct user in your database. For more information, read our <a href="%s">post here</a>.', 'paid-memberships-pro' )
+				),
+				esc_url( 'https://www.paidmembershipspro.com/pmpro-update-3-1/' )
+			);
+			?>
+		</p>
+		<p>
+			<a href="<?php echo esc_url( add_query_arg( 'pmpro-hide-upgrade_3_1-notice', '1' ) ); ?>"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></a>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'pmpro_show_upgrade_3_1_notice' );
+

--- a/includes/updates/upgrade_3_1.php
+++ b/includes/updates/upgrade_3_1.php
@@ -63,11 +63,12 @@ function pmpro_show_upgrade_3_1_notice() {
 	// Show a dismissable notice. Do not show a link to scrub data.
 	?>
 	<div class="notice notice-warning" id="pmpro-upgrade-3-1-notice">
+		<p><strong><?php esc_html_e( 'Important Notice: Paid Memberships Pro v3.1 Update', 'paid-memberships-pro' ); ?></strong></p>
 		<p>
 			<?php
 			printf(
 				wp_kses_post(
-					__( 'Paid Memberships Pro has detected data that may not be linked to the correct user in your database. For more information, read our <a href="%s">post here</a>.', 'paid-memberships-pro' )
+					__( 'In previous versions of PMPro, we discovered an issue where subscriptions were not linked to the correct user ID in the database. The current version you are running has resolved this issue, however we detect that some of your subscriptions need to be manually corrected. For more information and steps to resolve this for your site, read our <a href="%s">v3.1 release notes post here</a>.', 'paid-memberships-pro' )
 				),
 				esc_url( 'https://www.paidmembershipspro.com/pmpro-update-3-1/' )
 			);

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -371,17 +371,13 @@ function pmpro_checkForUpgrades() {
 	 * Delete the option for pmpro_accepted_credit_cards.
 	 * Modify and set new options for membership required messages.
 	 */
+	require_once( PMPRO_DIR . "/includes/updates/upgrade_3_1.php" );
 	if ( $pmpro_db_version < 3.1001 ) {
 		// Run the dbDelta function for fixing some int columns to be bigint.
-		// Added after 3.1 RCs were released, so DB version for this is 3.1001.
 		pmpro_db_delta();
 
 		// Run the upgrade function for 3.1.
-		if ( $pmpro_db_version < 3.1 ) {
-			require_once( PMPRO_DIR . "/includes/updates/upgrade_3_1.php" );
-			pmpro_upgrade_3_1(); // This function will update the db version.
-		}
-
+		pmpro_upgrade_3_1();
 		update_option( 'pmpro_db_version', '3.1001' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In 3.1, we are fixing some user_id columns (order meta, subscriptions, subscription meta) by changing the data type from int(11) to bigint(20). We want to show notices to sites that may have issues due to user IDs having been too high to be tracked in those tables.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

Testing this requires editing code to force the 3.1 update to run and either:
1. Having a site with user IDs larger than 4294967295
2. Editing the code to reduce 4294967295 in the query to something like 100

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
