### PR TITLE
Fixing saving Confirmation Page block

### DIFF
--- a/pages/confirmation.php
+++ b/pages/confirmation.php
@@ -13,6 +13,7 @@
 global $wpdb, $pmpro_invoice, $pmpro_msg, $pmpro_msgt;
 
 // If this file is loaded, $pmpro_invoice should have been set by preheaders/confirmation.php. If not, show an error.
+// Below, we should still check if $pmpro_invoice is empty as there are edge cases such as saving a page with the Confirmation block in the block editor.
 if ( empty( $pmpro_invoice ) ) {
 	$pmpro_msg = __( 'There was an error retrieving your order. Please contact the site owner.', 'paid-memberships-pro' );
 	$pmpro_msgt = 'pmpro_error';
@@ -134,7 +135,7 @@ if ( empty( $pmpro_invoice ) ) {
 	</section> <!-- end pmpro_confirmation -->
 </div> <!-- end pmpro -->
 <?php
-	if ( ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
+	if ( ! empty( $pmpro_invoice ) && ! pmpro_isLevelFree( $pmpro_invoice->membership_level ) ) {
 		// If the order is not free, show the full order, but make sure we don't show $pmpro_msg again.
 		$pmpro_msg = false;
 		$pmpro_msgt = false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes issue where you cannot save a page with the Confirmation Page block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
