### PR TITLE
Fixing reCAPTCHA and payment request button at checkout

### DIFF
--- a/js/pmpro-recaptcha-v3.js
+++ b/js/pmpro-recaptcha-v3.js
@@ -58,13 +58,11 @@ var pmpro_recaptcha_onloadCallback = function () {
     var recaptcha_widget = jQuery('#pmpro_btn-submit').prev();
     recaptcha_widget.insertAfter( submit_span );
 
-    // Update other submit buttons.
-    submit_buttons.each(function () {
-        if (jQuery(this).attr('id') != 'pmpro_btn-submit') {
-            jQuery(this).click(function (event) {
-                event.preventDefault();
-                grecaptcha.execute();
-            });
+    // Run when the form is submitted.
+    jQuery('#pmpro_form, .pmro_form').submit(function (event) {
+        if (!pmpro_recaptcha_validated) {
+            event.preventDefault();
+            grecaptcha.execute();
         }
     });
 };

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -288,7 +288,7 @@ jQuery( document ).ready( function( $ ) {
 			form.append( '<input type="hidden" name="AccountNumber" value="XXXXXXXXXXXX' + card.last4 + '"/>' );
 			form.append( '<input type="hidden" name="ExpirationMonth" value="' + ( '0' + card.exp_month ).slice( -2 ) + '"/>' );
 			form.append( '<input type="hidden" name="ExpirationYear" value="' + card.exp_year + '"/>' );
-			form.get(0).submit();
+			form.submit();
 			return true;
 		}
 	}

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -80,6 +80,12 @@ jQuery( document ).ready( function( $ ) {
 			return;
 		}
 
+		// If there is a payment method ID already, then this is a form submission after card authentication.
+		// This may be the case when the payment request button is used, for example.
+		if ( $( 'input[name="payment_method_id"]' ).length > 0 ) {
+			return;
+		}
+
 		var name, address;
 
 		// Prevent the form from submitting with the default action.
@@ -246,7 +252,7 @@ jQuery( document ).ready( function( $ ) {
 			form.append( '<input type="hidden" name="ExpirationYear" value="' + card.exp_year + '"/>' );
 
 			// and submit
-			form.get(0).submit();			
+			form.submit();			
 			
 		} else if ( response.paymentIntent || response.setupIntent ) {
 			// Card authentication was successful. Finish the checkout in PHP.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
There are two main fixes here:

In `pmpro-recaptcha-v3.js`, we were validating reCAPTCHA when the submit button was clicked. This did not run in cases where the checkout form was submitted via JS. To fix this behavior, this PR updates the validation to occur when the form is submitted. This is closer to how we validate the reCAPTCHA v2 as well.

In `pmpro-stripe.js`, we had code to "force submit" the checkout form with `form.get(0).submit();` after the payment request button was used or 3DS verification was completed. Although this worked for most use-cases, it prevents code running on the jQuery `.submit()` method to run. This prevented our new reCAPTCHA v3 code (and I assume the old v2 code) from running. The fix here was to just call `form.submit();`, which still allows `.submit()` methods to run.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Set up reCATCHA v3 and the Stripe payment request button
2. Check out with Apple/Google Pay
3. See that before PR, "missing input" error is shown. After PR, the checkout works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
