### PR TITLE
Abstracting captchas and moving reCAPTCHA into a single file

### DIFF
--- a/adminpages/securitysettings.php
+++ b/adminpages/securitysettings.php
@@ -18,10 +18,6 @@
 	// Save settings.
 	if( !empty( $_REQUEST['savesettings'] ) ) {
 		pmpro_setOption( "spamprotection", intval( $_POST['spamprotection'] ) );
-		pmpro_setOption( "recaptcha", intval( $_POST['recaptcha'] ) );
-		pmpro_setOption( "recaptcha_version", sanitize_text_field( $_POST['recaptcha_version'] ) );
-		pmpro_setOption( "recaptcha_publickey", sanitize_text_field( $_POST['recaptcha_publickey'] ) );
-		pmpro_setOption( "recaptcha_privatekey", sanitize_text_field( $_POST['recaptcha_privatekey'] ) );
 		if ( isset( $_POST['use_ssl'] ) ) {
 			// REQUEST['use_ssl'] will not be set if the entire site is already over HTTPS.
 			pmpro_setOption( "use_ssl", intval( $_POST['use_ssl'] ) );
@@ -33,6 +29,13 @@
 		}
 		pmpro_setOption( "nuclear_HTTPS", $nuclear_HTTPS );
 
+		/**
+		 * Fires after security settings are saved.
+		 *
+		 * @since TBD
+		 */
+		do_action( 'pmpro_save_security_settings' );
+
 		// Assume success.
 		$msg = true;
 		$msgt = __("Your security settings have been updated.", 'paid-memberships-pro' );
@@ -41,10 +44,6 @@
 
 	// Get settings.
 	$spamprotection = get_option( 'pmpro_spamprotection' );
-	$recaptcha = get_option( 'pmpro_recaptcha' );
-	$recaptcha_version = get_option( 'pmpro_recaptcha_version' );
-	$recaptcha_publickey = get_option( 'pmpro_recaptcha_publickey' );
-	$recaptcha_privatekey = get_option( 'pmpro_recaptcha_privatekey' );
 	$use_ssl = get_option( 'pmpro_use_ssl' );
 	$nuclear_HTTPS = get_option( 'pmpro_nuclear_HTTPS' );
 
@@ -162,45 +161,15 @@
 								<p class="description"><?php printf( esc_html__( 'Block IPs from checkout if there are more than %d failures within %d minutes.', 'paid-memberships-pro' ), (int)PMPRO_SPAM_ACTION_NUM_LIMIT, (int)round(PMPRO_SPAM_ACTION_TIME_LIMIT/60,2) );?></p>
 							</td>
 						</tr>
-						<tr>
-							<th scope="row" valign="top">
-								<label for="recaptcha"><?php esc_html_e('Use reCAPTCHA?', 'paid-memberships-pro' );?></label>
-							</th>
-							<td>
-								<select id="recaptcha" name="recaptcha">
-									<option value="0" <?php if( !$recaptcha ) { ?>selected="selected"<?php } ?>><?php esc_html_e( 'No', 'paid-memberships-pro' );?></option>
-									<!-- For reference, removed the Yes - Free memberships only. option -->
-									<option value="2" <?php if( $recaptcha > 0 ) { ?>selected="selected"<?php } ?>><?php esc_html_e( 'Yes - All memberships.', 'paid-memberships-pro' );?></option>
-								</select>
-								<p class="description"><?php esc_html_e( 'A free reCAPTCHA key is required.', 'paid-memberships-pro' );?> <a href="https://www.google.com/recaptcha/admin/create" target="_blank" rel="nofollow noopener"><?php esc_html_e('Click here to signup for reCAPTCHA', 'paid-memberships-pro' );?></a>.</p>
-							</td>
-						</tr>
-					</tbody>
-				</table>
-				<table class="form-table" id="recaptcha_settings" <?php if(!$recaptcha) { ?>style="display: none;"<?php } ?>>
-					<tbody>
-						<tr>
-							<th scope="row" valign="top"><label for="recaptcha_version"><?php esc_html_e( 'reCAPTCHA Version', 'paid-memberships-pro' );?>:</label></th>
-							<td>					
-								<select id="recaptcha_version" name="recaptcha_version">
-									<option value="2_checkbox" <?php selected( '2_checkbox', $recaptcha_version ); ?>><?php esc_html_e( ' v2 - Checkbox', 'paid-memberships-pro' ); ?></option>
-									<option value="3_invisible" <?php selected( '3_invisible', $recaptcha_version ); ?>><?php esc_html_e( 'v3 - Invisible', 'paid-memberships-pro' ); ?></option>
-								</select>
-								<p class="description"><?php esc_html_e( 'Changing your version will require new API keys.', 'paid-memberships-pro' ); ?></p>
-							</td>
-						</tr>
-						<tr>
-							<th scope="row"><label for="recaptcha_publickey"><?php esc_html_e('reCAPTCHA Site Key', 'paid-memberships-pro' );?>:</label></th>
-							<td>
-								<input type="text" id="recaptcha_publickey" name="recaptcha_publickey" value="<?php echo esc_attr($recaptcha_publickey);?>" class="regular-text code" />
-							</td>
-						</tr>
-						<tr>
-							<th scope="row"><label for="recaptcha_privatekey"><?php esc_html_e('reCAPTCHA Secret Key', 'paid-memberships-pro' );?>:</label></th>
-							<td>
-								<input type="text" id="recaptcha_privatekey" name="recaptcha_privatekey" value="<?php echo esc_attr($recaptcha_privatekey);?>" class="regular-text code" />
-							</td>
-						</tr>
+						<?php
+						/**
+						 * Fires after the spam protection settings are displayed.
+						 * Can be used to add additional spam protection settings.
+						 *
+						 * @since TBD
+						 */
+						do_action( 'pmpro_security_spam_fields' );
+						?>
 					</tbody>
 				</table>
 			</div>
@@ -423,12 +392,3 @@
 			<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e('Save Settings', 'paid-memberships-pro' );?>" />
 		</div>
 	</form>
-
-<script>
-	jQuery( document ).ready( function( $ ) {
-		//hide/show recaptcha settings
-		$( '#recaptcha' ).on( 'change', function( ev ) {
-			$( '#recaptcha_settings' ).toggle();
-		});
-	});
-</script>

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -304,7 +304,7 @@ add_action( 'pmpro_checkout_after_email', 'pmpro_checkout_after_email_fields' );
 function pmpro_checkout_after_captcha_fields() {
 	pmpro_display_fields_in_group( 'after_captcha', 'checkout' );
 }
-add_action( 'pmpro_checkout_after_captcha', 'pmpro_checkout_after_captcha_fields' );
+add_action( 'pmpro_checkout_before_submit_button', 'pmpro_checkout_after_captcha_fields' );
 
 //checkout boxes
 function pmpro_checkout_boxes_fields() {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3984,7 +3984,7 @@ function pmpro_show_discount_code() {
   * @return mixed $order Order object.
   */
  function pmpro_build_order_for_checkout() {
-	global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_levels, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user, $pmpro_requirebilling, $tospage, $username, $password, $password2, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear, $pmpro_states, $recaptcha, $recaptcha_privatekey, $CVV;
+	global $post, $gateway, $wpdb, $besecure, $discount_code, $discount_code_id, $pmpro_level, $pmpro_levels, $pmpro_msg, $pmpro_msgt, $pmpro_review, $skip_account_fields, $pmpro_paypal_token, $pmpro_show_discount_code, $pmpro_error_fields, $pmpro_required_billing_fields, $pmpro_required_user_fields, $wp_version, $current_user, $pmpro_requirebilling, $tospage, $username, $password, $password2, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear, $pmpro_states, $CVV;
 
 	$morder                   = new MemberOrder();
 	$morder->user_id          = $current_user->ID;

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -57,9 +57,21 @@ add_action( 'pmpro_checkout_preheader', 'pmpro_init_recaptcha' );
 add_action( 'pmpro_billing_preheader', 'pmpro_init_recaptcha', 9 ); // Run before the Stripe class loads pmpro-stripe.js
 
 /**
- * Outputs the HTML needed in the checkout form to display the ReCAPTCHA.
+ * Outputs the HTML needed to display ReCAPTCHA in a form.
  */
 function pmpro_recaptcha_get_html() {
+	static $already_shown = false;
+
+	// Make sure that we only show the captcha once.
+	if ( $already_shown ) {
+		return;
+	}
+
+	// If ReCAPTCHA is not enabled, bail.
+	if ( empty( get_option( 'pmpro_recaptcha' ) ) ) {
+		return;
+	}
+
 	// If ReCAPTCHA has already been validated, return.
 	if ( true === pmpro_recaptcha_is_validated() ) {
 		return;
@@ -81,20 +93,37 @@ function pmpro_recaptcha_get_html() {
 	}
 	$lang = apply_filters( 'pmpro_recaptcha_lang', $lang );
 
-	// Check which version of ReCAPTCHA we are using.
-	$recaptcha_version = get_option( 'pmpro_recaptcha_version' ); 
-	if( $recaptcha_version == '3_invisible' ) { ?>
-		<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey );?>" data-size="invisible" data-callback="onSubmit"></div>
+	?>
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
+		<?php
+
+		// Check which version of ReCAPTCHA we are using.
+		$recaptcha_version = get_option( 'pmpro_recaptcha_version' ); 
+		if( $recaptcha_version == '3_invisible' ) { ?>
+			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey );?>" data-size="invisible" data-callback="onSubmit"></div>
+				<script type="text/javascript"
+					src="https://www.google.com/recaptcha/api.js?onload=pmpro_recaptcha_onloadCallback&hl=<?php echo esc_attr( $lang );?>&render=explicit" async defer>
+				</script>
+		<?php } else { ?>
+			<div class="g-recaptcha" data-callback="pmpro_recaptcha_validatedCallback" data-expired-callback="pmpro_recaptcha_expiredCallback" data-sitekey="<?php echo esc_attr( $recaptcha_publickey );?>"></div>
 			<script type="text/javascript"
-				src="https://www.google.com/recaptcha/api.js?onload=pmpro_recaptcha_onloadCallback&hl=<?php echo esc_attr( $lang );?>&render=explicit" async defer>
+				src="https://www.google.com/recaptcha/api.js?hl=<?php echo esc_attr( $lang );?>">
 			</script>
-	<?php } else { ?>
-		<div class="g-recaptcha" data-callback="pmpro_recaptcha_validatedCallback" data-expired-callback="pmpro_recaptcha_expiredCallback" data-sitekey="<?php echo esc_attr( $recaptcha_publickey );?>"></div>
-		<script type="text/javascript"
-			src="https://www.google.com/recaptcha/api.js?hl=<?php echo esc_attr( $lang );?>">
-		</script>
-	<?php }				
+		<?php }
+		?>
+	</div>
+	<?php
+
+	// If we are on the checkout page, run the deprecated pmpro_checkout_after_captcha action.
+	if ( pmpro_is_checkout() ) {
+		do_action_deprecated( 'pmpro_checkout_after_captcha', array(), 'TBD', 'pmpro_checkout_before_submit_button' );
+	}
+
+	$already_shown = true;
 }
+add_action( 'pmpro_checkout_before_submit_button', 'pmpro_recaptcha_get_html' );
+add_action( 'pmpro_billing_before_submit_button', 'pmpro_recaptcha_get_html' );
+
 
 /**
  * AJAX Method to Validate a ReCAPTCHA Response Token
@@ -174,3 +203,114 @@ function pmpro_recaptcha_is_validated() {
 		return $recaptcha_errors;
 	}
 }
+
+/**
+ * Stop form submission if ReCAPTCHA is not validated.
+ *
+ * @since TBD
+ *
+ * @param bool $continue Whether to continue with form submission.
+ */
+function pmpro_recaptcha_validation_check( $continue = true ) {
+	// If the form is already not going to be submitted, return.
+	if ( ! $continue ) {
+		return false;
+	}
+
+	// If ReCAPTCHA is not enabled, return.
+	if ( empty( get_option( 'pmpro_recaptcha' ) ) ) {
+		return true;
+	}
+
+	// Check if reCAPTCHA is validated.
+	$recaptcha_valid = pmpro_recaptcha_is_validated();
+
+	if ( true === $recaptcha_valid ) {
+		return true;
+	} else {
+		pmpro_setMessage( sprintf( __( 'reCAPTCHA failed. (%s) Please try again.', 'paid-memberships-pro' ), $recaptcha_valid ), 'pmpro_error' );
+		return false;
+	}
+}
+add_filter( 'pmpro_registration_checks', 'pmpro_recaptcha_validation_check', 10, 1 );
+add_filter( 'pmpro_billing_update_checks', 'pmpro_recaptcha_validation_check', 10, 1 );
+
+/**
+ * Show reCAPTCHA settings on the PMPro settings page.
+ *
+ * @since TBD
+ */
+function pmpro_recaptcha_settings() {
+	// Get the current options.
+	$recaptcha = get_option( 'pmpro_recaptcha' );
+	$recaptcha_version = get_option( 'pmpro_recaptcha_version' );
+	$recaptcha_publickey = get_option( 'pmpro_recaptcha_publickey' );
+	$recaptcha_privatekey = get_option( 'pmpro_recaptcha_privatekey' );
+
+	// If reCAPTCHA is not enabled, hide some settings by default.
+	$tr_style = empty( $recaptcha ) ? 'display: none;' : '';
+
+	// Output settings fields.
+	?>
+	<tr>
+		<th scope="row" valign="top">
+			<label for="recaptcha"><?php esc_html_e('Use reCAPTCHA?', 'paid-memberships-pro' );?></label>
+		</th>
+		<td>
+			<select id="recaptcha" name="recaptcha">
+				<option value="0" <?php if( !$recaptcha ) { ?>selected="selected"<?php } ?>><?php esc_html_e( 'No', 'paid-memberships-pro' );?></option>
+				<!-- For reference, removed the Yes - Free memberships only. option -->
+				<option value="2" <?php if( $recaptcha > 0 ) { ?>selected="selected"<?php } ?>><?php esc_html_e( 'Yes - All memberships.', 'paid-memberships-pro' );?></option>
+			</select>
+			<p class="description"><?php esc_html_e( 'A free reCAPTCHA key is required.', 'paid-memberships-pro' );?> <a href="https://www.google.com/recaptcha/admin/create" target="_blank" rel="nofollow noopener"><?php esc_html_e('Click here to signup for reCAPTCHA', 'paid-memberships-pro' );?></a>.</p>
+		</td>
+	</tr>
+	<tr class='pmpro_recaptcha_settings' style='<?php esc_attr_e( $tr_style); ?>'>
+		<th scope="row" valign="top"><label for="recaptcha_version"><?php esc_html_e( 'reCAPTCHA Version', 'paid-memberships-pro' );?>:</label></th>
+		<td>					
+			<select id="recaptcha_version" name="recaptcha_version">
+				<option value="2_checkbox" <?php selected( '2_checkbox', $recaptcha_version ); ?>><?php esc_html_e( ' v2 - Checkbox', 'paid-memberships-pro' ); ?></option>
+				<option value="3_invisible" <?php selected( '3_invisible', $recaptcha_version ); ?>><?php esc_html_e( 'v3 - Invisible', 'paid-memberships-pro' ); ?></option>
+			</select>
+			<p class="description"><?php esc_html_e( 'Changing your version will require new API keys.', 'paid-memberships-pro' ); ?></p>
+		</td>
+	</tr>
+	<tr class='pmpro_recaptcha_settings' style='<?php esc_attr_e( $tr_style); ?>'>
+		<th scope="row"><label for="recaptcha_publickey"><?php esc_html_e('reCAPTCHA Site Key', 'paid-memberships-pro' );?>:</label></th>
+		<td>
+			<input type="text" id="recaptcha_publickey" name="recaptcha_publickey" value="<?php echo esc_attr($recaptcha_publickey);?>" class="regular-text code" />
+		</td>
+	</tr>
+	<tr class='pmpro_recaptcha_settings' style='<?php esc_attr_e( $tr_style); ?>'>
+		<th scope="row"><label for="recaptcha_privatekey"><?php esc_html_e('reCAPTCHA Secret Key', 'paid-memberships-pro' );?>:</label></th>
+		<td>
+			<input type="text" id="recaptcha_privatekey" name="recaptcha_privatekey" value="<?php echo esc_attr($recaptcha_privatekey);?>" class="regular-text code" />
+		</td>
+	</tr>
+	<script>
+		jQuery(document).ready(function() {
+			jQuery('#recaptcha').change(function() {
+				if(jQuery(this).val() == '2') {
+					jQuery('.pmpro_recaptcha_settings').show();
+				} else {
+					jQuery('.pmpro_recaptcha_settings').hide();
+				}
+			});
+		});
+	</script>
+	<?php
+}
+add_action( 'pmpro_security_spam_fields', 'pmpro_recaptcha_settings' );
+
+/**
+ * Save reCAPTCHA settings on the PMPro settings page.
+ *
+ * @since TBD
+ */
+function pmpro_recaptcha_settings_save() {
+	pmpro_setOption( "recaptcha", intval( $_POST['recaptcha'] ) );
+	pmpro_setOption( "recaptcha_version", sanitize_text_field( $_POST['recaptcha_version'] ) );
+	pmpro_setOption( "recaptcha_publickey", sanitize_text_field( $_POST['recaptcha_publickey'] ) );
+	pmpro_setOption( "recaptcha_privatekey", sanitize_text_field( $_POST['recaptcha_privatekey'] ) );
+}
+add_action( 'pmpro_save_security_settings', 'pmpro_recaptcha_settings_save' );

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -361,15 +361,6 @@
 						}
 						?>
 
-						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
-						<?php
-							$recaptcha = get_option("pmpro_recaptcha");
-							if ( $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) {
-								pmpro_recaptcha_get_html();
-							}
-						?>				
-						</div> <!-- end pmpro_captcha -->
-
 						<?php do_action("pmpro_billing_before_submit_button"); ?>
 
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_submit' ) ); ?>">

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -561,23 +561,11 @@ if ( empty( $default_gateway ) ) {
 				}
 			?>
 
-			<?php do_action( 'pmpro_checkout_after_tos_fields' ); ?>
-
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
 			<?php
-				$recaptcha = get_option( "pmpro_recaptcha");
-				if ( $recaptcha == 2 || $recaptcha == 1 ) {
-					pmpro_recaptcha_get_html();
-				}
-			?>
-			</div> <!-- end pmpro_captcha -->
-
-			<?php
-				do_action( 'pmpro_checkout_after_captcha' );
-				do_action( 'pmpro_checkout_before_submit_button' );
-
-				// Add nonce.
-				wp_nonce_field( 'pmpro_checkout_nonce', 'pmpro_checkout_nonce' );
+			do_action( 'pmpro_checkout_after_tos_fields' );
+			do_action( 'pmpro_checkout_before_submit_button' );
+			// Add nonce.
+			wp_nonce_field( 'pmpro_checkout_nonce', 'pmpro_checkout_nonce' );
 			?>
 
 			<?php if ( $pmpro_msg ) { ?>

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -198,16 +198,15 @@ if ($submit) {
             break;
         }
     }
-	
-	// Check reCAPTCHA if needed.
-    $recaptcha = get_option( "pmpro_recaptcha");
-    if (  $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) {
-        $recaptcha_validated = pmpro_recaptcha_is_validated(); // Returns true if validated, string error message if not.
-        if ( is_string( $recaptcha_validated ) ) {
-            $pmpro_msg  = sprintf( __( "reCAPTCHA failed. (%s) Please try again.", 'paid-memberships-pro' ), $recaptcha_validated );
-            $pmpro_msgt = "pmpro_error";
-        }
-    }
+
+    /**
+     * Mirror of pmpro_registration_checks filter for the billing page.
+     *
+     * @since TBD
+     *
+     * @param bool $continue_billing_update Whether to continue with the billing update.
+     */
+    $continue_billing_update = apply_filters( 'pmpro_billing_update_checks', true );
 	
     if (!empty($missing_billing_field)) {
         $pmpro_msg = __("Please complete all required fields.", 'paid-memberships-pro' );
@@ -218,7 +217,7 @@ if ($submit) {
     } elseif (!is_email($bemail)) {
         $pmpro_msg = __("The email address entered is in an invalid format. Please try again.", 'paid-memberships-pro' );
         $pmpro_msgt = "pmpro_error";
-    } elseif ( $pmpro_msgt == 'pmpro_error' ) {
+    } elseif ( empty( $continue_billing_update ) || $pmpro_msgt == 'pmpro_error' ) {
 		// Something else threw an error, maybe reCAPTCHA.		
 	} else {
         //all good. update billing info.

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -397,19 +397,6 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 			$pmpro_error_fields[] = "bconfirmemail";
 		}
 
-		//only continue if there are no other errors yet
-		if ( $pmpro_msgt != "pmpro_error" ) {
-			//check recaptcha first
-			$recaptcha = get_option( "pmpro_recaptcha");
-			if (  $recaptcha == 2 || ( $recaptcha == 1 && pmpro_isLevelFree( $pmpro_level ) ) ) {
-				$recaptcha_validated = pmpro_recaptcha_is_validated(); // Returns true if validated, string error message if not.
-				if ( is_string( $recaptcha_validated ) ) {
-					$pmpro_msg  = sprintf( __( "reCAPTCHA failed. (%s) Please try again.", 'paid-memberships-pro' ), $recaptcha_validated );
-					$pmpro_msgt = "pmpro_error";
-				}
-			}
-		}
-
 		// Only continue if there are no other errors yet
 		if ( $pmpro_msgt != "pmpro_error" ) {
 			// Do we need to create a user account?


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Abstracting reCAPTCHA-specific code out of the checkout and update billing pages to prepare for other CAPTCHAs to be added. All reCAPTCHA code is now within `includes/recaptcha.php` and reCAPTCHA-specific JS files.

Added actions:
- pmpro_security_spam_fields
- pmpro_save_security_settings
- pmpro_billing_update_checks

Deprecated actions:
- pmpro_checkout_after_captcha

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

