### PR TITLE
Change submit url to target the specific member panel, to keep the URL consistent

### DIFF
--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -89,9 +89,9 @@ abstract class PMPro_Member_Edit_Panel {
 
 			// Get the URL to submit to.
 			$submit_url = add_query_arg( [
-          'user_id' => self::get_user()->ID,
-          'pmpro_member_edit_panel' => $this->slug
-      ], admin_url( 'admin.php?page=pmpro-member' ) );
+				'user_id' => self::get_user()->ID,
+				'pmpro_member_edit_panel' => $this->slug
+			], admin_url( 'admin.php?page=pmpro-member' ) );
 			?>
 			<form class="pmpro-members" action="<?php echo esc_url( $submit_url ); ?>" method="post">
 				<?php

--- a/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
+++ b/adminpages/member-edit/pmpro-abstract-class-member-edit-panel.php
@@ -88,10 +88,12 @@ abstract class PMPro_Member_Edit_Panel {
 			echo wp_kses( $this->title_link, array( 'a' => array( 'href' => array(), 'target' => array(), 'class' => array() ) ) );
 
 			// Get the URL to submit to.
-			$submit_url = add_query_arg( 'user_id', self::get_user()->ID, admin_url( 'admin.php?page=pmpro-member' ) );
+			$submit_url = add_query_arg( [
+          'user_id' => self::get_user()->ID,
+          'pmpro_member_edit_panel' => $this->slug
+      ], admin_url( 'admin.php?page=pmpro-member' ) );
 			?>
 			<form class="pmpro-members" action="<?php echo esc_url( $submit_url ); ?>" method="post">
-				<input type="hidden" name="pmpro_member_edit_panel" value="<?php echo esc_attr( $this->slug ); ?>">
 				<?php
 				// Add a nonce.
 				wp_nonce_field( 'pmpro_member_edit_saved_panel_' . $this->slug, 'pmpro_member_edit_saved_panel_nonce' );
@@ -103,7 +105,7 @@ abstract class PMPro_Member_Edit_Panel {
 				if ( ! empty( $this->submit_text ) ) {
 					// If this is the selected panel, set the submit button ID.
 					// Needed for the 'user-profile' script on the user info panel when creating a new user.
-					$submit_id = $is_selected ? 'submit' : ''; 
+					$submit_id = $is_selected ? 'submit' : '';
 					?>
 					<p class="submit">
 						<input id="<?php echo esc_attr( $submit_id ); ?>" type="submit" name="submit" class="button button-primary" value="<?php echo esc_attr( $this->submit_text ); ?>">
@@ -112,7 +114,7 @@ abstract class PMPro_Member_Edit_Panel {
 				}
 				?>
 			</form>
-		</div>			
+		</div>
 		<?php
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Before this fix, when you change a Level manually, after saving you going to see that:
- You are still on the Member > Membership tab (because of the hidden field `pmpro_member_edit_panel`)
- The URL does NOT contain the `pmpro_member_edit_panel` anymore
- Refreshing the page will bring you away from the Member > Membership panel obviously

Moving the `pmpro_member_edit_panel` directive from the hidden field to the submit action will make the URL consistent after saving.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
