### PR TITLE
Create email template class

### DIFF
--- a/adminpages/emailtemplates-edit.php
+++ b/adminpages/emailtemplates-edit.php
@@ -18,7 +18,7 @@
 
 	// Email variables.
 	$email_variables = [
-		'general' => [
+		__( 'General Settings / Membership Info', 'paid-memberships-pro' ) => [
 			'!!name!!'                  => __( 'Display Name (Profile/Edit User > Display name publicly as)', 'paid-memberships-pro' ),
 			'!!user_login!!'            => __( 'Username', 'paid-memberships-pro' ),
 			'!!sitename!!'              => __( 'Site Title', 'paid-memberships-pro' ),
@@ -34,7 +34,7 @@
 			'!!login_url!!'            => __( 'Login URL', 'paid-memberships-pro' ),
 			'!!levels_url!!'           => __( 'Membership Levels Page URL', 'paid-memberships-pro' ),
 		],
-		'billing' => [
+		__( 'Billing Information', 'paid-memberships-pro' ) => [
 			'!!billing_address!!' => __( 'Billing Info Complete Address', 'paid-memberships-pro' ),
 			'!!billing_name!!'    => __( 'Billing Info Name', 'paid-memberships-pro' ),
 			'!!billing_street!!'  => __( 'Billing Info Street Address', 'paid-memberships-pro' ),
@@ -57,6 +57,15 @@
 			'!!membership_level_confirmation_message!!' => __( 'Custom Level Confirmation Message', 'paid-memberships-pro' ),
 		]
 	];
+
+	// If we have a PMPro_Email_Template class for this template, use those variables instead.
+	$email_template_class = PMPro_Email_Template::get_email_template( $edit );
+	if ( $email_template_class ) {
+		$email_variables = array(
+			__( 'Global Variables', 'paid-memberships-pro' ) => PMPro_Email_Template::get_base_email_template_variables_with_description(),
+			sprintf( __( '%s Variables', 'paid-memberships-pro' ), $email_template_class::get_template_name() ) => $email_template_class::get_email_template_variables_with_description(),
+		);
+	}
 ?>
 <hr class="wp-header-end">
 <div id="poststuff">
@@ -165,39 +174,27 @@
 					</div>
 					<div class="pmpro_section_inside">
 						<p><?php esc_html_e( 'Use the placeholder variables below to customize your member and admin emails with specific user or membership data.', 'paid-memberships-pro' ); ?></p>
-						<h3><?php esc_html_e('General Settings / Membership Info', 'paid-memberships-pro'); ?></h3>
-						<table class="widefat fixed striped">
-							<tbody>
-								<?php
-									foreach ( $email_variables['general'] as $email_variable => $description ) {
-										?>
-										<tr>
-											<th><code><?php echo esc_html( $email_variable ); ?></code></th>
-											<td><?php echo esc_html( $description ); ?></td>
-										</tr>
-										<?php
-								}
-								?>
-							</tbody>
-						</table>
-
-						<h3><?php esc_html_e( 'Billing Information', 'paid-memberships-pro' ); ?></h3>
-						<table class="widefat fixed striped">
-							<tbody>
-								<?php
-									foreach ( $email_variables['billing'] as $email_variable => $description ) {
-										?>
-										<tr>
-											<th>
-												<code><?php echo esc_html( $email_variable ); ?></code>
-											</th>
-											<td><?php echo esc_html( $description ); ?></td>
-										</tr>
-										<?php
-									}
-								?>
-							</tbody>
-						</table>
+						<?php
+						foreach ( $email_variables as $section => $variables ) {
+							?>
+							<h3><?php echo esc_html( $section ); ?></h3>
+							<table class="widefat fixed striped">
+								<tbody>
+									<?php
+										foreach ( $variables as $email_variable => $description ) {
+											?>
+											<tr>
+												<th><code><?php echo esc_html( $email_variable ); ?></code></th>
+												<td><?php echo esc_html( $description ); ?></td>
+											</tr>
+											<?php
+										}
+									?>
+								</tbody>
+							</table>
+							<?php
+						}
+						?>
 					</div> <!-- end pmpro_section_inside -->
 				</div> <!-- end pmpro_section -->
 			</div>

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -302,31 +302,8 @@
 			if(!$user)
 				return false;
 			
-			$this->email = $user->user_email;
-			$this->subject = sprintf(__('Your membership at %s has been CANCELLED', 'paid-memberships-pro'), get_option("blogname"));
-
-			$this->data = array(
-				'user_email' => $user->user_email, 
-				'display_name' => $user->display_name,
-				'header_name' => $user->display_name,
-				'user_login' => $user->user_login, 
-				'sitename' => get_option( 'blogname' ), 
-				'siteemail' => get_option( 'pmpro_from_email' ),
-				'levels_url' => pmpro_url( 'levels' )
-			);
-
-			if(!empty($old_level_id)) {
-				if(!is_array($old_level_id))
-					$old_level_id = array($old_level_id);
-				$this->data['membership_id'] = $old_level_id[0];	//pass just the first as the level id
-				$this->data['membership_level_name'] = pmpro_implodeToEnglish($wpdb->get_col("SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode("','", $old_level_id) . "')"));
-			} else {
-				$this->data['membership_id'] = '';
-				$this->data['membership_level_name'] = __('All Levels', 'paid-memberships-pro' );
-			}
-
-			$this->template = apply_filters("pmpro_email_template", "cancel", $this);
-			return $this->sendEmail();
+			$email = new PMPro_Email_Template_Cancel( $user, $old_level_id );
+			$email->send();
 		}
 		
 		/**

--- a/classes/email-templates/class-pmpro-email-template-cancel.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel.php
@@ -1,0 +1,174 @@
+<?php
+
+class PMPro_Email_Template_Cancel extends PMPro_Email_Template {
+	/**
+	 * The user object of the user to send the email to.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * The IDs of the membership levels that were cancelled.
+	 *
+	 * @var int
+	 */
+	protected $cancelled_level_ids;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User $user The user object of the user to send the email to.
+	 * @param int|array|null $cancelled_level_ids The ID or array of IDs of the membership levels that were cancelled. If null, "all" levels were cancelled.
+	 */
+	public function __construct( WP_User $user, $cancelled_level_ids ) {
+		$this->user = $user;
+		$this->cancelled_level_ids = $cancelled_level_ids;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'cancel';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return __( 'Cancel', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		return __( 'The site administrator can manually cancel a user\'s membership through the WordPress admin or the member can cancel their own membership through your site. This email is sent to the member as confirmation of a cancelled membership.', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return __( 'Your membership at !!sitename!! has been CANCELLED', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+		return __( '<p>Your membership at !!sitename!! has been cancelled.</p>
+
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+
+<p>If you did not request this cancellation and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+		return array(
+			'!!user_email!!' => __( 'The email address of the user who cancelled their membership.', 'paid-memberships-pro' ),
+			'!!display_name!!' => __( 'The display name of the user who cancelled their membership.', 'paid-memberships-pro' ),
+			'!!user_login!!' => __( 'The login name of the user who cancelled their membership.', 'paid-memberships-pro' ),
+			'!!membership_id!!' => __( 'The ID of the membership level that was cancelled.', 'paid-memberships-pro' ),
+			'!!membership_level_name!!' => __( 'The name of the membership level that was cancelled.', 'paid-memberships-pro' ),
+		);
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		return $this->user->user_email;
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		return $this->user->display_name;
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		global $wpdb;
+
+		$email_template_variables = array(
+			'user_email' => $this->user->user_email,
+			'display_name' => $this->user->display_name,
+			'user_login' => $this->user->user_login,
+		);
+
+		if ( empty( $this->cancelled_level_ids ) ) {
+			$email_template_variables['membership_id'] = '';
+			$email_template_variables['membership_level_name'] = __( 'All Levels', 'paid-memberships-pro' );
+		} elseif ( is_array( $this->cancelled_level_ids ) ) {
+			$email_template_variables['membership_id'] = $this->cancelled_level_ids[0]; // Pass just the first as the level id.
+			$email_template_variables['membership_level_name'] = pmpro_implodeToEnglish( $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode( "','", $this->cancelled_level_ids ) . "')" ) );
+		} else {
+			$email_template_variables['membership_id'] = $this->cancelled_level_ids;
+			$email_template_variables['membership_level_name'] = pmpro_implodeToEnglish( $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id = '" . $this->cancelled_level_ids . "'" ) );
+		}
+
+		return $email_template_variables;
+	}
+}
+
+/**
+ * Register the email template.
+ *
+ * @since TBD
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_templates_cancel( $email_templates ) {
+	$email_templates['cancel'] = 'PMPro_Email_Template_Cancel';
+
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_templates_cancel' );

--- a/classes/email-templates/class-pmpro-email-template.php
+++ b/classes/email-templates/class-pmpro-email-template.php
@@ -1,0 +1,172 @@
+<?php
+abstract class PMPro_Email_Template {
+	/**
+	 * Get all email templates.
+	 *
+	 * @since TBD
+	 *
+	 * @return array All email templates (template slug => email template class name).
+	 */
+	final public static function get_all_email_templates() {
+		/**
+		 * Allow email templates to be registered.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $email_templates All email templates (template slug => email template class name).
+		 */
+		return apply_filters( 'pmpro_email_templates', array() );
+	}
+
+	/**
+	 * Get an email template by its slug.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $template_slug The email template slug.
+	 * @return string|null The email template class name, or null if the email template is not found.
+	 */
+	final public static function get_email_template( string $template_slug ) {
+		$email_templates = self::get_all_email_templates();
+		return isset( $email_templates[ $template_slug ] ) ? $email_templates[ $template_slug ] : null;
+	}
+
+	/**
+	 * Send the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the email was sent successfully.
+	 */
+	final public function send() {
+		$pmpro_email           = new PMProEmail();
+		$pmpro_email->email    = $this->get_recipient_email();
+		$pmpro_email->subject  = $this->get_default_subject(); // This will be overridden if there is a subject saved in the database.
+		$pmpro_email->data     = array_merge( $this->get_base_email_template_variables(), $this->get_email_template_variables() );
+		$pmpro_email->template = apply_filters_deprecated( 'pmpro_email_template', array( $this->get_template_slug() ), 'TBD', 'pmpro_email_body' );
+		return $pmpro_email->sendEmail();
+	}
+
+	/**
+	 * Get the base email template variables that should be available for all emails.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	final protected function get_base_email_template_variables() {
+		$base_email_template_variables = array(
+			'site_name' => get_option( 'blogname' ),
+			'siteemail' => get_option( 'pmpro_from_email' ),
+			'site_url'  => home_url(),
+			'levels_url' => pmpro_url( 'levels' ),
+			'login_link' => pmpro_login_url(), 
+			'login_url' => pmpro_login_url(),
+			'header_name' => $this->get_recipient_name(),
+		);
+
+		return $base_email_template_variables;
+	}
+
+	/**
+	 * Get the base email template variables that should be available for all emails paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	final public static function get_base_email_template_variables_with_description() {
+		$base_email_template_variables_with_description = array(
+			'!!site_name!!' => __( 'The name of the site.', 'paid-memberships-pro' ),
+			'!!siteemail!!' => __( 'The email address of the site.', 'paid-memberships-pro' ),
+			'!!site_url!!'  => __( 'The URL of the site.', 'paid-memberships-pro' ),
+			'!!levels_url!!' => __( 'The URL of the page where users can view available membership levels.', 'paid-memberships-pro' ),
+			'!!login_link!!' => __( 'The URL of the login page.', 'paid-memberships-pro' ),
+			'!!login_url!!' => __( 'The URL of the login page.', 'paid-memberships-pro' ),
+			'!!header_name!!' => __( 'The name of the email recipient.', 'paid-memberships-pro' ),
+		);
+
+		return $base_email_template_variables_with_description;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email template slug.
+	 */
+	abstract public static function get_template_slug();
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	abstract public static function get_template_name();
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	abstract public static function get_template_description();
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default subject for the email.
+	 */
+	abstract public static function get_default_subject();
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The default body content for the email.
+	 */
+	abstract public static function get_default_body();
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	abstract public static function get_email_template_variables_with_description();
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	abstract public function get_recipient_email();
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	abstract public function get_recipient_name();
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	abstract public function get_email_template_variables();
+}

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -102,17 +102,6 @@ $pmpro_email_templates_defaults = array(
 ', 'paid-memberships-pro' ),
 		'help_text' => __( 'This email is sent out if a recurring payment has failed for a member, usually due to an expired or cancelled credit card. This email is sent to the site administrator.', 'paid-memberships-pro' )
 	),
-	'cancel' => array(
-		'subject' => __( "Your membership at !!sitename!! has been CANCELLED", 'paid-memberships-pro' ),
-		'description' => __('Cancel', 'paid-memberships-pro'),
-		'body' => __( '<p>Your membership at !!sitename!! has been cancelled.</p>
-
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-
-<p>If you did not request this cancellation and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ),
-		'help_text' => __( 'The site administrator can manually cancel a user\'s membership through the WordPress admin or the member can cancel their own membership through your site. This email is sent to the member as confirmation of a cancelled membership.', 'paid-memberships-pro' )
-	),
 	'cancel_admin'  => array(
 		'subject' => __( "Membership for !!user_login!! at !!sitename!! has been CANCELLED", 'paid-memberships-pro' ),
 		'description' => __('Cancel (admin)', 'paid-memberships-pro'),

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -415,6 +415,17 @@ if( 'stripe' === $default_gateway ) {
 	) );
 }
 
+// Add any templates registered via the PMPro_Email_Template class.
+$registered_templates = PMPro_Email_Template::get_all_email_templates();
+foreach ( $registered_templates as $registered_template_slug => $registered_template_class ) {
+	$pmpro_email_templates_defaults[ $registered_template_slug ] = array(
+		'subject'     => $registered_template_class::get_default_subject(),
+		'description' => $registered_template_class::get_template_name(),
+		'body'        => $registered_template_class::get_default_body(),
+		'help_text'   => $registered_template_class::get_template_description(),
+	);
+}
+
 /**
  * Filter default template settings and add new templates.
  *

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -50,6 +50,8 @@ require_once( PMPRO_DIR . '/classes/class-pmpro-levels.php' );
 require_once( PMPRO_DIR . '/classes/class-pmpro-subscription.php' );
 require_once( PMPRO_DIR . '/classes/class-pmpro-admin-activity-email.php' );        // setup the admin activity email
 
+require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template.php' ); // base class for email templates
+
 require_once( PMPRO_DIR . '/includes/filters.php' );                // filters, hacks, etc, moved into the plugin
 require_once( PMPRO_DIR . '/includes/reports.php' );                // load reports for admin (reports may also include tracking code, etc)
 

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -51,6 +51,7 @@ require_once( PMPRO_DIR . '/classes/class-pmpro-subscription.php' );
 require_once( PMPRO_DIR . '/classes/class-pmpro-admin-activity-email.php' );        // setup the admin activity email
 
 require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template.php' ); // base class for email templates
+require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template-cancel.php' ); // cancel email template
 
 require_once( PMPRO_DIR . '/includes/filters.php' );                // filters, hacks, etc, moved into the plugin
 require_once( PMPRO_DIR . '/includes/reports.php' );                // load reports for admin (reports may also include tracking code, etc)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding an abstract `PMPro_Email_Template` class to make email templates more structured along with a sample `PMPro_Email_Template_Cancel` class demonstrating how that class should be extended.

This approach has the immediate benefit of accurately listing email template variables when editing the email template:
![Screenshot 2024-10-28 at 1 56 04 PM](https://github.com/user-attachments/assets/d352f6f1-c201-451b-8a44-e30eb8bd74dd)

This PR still uses the `PMProEmail->sendEmail()` method to send emails and register templates with the `$pmpro_email_templates_defaults` hook, so no custom code should break with these changes. Down the line, though, these changes put us in a position to significantly clean up our code around emails and email templates.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
