### PR TITLE
Merging the Recurring Emails Add On

### DIFF
--- a/includes/crons.php
+++ b/includes/crons.php
@@ -35,6 +35,9 @@ function pmpro_get_crons() {
 		'pmpro_license_check_key'                  => [
 			'interval' => 'monthly',
 		],
+		'pmpro_cron_recurring_payment_reminders'  => [
+			'interval' => 'hourly',
+		],
 	];
 
 	/**

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -743,6 +743,72 @@ function pmpro_cancel_on_next_payment_date_deprecated() {
 add_action( 'plugins_loaded', 'pmpro_cancel_on_next_payment_date_deprecated', 20 );
 
 /**
+ * Old Recurring Emails functions.
+ */
+function pmpro_recurring_emails_deprecated() {
+	// pmpror_recurring_emails function.
+	if ( ! function_exists( 'pmpror_recurring_emails' ) ) {
+		function pmpror_recurring_emails() {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+			pmpro_cron_recurring_payment_reminders();
+		}
+	}
+
+	// pmpror_template_callback function.
+	if ( ! function_exists( 'pmpror_template_callback' ) ) {
+		function pmpror_template_callback( $buffer ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+			return $buffer;
+		}
+	}
+
+	// pmpror_load_plugin_text_domain function.
+	if ( ! function_exists( 'pmpror_load_plugin_text_domain' ) ) {
+		function pmpror_load_plugin_text_domain() {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
+	}
+
+	// pmpror_init_test function.
+	if ( ! function_exists( 'pmpror_init_test' ) ) {
+		function pmpror_init_test() {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
+	}
+
+	// pmpror_recurring_emails_legacy function.
+	if ( ! function_exists( 'pmpror_recurring_emails_legacy' ) ) {
+		function pmpror_recurring_emails_legacy() {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+			pmpro_cron_recurring_payment_reminders();
+		}
+	}
+
+	// pmpror_log function.
+	if ( ! function_exists( 'pmpror_log' ) ) {
+		function pmpror_log( $message ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
+	}
+
+	// pmpror_output_log function.
+	if ( ! function_exists( 'pmpror_output_log' ) ) {
+		function pmpror_output_log() {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+		}
+	}
+
+	// pmpro_recurring_emails_plugin_row_meta function.
+	if ( ! function_exists( 'pmpro_recurring_emails_plugin_row_meta' ) ) {
+		function pmpro_recurring_emails_plugin_row_meta( $links, $file ) {
+			_deprecated_function( __FUNCTION__, 'TBD' );
+			return $links;
+		}
+	}
+}
+add_action( 'plugins_loaded', 'pmpro_recurring_emails_deprecated', 20 );
+
+/**
  * Check for active Add Ons that are not yet MMPU compatible.
  *
  * @since 3.0
@@ -822,7 +888,11 @@ function pmpro_get_deprecated_add_ons() {
 		'pmpro-table-pages' => array(
 			'file' => 'pmpro-table-pages.php',
 			'label' => 'Table Layout Plugin Pages'
-		)
+		),
+		'pmpro-recurring-emails' => array(
+			'file' => 'pmpro-recurring-emails.php',
+			'label' => 'Recurring Emails'
+		),
 	);
 	
 	$deprecated = apply_filters( 'pmpro_deprecated_add_ons_list', $deprecated );

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -373,7 +373,19 @@ $pmpro_email_templates_defaults = array(
 
 <p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ),
 		'help_text' => __( 'This email is sent to the admin as confirmation of a refunded payment. The email is sent after your membership site receives notification of a successful payment refund through your gateway.', 'paid-memberships-pro' )
-	)
+	),
+	'membership_recurring' => array(
+		'subject' => __( "Your membership at !!sitename!! will renew soon", 'paid-memberships-pro' ),
+		'description' => __('Recurring Payment Reminder', 'paid-memberships-pro'),
+		'body' => __( '<p>Thank you for your membership to !!sitename!!.</p>
+
+<p>This is just a reminder that your !!membership_level_name!! membership will automatically renew on !!renewaldate!!.</p>
+
+<p>Account: !!display_name!! (!!user_email!!)</p>
+
+<p>If for some reason you do not want to renew your membership you can cancel by clicking here: !!cancel_link!!</p>', 'paid-memberships-pro' ),
+		'help_text' => __( 'This email is sent when a subscription is approaching its renewal date. The additional placeholders !!renewaldate!! and !!billing_amount!! can be used to print the date that the subscription will renew and the renewal price.', 'paid-memberships-pro' )
+	),
 );
 //we can hide the payment action required emails if default gateway isn't Stripe.
 $default_gateway = get_option( 'pmpro_gateway' );

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -243,3 +243,163 @@ function pmpro_cron_admin_activity_email() {
 		$pmproemail->sendAdminActivity();
 	}
 }
+
+add_action( 'pmpro_cron_recurring_payment_reminders', 'pmpro_cron_recurring_payment_reminders' );
+function pmpro_cron_recurring_payment_reminders() {
+	global $wpdb;
+
+	//Don't let anything run if PMPro is paused
+	if( pmpro_is_paused() ) {
+		return;
+	}
+
+	// Clean up errors in the memberships_users table that could cause problems.
+	pmpro_cleanup_memberships_users_table();
+
+	/**
+	 * Filter will set how many days before you want to send, and the template to use.
+	 *
+	 * @filter  pmpro_upcoming_recurring_payment_reminder
+	 *
+	 * @param   array $reminders key = # of days before payment will be charged (7 => 'membership_recurring')
+	 *                                  value = name of template to use w/o extension (membership_recurring.html)
+	 */
+	$emails = apply_filters( 'pmpro_upcoming_recurring_payment_reminder', array(
+		7 => 'membership_recurring',
+	) );
+	ksort( $emails, SORT_NUMERIC );
+
+	// Loop through each reminder and send reminders, keeping track of the previous $days value.
+	$previous_days = 0;
+	foreach ( $emails as $days => $template ) {
+		// Get all subscriptions that will renew between $previous_days and $days.
+		// Also need to check that we haven't already sent this reminder by checking subscription meta.
+		// Can't actually use the PMPro_Subscriptions class here, because it doesn't support searching by next payment date
+		$sqlQuery = $wpdb->prepare(
+			"SELECT subscription.*
+			FROM {$wpdb->pmpro_subscriptions} subscription
+			LEFT JOIN {$wpdb->pmpro_subscriptionmeta} last_next_payment_date 
+				ON subscription.id = last_next_payment_date.pmpro_subscription_id
+				AND last_next_payment_date.meta_key = 'pmprorm_last_next_payment_date'
+			LEFT JOIN {$wpdb->pmpro_subscriptionmeta} last_days
+				ON subscription.id = last_days.pmpro_subscription_id
+				AND last_days.meta_key = 'pmprorm_last_days'
+			WHERE subscription.status = 'active'
+			AND subscription.next_payment_date >= %s
+			AND subscription.next_payment_date < %s
+			AND ( last_next_payment_date.meta_value IS NULL
+				OR last_next_payment_date.meta_value != subscription.next_payment_date
+				OR last_days.meta_value > %d
+			)",
+			date_i18n( 'Y-m-d', strtotime( "+{$previous_days} days", current_time( 'timestamp' ) ) ),
+			date_i18n( 'Y-m-d', strtotime( "+{$days} days", current_time( 'timestamp' ) ) ),
+			$days
+		);
+
+		// Run the query.
+		$subscriptions_to_notify = $wpdb->get_results( $sqlQuery );
+
+		// Make sure that the query was successful.
+		if ( is_wp_error( $subscriptions_to_notify ) ) {
+			continue;
+		}
+
+
+		// Loop through each subscription and send reminder.
+		foreach ( $subscriptions_to_notify as $subscription_to_notify ) {
+			// Get the subscription object.
+			$subscription_obj = new PMPro_Subscription( $subscription_to_notify->id );
+
+			// Get the user.
+			$user = get_userdata( $subscription_obj->get_user_id() );
+			if ( empty( $user ) ) {
+				// No user. Let's update the metadata for the subscription and continue.
+				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_next_payment_date', $subscription_to_notify->next_payment_date );
+				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_days', $days );
+				continue;
+			}
+
+			// By default, only send emails if the last successful orders was 6 months before the next payment date or more.
+			$send_email = true;
+			$oldest_order = $subscription_obj->get_orders(
+				array(
+					'limit' => 1,
+					'status' => 'success',
+				)
+			);
+			if ( ! empty( $oldest_order ) ) {
+				$oldest_order = $oldest_order[0];
+
+				// Get the timestamp for the subscription.
+				$subscription_timestamp = $subscription_obj->get_next_payment_date( 'timestamp', false );
+
+				// Get the timestamp 6 months before the next payment date.
+				$notification_cutoff = strtotime( '-6 months', $subscription_timestamp );
+
+				// Add two days to the notification cutoff to err on the side of caution RE timezones.
+				$notification_cutoff = strtotime( '+2 days', $notification_cutoff );
+
+				// If the oldest order is newer than the notification cutoff, don't send the email.
+				if ( $oldest_order->timestamp > $notification_cutoff ) {
+					$send_email = false;
+				}
+			}
+
+			/**
+			 * Filter whether to send a recurring payment reminder email.
+			 *
+			 * @since TBD
+			 *
+			 * @param bool $send_email Whether to send the email.
+			 * @param PMPro_Subscription $subscription_obj The subscription object.
+			 * @param int $days The number of days before the next payment that the email is being sent.
+			 */
+			$send_email = apply_filters( 'pmpro_send_recurring_payment_reminder_email', $send_email, $subscription_obj, $days );
+
+			/**
+			 * @filter      pmprorm_send_reminder_to_user
+			 *
+			 * @deprecated TBD
+			 *
+			 * @param       boolean $send_mail - Whether to send mail or not (true by default)
+			 * @param       WP_User $user - User object being processed
+			 * @param       MembershipOrder $lastorder - Deprecated. Now passing null.
+			 */
+			$send_emails = apply_filters_deprecated( 'pmprorm_send_reminder_to_user', array( $send_email, $user, null ), 'TBD' );
+
+			if ( $send_emails ) {
+				// Get the level info.
+				$membership_level = pmpro_getLevel( $subscription_obj->get_membership_level_id() );
+
+				// Send the email.
+				$pmproemail = new PMProEmail();
+				$pmproemail->email    = $user->user_email;
+				$pmproemail->template = $template;
+				$pmproemail->data     = array(
+					'subject'               => $pmproemail->subject,
+					'name'                  => $user->display_name,
+					'user_login'            => $user->user_login,
+					'sitename'              => get_option( 'blogname' ),
+					'membership_id'         => $subscription_obj->get_membership_level_id(),
+					'membership_level_name' => empty( $membership_level ) ? sprintf( __( '[Deleted level #%d]', 'pmpro-recurring-emails' ), $subscription_obj->get_membership_level_id() ) : $membership_level->name,
+					'membership_cost'       => $subscription_obj->get_cost_text(),
+					'billing_amount'        => pmpro_formatPrice( $subscription_obj->get_billing_amount() ),
+					'renewaldate'           => date_i18n( get_option( 'date_format' ), $subscription_obj->get_next_payment_date() ),
+					'siteemail'             => get_option( "pmpro_from_email" ),
+					'login_link'            => wp_login_url(),
+					'display_name'          => $user->display_name,
+					'user_email'            => $user->user_email,
+					'cancel_link'           => wp_login_url( pmpro_url( 'cancel' ) ),
+				);
+				$pmproemail->sendEmail();
+			}
+
+			// Update the subscription meta to prevent duplicate emails.
+			update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_next_payment_date', $subscription_to_notify->next_payment_date );
+			update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_days', $days );
+		}
+
+		// Update the previous days value.
+		$previous_days = $days;
+	}
+}

--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -319,42 +319,16 @@ function pmpro_cron_recurring_payment_reminders() {
 				continue;
 			}
 
-			// By default, only send emails if the last successful orders was 6 months before the next payment date or more.
-			$send_email = true;
-			$oldest_order = $subscription_obj->get_orders(
-				array(
-					'limit' => 1,
-					'status' => 'success',
-				)
-			);
-			if ( ! empty( $oldest_order ) ) {
-				$oldest_order = $oldest_order[0];
-
-				// Get the timestamp for the subscription.
-				$subscription_timestamp = $subscription_obj->get_next_payment_date( 'timestamp', false );
-
-				// Get the timestamp 6 months before the next payment date.
-				$notification_cutoff = strtotime( '-6 months', $subscription_timestamp );
-
-				// Add two days to the notification cutoff to err on the side of caution RE timezones.
-				$notification_cutoff = strtotime( '+2 days', $notification_cutoff );
-
-				// If the oldest order is newer than the notification cutoff, don't send the email.
-				if ( $oldest_order->timestamp > $notification_cutoff ) {
-					$send_email = false;
-				}
-			}
-
 			/**
 			 * Filter whether to send a recurring payment reminder email.
 			 *
 			 * @since TBD
 			 *
-			 * @param bool $send_email Whether to send the email.
+			 * @param bool $send_email Whether to send the email. Default is true.
 			 * @param PMPro_Subscription $subscription_obj The subscription object.
 			 * @param int $days The number of days before the next payment that the email is being sent.
 			 */
-			$send_email = apply_filters( 'pmpro_send_recurring_payment_reminder_email', $send_email, $subscription_obj, $days );
+			$send_email = apply_filters( 'pmpro_send_recurring_payment_reminder_email', true, $subscription_obj, $days );
 
 			/**
 			 * @filter      pmprorm_send_reminder_to_user


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Merging the Recurring Emails Add On to notify customers of upcoming payments.

~~The main change from the original Add On is that, by default, users will only be notified of an upcoming payment if their previous payment was 6 months or more in the past. This modification is useful to comply with the laws of various countries and payment processors without spamming users each time that they have a more frequent payment.~~

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
