### PR TITLE
Making sure CardType is set on update billing page

### DIFF
--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -458,7 +458,6 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
                                 <input type="hidden" id="CardType" name="CardType" value="<?php echo esc_attr($CardType);?>" />
 								<script>
 									jQuery(document).ready(function() {
-											console.log('hit');
 											jQuery('#AccountNumber').validateCreditCard(function(result) {
 												var cardtypenames = {
 													"amex"                      : "American Express",

--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -456,6 +456,30 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-account-number', 'pmpro_payment-account-number' ) ); ?>">
                                 <input type="hidden" id="CardType" name="CardType" value="<?php echo esc_attr($CardType);?>" />
+								<script>
+									jQuery(document).ready(function() {
+											console.log('hit');
+											jQuery('#AccountNumber').validateCreditCard(function(result) {
+												var cardtypenames = {
+													"amex"                      : "American Express",
+													"diners_club_carte_blanche" : "Diners Club Carte Blanche",
+													"diners_club_international" : "Diners Club International",
+													"discover"                  : "Discover",
+													"jcb"                       : "JCB",
+													"laser"                     : "Laser",
+													"maestro"                   : "Maestro",
+													"mastercard"                : "Mastercard",
+													"visa"                      : "Visa",
+													"visa_electron"             : "Visa Electron"
+												};
+
+												if(result.card_type)
+													jQuery('#CardType').val(cardtypenames[result.card_type.name]);
+												else
+													jQuery('#CardType').val('Unknown Card Type');
+											});
+									});
+								</script>
 								<label for="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Card Number', 'paid-memberships-pro' );?></label>
 								<input id="AccountNumber" name="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'AccountNumber' ) ); ?>" type="text" value="<?php echo esc_attr($AccountNumber)?>" data-encrypted-name="number" autocomplete="off" />
 							</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By default, the Checkout page loads this code in `checkout.js`, but the billing page loads it inline when the CardType field is generated.

When using Braintree, the generation of the credit card fields is overwritten, so we need to make sure that the JS to populate the CardType field is included in both cases. With this PR, the checkout page will essentially have this JS loaded twice, which seems ok.

### How to test the changes in this Pull Request:

Update billing for a Braintree subscription. See that "Fill out required fields" error shows without this Pr, but billing update completes successfully with this PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
