### PR TITLE
Fix bottom errors not showing with Stripe

### DIFF
--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -231,6 +231,7 @@ jQuery( document ).ready( function( $ ) {
 
 			// error message
 			$( '#pmpro_message' ).text( response.error.message ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
+			$( '#pmpro_message_bottom' ).text( response.error.message ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
 			
 		} else if ( response.paymentMethod ) {			
 			// A payment method was created successfully. Submit the checkout form and finish the checkout in PHP.


### PR DESCRIPTION
* BUG FIX: Fixed an issue where errors for onsite Stripe validation would not show at the bottom of the checkout page (like other errors do).

Example of showing the error message at the bottom of the page:
![Screenshot 2024-11-12 at 08 45 06](https://github.com/user-attachments/assets/3bccb045-1f79-458f-a526-8f67b2447158)
