### PR TITLE
Combining the free and paid checkout order creation flow

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1673,9 +1673,12 @@
 
 		/**
 		 * Call the getSubscriptionStatus method of the gateway class.
+		 *
+		 * @deprecated TBD
 		 */
 		function getGatewaySubscriptionStatus()
 		{
+			_deprecated_function( __FUNCTION__, 'TBD' );
 			if (is_object($this->Gateway)) {
 				return $this->Gateway->getSubscriptionStatus( $this );
 			}
@@ -1683,9 +1686,12 @@
 
 		/**
 		 * Call the getTransactionStatus method of the gateway class.
+		 *
+		 * @deprecated TBD
 		 */
 		function getGatewayTransactionStatus()
 		{
+			_deprecated_function( __FUNCTION__, 'TBD' );
 			if (is_object($this->Gateway)) {
 				return $this->Gateway->getTransactionStatus( $this );
 			}

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -1,141 +1,29 @@
-<?php	
+<?php
+	/**
+	 * This class serves as a base class for all gateways and is also used for orders set to the `free` or `test` gateway.
+	 */
 	//require_once(dirname(__FILE__) . "/class.pmprogateway.php");
 	#[AllowDynamicProperties]
 	class PMProGateway
-	{	
-		function __construct($gateway = NULL)
-		{
-			$this->gateway = $gateway;
-			return $this->gateway;
-		}										
-		
-		function process(&$order)
-		{
-			//check for initial payment
-			if(floatval($order->InitialPayment) == 0)
-			{
-				//auth first, then process
-				if($this->authorize($order))
-				{						
-					$this->void($order);										
-					if(!pmpro_isLevelTrial($order->membership_level))
-					{
-						//subscription will start today with a 1 period trial
-						$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");
-						$order->TrialBillingPeriod = $order->BillingPeriod;
-						$order->TrialBillingFrequency = $order->BillingFrequency;													
-						$order->TrialBillingCycles = 1;
-						$order->TrialAmount = 0;
-						
-						//add a billing cycle to make up for the trial, if applicable
-						if(!empty($order->TotalBillingCycles))
-							$order->TotalBillingCycles++;
-					}
-					elseif($order->InitialPayment == 0 && $order->TrialAmount == 0)
-					{
-						//it has a trial, but the amount is the same as the initial payment, so we can squeeze it in there
-						$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");														
-						$order->TrialBillingCycles++;
-						
-						//add a billing cycle to make up for the trial, if applicable
-						if($order->TotalBillingCycles)
-							$order->TotalBillingCycles++;
-					}
-					else
-					{
-						//add a period to the start date to account for the initial payment
-						$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s", strtotime("+ " . $order->BillingFrequency . " " . $order->BillingPeriod, current_time("timestamp")));
-					}
-					
-					$order->ProfileStartDate = apply_filters("pmpro_profile_start_date", $order->ProfileStartDate, $order);
-					return $this->subscribe($order);
-				}
-				else
-				{
-					if(empty($order->error))
-						$order->error = __("Unknown error: Authorization failed.", 'paid-memberships-pro' );
-					return false;
-				}
-			}
-			else
-			{
-				//charge first payment
-				if($this->charge($order))
-				{							
-					//set up recurring billing					
-					if(pmpro_isLevelRecurring($order->membership_level))
-					{						
-						if(!pmpro_isLevelTrial($order->membership_level))
-						{
-							//subscription will start today with a 1 period trial
-							$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");
-							$order->TrialBillingPeriod = $order->BillingPeriod;
-							$order->TrialBillingFrequency = $order->BillingFrequency;													
-							$order->TrialBillingCycles = 1;
-							$order->TrialAmount = 0;
-							
-							//add a billing cycle to make up for the trial, if applicable
-							if(!empty($order->TotalBillingCycles))
-								$order->TotalBillingCycles++;
-						}
-						elseif($order->InitialPayment == 0 && $order->TrialAmount == 0)
-						{
-							//it has a trial, but the amount is the same as the initial payment, so we can squeeze it in there
-							$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s");														
-							$order->TrialBillingCycles++;
-							
-							//add a billing cycle to make up for the trial, if applicable
-							if(!empty($order->TotalBillingCycles))
-								$order->TotalBillingCycles++;
-						}
-						else
-						{
-							//add a period to the start date to account for the initial payment
-							$order->ProfileStartDate = date_i18n("Y-m-d\TH:i:s", strtotime("+ " . $order->BillingFrequency . " " . $order->BillingPeriod, current_time("timestamp")));
-						}
-						
-						$order->ProfileStartDate = apply_filters("pmpro_profile_start_date", $order->ProfileStartDate, $order);
-						if($this->subscribe($order))
-						{
-							return true;
-						}
-						else
-						{
-							if($this->void($order))
-							{
-								if(!$order->error)
-									$order->error = __("Unknown error: Payment failed.", 'paid-memberships-pro' );
-							}
-							else
-							{
-								if(!$order->error)
-									$order->error = __("Unknown error: Payment failed.", 'paid-memberships-pro' );
-								
-								$order->error .= " " . __("A partial payment was made that we could not void. Please contact the site owner immediately to correct this.", 'paid-memberships-pro' );
-							}
-							
-							return false;								
-						}
-					}
-					else
-					{
-						//only a one time charge
-						$order->status = "success";	//saved on checkout page											
-						return true;
-					}
-				}
-				else
-				{
-					if(empty($order->error))
-						$order->error = __("Unknown error: Payment failed.", 'paid-memberships-pro' );
-					
-					return false;
-				}	
-			}	
+	{
+		/**
+		 * Process the payment for a checkout order.
+		 * This includes charging the inital payment and setting up a subscription if applicable.
+		 *
+		 * @param MemberOrder $order The order object to process.
+		 * @return bool True if the payment was processed successfully, false otherwise.
+		 */
+		function process( &$order ) {
+			return true;
 		}
-		
+
+		/**
+		 * @deprecated TBD
+		 */
 		function authorize(&$order)
 		{
+			_deprecated_function( __METHOD__, 'TBD' );
+
 			//create a code for the order
 			if(empty($order->code))
 				$order->code = $order->getRandomCode();
@@ -145,9 +33,14 @@
 			$order->updateStatus("authorized");													
 			return true;					
 		}
-		
+
+		/**
+		 * @deprecated TBD
+		 */
 		function void(&$order)
 		{
+			_deprecated_function( __METHOD__, 'TBD' );
+
 			//need a transaction id
 			if(empty($order->payment_transaction_id))
 				return false;
@@ -157,9 +50,14 @@
 			$order->updateStatus("voided");					
 			return true;
 		}	
-		
+
+		/**
+		 * @deprecated TBD
+		 */
 		function charge(&$order)
 		{
+			_deprecated_function( __METHOD__, 'TBD' );
+
 			//create a code for the order
 			if(empty($order->code))
 				$order->code = $order->getRandomCode();
@@ -169,9 +67,14 @@
 			$order->updateStatus("success");					
 			return true;						
 		}
-		
+
+		/**
+		 * @deprecated TBD
+		 */
 		function subscribe(&$order)
 		{
+			_deprecated_function( __METHOD__, 'TBD' );
+
 			//create a code for the order
 			if(empty($order->code))
 				$order->code = $order->getRandomCode();
@@ -184,26 +87,50 @@
 			$order->subscription_transaction_id = "TEST" . $order->code;				
 			return true;
 		}	
-		
-		function update(&$order)
-		{
+
+		/**
+		 * Update the billing information for the subscription associated with the passed order.
+		 *
+		 * @param MemberOrder $order The order object associated with the subscription to update.
+		 * @return bool True if the billing information was updated successfully, false otherwise.
+		 */
+		function update( &$order ) {
 			//simulate a successful billing update
 			return true;
 		}
-		
-		function cancel(&$order)
-		{
+
+		/**
+		 * Cancel the subscription associated with the passed order.
+		 *
+		 * @deprecated TBD Use cancel_subscription insetad.
+		 *
+		 * @param MemberOrder $order The order object associated with the subscription to cancel.
+		 * @return bool True if the subscription was canceled successfully, false otherwise.
+		 */
+		function cancel( &$order ) {
 			//require a subscription id
 			if(empty($order->subscription_transaction_id))
-				return false;
-			
-			//simulate a successful cancel
-			$order->updateStatus("cancelled");					
+				return false;				
 			return true;
-		}	
-		
+		}
+
+		/**
+		 * Cancel a payment subscription.
+		 *
+		 * @param PMPro_Subscription $subscription The subscription to cancel.
+		 * @return bool True if the subscription was canceled successfully, false otherwise.
+		 */
+		function cancel_subscription( $subscription ) {
+			// Simulate a successful subscription cancelation.
+			return true;
+		}
+
+		/**
+		 * @deprecated TBD
+		 */
 		function getSubscriptionStatus(&$order)
 		{
+			_deprecated_function( __METHOD__, 'TBD' );
 			//require a subscription id
 			if(empty($order->subscription_transaction_id))
 				return false;
@@ -212,8 +139,12 @@
 			return array();
 		}
 
+		/**
+		 * @deprecated TBD
+		 */
 		function getTransactionStatus(&$order)
-		{			
+		{
+			_deprecated_function( __METHOD__, 'TBD' );	
 			//this looks different for each gateway, but generally an array of some sort
 			return array();
 		}		

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -1179,7 +1179,8 @@
 				if(!empty($order->id) && !empty($order->subscription_transaction_id) && $order->gateway == "paypalexpress")
 				{
 					//get the subscription status
-					$status = $order->getGatewaySubscriptionStatus();
+					$gateway = new PMProGateway_paypalexpress();
+					$status = $gateway->getSubscriptionStatus($order);
 
 					if(!empty($status) && !empty($status['NEXTBILLINGDATE']))
 					{

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3982,9 +3982,12 @@ function pmpro_show_discount_code() {
  /**
   * Build the order object used at checkout.
   * @since 2.1
+  * @deprecated TBD
   * @return mixed $order Order object.
   */
  function pmpro_build_order_for_checkout() {
+	_deprecated_function( __FUNCTION__, 'TBD' );
+
 	global $gateway, $pmpro_level, $current_user, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear, $CVV;
 
 	// Create a new order object.

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -527,10 +527,6 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 					$morder->tax              = pmpro_round_price( $morder->getTax( true ) );
 					$morder->total            = pmpro_round_price( $morder->subtotal + $morder->tax );
 
-					if ( ! $pmpro_requirebilling ) {
-						$morder = apply_filters( "pmpro_checkout_order_free", $morder );
-					}
-
 					// Finish setting up the order.
 					$morder->setGateway();
 					$morder->getMembershipLevelAtCheckout();	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, free and paid MemberOrders are created at different points in the checkout preheader. This PR moves all of the order creation logic to a single location to simplify the overall checkout flow.

Part of this work was reviewing the `PMProGateway` class. This class handles free checkouts and checkouts using the "test" gateway (when the `gateway` for an order is the empty string). In this class, there are many methods (such as `authorize()`, `charge()` and `subscribe()`) that provide an outline for how a payment gateway could function, but ultimately, the approach needed to code each gateway varies significantly and the existing sample code is outdated. For this reason, the sample `process()` function logic along with the corresponding helper methods are being removed and deprecated as they are not necessary for free/test checkouts and they are not "standard" across all other gateway classes.

TLDR: Each gateway should be responsible for its own `process()` method. The base `PMProGateway` class no longer tries to outline how this should work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
