### PR TITLE
pmpro-buddypress field sync support in GUI

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1342,11 +1342,12 @@ function pmpro_get_field_html( $field = null ) {
         $field_type = $field->type;
         $field_required = $field->required;
         $field_readonly = $field->readonly;     	
-        $field_profile = $field->profile;
+		$field_buddypress = $field->buddypress;    	
         $field_wrapper_class = $field->wrapper_class;
         $field_element_class = $field->element_class;
         $field_hint = $field->hint;
         $field_options = $field->options;
+		$field_profile = $field->profile;
     } else {
         // Default field values
         $field_label = '';
@@ -1359,6 +1360,7 @@ function pmpro_get_field_html( $field = null ) {
         $field_element_class = '';
         $field_hint = '';
         $field_options = '';
+		$field_buddypress = '';
     }
     
 	// Other vars
@@ -1480,6 +1482,15 @@ function pmpro_get_field_html( $field = null ) {
                     <span class="description"><?php esc_html_e( 'Assign a custom CSS selector to the field', 'paid-memberships-pro' ); ?></span>
                 </div> <!-- end pmpro_userfield-field-setting -->
             </div> <!-- end pmpro_userfield-field-setting-dual -->
+			
+			<?php if(defined('PMPROBP_DIR')) : ?>
+				<div class="pmpro_userfield-field-setting">
+                    <label>
+                        <?php esc_html_e( 'BP Field name', 'paid-memberships-pro' ); ?><br />
+						<input type="text" name="pmpro_userfields_field_buddypress" value="<?php echo esc_attr( $field_buddypress );?>" />
+                    </label>                    
+                </div> <!-- end pmpro_userfield-field-setting -->
+			<?php endif; ?>
 
             <div class="pmpro_userfield-field-setting">
                 <label>
@@ -1615,6 +1626,7 @@ function pmpro_load_user_fields_from_settings() {
                     'options' => $options,
                     'levels' => $levels,
                     'memberslistcsv' => true,
+					'buddypress' => $settings_field->buddypress,
                 )
             );
             pmpro_add_user_field( $group->name, $field );

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1341,13 +1341,13 @@ function pmpro_get_field_html( $field = null ) {
         $field_name = $field->name;
         $field_type = $field->type;
         $field_required = $field->required;
-        $field_readonly = $field->readonly;     	
-		$field_buddypress = $field->buddypress;    	
+        $field_readonly = $field->readonly; 
+        $field_profile = $field->profile;    	
         $field_wrapper_class = $field->wrapper_class;
         $field_element_class = $field->element_class;
         $field_hint = $field->hint;
         $field_options = $field->options;
-		$field_profile = $field->profile;
+        $field_buddypress = $field->buddypress;    	
     } else {
         // Default field values
         $field_label = '';
@@ -1360,7 +1360,7 @@ function pmpro_get_field_html( $field = null ) {
         $field_element_class = '';
         $field_hint = '';
         $field_options = '';
-		$field_buddypress = '';
+        $field_buddypress = '';
     }
     
 	// Other vars
@@ -1482,15 +1482,15 @@ function pmpro_get_field_html( $field = null ) {
                     <span class="description"><?php esc_html_e( 'Assign a custom CSS selector to the field', 'paid-memberships-pro' ); ?></span>
                 </div> <!-- end pmpro_userfield-field-setting -->
             </div> <!-- end pmpro_userfield-field-setting-dual -->
-			
-			<?php if(defined('PMPROBP_DIR')) : ?>
-				<div class="pmpro_userfield-field-setting">
+
+            <?php if(defined('PMPROBP_DIR')) : ?>
+                <div class="pmpro_userfield-field-setting">
                     <label>
-                        <?php esc_html_e( 'BP Field name', 'paid-memberships-pro' ); ?><br />
-						<input type="text" name="pmpro_userfields_field_buddypress" value="<?php echo esc_attr( $field_buddypress );?>" />
+                        <?php esc_html_e( 'BP XField Name', 'paid-memberships-pro' ); ?><br />
+                        <input type="text" placeholder="The Name of the Xprofile Field, or blank to not sync" name="pmpro_userfields_field_buddypress" value="<?php echo esc_attr( $field_buddypress );?>" />
                     </label>                    
                 </div> <!-- end pmpro_userfield-field-setting -->
-			<?php endif; ?>
+                <?php endif; ?>
 
             <div class="pmpro_userfield-field-setting">
                 <label>
@@ -1626,7 +1626,7 @@ function pmpro_load_user_fields_from_settings() {
                     'options' => $options,
                     'levels' => $levels,
                     'memberslistcsv' => true,
-					'buddypress' => $settings_field->buddypress,
+                    'buddypress' => $settings_field->buddypress,
                 )
             );
             pmpro_add_user_field( $group->name, $field );

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -498,6 +498,7 @@ function pmpro_userfields_prep_click_events() {
 				let field_element_class = jQuery(this).find('input[name=pmpro_userfields_field_divclass]').val();
 				let field_hint = jQuery(this).find('textarea[name=pmpro_userfields_field_hint]').val();
 				let field_options = jQuery(this).find('textarea[name=pmpro_userfields_field_options]').val();
+				let field_buddypress = jQuery(this).find('input[name=pmpro_userfields_field_buddypress]').val() || "";
 
 				// Get level ids.            
 				let field_levels = [];
@@ -517,6 +518,7 @@ function pmpro_userfields_prep_click_events() {
 					'element_class': field_element_class,
 					'hint': field_hint,
 					'options': field_options,
+					'buddypress': field_buddypress,
 				}
 
 				// Add to array. (Only if it has a label or name.)


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Brings across the abilty to enable Syncing PMPRO Fields to  BP XProfile fields via the GUI instead of just via register helper code defined fields.
Adds a new input thats only visible in the user field settings if pmpro-buddypress is enabled, that lets you set the $field->buddypress value via GUI.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?


### Changelog entry

> Add support for GUI user fields to support BP sync if pmpro-buddypress is installed.
