### PR TITLE
Adding "one use per user" discount code setting

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -449,7 +449,7 @@
 
 						<tr>
 							<th scope="row" valign="top"><label for="code"><?php esc_html_e('Code', 'paid-memberships-pro' );?></label></th>
-							<td><input name="code" type="text" size="20" value="<?php echo esc_attr( $code->code ); ?>" /></td>
+							<td><input name="code" id="code" type="text" size="20" value="<?php echo esc_attr( $code->code ); ?>" /></td>
 						</tr>
 
 						<?php
@@ -488,7 +488,7 @@
 						<tr>
 							<th scope="row" valign="top"><label for="starts"><?php esc_html_e('Start Date', 'paid-memberships-pro' );?></label></th>
 							<td>
-								<select name="starts_month">
+								<select name="starts_month" id="starts">
 									<?php
 										for($i = 1; $i < 13; $i++)
 										{
@@ -506,7 +506,7 @@
 						<tr>
 							<th scope="row" valign="top"><label for="expires"><?php esc_html_e('Expiration Date', 'paid-memberships-pro' );?></label></th>
 							<td>
-								<select name="expires_month">
+								<select name="expires_month" id="expires">
 									<?php
 										for($i = 1; $i < 13; $i++)
 										{
@@ -522,18 +522,21 @@
 						</tr>
 
 						<tr>
-							<th scope="row" valign="top"><label for="uses"><?php esc_html_e('Total Uses', 'paid-memberships-pro' );?></label></th>
+							<th scope="row" valign="top"><label for="uses"><?php esc_html_e( 'Limit Total Uses', 'paid-memberships-pro' );?></label></th>
 							<td>
-								<input name="uses" type="text" size="10" value="<?php if ( ! empty( $code->uses ) ) echo esc_attr( $code->uses ); ?>" />
-								<p class="description"><?php esc_html_e('Leave blank for unlimited uses.', 'paid-memberships-pro' );?></p>
+								<input name="uses" id="uses" type="text" size="10" value="<?php if ( ! empty( $code->uses ) ) echo esc_attr( $code->uses ); ?>" />
+								<p class="description">
+									<?php esc_html_e( 'Define the maximum number of times this discount code can be used across all users.', 'paid-memberships-pro' ); ?>
+									<?php esc_html_e('Leave blank for unlimited uses.', 'paid-memberships-pro' ); ?>
+								</p>
 							</td>
 						</tr>
 
 						<tr>
-							<th scope="row" valign="top"><label for="one_use_per_user"><?php esc_html_e('One Use Per User', 'paid-memberships-pro' );?></label></th>
+							<th scope="row" valign="top"><label for="one_use_per_user"><?php esc_html_e( 'Limit Per User', 'paid-memberships-pro' );?></label></th>
 							<td>
-								<input name="one_use_per_user" type="checkbox" value="1" <?php if ( ! empty( $code->one_use_per_user ) ) checked( $code->one_use_per_user, 1 ); ?> />
-								<p class="description"><?php esc_html_e('Check this box to limit the code to one use per user.', 'paid-memberships-pro' );?></p>
+								<input name="one_use_per_user" id="one_use_per_user" type="checkbox" value="1" <?php if ( ! empty( $code->one_use_per_user ) ) checked( $code->one_use_per_user, 1 ); ?> />
+								<label for="one_use_per_user"><?php esc_html_e('Restrict this discount code to a single use per unique user.', 'paid-memberships-pro' );?></label>
 							</td>
 						</tr>
 

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -68,6 +68,7 @@
 		$expires_day = intval($_POST['expires_day']);
 		$expires_year = intval($_POST['expires_year']);
 		$uses = intval($_POST['uses']);
+		$one_use_per_user = ! empty( $_POST['one_use_per_user'] ) ? 1 : 0;
 
 		//fix up dates
 		$starts = date("Y-m-d", strtotime($starts_month . "/" . $starts_day . "/" . $starts_year, $now ));
@@ -81,13 +82,15 @@
 				'code' => $code,
 				'starts' => $starts,
 				'expires' => $expires,
-				'uses' => $uses
+				'uses' => $uses,
+				'one_use_per_user' => $one_use_per_user
 			),
 			array(
 				'%d',
 				'%s',
 				'%s',
 				'%s',
+				'%d',
 				'%d'
 			)
 		);
@@ -519,10 +522,18 @@
 						</tr>
 
 						<tr>
-							<th scope="row" valign="top"><label for="uses"><?php esc_html_e('Uses', 'paid-memberships-pro' );?></label></th>
+							<th scope="row" valign="top"><label for="uses"><?php esc_html_e('Total Uses', 'paid-memberships-pro' );?></label></th>
 							<td>
 								<input name="uses" type="text" size="10" value="<?php if ( ! empty( $code->uses ) ) echo esc_attr( $code->uses ); ?>" />
 								<p class="description"><?php esc_html_e('Leave blank for unlimited uses.', 'paid-memberships-pro' );?></p>
+							</td>
+						</tr>
+
+						<tr>
+							<th scope="row" valign="top"><label for="one_use_per_user"><?php esc_html_e('One Use Per User', 'paid-memberships-pro' );?></label></th>
+							<td>
+								<input name="one_use_per_user" type="checkbox" value="1" <?php if ( ! empty( $code->one_use_per_user ) ) checked( $code->one_use_per_user, 1 ); ?> />
+								<p class="description"><?php esc_html_e('Check this box to limit the code to one use per user.', 'paid-memberships-pro' );?></p>
 							</td>
 						</tr>
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1890,7 +1890,7 @@ function pmpro_getDiscountCode( $seed = null ) {
  * Is a discount code valid - $level_id could be a scalar or an array (or unset)
  */
 function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = false ) {
-	global $wpdb;
+	global $wpdb, $current_user;
 
 	$error = false;
 	$dbcode = false;
@@ -1938,6 +1938,16 @@ function pmpro_checkDiscountCode( $code, $level_id = null, $return_errors = fals
 			$used = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $dbcode->id ) . "'" );
 			if ( $used >= $dbcode->uses ) {
 				$error = __( 'This discount code is no longer valid.', 'paid-memberships-pro' );
+			}
+		}
+	}
+
+	// check if this code is limited to one use per user
+	if ( ! $error ) {
+		if ( ! empty( $dbcode->one_use_per_user ) && ! empty( $current_user->ID ) ) {
+			$used = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pmpro_discount_codes_uses WHERE code_id = '" . esc_sql( $dbcode->id ) . "' AND user_id = '" . esc_sql( $current_user->ID ) . "'" );
+			if ( $used > 0 ) {
+				$error = __( 'You have already used the discount code provided.', 'paid-memberships-pro' );
 			}
 		}
 	}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -392,6 +392,15 @@ function pmpro_checkForUpgrades() {
 		pmpro_upgrade_3_2();
 		update_option( 'pmpro_db_version', '3.2' );
 	}
+
+	/**
+	 * Version 3.4
+	 * Adding `one_use_per_user` column to discount codes.
+	 */
+	if ( $pmpro_db_version < 3.4 ) {
+		pmpro_db_delta();
+		update_option( 'pmpro_db_version', '3.4' );
+	}
 }
 
 function pmpro_db_delta() {
@@ -567,6 +576,7 @@ function pmpro_db_delta() {
 		  `starts` date NOT NULL,
 		  `expires` date NOT NULL,
 		  `uses` int(11) NOT NULL,
+		  `one_use_per_user` tinyint(4) NOT NULL DEFAULT '0',
 		  PRIMARY KEY  (`id`),
 		  UNIQUE KEY `code` (`code`),
 		  KEY `starts` (`starts`),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add a checkbox input to discount codes to only allow that code to be used once per user.
![Screenshot 2024-10-23 at 1 29 12 PM](https://github.com/user-attachments/assets/8dfde81b-fa7a-4728-98b3-871086c11940)
![Screenshot 2024-10-23 at 1 29 05 PM](https://github.com/user-attachments/assets/343cc3d9-f140-4639-8dd0-d3b04266e87f)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
