### PR TITLE
Fix user fields applying default value when '0' is set

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -669,7 +669,7 @@ class PMPro_Field {
 			$r_end .= "</div>";
 		}
 
-		if ( empty( $value ) && pmpro_is_checkout() ) {
+		if ( '' === $value && pmpro_is_checkout() ) {
 			/**
 			 * Filter to set the default value for a field. The default value will only load if no value is already found.
 			 * 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Enter `0` into a text field at checkout and complete checkout. See that, before this fix, if you go to the checkout page again, the field appears with the "default" value set for the user field instead of `0`. After this fix, `0` shows correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
