### PR TITLE
Adds a "Default Value" field for certain User Fields

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -255,6 +255,15 @@ class PMPro_Field {
 	 */
 	public $html = '';
 
+	/**
+	 * The default value for a field.
+	 * 
+	 * @since TBD
+	 * 
+	 * @var string
+	 */
+	public $default = '';
+
 	function __construct($name = NULL, $type = NULL, $attr = NULL) {
 		if ( ! empty( $name ) )
 			return $this->set( $name, $type, $attr );
@@ -639,6 +648,18 @@ class PMPro_Field {
 		if ( is_admin() ) {
 			$r_beginning .= '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-' . esc_attr( $this->type ), 'pmpro_form_field-' . esc_attr( $this->type ) ) ) . '">';
 			$r_end .= "</div>";
+		}
+
+		if ( empty( $value ) ) {
+			/**
+			 * Filter to set the default value for a field. The default value will only load if no value is already found.
+			 * 
+			 * @param string $value The default value for the field.
+			 * @param object $this The field object.
+			 * 
+			 * @since TBD
+			 */
+			$value = apply_filters( 'pmpro_field_default_value', $this->default, $this );
 		}
 
 		if($this->type == "text")

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1347,6 +1347,7 @@ function pmpro_get_field_html( $field = null ) {
         $field_element_class = $field->element_class;
         $field_hint = $field->hint;
         $field_options = $field->options;
+		$field_default = $field->default;
     } else {
         // Default field values
         $field_label = '';
@@ -1359,6 +1360,7 @@ function pmpro_get_field_html( $field = null ) {
         $field_element_class = '';
         $field_hint = '';
         $field_options = '';
+		$field_default = '';
     }
     
 	// Other vars
@@ -1498,6 +1500,13 @@ function pmpro_get_field_html( $field = null ) {
                 <span class="description"><?php esc_html_e( 'One option per line. To set separate values and labels, use value:label.', 'paid-memberships-pro' ); ?></span>
             </div> <!-- end pmpro_userfield-field-setting -->
             
+			<div class="pmpro_userfield-field-setting">
+				<label>
+					<?php esc_html_e( 'Default Value (optional)', 'paid-memberships-pro' ); ?><br />
+					<input type="text" name="pmpro_userfields_field_default" value="<?php echo esc_attr( $field_default ); ?>" />
+				</label>
+			</div> <!-- end pmpro_userfield-field-setting -->
+
             <div class="pmpro_userfield-field-actions">            
                 <button name="pmpro_userfields_close_field" class="button button-secondary pmpro_userfields_close_field">
                     <?php esc_html_e( 'Close Field', 'paid-memberships-pro' ); ?>
@@ -1616,6 +1625,7 @@ function pmpro_load_user_fields_from_settings() {
                     'options' => $options,
                     'levels' => $levels,
                     'memberslistcsv' => true,
+					'default' => $settings_field->default,
                 )
             );
             pmpro_add_user_field( $group->name, $field );

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -441,7 +441,7 @@ function pmpro_userfields_prep_click_events() {
 		var fieldtype = jQuery(this).val();
 		var fielddefault = fieldsettings.find('input[name=pmpro_userfields_field_default]').parents('.pmpro_userfield-field-setting');
 
-		var defaulttypes = ['text', 'textarea', 'checkbox', 'radio', 'select', 'select2', 'multiselect', 'date', 'readonly'];
+		var defaulttypes = ['text', 'textarea', 'checkbox', 'radio', 'select', 'select2', 'multiselect', 'date', 'readonly', 'hidden'];
 
 		if (jQuery.inArray(fieldtype, defaulttypes) > -1) {
 			fielddefault.show();

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -434,6 +434,22 @@ function pmpro_userfields_prep_click_events() {
 		}
 	});
 
+	// Toggle default field based on type.
+	jQuery('select[name=pmpro_userfields_field_type]').on('change', function (event) {
+		var fieldcontainer = jQuery(this).parents('.pmpro_userfield-group-field');
+		var fieldsettings = fieldcontainer.children('.pmpro_userfield-field-settings');
+		var fieldtype = jQuery(this).val();
+		var fielddefault = fieldsettings.find('input[name=pmpro_userfields_field_default]').parents('.pmpro_userfield-field-setting');
+
+		var defaulttypes = ['text', 'textarea', 'checkbox', 'radio', 'select', 'select2', 'multiselect'];
+
+		if (jQuery.inArray(fieldtype, defaulttypes) > -1) {
+			fielddefault.show();
+		} else {
+			fielddefault.hide();
+		}
+	});
+
 	// Suggest name after leaving label field.
 	jQuery('input[name=pmpro_userfields_field_label]').on('focusout', function (event) {
 		var fieldcontainer = jQuery(this).parents('.pmpro_userfield-group-field');
@@ -498,6 +514,7 @@ function pmpro_userfields_prep_click_events() {
 				let field_element_class = jQuery(this).find('input[name=pmpro_userfields_field_divclass]').val();
 				let field_hint = jQuery(this).find('textarea[name=pmpro_userfields_field_hint]').val();
 				let field_options = jQuery(this).find('textarea[name=pmpro_userfields_field_options]').val();
+				let field_default = jQuery(this).find('input[name=pmpro_userfields_field_default]').val();
 
 				// Get level ids.            
 				let field_levels = [];
@@ -517,6 +534,7 @@ function pmpro_userfields_prep_click_events() {
 					'element_class': field_element_class,
 					'hint': field_hint,
 					'options': field_options,
+					'default': field_default
 				}
 
 				// Add to array. (Only if it has a label or name.)

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -441,7 +441,7 @@ function pmpro_userfields_prep_click_events() {
 		var fieldtype = jQuery(this).val();
 		var fielddefault = fieldsettings.find('input[name=pmpro_userfields_field_default]').parents('.pmpro_userfield-field-setting');
 
-		var defaulttypes = ['text', 'textarea', 'checkbox', 'radio', 'select', 'select2', 'multiselect'];
+		var defaulttypes = ['text', 'textarea', 'checkbox', 'radio', 'select', 'select2', 'multiselect', 'date', 'readonly'];
 
 		if (jQuery.inArray(fieldtype, defaulttypes) > -1) {
 			fielddefault.show();


### PR DESCRIPTION
* ENHANCEMENT: Adds a default value option for fields: text, textarea, select, radio, number, date, read only, and hidden. A new filter is also available to be used for the default value for all fields `pmpro_field_default_value`.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
