### PR TITLE
Better select dropdown field arrow; fixes for dark background themes

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -276,7 +276,7 @@
 	}
 
 	.pmpro_form_input {
-		background-color: var(--pmpro--color--white);
+		background-color: var(--pmpro--color--base);
 		border: 1px solid var(--pmpro--color--border);
 		border-radius: var(--pmpro--base--border-radius);
 		box-shadow: none;
@@ -296,6 +296,17 @@
 		width: 100%;
 	}
 
+	.pmpro_form_input-select {
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+		background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/></svg>');
+		background-position: right var(--pmpro--base--spacing--small) center;
+		background-repeat: no-repeat;
+		background-size: 16px 16px;
+		padding-right: calc(var(--pmpro--base--spacing--small) + 20px);
+	}
+
 	.pmpro_form_input-text:focus,
 	.pmpro_form_input-email:focus,
 	.pmpro_form_input-url:focus,
@@ -309,7 +320,7 @@
 	.pmpro_form_input-file:focus,
 	.pmpro_form_input-date:focus,
 	.pmpro_form_input-textarea:focus {
-		background-color: var(--pmpro--color--white);
+		background-color: var(--pmpro--color--base);
 		border-color: #80BDFF;
 		box-shadow: 0 0 0 0.2rem rgba(0,123,255,.25);
 		outline: none;

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -292,6 +292,17 @@
 		width: 100%;
 	}
 
+	.pmpro_form_input-select {
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+		background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/></svg>');
+		background-position: right var(--pmpro--base--spacing--small) center;
+		background-repeat: no-repeat;
+		background-size: 16px 16px;
+		padding-right: calc(var(--pmpro--base--spacing--small) + 20px);
+	}
+
 	.pmpro_form_input-text:focus,
 	.pmpro_form_input-email:focus,
 	.pmpro_form_input-url:focus,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Improvements to the select field dropdown appearance across themes.

Fixing the base variation to work better for dark mode - high contrast already had these fixes these I think I missed when we were going back and forth on how we wanted to handle field background colors / text colors.

![Screenshot 2024-08-06 at 1 58 35 PM](https://github.com/user-attachments/assets/25623892-985f-4fb5-8055-73757004a605)
![Screenshot 2024-08-06 at 2 01 48 PM](https://github.com/user-attachments/assets/253668fe-8cd6-408b-86af-148b75ad0b14)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
