### PR TITLE
Adding hook pmpro_lost_password_before_submit_button

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -667,6 +667,14 @@ function pmpro_lost_password_form() { ?>
 				<input type="text" name="user_login" id="user_login" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text pmpro_form_input-required pmpro_form_input-user_login', 'user_login' ) ); ?>" aria-required="true" />
 			</div>
 		</div> <!-- end pmpro_form_fields -->
+		<?php 
+		/**
+		 * Insert HTML before the submit button on the lost password form.
+		 * 
+		 * @since TBD
+		 */
+		echo do_action( 'pmpro_lost_password_before_submit_button' ); 
+		?>
 		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
 			<input type="hidden" name="pmpro_login_form_used" value="1" />
 			<input type="submit" name="submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit', 'pmpro_btn-submit' ) ); ?>" value="<?php esc_attr_e( 'Get New Password', 'paid-memberships-pro' ); ?>" />

--- a/includes/login.php
+++ b/includes/login.php
@@ -673,7 +673,7 @@ function pmpro_lost_password_form() { ?>
 		 * 
 		 * @since TBD
 		 */
-		echo do_action( 'pmpro_lost_password_before_submit_button' ); 
+		do_action( 'pmpro_lost_password_before_submit_button' ); 
 		?>
 		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">
 			<input type="hidden" name="pmpro_login_form_used" value="1" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Alternative to #3073

Resolves #3072

This solution mirrors the `pmpro_checkout_before_submit_button` and `pmpro_billing_before_submit_button` hooks that we have on the checkout and update billing forms.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
