### PR TITLE
Refactoring checkout preheader to create user whenever possible

### DIFF
--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -76,7 +76,7 @@ function pmpro_cloudflare_turnstile_validation( $okay ) {
 
 	return $okay;
 }
-add_action( 'pmpro_registration_checks', 'pmpro_cloudflare_turnstile_validation' );
+add_action( 'pmpro_checkout_checks', 'pmpro_cloudflare_turnstile_validation' );
 add_action( 'pmpro_billing_update_checks', 'pmpro_cloudflare_turnstile_validation' );
 
 /**

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -549,7 +549,7 @@ function pmpro_registration_checks_for_user_fields( $okay ) {
 	//return whatever status was before
 	return $okay;
 }
-add_filter( 'pmpro_registration_checks', 'pmpro_registration_checks_for_user_fields' );
+add_filter( 'pmpro_checkout_order_creation_checks', 'pmpro_registration_checks_for_user_fields' );
 
 /**
  * Sessions vars for TwoCheckout. PayPal Express was updated to store in order meta.

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -232,7 +232,7 @@ function pmpro_recaptcha_validation_check( $continue = true ) {
 		return false;
 	}
 }
-add_filter( 'pmpro_registration_checks', 'pmpro_recaptcha_validation_check', 10, 1 );
+add_filter( 'pmpro_checkout_checks', 'pmpro_recaptcha_validation_check', 10, 1 );
 add_filter( 'pmpro_billing_update_checks', 'pmpro_recaptcha_validation_check', 10, 1 );
 
 /**

--- a/includes/terms-of-service.php
+++ b/includes/terms-of-service.php
@@ -174,7 +174,8 @@ function pmpro_validate_tos_at_checkout( $pmpro_continue_registration ) {
 
 	return $pmpro_continue_registration;
 }
-add_filter( 'pmpro_registration_checks', 'pmpro_validate_tos_at_checkout' );
+add_filter( 'pmpro_checkout_user_creation_checks', 'pmpro_validate_tos_at_checkout' );
+add_filter( 'pmpro_checkout_order_creation_checks', 'pmpro_validate_tos_at_checkout' );
 
 /**
  * Update TOS consent log after checkout.

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -18,28 +18,26 @@ if ( ! empty( $_REQUEST['pmpro_order'] ) ) {
 	$order_code = sanitize_text_field( $_REQUEST['pmpro_order'] );
 	$order_obj  = new MemberOrder( $order_code );
 	if ( ! empty( $order_obj->id ) ) {
-		$morder = $order_obj;
-
-		// If the order is not for the current user or the order is in error status, redirect to the account page.
-		if ( $current_user->ID != $morder->user_id || 'error' === $morder->status ) {
-			wp_redirect( pmpro_url( 'account' ) );
-			exit;
-		}
-
-		// If the order has already had a payment submitted, redirect to the confirmation page.
-		if ( in_array( $morder->status, array( 'success', 'pending' ) ) ) {
-			wp_redirect( pmpro_url( 'confirmation', '?level=' . $morder->membership_id ) );
-			exit;
-		}
-
-		pmpro_pull_checkout_data_from_order( $morder );
-
 		// $pmpro_review is a legacy variable from the old PayPal Express flow. When set, it was used to
 		// display a version of the checkout page where the user could review their order before submitting.
 		// Fields were not editable.
 		// We are reworking this variable to maintain backwards compatiblity with custom page templates and
 		// setting it whenever a token order is passed in the URL and requires addtional payment steps.
-		$pmpro_review = $morder;
+		$pmpro_review = $order_obj;
+
+		// If the order is not for the current user or the order is in error status, redirect to the account page.
+		if ( $current_user->ID != $pmpro_review->user_id || 'error' === $pmpro_review->status ) {
+			wp_redirect( pmpro_url( 'account' ) );
+			exit;
+		}
+
+		// If the order has already had a payment submitted, redirect to the confirmation page.
+		if ( in_array( $pmpro_review->status, array( 'success', 'pending' ) ) ) {
+			wp_redirect( pmpro_url( 'confirmation', '?level=' . $pmpro_review->membership_id ) );
+			exit;
+		}
+
+		pmpro_pull_checkout_data_from_order( $pmpro_review );
 	} else {
 		// This is an invalid order. Redirect to the account page.
 		wp_redirect( pmpro_url( 'account' ) );
@@ -48,8 +46,8 @@ if ( ! empty( $_REQUEST['pmpro_order'] ) ) {
 }
 
 //was a gateway passed?
-if ( ! empty( $morder ) ) {
-	$gateway = $morder->gateway;
+if ( ! empty( $pmpro_review ) ) {
+	$gateway = $pmpro_review->gateway;
 } elseif ( ! empty( $_REQUEST['gateway'] ) ) {
 	$gateway = sanitize_text_field($_REQUEST['gateway']);
 } else {
@@ -123,15 +121,6 @@ do_action( 'pmpro_checkout_preheader' );
 
 // We set a global var for add-ons that are expecting it.
 $pmpro_show_discount_code = pmpro_show_discount_code();
-
-//by default we show the account fields if the user isn't logged in
-if ( $current_user->ID ) {
-	$skip_account_fields = true;
-} else {
-	$skip_account_fields = false;
-}
-//in case people want to have an account created automatically
-$skip_account_fields = apply_filters( "pmpro_skip_account_fields", $skip_account_fields, $current_user );
 
 //load em up (other fields)
 global $username, $password, $password2, $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bphone, $bemail, $bconfirmemail, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
@@ -311,7 +300,7 @@ $pmpro_required_user_fields    = apply_filters( "pmpro_required_user_fields", $p
 //pmpro_confirmed is set to true later if payment goes through
 $pmpro_confirmed = false;
 
-//check their fields if they clicked continue
+// If there was a checkout submission, make sure that the form submission is valid.
 if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 	// Check the nonce.
 	if ( empty( $_REQUEST['pmpro_checkout_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['pmpro_checkout_nonce'] ), 'pmpro_checkout_nonce' ) ) {
@@ -324,24 +313,100 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 		}
 	}
 
-	//make sure javascript is ok
+	// Make sure javascript is ok.
 	if ( apply_filters( "pmpro_require_javascript_for_checkout", true ) && ! empty( $_REQUEST['checkjavascript'] ) && empty( $_REQUEST['javascriptok'] ) ) {
 		pmpro_setMessage( __( "There are JavaScript errors on the page. Please contact the webmaster.", 'paid-memberships-pro' ), "pmpro_error" );
 	}
 
-	// If we're skipping the account fields and there is no user, we need to create a username and password.
-	if ( $skip_account_fields && ! $current_user->ID ) {
-		// Generate the username using the first name, last name and/or email address.
-		$username = pmpro_generateUsername( $bfirstname, $blastname, $bemail );
+	// Make sure honeypot is ok.
+	if ( ! empty( $fullname ) ) {
+		pmpro_setMessage( __( "Are you a spammer?", 'paid-memberships-pro' ), "pmpro_error" );
+		$pmpro_error_fields[] = "fullname";
+	}
+}
 
-		// Generate the password.
-		$password  = wp_generate_password();
+// If there is still a valid checkout submission, allow custom code to halt the checkout.
+if ( $submit && $pmpro_msgt != "pmpro_error" ) {
+	/**
+	 * Filter whether the current checkout should continue.
+	 *
+	 * This filter will be checked every time that a checkout form is submitted regardless of if there is already a user or if $pmpro_review is set.
+	 * It should be used for checks that have to do with the form submisision itself, such as captchas.
+	 *
+	 * @param bool $pmpro_checkout_checks True if the checkout should continue.
+	 */
+	$pmpro_checkout_checks = apply_filters( "pmpro_checkout_checks", true );
+	if ( ! $pmpro_checkout_checks ) {
+		// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
+		pmpro_setMessage( __( 'Checkout checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );
+	}
+}
 
-		// Set the password confirmation to the generated password.
-		$password2 = $password;
+// If there is still a valid checkout submission and we don't have an order yet, run the the code needed to get to that point in the checkout process.
+if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
+	// Fill out account fields if we are skipping the account fields and we don't have a user yet.
+	/**
+	 * Set whether the account fields should be skipped on the checkout page.
+	 * This filter is useful when you do not want to show the account fields during the initial signup process.
+	 *
+	 * @param bool $skip_account_fields True if the account fields should be skipped.
+	 * @param WP_User|null $current_user The current user object or null if there is no user.
+	 */
+	$skip_account_fields = apply_filters( "pmpro_skip_account_fields", ! empty( $current_user->ID ), $current_user );
+	if ( empty( $current_user->ID ) && $skip_account_fields ) {
+		// If the first name, last name, and email address are set, use them to generate the username and password.
+		if ( ! empty( $bfirstname ) && ! empty( $blastname ) && ! empty( $bemail ) ) {
+			// Generate the username using the first name, last name and/or email address.
+			$username = pmpro_generateUsername( $bfirstname, $blastname, $bemail );
+
+			// Generate the password.
+			$password  = wp_generate_password();
+
+			// Set the password confirmation to the generated password.
+			$password2 = $password;
+		}
 	}
 
-	//check billing fields
+	// If we don't have a user yet, check the user fields.
+	if ( empty( $current_user->ID ) ) {
+		foreach ( $pmpro_required_user_fields as $key => $field ) {
+			if ( ! $field ) {
+				$pmpro_error_fields[] = $key;
+			}
+		}
+		if ( ! empty( $pmpro_error_fields ) ) {
+			pmpro_setMessage( __( "Please complete all required fields.", 'paid-memberships-pro' ), "pmpro_error" );
+		}
+		if ( $password != $password2 ) {
+			pmpro_setMessage( __( "Your passwords do not match. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
+			$pmpro_error_fields[] = "password";
+			$pmpro_error_fields[] = "password2";
+		}
+		if ( strcasecmp($bemail, $bconfirmemail) !== 0 ) {
+			pmpro_setMessage( __( "Your email addresses do not match. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
+			$pmpro_error_fields[] = "bemail";
+			$pmpro_error_fields[] = "bconfirmemail";
+		}
+		if ( ! is_email( $bemail ) ) {
+			pmpro_setMessage( __( "The email address entered is in an invalid format. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
+			$pmpro_error_fields[] = "bemail";
+			$pmpro_error_fields[] = "bconfirmemail";
+		}
+		$ouser = get_user_by( 'login', $username );
+		if ( ! empty( $ouser->user_login ) ) {
+			pmpro_setMessage( __( "That username is already taken. Please try another.", 'paid-memberships-pro' ), "pmpro_error" );
+			$pmpro_error_fields[] = "username";
+		}
+		$oldem_user = get_user_by( 'email', $bemail );
+		$oldem_user = apply_filters_deprecated( "pmpro_checkout_oldemail", array( ( false !== $oldem_user ? $oldem_user->user_email : null ) ), 'TBD' );
+		if ( ! empty( $oldem_user ) ) {
+			pmpro_setMessage( __( "That email address is already in use. Please log in, or use a different email address.", 'paid-memberships-pro' ), "pmpro_error" );
+			$pmpro_error_fields[] = "bemail";
+			$pmpro_error_fields[] = "bconfirmemail";
+		}
+	}
+
+	// Make sure to mark billing fields as missing if they aren't filled out.
 	if ( $pmpro_requirebilling ) {
 		//filter
 		foreach ( $pmpro_required_billing_fields as $key => $field ) {
@@ -351,254 +416,251 @@ if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 		}
 	}
 
-	//check user fields
-	if ( empty( $current_user->ID ) ) {
-		foreach ( $pmpro_required_user_fields as $key => $field ) {
-			if ( ! $field ) {
-				$pmpro_error_fields[] = $key;
+	// If there is still a vaild checkout submission, give custom code the chance to halt all checkouts (to be deprecated).
+	if ( $pmpro_msgt != "pmpro_error" ) {
+		/**
+		 * Filter whether the current checkout should continue.
+		 * Note: This will be deprecated in a future version. Use pmpro_checkout_checks, pmpro_checkout_user_creation_checks, or pmpro_checkout_order_creation_checks instead.
+		 *
+		 * @param bool $pmpro_continue_registration True if the checkout should continue.
+		 */
+		$pmpro_continue_registration = apply_filters( "pmpro_registration_checks", true );
+		if ( ! $pmpro_continue_registration ) {
+			// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
+			pmpro_setMessage( __( 'Checkout checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );
+		}
+	}
+
+	// If there is still a valid checkout submission and we don't have a user yet, give custom code the chance to halt user creation.
+	if ( $pmpro_msgt != "pmpro_error" && empty( $current_user->ID ) ) {
+		/**
+		 * Filter whether this checkout should proceed to the user creation step.
+		 *
+		 * @param bool $pmpro_checkout_user_creation_checks True if the checkout should continue.
+		 */
+		$pmpro_checkout_user_creation_checks = apply_filters( 'pmpro_checkout_user_creation_checks', true );
+		if ( ! $pmpro_checkout_user_creation_checks ) {
+			// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
+			pmpro_setMessage( __( 'User creation checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );
+		}
+	}
+
+	// If there is still a vaild checkout submission but we don't have a user yet, create one.
+	if ( $pmpro_msgt != "pmpro_error" && empty( $current_user->ID ) ) {
+		//first name
+		if ( ! empty( $_REQUEST['first_name'] ) ) {
+			$first_name = sanitize_text_field( $_REQUEST['first_name'] );
+		} else {
+			$first_name = $bfirstname;
+		}
+		//last name
+		if ( ! empty( $_REQUEST['last_name'] ) ) {
+			$last_name = sanitize_text_field( $_REQUEST['last_name'] );
+		} else {
+			$last_name = $blastname;
+		}
+
+		//insert user
+		$new_user_array = apply_filters( 'pmpro_checkout_new_user_array', array(
+				"user_login" => $username,
+				"user_pass"  => $password,
+				"user_email" => $bemail,
+				"first_name" => $first_name,
+				"last_name"  => $last_name
+			)
+		);
+
+		$user_id = apply_filters_deprecated( 'pmpro_new_user', array( '', $new_user_array ), 'TBD' );
+		if ( empty( $user_id ) ) {
+			$user_id = wp_insert_user( $new_user_array );
+		}
+
+		if ( empty( $user_id ) || is_wp_error( $user_id ) ) {
+			$e_msg = '';
+
+			if ( is_wp_error( $user_id ) ) {
+				$e_msg = $user_id->get_error_message();
 			}
+
+			$pmpro_msg  = __( "There was an error setting up your account. Please contact us.", 'paid-memberships-pro' ) . sprintf( " %s", $e_msg ); // Dirty 'don't break translation hack.
+			$pmpro_msgt = "pmpro_error";
+		} elseif ( apply_filters( 'pmpro_setup_new_user', true, $user_id, $new_user_array, $pmpro_level ) ) {
+
+			pmpro_maybe_send_wp_new_user_notification( $user_id, $pmpro_level->id );
+
+			$wpuser = get_userdata( $user_id );
+			$wpuser->set_role( get_option( 'default_role', 'subscriber' ) );
+
+			/**
+			 * Allow hooking before the user authentication process when setting up new user.
+			 *
+			 * @since 2.5.10
+			 *
+			 * @param int $user_id The user ID that is being setting up.
+			 */
+			do_action( 'pmpro_checkout_before_user_auth', $user_id );
+
+
+			//okay, log them in to WP
+			$creds                  = array();
+			$creds['user_login']    = $new_user_array['user_login'];
+			$creds['user_password'] = $new_user_array['user_pass'];
+			$creds['remember']      = true;
+			$user                   = wp_signon( $creds, false );
+			//setting some cookies
+			wp_set_current_user( $user_id, $username );
+			wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
+			global $current_user;
+			if ( ! $current_user->ID && $user->ID ) {
+				$current_user = $user;
+			} //in case the user just signed up
+			pmpro_set_current_user();
+
+			// Update nonce value to be for this new user when we load the checkout page.
+			add_filter( 'pmpro_update_nonce_at_checkout', '__return_true' );
+
+			// Skip the account fields since we just created an account.
+			$skip_account_fields = true;
 		}
 	}
 
-	if ( ! empty( $pmpro_error_fields ) ) {
-		pmpro_setMessage( __( "Please complete all required fields.", 'paid-memberships-pro' ), "pmpro_error" );
-	}
-	if ( ! empty( $password ) && $password != $password2 ) {
-		pmpro_setMessage( __( "Your passwords do not match. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
-		$pmpro_error_fields[] = "password";
-		$pmpro_error_fields[] = "password2";
-	}
-	if ( strcasecmp($bemail, $bconfirmemail) !== 0 ) {
-		pmpro_setMessage( __( "Your email addresses do not match. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
-		$pmpro_error_fields[] = "bemail";
-		$pmpro_error_fields[] = "bconfirmemail";
-	}
-	if ( ! empty( $bemail ) && ! is_email( $bemail ) ) {
-		pmpro_setMessage( __( "The email address entered is in an invalid format. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
-		$pmpro_error_fields[] = "bemail";
-		$pmpro_error_fields[] = "bconfirmemail";
-	}
-	if ( ! in_array( $gateway, $valid_gateways ) ) {
-		pmpro_setMessage( __( "Invalid gateway.", 'paid-memberships-pro' ), "pmpro_error" );
-	}
-	if ( ! empty( $fullname ) ) {
-		pmpro_setMessage( __( "Are you a spammer?", 'paid-memberships-pro' ), "pmpro_error" );
-	}
-
-	if ( $pmpro_msgt == "pmpro_error" ) {
-		$pmpro_continue_registration = false;
-	} else {
-		$pmpro_continue_registration = true;
-	}
-	$pmpro_continue_registration = apply_filters( "pmpro_registration_checks", $pmpro_continue_registration );
-
-	if ( $pmpro_continue_registration ) {
-		//if creating a new user, check that the email and username are available
-		if ( empty( $current_user->ID ) ) {
-			$ouser      = get_user_by( 'login', $username );
-			$oldem_user = get_user_by( 'email', $bemail );
-
-			//this hook can be used to allow multiple accounts with the same email address
-			$oldemail = apply_filters( "pmpro_checkout_oldemail", ( false !== $oldem_user ? $oldem_user->user_email : null ) );
+	// If there is still a valid checkout submission, check the billing fields.
+	if ( $pmpro_msgt != "pmpro_error" ) {
+		// We can check the billing fields at this point by checking if $pmpro_error_fields is not empty.
+		if ( ! empty( $pmpro_error_fields ) ) {
+			pmpro_setMessage( __( "Please complete all required fields.", 'paid-memberships-pro' ), "pmpro_error" );
 		}
-
-		if ( ! empty( $ouser->user_login ) ) {
-			pmpro_setMessage( __( "That username is already taken. Please try another.", 'paid-memberships-pro' ), "pmpro_error" );
-			$pmpro_error_fields[] = "username";
-		}
-
-		if ( ! empty( $oldemail ) ) {
-			pmpro_setMessage( __( "That email address is already in use. Please log in, or use a different email address.", 'paid-memberships-pro' ), "pmpro_error" );
+		if ( ! empty( $bemail ) && ! is_email( $bemail ) ) {
+			pmpro_setMessage( __( "The email address entered is in an invalid format. Please try again.", 'paid-memberships-pro' ), "pmpro_error" );
 			$pmpro_error_fields[] = "bemail";
 			$pmpro_error_fields[] = "bconfirmemail";
 		}
-
-		// Only continue if there are no other errors yet
-		if ( $pmpro_msgt != "pmpro_error" ) {
-			// Do we need to create a user account?
-			if ( ! $current_user->ID ) {
-				// Yes, create user.
-
-				//first name
-				if ( ! empty( $_REQUEST['first_name'] ) ) {
-					$first_name = sanitize_text_field( $_REQUEST['first_name'] );
-				} else {
-					$first_name = $bfirstname;
-				}
-				//last name
-				if ( ! empty( $_REQUEST['last_name'] ) ) {
-					$last_name = sanitize_text_field( $_REQUEST['last_name'] );
-				} else {
-					$last_name = $blastname;
-				}
-
-				//insert user
-				$new_user_array = apply_filters( 'pmpro_checkout_new_user_array', array(
-						"user_login" => $username,
-						"user_pass"  => $password,
-						"user_email" => $bemail,
-						"first_name" => $first_name,
-						"last_name"  => $last_name
-					)
-				);
-
-				$user_id = apply_filters( 'pmpro_new_user', '', $new_user_array );
-				if ( empty( $user_id ) ) {
-					$user_id = wp_insert_user( $new_user_array );
-				}
-
-				if ( empty( $user_id ) || is_wp_error( $user_id ) ) {
-					$e_msg = '';
-
-					if ( is_wp_error( $user_id ) ) {
-						$e_msg = $user_id->get_error_message();
-					}
-
-					$pmpro_msg  = __( "There was an error setting up your account. Please contact us.", 'paid-memberships-pro' ) . sprintf( " %s", $e_msg ); // Dirty 'don't break translation hack.
-					$pmpro_msgt = "pmpro_error";
-				} elseif ( apply_filters( 'pmpro_setup_new_user', true, $user_id, $new_user_array, $pmpro_level ) ) {
-
-					pmpro_maybe_send_wp_new_user_notification( $user_id, $pmpro_level->id );
-
-					$wpuser = get_userdata( $user_id );
-					$wpuser->set_role( get_option( 'default_role', 'subscriber' ) );
-
-					/**
-					 * Allow hooking before the user authentication process when setting up new user.
-					 *
-					 * @since 2.5.10
-					 *
-					 * @param int $user_id The user ID that is being setting up.
-					 */
-					do_action( 'pmpro_checkout_before_user_auth', $user_id );
-
-
-					//okay, log them in to WP
-					$creds                  = array();
-					$creds['user_login']    = $new_user_array['user_login'];
-					$creds['user_password'] = $new_user_array['user_pass'];
-					$creds['remember']      = true;
-					$user                   = wp_signon( $creds, false );
-					//setting some cookies
-					wp_set_current_user( $user_id, $username );
-					wp_set_auth_cookie( $user_id, true, apply_filters( 'pmpro_checkout_signon_secure', force_ssl_admin() ) );
-					global $current_user;
-					if ( ! $current_user->ID && $user->ID ) {
-						$current_user = $user;
-					} //in case the user just signed up
-					pmpro_set_current_user();
-
-					// Update nonce value to be for this new user when we load the checkout page.
-					add_filter( 'pmpro_update_nonce_at_checkout', '__return_true' );
-
-					// Skip the account fields since we just created an account.
-					$skip_account_fields = true;
-				}
-			} else {
-				$user_id = $current_user->ID;
-			}
-
-			//no errors yet
-			if ( $pmpro_msgt != "pmpro_error" ) {
-				do_action( 'pmpro_checkout_before_processing' );
-
-				// If we don't have a checkout order yet, create one.
-				if ( empty( $morder ) ) {
-					$morder                   = new MemberOrder();
-					$morder->user_id          = $current_user->ID;
-					$morder->membership_id    = $pmpro_level->id;
-					$morder->cardtype         = $CardType;
-					$morder->accountnumber    = $AccountNumber;
-					$morder->expirationmonth  = $ExpirationMonth;
-					$morder->expirationyear   = $ExpirationYear;
-					$morder->gateway          = $pmpro_requirebilling ? $gateway : 'free';
-					$morder->billing          = new stdClass();
-					$morder->billing->name    = $bfirstname . " " . $blastname;
-					$morder->billing->street  = trim( $baddress1 );
-					$morder->billing->street2 = trim( $baddress2 );
-					$morder->billing->city    = $bcity;
-					$morder->billing->state   = $bstate;
-					$morder->billing->country = $bcountry;
-					$morder->billing->zip     = $bzipcode;
-					$morder->billing->phone   = $bphone;
-
-					// Calculate the order subtotal, tax, and total.
-					$morder->subtotal         = pmpro_round_price( $pmpro_level->initial_payment );
-					$morder->tax              = pmpro_round_price( $morder->getTax( true ) );
-					$morder->total            = pmpro_round_price( $morder->subtotal + $morder->tax );
-
-					// Finish setting up the order.
-					$morder->setGateway();
-					$morder->getMembershipLevelAtCheckout();	
-
-					// Filter for order, since v1.8
-					if ( $pmpro_requirebilling ) {
-						$morder = apply_filters( 'pmpro_checkout_order', $morder );
-					} else {
-						$morder = apply_filters( 'pmpro_checkout_order_free', $morder );
-					}
-				}
-
-				// Process the payment.
-				$pmpro_processed = $morder->process();
-				if ( ! empty( $pmpro_processed ) ) {
-					$pmpro_msg       = __( "Payment accepted.", 'paid-memberships-pro' );
-					$pmpro_msgt      = "pmpro_success";
-					$pmpro_confirmed = true;
-				} else {
-					/**
-					 * Allow running code when processing fails.
-					 *
-					 * @since 2.7
-					 * @param MemberOrder $morder The order object used at checkout.
-					 */
-					do_action( 'pmpro_checkout_processing_failed', $morder );
-
-					// Make sure we have an error message.
-					$pmpro_msg = !empty( $morder->error ) ? $morder->error : null;
-					if ( empty( $pmpro_msg ) ) {
-						$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", 'paid-memberships-pro' );
-					}
-					if ( ! empty( $morder->error_type ) ) {
-						$pmpro_msgt = $morder->error_type;
-					} else {
-						$pmpro_msgt = "pmpro_error";
-					}
-				}
-			}
+		if ( ! in_array( $gateway, $valid_gateways ) ) {
+			pmpro_setMessage( __( "Invalid gateway.", 'paid-memberships-pro' ), "pmpro_error" );
 		}
-	}    //endif ($pmpro_continue_registration)
+		if ( ! empty( $fullname ) ) {
+			pmpro_setMessage( __( "Are you a spammer?", 'paid-memberships-pro' ), "pmpro_error" );
+		}
+	}
+
+	// If there is still a valid checkout submission, give custom code the chance to halt checkout.
+	if ( $pmpro_msgt != "pmpro_error" ) {
+		/**
+		 * Filter whether this checkout should proceed to the order creation step.
+		 *
+		 * @param bool $pmpro_checkout_checks True if the checkout should continue.
+		 */
+		$pmpro_checkout_order_creation_checks = apply_filters( "pmpro_checkout_order_creation_checks", true );
+		if ( ! $pmpro_checkout_order_creation_checks ) {
+			// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
+			pmpro_setMessage( __( 'Order creation checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );
+		}
+	}
+
+	// If there is still a valid checkout submission, create the order.
+	if ( $pmpro_msgt != "pmpro_error" ) {
+		$pmpro_review                   = new MemberOrder();
+		$pmpro_review->user_id          = $current_user->ID;
+		$pmpro_review->membership_id    = $pmpro_level->id;
+		$pmpro_review->cardtype         = $CardType;
+		$pmpro_review->accountnumber    = $AccountNumber;
+		$pmpro_review->expirationmonth  = $ExpirationMonth;
+		$pmpro_review->expirationyear   = $ExpirationYear;
+		$pmpro_review->gateway          = $pmpro_requirebilling ? $gateway : 'free';
+		$pmpro_review->billing          = new stdClass();
+		$pmpro_review->billing->name    = $bfirstname . " " . $blastname;
+		$pmpro_review->billing->street  = trim( $baddress1 );
+		$pmpro_review->billing->street2 = trim( $baddress2 );
+		$pmpro_review->billing->city    = $bcity;
+		$pmpro_review->billing->state   = $bstate;
+		$pmpro_review->billing->country = $bcountry;
+		$pmpro_review->billing->zip     = $bzipcode;
+		$pmpro_review->billing->phone   = $bphone;
+
+		// Calculate the order subtotal, tax, and total.
+		$pmpro_review->subtotal         = pmpro_round_price( $pmpro_level->initial_payment );
+		$pmpro_review->tax              = pmpro_round_price( $pmpro_review->getTax( true ) );
+		$pmpro_review->total            = pmpro_round_price( $pmpro_review->subtotal + $pmpro_review->tax );
+
+		// Finish setting up the order.
+		$pmpro_review->setGateway();
+		$pmpro_review->getMembershipLevelAtCheckout();	
+
+		// Filter for order, since v1.8
+		if ( $pmpro_requirebilling ) {
+			$pmpro_review = apply_filters( 'pmpro_checkout_order', $pmpro_review );
+		} else {
+			$pmpro_review = apply_filters( 'pmpro_checkout_order_free', $pmpro_review );
+		}
+	}
+} // End if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) )
+
+// If there is still a valid checkout submission, process the order.
+if ( $submit && $pmpro_msgt != "pmpro_error" && ! empty( $pmpro_review ) ) {
+	do_action( 'pmpro_checkout_before_processing' );
+
+	// Process the payment.
+	$pmpro_processed = $pmpro_review->process();
+	if ( ! empty( $pmpro_processed ) ) {
+		$pmpro_msg       = __( "Payment accepted.", 'paid-memberships-pro' );
+		$pmpro_msgt      = "pmpro_success";
+		$pmpro_confirmed = true;
+	} else {
+		/**
+		 * Allow running code when processing fails.
+		 *
+		 * @since 2.7
+		 * @param MemberOrder $pmpro_review The order object used at checkout.
+		 */
+		do_action( 'pmpro_checkout_processing_failed', $pmpro_review );
+
+		// Make sure we have an error message.
+		$pmpro_msg = !empty( $pmpro_review->error ) ? $pmpro_review->error : null;
+		if ( empty( $pmpro_msg ) ) {
+			$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", 'paid-memberships-pro' );
+		}
+		if ( ! empty( $pmpro_review->error_type ) ) {
+			$pmpro_msgt = $pmpro_review->error_type;
+		} else {
+			$pmpro_msgt = "pmpro_error";
+		}
+	}
 }
 
-// Hook to check payment confirmation or replace it. If we get an array back, pull the values (morder) out
+// Hook to check payment confirmation or replace it. If we get an array back, pull the values (pmpro_review) out
 // All of this is deprecated and will be removed in a future version.
-if ( empty( $morder ) ) {
-	// make sure we have at least an empty morder here to avoid a warning
-	$morder = false;
+if ( empty( $pmpro_review ) ) {
+	// make sure we have at least an empty order here to avoid a warning
+	$pmpro_review = false;
 }
-$pmpro_confirmed_data = apply_filters_deprecated( 'pmpro_checkout_confirmed', array( $pmpro_confirmed, $morder ), 'TBD' );
+$pmpro_confirmed_data = apply_filters_deprecated( 'pmpro_checkout_confirmed', array( $pmpro_confirmed, $pmpro_review ), 'TBD' );
 if ( is_array( $pmpro_confirmed_data ) ) {
 	extract( $pmpro_confirmed_data );
+
+	// Our old PPE integration had $morder dynamically set here. We changed that variable name to $pmpro_review. In case other integrations are using this filter, set $pmpro_review to $morder.
+	if ( ! empty( $morder ) ) {
+		$pmpro_review = $morder;
+	}
 } else {
 	$pmpro_confirmed = $pmpro_confirmed_data;
 }
 
 // If the payment was successful, complete the checkout.
 if ( ! empty( $pmpro_confirmed ) ) {
-	if ( pmpro_complete_checkout( $morder ) ) {
+	if ( pmpro_complete_checkout( $pmpro_review ) ) {
 		//redirect to confirmation
 		$rurl = pmpro_url( "confirmation", "?pmpro_level=" . $pmpro_level->id );
-		$rurl = apply_filters( "pmpro_confirmation_url", $rurl, $user_id, $pmpro_level );
+		$rurl = apply_filters( "pmpro_confirmation_url", $rurl, $current_user->ID, $pmpro_level );
 		wp_redirect( $rurl );
 		exit;
 	} else {
 
 		// Something went wrong with the checkout.
 		// If we get here, then the call to pmpro_changeMembershipLevel() returned false within pmpro_complete_checkout(). Let's try to cancel the payment.
-		$test = (array) $morder;
-		if ( ! empty( $test ) && $morder->cancel() ) {
+		$test = (array) $pmpro_review;
+		if ( ! empty( $test ) && $pmpro_review->cancel() ) {
 			$pmpro_msg = __( "IMPORTANT: Something went wrong while processing your checkout. Your credit card authorized, but we cancelled the order immediately. You should not try to submit this form again. Please contact the site owner to fix this issue.", 'paid-memberships-pro' );
-			$morder    = null;
+			$pmpro_review    = null;
 		} else {
 			$pmpro_msg = __( "IMPORTANT: Something went wrong while processing your checkout. Your credit card was charged, but we couldn't assign your membership. You should not submit this form again. Please contact the site owner to fix this issue.", 'paid-memberships-pro' );
 		}
@@ -638,4 +700,4 @@ pmpro_getAllLevels();
  * Hook to run actions after the checkout preheader is loaded.
  * @since 2.1
  */
-do_action( 'pmpro_after_checkout_preheader', $morder );
+do_action( 'pmpro_after_checkout_preheader', $pmpro_review );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The main goal of this PR is to allow a WP user to be created even when some checkout fields are still empty or invalid (ex. billing fields, required donation fields, sponsored member account fields, etc).

As a part of this work, the checkout preheader flow is more clearly separated into steps that avoid deeply nested `if` statements. This refactoring work should help to simplify updating this code in the future.

This work also looks to replace the `pmpro_registration_checks` filter with three filters for three separate use-cases:
- `pmpro_checkout_checks` runs every time that the checkout form is submitted. This is useful for captchas that we always want to check.
- `pmpro_checkout_user_creation_checks` runs before a WP user is created. Since this PR makes PMPro more flexible with when users are created, this is the hook that should be used to, for example, restrict the domains of email addresses signing up for the website.
- `pmpro_checkout_order_creation_checks` runs before an order is created at checkout. This is is the filter that will be used most often of the 3 and is used to halt individual checkout attempts. This is where custom code would validate donation amounts, shipping address fields, etc.

This PR also keeps `pmpro_registration_checks` functional and will prevent both users and orders from being created. This is how the filter currently functions. The deprecation timeline for this filter looks something like this:
- Push out the replacement filters ASAP
- Once the replacement filters have been in the wild for a while (maybe a year or so), begin using them in Add Ons
- Once most of the Add Ons are using the new filter, mark `pmpro_registration_checks` as deprecated
- Once the filter is deprecated for a reasonable amount of time (maybe another year or so), remove it during the next major release

There are also a couple of smaller changes in this PR such as deprecating some filters that never appear to really be used in our Add Ons or code recipes and replacing references to the local `$morder` variable to the global `$pmpro_review` variable that we want to support moving forwards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
