### PR TITLE
Checking if constant SITENAME is already defined

### DIFF
--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -162,7 +162,9 @@ if ( is_admin() ) {
 /*
 	Definitions
 */
-define( 'SITENAME', str_replace( '&#039;', "'", get_bloginfo( 'name' ) ) );
+if ( ! defined( 'SITENAME' ) ) {
+	define( 'SITENAME', str_replace( '&#039;', "'", get_bloginfo( 'name' ) ) );
+}
 if ( ! defined( 'SITEURL'  ) ) {
 	$urlparts = explode( '//', home_url() );
 	define( 'SITEURL', $urlparts[1] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Avoiding errors if SITENAME constant is already defined.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
