### PR TITLE
Removes the CardType field being required

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -182,7 +182,6 @@ if ($submit) {
         "bphone" => $bphone,
         "bemail" => $bemail,
         "bcountry" => $bcountry,
-        "CardType" => $CardType,
         "AccountNumber" => $AccountNumber,
         "ExpirationMonth" => $ExpirationMonth,
         "ExpirationYear" => $ExpirationYear,

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -272,7 +272,6 @@ $pmpro_required_billing_fields = array(
 	"bphone"          => $bphone,
 	"bemail"          => $bemail,
 	"bcountry"        => $bcountry,
-	"CardType"        => $CardType,
 	"AccountNumber"   => $AccountNumber,
 	"ExpirationMonth" => $ExpirationMonth,
 	"ExpirationYear"  => $ExpirationYear,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the CardType field from being required on the checkout and billing forms. 

### How to test the changes in this Pull Request:

1. Use a gateway that uses our own card field form such as Braintree or Auth.net
2. Fill out your card details and hit submit
3. The 'CardType' field was previously marked as required but is no longer set in this form anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

