### PR TITLE
Workaround to use get_date_from_gmt to format into 'U'

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -783,6 +783,12 @@ class PMPro_Subscription {
 
 		// Get date in WP local timezone.
 		if ( $local_time ) {
+			if( 'U' === $format ){
+				// When formatting using the epoch, the date must already consider the timezone offset.
+				// Then, first apply a simple format to add the timezone.
+				$date = get_date_from_gmt( $date );
+			}
+
 			return get_date_from_gmt( $date, $format );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix the next payment date TIME (and the cancel date TIME if using CONPD in core) to consider the timezone.
When usign get_date_from_gmt with format = 'U', the result does not consider the timezone.
Then, a solution is to call that function twice. One to add the timezone, then to format the datetime.

### How to test the changes in this Pull Request:

1. Create a new subscription
2. Check the TIME of the next payment/cancellation

It will be a cycle ahead (MINUS or PLUS the timezone).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
