### PR TITLE
Adding user ID to getRandomCode() in case other hash parameters are identical

### DIFF
--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -1573,7 +1573,7 @@
 		 * Get a random code to use as the order code.
 		 */
 		function getRandomCode() {
-			global $wpdb;
+			global $wpdb, $current_user;
 
 			// We mix this with the seed to make sure we get unique codes.
 			static $count = 0;
@@ -1589,7 +1589,8 @@
 			}
 
 			while( empty( $code ) ) {
-				$scramble = md5( $auth_code . microtime() . $secure_auth_code . $count );
+				$current_user_id = ! empty( $current_user->ID ) ? $current_user->ID : 0;
+				$scramble = md5( $auth_code . microtime() . $secure_auth_code . $current_user_id . $count );
 				$code = substr( $scramble, 0, 10 );
 				$code = apply_filters( 'pmpro_random_code', $code, $this );	//filter
 				$check = $wpdb->get_var( $wpdb->prepare( "SELECT id FROM $wpdb->pmpro_membership_orders WHERE code = %s LIMIT 1", $code ) );


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding user ID to getRandomCode() in case other hash parameters are identical. Specifically for cases where to orders are purchased at the exact same time and `rand()` produces the same result for the `$auth_code` and `secure_auth_code`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
