### PR TITLE
Adding screen reader text to empty header row

### DIFF
--- a/pages/levels.php
+++ b/pages/levels.php
@@ -75,7 +75,7 @@ $level_groups  = pmpro_get_level_groups_in_order();
 									<tr>
 										<th><?php esc_html_e('Level', 'paid-memberships-pro' );?></th>
 										<th><?php esc_html_e('Price', 'paid-memberships-pro' );?></th>	
-										<th>&nbsp;</th>
+										<th><span class="screen-reader-text"><?php esc_html_e( 'Action', 'paid-memberships-pro' ); ?></span></th>
 									</tr>
 								</thead>
 								<tbody>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Small update to improve a11y of the levels page. 

### Changelog entry
* ENHANCEMENT: Added screen reader text to identify an empty header row on levels table output.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
