### PR TITLE
Ensure echoing when escaping attributes

### DIFF
--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -393,7 +393,7 @@ if ( empty( $default_gateway ) ) {
 										</select>
 									</div> <!-- end pmpro_form_field-bcountry -->
 								<?php } else { ?>
-									<input type="hidden" name="bcountry" id="bcountry" value="<?php esc_attr_e( $pmpro_default_country ) ?>" />
+									<input type="hidden" name="bcountry" id="bcountry" value="<?php echo esc_attr( $pmpro_default_country ); ?>" />
 								<?php } ?>
 							<?php if($skip_account_fields) { ?>
 							<?php

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -186,9 +186,9 @@ if ( empty( $default_gateway ) ) {
 
 						<?php if ( ! $skip_account_fields && ! $pmpro_review ) { ?>
 
-							<?php 
+							<?php
 								// Get discount code from URL parameter, so if the user logs in it will keep it applied.
-								$discount_code_link = !empty( $discount_code) ? '&pmpro_discount_code=' . $discount_code : ''; 
+								$discount_code_link = !empty( $discount_code) ? '&pmpro_discount_code=' . $discount_code : '';
 							?>
 
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-username pmpro_form_field-required', 'pmpro_form_field-username' ) ); ?>">
@@ -281,7 +281,7 @@ if ( empty( $default_gateway ) ) {
 								<input id="fullname" name="fullname" type="text" value="" autocomplete="off"/> <strong><?php esc_html_e('LEAVE THIS BLANK', 'paid-memberships-pro' );?></strong>
 							</div> <!-- end pmpro_hidden -->
 
-						<?php } elseif ( $current_user->ID && ! $pmpro_review ) { ?>			
+						<?php } elseif ( $current_user->ID && ! $pmpro_review ) { ?>
 							<div id="pmpro_account_loggedin">
 							<?php
 								$allowed_html = array(
@@ -393,7 +393,7 @@ if ( empty( $default_gateway ) ) {
 										</select>
 									</div> <!-- end pmpro_form_field-bcountry -->
 								<?php } else { ?>
-									<input type="hidden" name="bcountry" id="bcountry" value="<?php esc_attr( $pmpro_default_country ) ?>" />
+									<input type="hidden" name="bcountry" id="bcountry" value="<?php esc_attr_e( $pmpro_default_country ) ?>" />
 								<?php } ?>
 							<?php if($skip_account_fields) { ?>
 							<?php

--- a/shortcodes/checkout_button.php
+++ b/shortcodes/checkout_button.php
@@ -14,9 +14,9 @@ function pmpro_checkout_button_shortcode($atts, $content=null, $code="")
 		'text' => NULL,
 		'class' => NULL
 	), $atts));
-	
+
 	ob_start(); ?>
- 	<span class="<?php esc_attr( pmpro_get_element_class( 'span_pmpro_checkout_button' ) ); ?>">
+ 	<span class="<?php esc_attr_e( pmpro_get_element_class( 'span_pmpro_checkout_button' ) ); ?>">
  		<?php
 			//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo pmpro_getCheckoutButton($level, $text, $class);

--- a/shortcodes/checkout_button.php
+++ b/shortcodes/checkout_button.php
@@ -16,7 +16,7 @@ function pmpro_checkout_button_shortcode($atts, $content=null, $code="")
 	), $atts));
 
 	ob_start(); ?>
- 	<span class="<?php esc_attr_e( pmpro_get_element_class( 'span_pmpro_checkout_button' ) ); ?>">
+ 	<span class="<?php echo esc_attr( pmpro_get_element_class( 'span_pmpro_checkout_button' ) ); ?>">
  		<?php
 			//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo pmpro_getCheckoutButton($level, $text, $class);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves the issue we had about required field not filled in in checkout without additional warning.
This is because when not using international addresses, the default country is not written into the hidden field.

### How to test the changes in this Pull Request:

1. Deactivate international addresses (via filter)
2. Then see the checkout working again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
