### PR TITLE
Fix our lost password form submitting to the LifterLMS form (when streamline is enabled)

### DIFF
--- a/includes/compatibility/lifterlms.php
+++ b/includes/compatibility/lifterlms.php
@@ -635,3 +635,23 @@ function pmpro_lifter_ajax_llms_widget_sold_pmpro() {
 	exit;
 }
 add_filter( 'wp_ajax_llms_widget_sold_pmpro', 'pmpro_lifter_ajax_llms_widget_sold_pmpro' );
+
+/**
+ * Make sure the PMPro lost password form
+ * doesn't submit to the LifterLMS lost password form.
+ *
+ * @since TBD
+ */
+function pmpro_maybe_remove_lifterlms_lostpassword_url_filter() {
+	// Bail	if streamline is not enabled.
+	if ( ! get_option( 'pmpro_lifter_streamline' ) ) {
+		return;
+	}
+
+	global $pmpro_pages;
+
+	if ( ! empty( $pmpro_pages ) && ! empty( $pmpro_pages['login'] ) && is_page( $pmpro_pages['login'] ) ) {
+		remove_filter( 'lostpassword_url', 'llms_lostpassword_url', 10, 0 );
+	}
+}
+add_action( 'wp', 'pmpro_maybe_remove_lifterlms_lostpassword_url_filter' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
PMPro's login form was submitting to the filtered LifterLMS Student Dashboard page. This update unhooks the LifterLMS lostpassword_url filter (similar to how we do for WooCommerce), so that our password reset process works as intended.

