### PR TITLE
Adds pmpro_method_defined_in_class and uses in PMPro_Subscription class

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1186,7 +1186,15 @@ class PMPro_Subscription {
 		$cancelled = false;
 		$gateway_object = $this->get_gateway_object();
 		if ( is_object( $gateway_object ) ) {
-			if ( method_exists( $gateway_object, 'cancel_subscription' ) ) {
+			/**
+			 * Note here. We want to check if the gateway class
+			 * _overrides_ the cancel_subscription method.
+			 * So we use our new pmpro_method_defined_in_class() function.
+			 * If not, we just look for a cancel method and fallback to cancelling that way.
+			 * For that method_exists check, we are okay if the cancel method is in
+			 * the extended class or the base class.
+			 */
+			if ( pmpro_method_defined_in_class( $gateway_object, 'cancel_subscription' ) ) {
 				$cancelled = $gateway_object->cancel_subscription( $this );
 			} elseif ( method_exists( $gateway_object, 'cancel' ) ) {
 				// Legacy: Build an order to pass to the old cancel() methods in gateways.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4932,3 +4932,27 @@ function pmpro_get_subscription_period_end_date_for_order( $order, $date_format 
 	// Format and return the end date.
 	return date_i18n( $date_format, $period_end );
 }
+
+/**
+ * Check if a method is specifically defined in the given object's class, not inherited.
+ *
+ * @since 3.2.2
+ * @param object $object The object to check for the method.
+ * @param string $method_name The name of the method to check.
+ * @return bool True if the method is overridden in the object's class, false otherwise.
+ */
+function pmpro_method_defined_in_class( $object, $method_name ) {
+    // Get the class of the object.
+    $reflection_class = new ReflectionClass( $object );
+
+    // Check if the method exists in this class.
+    if ( !$reflection_class->hasMethod( $method_name ) ) {
+        return false; // The method doesn't exist at all.
+    }
+
+    // Get the method reflection.
+    $method = $reflection_class->getMethod( $method_name );
+
+    // Check if the method's declaring class is the same as the object's class.
+    return $method->getDeclaringClass()->getName() === $reflection_class->getName();
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The pmpro_method_defined_in_class() checks if a method is specifically defined in the given object's class, not inherited.

We then use that method in the PMPro_Subscription class to detect if the gateway classes hasn't overridden the default cancel_subscription() method. In that case, we want to fallback and use the old cancel method instead.

### How to test the changes in this Pull Request:

This was tested using the Paystack Add On for PMPro. In versions of PMPro before 3.2, that gateway was able to cancel the subscription at the gateway. When using 3.2 without this fix, the subscription is not cancelled at the gateway (it is cancelled locally though). When using this fix, the subscription is once again cancelled at the gateway.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed issue where some third party gateways were no longer cancelling subscriptions at the gateway when cancelled locally in WP/PMPro. If you were using a gateway that is not included with the core PMPro plugin, please double check all recent cancellations to make sure they were sync'd to your gateway. If not, you will have to cancel those subscriptions at the gateway manually.
