### PR TITLE
Fixed User Field File Upload missing file types.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4799,8 +4799,8 @@ function pmpro_check_upload( $file_index ) {
 						return ltrim( $type, '.' );
 					}, $allowed_mime_types );
 
-					// Check the file type against the allowed types.
-					if ( ! in_array( $filetype['ext'], $allowed_mime_types ) ) {
+					// Check the file type against the allowed types. If empty allowed mimes, assume any file upload is okay.
+					if ( ! empty( $allowed_mime_types ) && ! in_array( $filetype['ext'], $allowed_mime_types ) ) {
 						return new WP_Error( 'pmpro_upload_file_type_error', sprintf( esc_html__( 'Invalid file type. Please try uploading the file type(s): %s', 'paid-memberships-pro' ), implode( ',' ,$allowed_mime_types ) ) );
 					}
 					


### PR DESCRIPTION
* BUG FIX: Fixed an issue where no file restrictions were restricting file uploads.

Note, I ran a test with no file restrictions as well as specific file type uploads.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
