### PR TITLE
Add hook inside lost password form

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -665,6 +665,16 @@ function pmpro_lost_password_form() { ?>
 					<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ); ?>"> <abbr title="<?php esc_html_e( 'Required Field', 'paid-memberships-pro' ); ?>">*</abbr></span>
 				</label>
 				<input type="text" name="user_login" id="user_login" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text pmpro_form_input-required pmpro_form_input-user_login', 'user_login' ) ); ?>" aria-required="true" />
+				<?php 
+					/**
+					 * Insert HTML after the lost password form fields.
+					 * 
+					 * @since 3.2
+					 * 
+					 * @param string $html The HTML to be output.
+					 */
+					echo apply_filters( 'pmpro_lost_password_after_fields', '' ); 
+				?> 
 			</div>
 		</div> <!-- end pmpro_form_fields -->
 		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Add  `pmpro_lost_password_after_fields` filter.

Resolves #3072 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

ENHANCEMENT: Added filter to insert extra HTML inside lost password form.
