### PR TITLE
Mark Authorize.net as deprecated

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1011,6 +1011,7 @@ add_filter( 'plugin_action_links', 'pmpro_deprecated_add_ons_action_links', 10, 
  * The 2Checkout gateway was deprecated in v2.6.
  * Cybersource was deprecated in 2.10.
  * PayPal Website Payments Pro was deprecated in 2.10.
+ * Authorize.net was deprecated in 3.2.
  *
  * This code will add it back those gateways if it was the selected gateway.
  * In future versions, we will remove gateway code entirely.
@@ -1027,7 +1028,7 @@ function pmpro_check_for_deprecated_gateways() {
 	}
 	$default_gateway = get_option( 'pmpro_gateway' );
 
-	$deprecated_gateways = array( 'twocheckout', 'cybersource', 'paypal' );
+	$deprecated_gateways = array( 'twocheckout', 'cybersource', 'paypal', 'authorizenet' );
 	foreach ( $deprecated_gateways as $deprecated_gateway ) {
 		if ( $default_gateway === $deprecated_gateway || in_array( $deprecated_gateway, $undeprecated_gateways ) ) {
 			require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_' . $deprecated_gateway . '.php' );

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -120,8 +120,6 @@ require_once( PMPRO_DIR . '/includes/blocks.php' ); // Set up blocks.
 require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway.php' ); // loaded by memberorder class when needed
 
 // load payment gateway class
-require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_authorizenet.php' );
-
 if ( version_compare( PHP_VERSION, '5.4.45', '>=' ) ) {
 	require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_braintree.php' );
 }
@@ -192,7 +190,6 @@ function pmpro_gateways() {
 		'paypalexpress'     => __( 'PayPal Express', 'paid-memberships-pro' ),
 		'payflowpro'        => __( 'PayPal Payflow Pro/PayPal Pro', 'paid-memberships-pro' ),
 		'paypalstandard'    => __( 'PayPal Standard', 'paid-memberships-pro' ),
-		'authorizenet'      => __( 'Authorize.net', 'paid-memberships-pro' ),
 		'braintree'         => __( 'Braintree Payments', 'paid-memberships-pro' ),
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Sites already using Authorize.net will be able to continue using that gateway, but it will not be shown as an option on new sites.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
