### PR TITLE
Fix display issue on iPhone where password field and toggle were over…

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -973,6 +973,10 @@
 			width: auto;
 		}
 
+		#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) {
+			width: 100%;
+		}
+
 	}
 
 }

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -958,6 +958,10 @@
 			width: auto;
 		}
 
+		#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) {
+			width: 100%;
+		}
+
 	}
 
 }


### PR DESCRIPTION
…lapping other fields

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes display issue where password field would overlap others in the Account Information section on Membership Checkout only when the "confirm" field was also shown. This appeared to only be happening on iOS mobile devices.

![Screenshot 2024-07-22 at 10 50 07 AM](https://github.com/user-attachments/assets/de9b02f7-7e97-463d-9395-c090d25d8757)
Before fix - overlap


![Screenshot 2024-07-22 at 10 49 58 AM](https://github.com/user-attachments/assets/c625dfbb-0cb9-4b4a-94db-047091648c30)
With fix - no overlap

In tests, this was not an issue on the regular password login / reset fields OR on the logged in profile edit > change password view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
