### PR TITLE
Sorting the display of the My Memberships section of the Membership Account page by the Levels Order stored in options

### DIFF
--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -40,6 +40,11 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 	// Get the current user's membership levels.
 	$mylevels = pmpro_getMembershipLevelsForUser();
 
+	// Sort the levels by the levels order.
+	if ( ! empty( $mylevels ) ) {
+		$mylevels = pmpro_sort_levels_by_order( $mylevels );
+	}
+
 	// Remove the filter so we don't mess up other stuff.
 	remove_filter( 'pmpro_disable_admin_membership_access', '__return_true', 15 ); 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now showing the list of a member's active levels in the My Memberships section of the Membership Account page sorted by the levels order stored in wp_options.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Now showing a member's list of active memberships sorted by the site's defined levels order.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
