### PR TITLE
Fixing free orders when PPS is the set gateway

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -197,6 +197,11 @@
 			if(empty($morder))
 				return;
 
+			// If this isn't a PayPal Standard order, bail.
+			if ( 'paypalstandard' !== $morder->gateway ) {
+				return;
+			}
+
 			$morder->user_id = $user_id;
 			$morder->saveOrder();
 

--- a/classes/gateways/class.pmprogateway_twocheckout.php
+++ b/classes/gateways/class.pmprogateway_twocheckout.php
@@ -227,6 +227,12 @@
 			if(empty($morder))
 				return;
 
+			// If this isn't a 2Checkout order, bail.
+			if ( 'twocheckout' !== $morder->gateway ) {
+				return;
+			}
+
+
 			$morder->user_id = $user_id;
 			$morder->saveOrder();
 


### PR DESCRIPTION
### All Submissions:

Fixing free orders when PayPal Standard is the set gateway.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
