### PR TITLE
Initial work to add Elementor widget versions of our core page shortcodes

### DIFF
--- a/includes/compatibility/elementor/class-pmpro-elementor.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor.php
@@ -30,13 +30,20 @@ class PMPro_Elementor {
 	 * Register new section for PMPro Required Membership Levels.
 	 */
 	public function __construct() {
-        
-        require_once( __DIR__ . '/class-pmpro-elementor-content-restriction.php' );
-        // Register new section to display restriction controls
-        $this->register_sections();
 
-        $this->content_restriction();
-	}
+		require_once( __DIR__ . '/class-pmpro-elementor-content-restriction.php' );
+
+		// Register our custom widgets.
+		add_action( 'elementor/widgets/widgets_registered', array( $this, 'init' ) );
+
+		// Create a new category for our widgets.
+		add_action( 'elementor/elements/categories_registered', array( $this, 'add_widget_categories' ) );
+
+		// Register new section to display restriction controls
+		$this->register_sections();
+		$this->content_restriction();
+
+    }
 
     /**
      *
@@ -49,6 +56,45 @@ class PMPro_Elementor {
             self::$_instance = new self();
 
         return self::$_instance;
+    }
+
+	/**
+	 * Initialize the widgets.
+	 */
+	public function init() {
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-base.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-account.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-billing.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-cancel.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-checkout.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-confirmation.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-order.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-levels.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-login.php';
+		require_once __DIR__ . '/widgets/class-pmpro-elementor-widget-member-profile-edit.php';
+
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Account() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Billing() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Cancel() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Checkout() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Confirmation() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Order() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Levels() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Login() );
+		\Elementor\Plugin::instance()->widgets_manager->register( new PMPro_Elementor_Widget_Member_Profile_Edit() );
+	}
+
+    /**
+     * Add a new category for our widgets.
+     */
+    public function add_widget_categories( $elements_manager ) {
+        $elements_manager->add_category(
+            'paid-memberships-pro',
+            [
+                'title' => __( 'Paid Memberships Pro', 'paid-memberships-pro' ),
+                'icon'  => 'dashicons-before admin-users',
+            ]
+        );
     }
 
     private function register_sections() {

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-account.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-account.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Account extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_account_widget';
+	}
+
+	public function get_title() {
+		return __( 'PMPro Page: Account (Full)', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'PMPro Page: Account (Full)', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Displays all sections of the Membership Account page including Memberships, Profile, Orders, and Member Links. These sections can also be added via separate widgets.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_account]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-base.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-base.php
@@ -1,0 +1,39 @@
+<?php
+
+abstract class PMPro_Elementor_Widget_Base extends \Elementor\Widget_Base {
+
+	public function __construct( $data = array(), $args = null ) {
+		parent::__construct( $data, $args );
+	}
+
+	public function get_icon() {
+		return 'dashicons-before dashicons-admin-users';
+	}
+
+	public function get_categories() {
+		return array( 'paid-memberships-pro' );
+	}
+
+	protected function add_footer_promo_control() {
+
+		$this->add_control(
+			'pmpro_footer_promo',
+			array(
+				'label'           => '',
+				'type'            => \Elementor\Controls_Manager::RAW_HTML,
+				'raw'             => '<hr><p style="margin-top: 20px;">' . sprintf( esc_html__( 'Learn more about %1$sediting your PMPro-powered membership site with Elementor%2$s', 'paid-memberships-pro' ), '<a target="_blank" href="#">', '</a>' ) . '</p>',
+				'content_classes' => 'pmpro-footer-promo',
+			)
+		);
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo 'hi';
+	}
+
+	protected function _content_template() {
+		// Define your template variables here
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-billing.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-billing.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Billing extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_billing_widget';
+	}
+
+	public function get_title() {
+		return __( 'PMPro Page: Billing', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'PMPro Page: Billing', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic page section to display the member billing information. Members can update their subscription payment method from this form.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_billing]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-cancel.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-cancel.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Cancel extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_cancel_widget';
+	}
+
+	public function get_title() {
+		return __( 'PMPro Page: Cancel', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'PMPro Page: Cancel', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic page section where members can cancel their membership and active subscription if applicable.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_cancel]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-checkout.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-checkout.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Checkout extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_checkout_widget';
+	}
+
+	public function get_title() {
+		return __( 'Membership Checkout Form', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'Membership Checkout Form', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic form that allows users to complete free registration or paid checkout for the selected membership level.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_checkout]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-confirmation.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-confirmation.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Confirmation extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_confirmation_widget';
+	}
+
+	public function get_title() {
+		return __( 'PMPro Page: Confirmation', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'PMPro Page: Confirmation', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic page section that displays a confirmation message and purchase information for the active member immediately after membership registration and checkout.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_confirmation]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-levels.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-levels.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Levels extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_levels_widget';
+	}
+
+	public function get_title() {
+		return __( 'Membership Levels and Pricing Table', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'Membership Levels and Pricing Table', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic page section that displays a list of membership levels and pricing, linked to membership checkout. To reorder the display, navigate to Memberships > Settings > Levels.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_levels]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-login.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-login.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Login extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_login_widget';
+	}
+
+	public function get_title() {
+		return __( 'Login Form', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'Login Form', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic form that allows users to log in or recover a lost password. Logged in users can see a welcome message with the selected custom menu.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_login]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-member-profile-edit.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-member-profile-edit.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Member_Profile_Edit extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_member_profile_edit_widget';
+	}
+
+	public function get_title() {
+		return __( 'PMPro Page: Account Profile Edit', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'PMPro Page: Account Profile Edit', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic form that allows the current logged in member to edit their default user profile information and any custom user profile fields.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_member_profile_edit]' );
+	}
+}

--- a/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-order.php
+++ b/includes/compatibility/elementor/widgets/class-pmpro-elementor-widget-order.php
@@ -1,0 +1,41 @@
+<?php
+
+class PMPro_Elementor_Widget_Order extends PMPro_Elementor_Widget_Base {
+
+	public function get_name() {
+		return 'pmpro_order_widget';
+	}
+
+	public function get_title() {
+		return __( 'PMPro Page: Orders', 'paid-memberships-pro' );
+	}
+
+	protected function _register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			array(
+				'label' => __( 'PMPro Page: Orders', 'paid-memberships-pro' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_CONTENT,
+			)
+		);
+
+		$this->add_control(
+			'description',
+			array(
+				'label'     => esc_html__( 'Dynamic page section that displays a list of all orders (purchase history) for the active member. Each order can be selected and viewed in full detail.', 'paid-memberships-pro' ),
+				'type'      => \Elementor\Controls_Manager::HEADING,
+				'separator' => 'before',
+			)
+		);
+
+		$this->add_footer_promo_control();
+
+		$this->end_controls_section();
+	}
+
+	protected function render() {
+		$settings = $this->get_settings_for_display();
+
+		echo do_shortcode( '[pmpro_invoice]' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This is the start of some work to add Elementor Widget versions of our various shortcodes. This version has mixed rendering the Elementor preview - some preview nicely while others just show as an unrendered shortcode.

That might be ok. Maybe not. Page builder people definitely have ideas of how the visual building experience should function. This is a positive step in the direction of giving them the ability to insert our "things" in their pages.

We can consider to do more work here per-widget to add settings, we could convert PMPro pages from the shortcode to the "widget" when people click "Edit With Elementor" and we detect our shortcode was in use. I'll be writing a pitch related to this exploratory work.

![Screenshot 2024-07-19 at 12 43 15 PM](https://github.com/user-attachments/assets/12516682-947d-467f-a4fa-7803524be318)
![Screenshot 2024-07-19 at 12 43 29 PM](https://github.com/user-attachments/assets/1d9de32e-57b8-428c-a642-0840731d88f0)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
