### PR TITLE
Fix setting code_id in memberships users table

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -210,6 +210,11 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 	 */
 	$enddate = apply_filters( "pmpro_checkout_end_date", $enddate, $order->user_id, $pmpro_level, $startdate );
 
+	// If we have a discount code but not the ID, get the ID.
+	if ( ! empty( $discount_code ) && empty( $discount_code_id ) ) {
+		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
+	}
+
 	//custom level to change user to
 	$custom_level = array(
 		'user_id'         => $order->user_id,
@@ -233,21 +238,18 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 		$order->saveOrder();
 
 		//add discount code use
-		if ( ! empty( $discount_code ) ) {
-			$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
-			if ( ! empty( $discount_code_id ) ) {
-				$wpdb->query(
-					$wpdb->prepare(
-						"INSERT INTO {$wpdb->pmpro_discount_codes_uses} 
-							( code_id, user_id, order_id, timestamp ) 
-							VALUES( %d, %d, %s, %s )",
-						$discount_code_id,
-						$order->user_id,
-						$order->id,
-						current_time( 'mysql' )
-					)	
-				);
-			}
+		if ( ! empty( $discount_code_id ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO {$wpdb->pmpro_discount_codes_uses} 
+						( code_id, user_id, order_id, timestamp ) 
+						VALUES( %d, %d, %s, %s )",
+					$discount_code_id,
+					$order->user_id,
+					$order->id,
+					current_time( 'mysql' )
+				)	
+			);
 			do_action( 'pmpro_discount_code_used', $discount_code_id, $order->user_id, $order->id );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Make sure that `$discount_code_id` is set before adding the entry to the memberships users table. This fixes functionality in the deprecated Sponsored Members Add On.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
