### PR TITLE
Adding data-title attributes to Membership Levels table

### DIFF
--- a/css/frontend/base.css
+++ b/css/frontend/base.css
@@ -572,11 +572,13 @@ button[type="button"]#other_discount_code_toggle:focus {
 		content: attr(data-title) ": ";
 	}
 
-	.pmpro_table_cancel tbody tr td:last-child {
+	.pmpro_table_cancel tbody tr td:last-child,
+	.pmpro_levels_table tbody tr td:last-child {
 		display: block;
 	}
 
-	.pmpro_table_cancel tbody tr td:last-child::before {
+	.pmpro_table_cancel tbody tr td:last-child::before,
+	.pmpro_levels_table tbody tr td:last-child::before {
 		content: "";
 	}
 }

--- a/pages/levels.php
+++ b/pages/levels.php
@@ -95,8 +95,8 @@ $level_groups  = pmpro_get_level_groups_in_order();
 										$element_class = implode( ' ', array_unique( $element_classes ) );
 									?>
 									<tr id="pmpro_level-<?php echo esc_attr( $level->id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $element_class, 'pmpro_level-' . esc_attr( $level->id ) ) ); ?>">
-										<th ><?php echo esc_html( $level->name ); ?></th>
-										<td>
+										<th data-title="<?php esc_attr_e( 'Level', 'paid-memberships-pro' ); ?>"><?php echo esc_html( $level->name ); ?></th>
+										<td data-title="<?php esc_attr_e( 'Price', 'paid-memberships-pro' ); ?>">
 											<?php
 												$cost_text = pmpro_getLevelCost( $level, true, true );
 												if ( ! empty($cost_text ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Small catch so the levels table collapses nicely for mobile.
