### PR TITLE
Removing testing code causing billing address to always show on update billing

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -187,7 +187,7 @@
 
 						<?php
 							$pmpro_include_billing_address_fields = apply_filters('pmpro_include_billing_address_fields', true);
-							if($pmpro_include_billing_address_fields  || true)
+							if($pmpro_include_billing_address_fields )
 							{
 						?>
 						<fieldset id="pmpro_billing_address_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_billing_address_fields' ) ); ?>">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Screenshot of up
![Screenshot 2024-07-24 at 10 37 19 AM](https://github.com/user-attachments/assets/c5007e4d-790a-4af5-a776-59da42981b1b)
date billing page after fix with billing address disabled:


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
