### PR TITLE
Now setting the discount code ID on orders before saving

### DIFF
--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -180,6 +180,11 @@ if ( ! empty( $_REQUEST['save'] ) ) {
 		}
 	}
 
+	// Set the discount code.
+	if( isset( $_REQUEST['discount_code_id'] ) ) {
+		$order->discount_code_id = intval( $_REQUEST['discount_code_id'] );
+	}
+
 	// check nonce for saving
 	$nonceokay = true;
 	if ( empty( $_REQUEST['pmpro_orders_nonce'] ) || ! check_admin_referer( 'save', 'pmpro_orders_nonce' ) ) {
@@ -194,11 +199,6 @@ if ( ! empty( $_REQUEST['save'] ) ) {
 	} else {
 		$pmpro_msg  = __( 'Error saving order.', 'paid-memberships-pro' );
 		$pmpro_msgt = 'error';
-	}
-
-	// also update the discount code if needed
-	if( isset( $_REQUEST['discount_code_id'] ) ) {
-		$order->updateDiscountCode( intval( $_REQUEST['discount_code_id'] ) );
 	}
 } else {
 	// order passed?

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -241,23 +241,22 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 	//change level and continue "checkout"
 	if ( pmpro_changeMembershipLevel( $custom_level, $order->user_id, 'changed' ) !== false ) {
 		// Mark the order as successful.
-		$order->status                 = "success";
+		$order->status = "success";
+		if ( ! empty( $discount_code_id ) ) {
+			/**
+			 * Ideally, we would set the discount code ID on the order when it is initially created, but
+			 * this would conflict with Add Ons and custom code (specifically Sponsored Members) that
+			 * expect discount codes only to be set after successful checkouts.
+			 *
+			 * @TODO: In the next breaking release, we should set the discount code ID on the order when it is initially created.
+			 */
+			$order->discount_code_id = $discount_code_id;
+		}
 		$order->saveOrder();
 
 		//add discount code use
 		if ( ! empty( $discount_code_id ) ) {
-			$wpdb->query(
-				$wpdb->prepare(
-					"INSERT INTO {$wpdb->pmpro_discount_codes_uses} 
-						( code_id, user_id, order_id, timestamp ) 
-						VALUES( %d, %d, %s, %s )",
-					$discount_code_id,
-					$order->user_id,
-					$order->id,
-					current_time( 'mysql' )
-				)	
-			);
-			do_action( 'pmpro_discount_code_used', $discount_code_id, $order->user_id, $order->id );
+			do_action_deprecated( 'pmpro_discount_code_used', array( $discount_code_id, $order->user_id, $order->id ), 'TBD', 'pmpro_added_order' );
 		}
 
 		//save first and last name fields


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently, discount codes are set for orders after the orders have been saved. This means that the discount code attributes are not correct during the `pmpro_added_order` hook and the `pmpro_updated_order` hook.

This PR updates the logic when saving orders at checkout and on the Edit Order page to set the discount code during the order save process to make sure that those actions work as expected.

Note: When using offiste gateways (such as Stripe Checkout or PayPal Express), the discount code will still not be available during the `pmpro_added_order` hook. This is because the order is initially added in `token` status and is later updated to `success` with the discount code added once the checkout is complete. In these cases, it is best to use the `pmpro_after_checkout` or `pmpro_order_status_success` hooks.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
