### PR TITLE
Comment out cancel_subscription method in the pmprogateway class

### DIFF
--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -102,7 +102,7 @@
 		/**
 		 * Cancel the subscription associated with the passed order.
 		 *
-		 * @deprecated 3.2 Use cancel_subscription insetad.
+		 * @deprecated 3.2 Use cancel_subscription instead by overriding it in each gateway class.
 		 *
 		 * @param MemberOrder $order The order object associated with the subscription to cancel.
 		 * @return bool True if the subscription was canceled successfully, false otherwise.
@@ -119,11 +119,12 @@
 		 *
 		 * @param PMPro_Subscription $subscription The subscription to cancel.
 		 * @return bool True if the subscription was canceled successfully, false otherwise.
-		 */
-		function cancel_subscription( $subscription ) {
-			// Simulate a successful subscription cancelation.
-			return true;
-		}
+		 *
+		 * function cancel_subscription( $subscription ) {
+		 *  // Simulate a successful subscription cancelation.
+		 *	 return true;
+		 * }
+		*/
 
 		/**
 		 * @deprecated 3.2


### PR DESCRIPTION
This is a temporary fix to remove the update_subscription method from the base gateway class as we have checks to see if the method_exists for a gateway object. I've commented this out versus entirely removing it from the class so developers can reference this.

This will always return true since we are extending the base class and `method_exists` isn't smart enough to know if we're overriding the method or not within our actual gateway used class.

Gateways may still declare the `cancel_subscription` method and use this as the preffered/newer way of doing things and gateways that are still using the deprecated `cancel()` method would still work.