### PR TITLE
WordPress 6.7 compat. Fix doing_it_wrong notice related to early translations

### DIFF
--- a/adminpages/reports.php
+++ b/adminpages/reports.php
@@ -6,6 +6,15 @@
 global $pmpro_reports;
 
 /**
+ * Filter the admin reports provided by our core, our Add Ons, and other plugins/themes.
+ *
+ * @since TBD
+ *
+ * @param array  $pmpro_reports The registered reports.
+ */
+$pmpro_reports = apply_filters( 'pmpro_registered_reports', $pmpro_reports );
+
+/**
 * Load the Paid Memberships Pro dashboard-area header
 */
 require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>

--- a/adminpages/reports.php
+++ b/adminpages/reports.php
@@ -6,15 +6,6 @@
 global $pmpro_reports;
 
 /**
- * Filter the admin reports provided by our core, our Add Ons, and other plugins/themes.
- *
- * @since TBD
- *
- * @param array  $pmpro_reports The registered reports.
- */
-$pmpro_reports = apply_filters( 'pmpro_registered_reports', $pmpro_reports );
-
-/**
 * Load the Paid Memberships Pro dashboard-area header
 */
 require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>

--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -3,17 +3,19 @@
 	PMPro Report
 	Title: Logins
 	Slug: login
-	
-	For each report, add a line like:
-	global $pmpro_reports;
-	$pmpro_reports['slug'] = 'Title';
-	
-	For each report, also write two functions:
+
+	For each report, write three functions:
+	* pmpro_report_{slug}_register() to register the widget (slug and title).
 	* pmpro_report_{slug}_widget()   to show up on the report homepage.
 	* pmpro_report_{slug}_page()     to show up when users click on the report page widget.
 */
-global $pmpro_reports;
-$pmpro_reports['login'] = __('Visits, Views, and Logins', 'paid-memberships-pro');
+function pmpro_report_login_register( $pmpro_reports ) {
+	$pmpro_reports['login'] = __( 'Visits, Views, and Logins', 'paid-memberships-pro' );
+
+	return $pmpro_reports;
+}
+
+add_filter( 'pmpro_registered_reports', 'pmpro_report_login_register' );
 
 function pmpro_report_login_widget() {
 	global $wpdb, $pmpro_reports;

--- a/adminpages/reports/members-per-level.php
+++ b/adminpages/reports/members-per-level.php
@@ -4,16 +4,18 @@
 	Title: Members per Level
 	Slug: members_per_level
 
-	For each report, add a line like:
-	global $pmpro_reports;
-	$pmpro_reports['slug'] = 'Title';
-
-	For each report, also write two functions:
+	For each report, write three functions:
+	* pmpro_report_{slug}_register() to register the widget (slug and title).
 	* pmpro_report_{slug}_widget()   to show up on the report homepage.
 	* pmpro_report_{slug}_page()     to show up when users click on the report page widget.
 */
-global $pmpro_reports;
-$pmpro_reports['members_per_level'] = __('Active Members Per Level', 'paid-memberships-pro' );
+function pmpro_report_members_per_level_register( $pmpro_reports ) {
+	$pmpro_reports['members_per_level'] = __('Active Members Per Level', 'paid-memberships-pro' );
+
+	return $pmpro_reports;
+}
+
+add_filter( 'pmpro_registered_reports', 'pmpro_report_members_per_level_register' );
 
 // Enqueue Google Visualization JS on report page
 function pmpro_report_members_per_level_init() {

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -4,16 +4,18 @@
 	Title: Membership Stats
 	Slug: memberships
 
-	For each report, add a line like:
-	global $pmpro_reports;
-	$pmpro_reports['slug'] = 'Title';
-
-	For each report, also write two functions:
+	For each report, write three functions:
+	* pmpro_report_{slug}_register() to register the widget (slug and title).
 	* pmpro_report_{slug}_widget()   to show up on the report homepage.
 	* pmpro_report_{slug}_page()     to show up when users click on the report page widget.
 */
-global $pmpro_reports;
-$pmpro_reports['memberships'] = __( 'Membership Stats', 'paid-memberships-pro' );
+function pmpro_report_memberships_register( $pmpro_reports ) {
+	$pmpro_reports['memberships'] = __( 'Membership Stats', 'paid-memberships-pro' );
+
+	return $pmpro_reports;
+}
+
+add_filter( 'pmpro_registered_reports', 'pmpro_report_memberships_register' );
 
 // queue Google Visualization JS on report page
 function pmpro_report_memberships_init() {

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -4,20 +4,23 @@
 	Title: Sales
 	Slug: sales
 
-	For each report, add a line like:
-	global $pmpro_reports;
-	$pmpro_reports['slug'] = 'Title';
-
-	For each report, also write two functions:
+	For each report, write three functions:
+	* pmpro_report_{slug}_register() to register the widget (slug and title).
 	* pmpro_report_{slug}_widget()   to show up on the report homepage.
 	* pmpro_report_{slug}_page()     to show up when users click on the report page widget.
 */
-global $pmpro_reports;
-$gateway_environment = get_option( "pmpro_gateway_environment");
-if($gateway_environment == "sandbox")
-	$pmpro_reports['sales'] = __('Sales and Revenue (Testing/Sandbox)', 'paid-memberships-pro' );
-else
-	$pmpro_reports['sales'] = __('Sales and Revenue', 'paid-memberships-pro' );
+function pmpro_report_sales_register( $pmpro_reports ) {
+	$gateway_environment = get_option( "pmpro_gateway_environment" );
+	if ( $gateway_environment == "sandbox" ) {
+		$pmpro_reports['sales'] = __( 'Sales and Revenue (Testing/Sandbox)', 'paid-memberships-pro' );
+	} else {
+		$pmpro_reports['sales'] = __( 'Sales and Revenue', 'paid-memberships-pro' );
+	}
+
+	return $pmpro_reports;
+}
+
+add_filter( 'pmpro_registered_reports', 'pmpro_report_sales_register' );
 
 //queue Google Visualization JS on report page
 function pmpro_report_sales_init()

--- a/includes/fields.php
+++ b/includes/fields.php
@@ -6,7 +6,7 @@ $pmpro_user_fields = array();
 // Add default group.
 $cb = new stdClass();
 $cb->name = 'checkout_boxes';
-$cb->label = apply_filters( 'pmpro_default_field_group_label', __( 'More Information','paid-memberships-pro' ) );
+$cb->label = apply_filters( 'pmpro_default_field_group_label', 'More Information' );
 $cb->order = 0;
 $pmpro_field_groups = array( 'checkout_boxes' => $cb );
 

--- a/includes/reports.php
+++ b/includes/reports.php
@@ -4,6 +4,17 @@ if( null === $pmpro_reports ) {
 	$pmpro_reports = array();
 }
 
+/**
+ * Populate the $pmpro_reports global.
+ *
+ * @since TBD
+ */
+function pmpro_populate_reports() {
+	global $pmpro_reports;
+	$pmpro_reports = apply_filters( 'pmpro_registered_reports', $pmpro_reports );
+}
+add_action( 'init', 'pmpro_populate_reports', 5 );
+
 /*
 	Load Reports From Theme
 */

--- a/includes/reports.php
+++ b/includes/reports.php
@@ -1,4 +1,9 @@
 <?php
+global $pmpro_reports;
+if( null === $pmpro_reports ) {
+	$pmpro_reports = array();
+}
+
 /*
 	Load Reports From Theme
 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some setups are showing a doing_it_wrong notice starting from WP6.7 (related to https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/)

To investigate on your local env and see all the errors, modify your core `function _load_textdomain_just_in_time` this way:
![Screenshot 2024-11-14 at 12 23 14](https://github.com/user-attachments/assets/69eb8476-4caf-4442-af3c-e7a28b442554)

Causes:
1. Reports registration. Fixed 2e9bfe32341f07547188b0d5716adf2f5e578680
2. (not fixed in this PR) User fields default group name (which is also tricky to be filtered because it runs way before other plugins and themes)
![Screenshot 2024-11-14 at 12 26 46](https://github.com/user-attachments/assets/d7769d8f-9dd5-4b3f-9db5-fa1e833690b8)

Tests to be done:
- [ ] Backward compatibility for the admin reports from third party plugins/themes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] TEST TO BE DONE!!!

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
