### PR TITLE
Showing city and zip in billing address even when missing a state

### DIFF
--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -1131,30 +1131,15 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 			$r .= esc_html( $item->cardtype ) . ': x' . esc_html( last4( $item->accountnumber ) ) . '<br />';
 		}
 
-		if ( ! empty( $item->billing->name ) ) {
-			$r .= esc_html( $item->billing->name ) . '<br />';
-		}
-
-		if ( ! empty( $item->billing->street ) ) {
-			$r .= esc_html( $item->billing->street ) . '<br />';
-		}
-
-		if ( ! empty( $item->billing->street2 ) ) {
-			$r .= esc_html( $item->billing->street2 ) . '<br />';
-		}
-
-		if ( $item->billing->city && $item->billing->state ) {
-			$r .= esc_html( $item->billing->city ) . ', ';
-			$r .= esc_html( $item->billing->state ) . ' ';
-			$r .= esc_html( $item->billing->zip ) . ' ';
-			if ( ! empty( $item->billing->country ) ) {
-				$r .= esc_html( $item->billing->country );
-			}
-		}
-
-		if ( ! empty( $item->billing->phone ) ) {
-			$r .= '<br />' . esc_html( formatPhone( $item->billing->phone ) );
-		}
+		$name = empty( $item->billing->name ) ? '' : $item->billing->name;
+		$street = empty( $item->billing->street ) ? '' : $item->billing->street;
+		$street2 = empty( $item->billing->street2 ) ? '' : $item->billing->street2;
+		$city = empty( $item->billing->city ) ? '' : $item->billing->city;
+		$state = empty( $item->billing->state ) ? '' : $item->billing->state;
+		$zip = empty( $item->billing->zip ) ? '' : $item->billing->zip;
+		$country = empty( $item->billing->country ) ? '' : $item->billing->country;
+		$phone = empty( $item->billing->phone ) ? '' : $item->billing->phone;
+		$r .= pmpro_formatAddress( $name, $street, $street2, $city, $state, $zip, $country, $phone );
 
 		// If this column is completely empty, set $r to a dash.
 		if ( empty( $r ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3064,6 +3064,12 @@ function pmpro_formatAddress( $name, $address1, $address2, $city, $state, $zip, 
 		}
 
 		$address .= "\n";
+	} elseif ( ! empty( $city ) ) {
+		$address .= $city;
+		if ( ! empty( $zip ) ) {
+			$address .= ' ' . $zip;
+		}
+		$address .= "\n";
 	}
 
 	if ( ! empty( $country ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Some addresses, such as those in Belgium, have cities and postal codes but not states. Currently in PMPro, if a state is not present, we do not show the city or postal code. This PR updates PMPro to account for these types of addresses.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Set up Stripe Checkout to always collect billing address
2. Check out using a Belgian billing address
3. See that city and zip were not shown in PMPro email/orders page before this PR, but are afterwards.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
