### PR TITLE
Fixing calling getDiscountCode() on orders without an ID

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1043,10 +1043,16 @@
 		 * @param bool $force If true, it will query the database again.
 		 *
 		 */
-		function getDiscountCode($force = false)
-		{
-			if(!empty($this->discount_code) && !$force)
+		function getDiscountCode( $force = false ) {
+			// If the order doesn't have an ID yet, we don't want to search the database for a use matching a null order ID.
+			if ( empty( $this->id ) ) {
+				return null;
+			}
+
+			// If we already have the discount code, return it.
+			if ( ! empty ($this->discount_code ) && ! $force ) {
 				return $this->discount_code;
+			}
 
 			global $wpdb;
 			$this->discount_code = $wpdb->get_row( $wpdb->prepare( "SELECT dc.* FROM $wpdb->pmpro_discount_codes dc LEFT JOIN $wpdb->pmpro_discount_codes_uses dcu ON dc.id = dcu.code_id WHERE dcu.order_id = %d LIMIT 1", $this->id ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes a bug with Subscription Delays and any plugin that calls MemberOrder->getDiscountCode() before an order has an ID.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
