### PR TITLE
Explicitly allow setting a null expiration date via pmpro_set_expiration_date().

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4731,7 +4731,7 @@ function pmpro_sanitize_period( $period ) {
  *
  * @param int $user_id The ID of the user to update.
  * @param int $level_id The ID of the level to update.
- * @param int|string $enddate The date to set the enddate to.
+ * @param int|string|null $enddate The date to set the enddate to.
  */
 function pmpro_set_expiration_date( $user_id, $level_id, $enddate ) {
 	global $wpdb;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`pmpro_set_expiration_date()` already works with `null` values (since `$wpdb->update()` already works with them), but the PHPDocs do not reflect this. Seeing as that the alternative of zero-dates is [not recommended](https://github.com/strangerstudios/paid-memberships-pro/issues/892), I think it would be good to officially support passing `null` to the `enddate` parameter of this function.

### How to test the changes in this Pull Request:

There's not really anything to test, functionality-wise. This just makes static analysis tools like PHPStan/Psalm stop complaining when you pass `null` as the `enddate` argument in `pmpro_set_expiration_date()`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Officially support passing `null` as `enddate` argument in `pmpro_set_expiration_date()`.
