### PR TITLE
Fixing no access message default if no levels page or checkout pages are assigned.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2129,11 +2129,16 @@ function pmpro_get_no_access_message( $content, $level_ids, $level_names = NULL 
 			if ( count( $level_ids ) !== 1 ) {
 				$header = __( 'Membership Required', 'paid-memberships-pro' );
 				$body = '<p>' . __(' You must be a member to access this content.', 'paid-memberships-pro') . '</p>';
-				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
+				// Add a link to the levels page if it's set.
+				if ( ! empty( pmpro_url( 'levels' ) ) ) {
+					$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="!!levels_page_url!!">' . __( 'View Membership Levels', 'paid-memberships-pro' ) . '</a></p>';
+				}
 			} else {
 				$header = __( '!!levels!! Membership Required', 'paid-memberships-pro' );
 				$body = '<p>' . __(' You must be a !!levels!! member to access this content.', 'paid-memberships-pro') . '</p>';
-				$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . current( $level_ids ) ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
+				if ( ! empty( pmpro_url( 'checkout' ) ) ) {
+					$body .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . esc_url( pmpro_url( 'checkout', '?pmpro_level=' . current( $level_ids ) ) ) . '">' . __( 'Join Now', 'paid-memberships-pro' ) . '</a></p>';
+				}
 			}
 			/**
 			 * Filter the header message for the no access message.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
A user has a site with a single level that they manually add people to. They do not want to have people sign up on their own.

I realized that our smart no access messages assumes there is an assigned levels page and checkout page. While it is 100% advisable for membership sites to do this, I can see a case where a site has no public levels and no checkout process.

This PR makes the smart message smarter.
