### PR TITLE
Style the Terms of Service input consistently with the rest of the ch…

### DIFF
--- a/includes/terms-of-service.php
+++ b/includes/terms-of-service.php
@@ -65,43 +65,47 @@ function pmpro_show_tos_at_checkout() {
 	// Show the TOS checkbox.
 	?>
 	<fieldset id="pmpro_tos_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_tos_fields' ) ); ?>">
-		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
-			<?php
-				if ( isset( $_REQUEST['tos'] ) ) {
-					$tos = intval( $_REQUEST['tos'] );
-				} else {
-					$tos = "";
-				}
-			?>
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-checkbox pmpro_form_field-required' ) ); ?>">
-				<label class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label pmpro_clickable', 'tos' ) ); ?>" for="tos">
-					<input type="checkbox" name="tos" value="1" id="tos" <?php checked( 1, $tos ); ?> class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-checkbox pmpro_form_input-required', 'tos' ) ); ?>" />
+		<div class="pmpro_card">
+			<div class="pmpro_card_content">
+				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
 					<?php
-						$tos_label = sprintf( __( 'I agree to the <a href="%1$s" target="_blank">%2$s</a>', 'paid-memberships-pro' ), esc_url( get_permalink( $tospage->ID ) ), esc_html( $tospage->post_title ) );
-						/**
-						 * Filter the Terms of Service field label.
-						 *
-						 * @since 3.1
-						 *
-						 * @param string $tos_label The field label.
-						 * @param object $tospage The Terms of Service page object.
-						 * @return string The filtered field label.
-						 */
-						$tos_label = apply_filters( 'pmpro_tos_field_label', $tos_label, $tospage );
-						echo wp_kses_post( $tos_label );
+						if ( isset( $_REQUEST['tos'] ) ) {
+							$tos = intval( $_REQUEST['tos'] );
+						} else {
+							$tos = "";
+						}
 					?>
-				</label>
-			</div> <!-- end pmpro_form_field-tos -->
-			<?php
-				/**
-				 * Allow adding text or more checkboxes after the Tos checkbox
-				 * This is NOT intended to support multiple Tos checkboxes
-				 *
-				 * @since 2.8
-				 */
-				do_action_deprecated( 'pmpro_checkout_after_tos', array(), '3.2' );
-			?>
-		</div> <!-- end pmpro_form_fields -->
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-checkbox pmpro_form_field-required' ) ); ?>">
+						<label class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label pmpro_clickable', 'tos' ) ); ?>" for="tos">
+							<input type="checkbox" name="tos" value="1" id="tos" <?php checked( 1, $tos ); ?> class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-checkbox pmpro_form_input-required', 'tos' ) ); ?>" />
+							<?php
+								$tos_label = sprintf( __( 'I agree to the <a href="%1$s" target="_blank">%2$s</a>', 'paid-memberships-pro' ), esc_url( get_permalink( $tospage->ID ) ), esc_html( $tospage->post_title ) );
+								/**
+								 * Filter the Terms of Service field label.
+								 *
+								 * @since 3.1
+								 *
+								 * @param string $tos_label The field label.
+								 * @param object $tospage The Terms of Service page object.
+								 * @return string The filtered field label.
+								 */
+								$tos_label = apply_filters( 'pmpro_tos_field_label', $tos_label, $tospage );
+								echo wp_kses_post( $tos_label );
+							?>
+						</label>
+					</div> <!-- end pmpro_form_field-tos -->
+					<?php
+						/**
+						 * Allow adding text or more checkboxes after the Tos checkbox
+						 * This is NOT intended to support multiple Tos checkboxes
+						 *
+						 * @since 2.8
+						 */
+						do_action_deprecated( 'pmpro_checkout_after_tos', array(), '3.2' );
+					?>
+				</div> <!-- end pmpro_form_fields -->
+			</div> <!-- end pmpro_card -->
+		</div> <!-- end pmpro_card_content -->
 	</fieldset> <!-- end pmpro_tos_fields -->
 	<?php
 	do_action_deprecated( 'pmpro_checkout_after_tos_fields', array(), '3.2' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The Terms of Service input checkbox was not consistently styled with the cards. This makes it look out of place, and a bit hidden. Especially on sites with dark backgrounds such as in the follow example:

Before:
<img width="912" alt="image" src="https://github.com/user-attachments/assets/0aa9c1eb-f5be-4115-96ec-501e783bc7d8">

After:
<img width="912" alt="image" src="https://github.com/user-attachments/assets/888d2d2d-738d-4954-92bc-0920ffa90e58">


### How to test the changes in this Pull Request:

1. Create a checkout with terms of service
2. Check the page is displayed correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Card formatting applied to Terms of Service input fieldset