### PR TITLE
Fixing Stripe Checkout always overwriting tax value

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -504,8 +504,11 @@
 			$currency_unit_multiplier = pow( 10, intval( $currency['decimals'] ) );
 
 			$order->total    = (float) $checkout_session->amount_total / $currency_unit_multiplier;
-			$order->subtotal = (float) $checkout_session->amount_subtotal / $currency_unit_multiplier;
-			$order->tax      = (float) $checkout_session->total_details->amount_tax / $currency_unit_multiplier;
+			if ( ! empty( get_option( 'pmpro_stripe_tax_id_collection_enabled' ) ) ) {
+				// If Stripe calculated tax, use that. Otherwise, keep the tax calculated by PMPro.
+				$order->subtotal = (float) $checkout_session->amount_subtotal / $currency_unit_multiplier;
+				$order->tax      = (float) $checkout_session->total_details->amount_tax / $currency_unit_multiplier;
+			}
 
 			// Was the checkout session successful?
 			if ( $checkout_session->payment_status == "paid" ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When using Stripe Checkout, PMPro will always use the tax calculated by Stripe. This means that if a site is using the VAT Add On, the tax calculated by the Add On will be overwritten by the $0 tax calculated by Stripe.

This PR fixes that issue to only overwrite tax if Stripe is set up to calculate tax.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
