### PR TITLE
Exploratory PR to allow people to adjust the style of the mounted Stripe Elements fields.

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -776,7 +776,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'updatePaymentRequestButton' => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
 					'currency' => strtolower( $pmpro_currency ),
 					'accountCountry' => $stripe->get_account_country(),
-					'style' => apply_filters( 'pmpro_stripe_card_element_styles', array() ),
+					'style' => apply_filters( 'pmpro_stripe_card_element_style', array() ),
 				);
 
 				if ( ! empty( $order ) ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -776,7 +776,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'updatePaymentRequestButton' => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
 					'currency' => strtolower( $pmpro_currency ),
 					'accountCountry' => $stripe->get_account_country(),
-					'style' => apply_filters( 'pmpro_stripe_elements_styles', array() ),
+					'style' => apply_filters( 'pmpro_stripe_card_element_styles', array() ),
 				);
 
 				if ( ! empty( $order ) ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -776,6 +776,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'updatePaymentRequestButton' => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
 					'currency' => strtolower( $pmpro_currency ),
 					'accountCountry' => $stripe->get_account_country(),
+					'style' => apply_filters( 'pmpro_stripe_elements_styles', array() ),
 				);
 
 				if ( ! empty( $order ) ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -776,7 +776,7 @@ class PMProGateway_stripe extends PMProGateway {
 					'updatePaymentRequestButton' => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
 					'currency' => strtolower( $pmpro_currency ),
 					'accountCountry' => $stripe->get_account_country(),
-					'style' => apply_filters( 'pmpro_stripe_card_element_style', array() ),
+					'style' => apply_filters( 'pmpro_stripe_card_element_style', array( 'base' => array( 'fontSize' => '16px' ) ) ),
 				);
 
 				if ( ! empty( $order ) ) {

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -19,9 +19,9 @@ jQuery( document ).ready( function( $ ) {
 	 * Set up default credit card fields.
 	 */
 	// Create Elements.
-	cardNumber = elements.create('cardNumber');
-	cardExpiry = elements.create('cardExpiry');
-	cardCvc = elements.create('cardCvc');
+	cardNumber = elements.create('cardNumber', { style: pmproStripe.style });
+	cardExpiry = elements.create('cardExpiry', { style: pmproStripe.style });
+	cardCvc = elements.create('cardCvc', { style: pmproStripe.style });
 
 	// Mount Elements. Ensure CC field is present before loading Stripe.
 	if ( $( '#AccountNumber' ).length > 0 ) { 

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -15,10 +15,7 @@ jQuery( document ).ready( function( $ ) {
 	}
 	elements = stripe.elements();
 
-	/**
-	 * Set up default credit card fields.
-	 */
-	// Create Elements.
+	// Set up default credit card fields.
 	cardNumber = elements.create('cardNumber', { style: pmproStripe.style });
 	cardExpiry = elements.create('cardExpiry', { style: pmproStripe.style });
 	cardCvc = elements.create('cardCvc', { style: pmproStripe.style });


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
People with dark themes have no way to target and style the Stripe elements fields that get added via JS. This PR adds a new filter `pmpro_stripe_card_element_style` so that custom styles can be added.

Here is an example of using this hook to make the placeholder and field values white. You may still need custom CSS to override core PMPro style variations and how background colors and borders are set.

https://gist.github.com/kimcoleman/ab5282830d18252ec39b9dab124d6e7a