### PR TITLE
Now only loading billing addresses from user meta when initially loading the checkout page

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -680,7 +680,7 @@ if ( ! empty( $pmpro_confirmed ) ) {
 
 	// Default billing address fields from the values stored in user meta.
 	// Note that this will be removed in a future update as billing addresses are no longer stored in user meta by default.
-	if ( ! empty( $current_user->ID ) && empty( $pmpro_review ) ) {
+	if ( ! empty( $current_user->ID ) && empty( $submit ) ) {
 		$bfirstname    = get_user_meta( $current_user->ID, "pmpro_bfirstname", true );
 		$blastname     = get_user_meta( $current_user->ID, "pmpro_blastname", true );
 		$baddress1     = get_user_meta( $current_user->ID, "pmpro_baddress1", true );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -678,8 +678,9 @@ if ( ! empty( $pmpro_confirmed ) ) {
 		$pmpro_msgt = "";
 	}
 
-	//default values from DB
-	if ( ! empty( $current_user->ID ) ) {
+	// Default billing address fields from the values stored in user meta.
+	// Note that this will be removed in a future update as billing addresses are no longer stored in user meta by default.
+	if ( ! empty( $current_user->ID ) && empty( $pmpro_review ) ) {
 		$bfirstname    = get_user_meta( $current_user->ID, "pmpro_bfirstname", true );
 		$blastname     = get_user_meta( $current_user->ID, "pmpro_blastname", true );
 		$baddress1     = get_user_meta( $current_user->ID, "pmpro_baddress1", true );


### PR DESCRIPTION
Fixes an issue where Stripe 3DS checks will fail when billing addresses are required at checkout.

These lines will be removed in a future update as we are no longer storing billing addresses in user meta.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
