### PR TITLE
[BUGFIXING] Users with editor Role can't restrict content from sideba…

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -1195,7 +1195,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				'/pmpro/v1/me' => true,
 				'/pmpro/v1/recent_memberships' => 'pmpro_edit_members',
 				'/pmpro/v1/recent_orders' => 'pmpro_orders',
-				'/pmpro/v1/post_restrictions' => 'pmpro_edit_members',
+				'/pmpro/v1/post_restrictions' => 'edit_others_posts',
 			);
 			$route_caps = apply_filters( 'pmpro_rest_api_route_capabilities', $route_caps, $request );
 			
@@ -1209,8 +1209,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 					// No permission for this method, default to false.
 					$permission_to_check = false;
 				} else {
-					// Same permission for all methods, use it.
-					$permission_to_check = $route_caps[$route];
+					// If it's a boolean return it if it's a string ask if user can
+					$permission_to_check = $route_caps[$route] || current_user_can( $route_caps[$route] );
 				}
 
 				// Check the permission.


### PR DESCRIPTION
…r block

 * Add a different User role to the REST API Permissions check to allow restrict post to editors as well.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Tweak `pmpro_rest_api_get_permissions_check` function to allow Editor users role to be able to restrict posts from require membership sidebar widget 

Resolves #3215 .

### How to test the changes in this Pull Request:

Follow steps described in the issue above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
