### PR TITLE
Test wp_options values for notifications

### DIFF
--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -436,6 +436,40 @@ function pmpro_notification_test_pmpro_setting( $data ) {
 }
 
 /**
+ * Test any wp_option setting for a specific value.
+ * @param array $data Array from the notification with [0] option name to check [1] value to check for.
+ * @returns bool true if an option if found with the specified name and value.
+ */
+function pmpro_notification_test_wp_option( $data ) {
+	if ( ! is_array( $data ) || !isset( $data[0] ) || !isset( $data[1] ) ) {
+		return false;
+	}
+	
+	$option_value = get_option( $data[0] );	
+	if ( isset( $option_value ) ) {
+		// If it's an array of data, check if if the value is correct.
+		if ( is_array( $option_value ) ) {
+			// in_array?
+			if ( in_array( $data[1], $option_value ) ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		// If it's a single value, check if it matches.
+		if ( $option_value == $data[1] ) {
+			return true;
+		} else {
+			return false;
+		}
+
+	} else { // no option value found for the key.
+		return false;
+	}
+}
+
+/**
  * PMPro site URL test.
  * @param string $string String or array of strings to look for in the site URL
  * @returns bool true if the string shows up in the site URL

--- a/includes/notifications.php
+++ b/includes/notifications.php
@@ -437,7 +437,7 @@ function pmpro_notification_test_pmpro_setting( $data ) {
 
 /**
  * Test any wp_option setting for a specific value.
- * @param array $data Array from the notification with [0] option name to check [1] value to check for.
+ * @param array $data notification data that is passed through this function to check if the value (data[1]) is set for the key (data[0]) or in an array should the option be an array.
  * @returns bool true if an option if found with the specified name and value.
  */
 function pmpro_notification_test_wp_option( $data ) {


### PR DESCRIPTION
* ENHANCEMENT: Added notification check for wp_option (general) option which will help for compatibility plugins AND any of our own pmpro related options that are arrays.

This has been tested with a custom JSON file, as well as various option values both single values and arrays. The structure of the JSON required follows the pmpro_setting logic and extended into non-pmpro options.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?