### PR TITLE
Supporting setting profile start date on checkout level

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1611,6 +1611,7 @@ class PMProGateway_stripe extends PMProGateway {
 			if (
 				empty( $level->trial_limit ) && // Check if there is a trial period.
 				$filtered_trial_period_days === $unfiltered_trial_period_days && // Check if the trial period is the same as the filtered trial period.
+				empty( $level->profile_start_date ) && // Check if the profile start date set directly on the level is empty.
 				( ! empty( $initial_payment_amount ) && $initial_payment_amount === $recurring_payment_amount ) // Check if the initial payment and recurring payment prices are the same.
 				) {
 				// We can combine the initial payment and the recurring payment.

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -13,10 +13,16 @@
  */
 function pmpro_calculate_profile_start_date( $order, $date_format, $filter = true ) {
 	// Get the checkout level.
-	$level = $order->getMembershipLevelAtCheckout();
+	$level = $order->getMembershipLevelAtCheckout();	
 
-	// Calculate the profile start date.
-	$profile_start_date = date_i18n( 'Y-m-d H:i:s', strtotime( '+ ' . $level->cycle_number . ' ' . $level->cycle_period ) );
+	// If the level already has a profile start date set, use it. Otherwise, calculate it based on the cycle number and period.
+	if ( ! empty( $level->profile_start_date ) ) {
+		// Use the profile start date that is already set.
+		$profile_start_date = date_i18n( 'Y-m-d H:i:s', strtotime( $level->profile_start_date ) );
+	} else {
+		// Calculate the profile start date based on the cycle number and period.
+		$profile_start_date = date_i18n( 'Y-m-d H:i:s', strtotime( '+ ' . $level->cycle_number . ' ' . $level->cycle_period ) );
+	}
 
 	// Filter the profile start date if needed.
 	if ( $filter ) {
@@ -28,13 +34,14 @@ function pmpro_calculate_profile_start_date( $order, $date_format, $filter = tru
 		 * to use that format in case we update this code in the future.
 		 *
 		 * @since 1.4
+		 * @deprecated TBD Set the 'profile_start_date' property on the checkout level object instead.
 		 *
 		 * @param string $profile_start_date The profile start date in UTC YYYY-MM-DD HH:MM:SS format.
 		 * @param MemberOrder $order         The order that the profile start date is being calculated for.
 		 *
 		 * @return string The profile start date in UTC YYYY-MM-DD HH:MM:SS format.
 		 */
-		$profile_start_date = apply_filters( 'pmpro_profile_start_date', $profile_start_date, $order );
+		$profile_start_date = apply_filters_deprecated( 'pmpro_profile_start_date', array( $profile_start_date, $order ), 'TBD' );
 	}
 
 	// Convert $profile_start_date to correct format.

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -13,7 +13,7 @@
  */
 function pmpro_calculate_profile_start_date( $order, $date_format, $filter = true ) {
 	// Get the checkout level.
-	$level = $order->getMembershipLevelAtCheckout();	
+	$level = $order->getMembershipLevelAtCheckout();
 
 	// If the level already has a profile start date set, use it. Otherwise, calculate it based on the cycle number and period.
 	if ( ! empty( $level->profile_start_date ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Profile start dates are currently calculated and filtered when creating a subscription at the payment gateway. Although this works well for the vast majority of use cases, it gets complicated when custom code wants to adjust the billing amount and set a profile start date at the same time (for example, prorations).

This PR adds a support for a new `profile_start_date` property on the checkout level object that can be adjusted during the `pmpro_checkout_level` filter. This makes adjusting the `profile_start_date` at checkout the same process as any other level property.

This PR will also begin throwing deprecation warnings for the existing `pmpro_profile_start_date` filter to encourage developers to use `pmpro_checkout_level`. This will ensure that everyone is adjusting the profile start date in the same way and will allow us to remove the `pmpro_profile_start_date` filter in a future update.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
