### PR TITLE
Passing the checkout level to hooks during checkout flow instead of caching

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2607,16 +2607,6 @@ function pmpro_are_any_visible_levels() {
 function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 	global $pmpro_level, $wpdb, $post;
 
-	static $function_cache = array();
-
-	// Check if we have a cached value to use.
-	$cache_key = md5( serialize( array( $level_id, $discount_code ) ) );
-	if ( array_key_exists( $cache_key, $function_cache ) ) {
-		// Set the global and return the cached value.
-		$pmpro_level = $function_cache[ $cache_key ];
-		return $pmpro_level;
-	}
-
 	// Reset $pmpro_level global.
 	$pmpro_level = null;
 
@@ -2702,11 +2692,6 @@ function pmpro_getLevelAtCheckout( $level_id = null, $discount_code = null ) {
 
 	// Filter the level (for upgrades, etc).
 	$pmpro_level = apply_filters( 'pmpro_checkout_level', $pmpro_level );
-
-	// Cache the result for future use if this is a "top level" call to this function.
-	if ( ! doing_filter( 'pmpro_checkout_level' ) ) {
-		$function_cache[ $cache_key ] = $pmpro_level;
-	}
 
 	return $pmpro_level;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2595,7 +2595,11 @@ function pmpro_are_any_visible_levels() {
 }
 
 /**
- * Get level at checkout and place into $pmpro_level global.
+ * Get level at checkout.
+ * 
+ * This function is only meant to be called once during checkout. Afterwards, the
+ * checkout level object should be passed to relevent hooks/filters.
+ *
  * If no level is passed or found in the URL parameters, global vars,
  * or in the post options, then this will return the first level found.
  *

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -36,7 +36,16 @@ if ( empty( $default_gateway ) ) {
 
 <div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
 
-	<?php do_action( 'pmpro_checkout_before_form' ); ?>
+	<?php
+	/**
+	 * Fires before the checkout form.
+	 *
+	 * @since TBD Added $pmpro_level as a parameter.
+	 *
+	 * @param object $pmpro_level The PMPro Level object being purchased.
+	 */
+	do_action( 'pmpro_checkout_before_form', $pmpro_level );
+	?>
 
 	<section id="pmpro_level-<?php echo intval( $pmpro_level->id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_checkout_gateway_class, 'pmpro_level-' . $pmpro_level->id ) ); ?>">
 
@@ -148,7 +157,16 @@ if ( empty( $default_gateway ) ) {
 							?>
 						</div> <!-- end #pmpro_level_cost -->
 
-						<?php do_action( 'pmpro_checkout_after_level_cost' ); ?>
+						<?php
+						/**
+						 * Fires after the level cost text is shown.
+						 *
+						 * @since TBD Added $pmpro_level as a parameter.
+						 *
+						 * @param object $pmpro_level The PMPro Level object being purchased.
+						 */
+						do_action( 'pmpro_checkout_after_level_cost', $pmpro_level );
+						?>
 
 					</div> <!-- end pmpro_card_content -->
 					<?php if ( $pmpro_show_discount_code ) { ?>
@@ -174,7 +192,16 @@ if ( empty( $default_gateway ) ) {
 				} // if ( $include_pricing_fields )
 			?>
 
-			<?php do_action( 'pmpro_checkout_after_pricing_fields' ); ?>
+			<?php
+			/**
+			 * Fires after the pricing fields are shown.
+			 *
+			 * @since TBD Added $pmpro_level as a parameter.
+			 *
+			 * @param object $pmpro_level The PMPro Level object being purchased.
+			 */
+			do_action( 'pmpro_checkout_after_pricing_fields', $pmpro_level );
+			?>
 
 			<?php
 			// Define whether we should show the Account Information box.
@@ -323,7 +350,16 @@ if ( empty( $default_gateway ) ) {
 
 			<?php do_action( 'pmpro_checkout_after_user_fields' ); ?>
 
-			<?php do_action( 'pmpro_checkout_boxes' ); ?>
+			<?php
+			/**
+			 * Add additional checkout boxes to the checkout page.
+			 *
+			 * @since TBD Added $pmpro_level as a parameter.
+			 *
+			 * @param object $pmpro_level The PMPro Level object being purchased.
+			 */
+			do_action( 'pmpro_checkout_boxes', $pmpro_level );
+			?>
 
 			<?php
 				$pmpro_include_billing_address_fields = apply_filters('pmpro_include_billing_address_fields', true);
@@ -503,8 +539,23 @@ if ( empty( $default_gateway ) ) {
 			?>
 
 			<?php
-      do_action( 'pmpro_checkout_after_payment_information_fields' );
-			do_action( 'pmpro_checkout_before_submit_button' );
+			/**
+			 * Fires after the payment information fields on the checkout page.
+			 *
+			 * @since TBD Added $pmpro_level as a parameter.
+			 *
+			 * @param object $pmpro_level The PMPro Level object being purchased.
+			 */
+      		do_action( 'pmpro_checkout_after_payment_information_fields', $pmpro_level );
+
+			/**
+			 * Fires before the submit button on the checkout page.
+			 *
+			 * @since TBD Added $pmpro_level as a parameter.
+			 *
+			 * @param object $pmpro_level The PMPro Level object being purchased.
+			 */
+			do_action( 'pmpro_checkout_before_submit_button', $pmpro_level );
 
 			// Add nonce.
 			wp_nonce_field( 'pmpro_checkout_nonce', 'pmpro_checkout_nonce' );
@@ -560,7 +611,16 @@ if ( empty( $default_gateway ) ) {
 
 		</form> <!-- end pmpro_form -->
 
-		<?php do_action( 'pmpro_checkout_after_form' ); ?>
+		<?php
+		/**
+		 * Fires after the submit button on the checkout page.
+		 *
+		 * @since TBD Added $pmpro_level as a parameter.
+		 *
+		 * @param object $pmpro_level The PMPro Level object being purchased.
+		 */
+		do_action( 'pmpro_checkout_after_form', $pmpro_level );
+		?>
 
 	</section> <!-- end pmpro_level-ID -->
 

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -116,8 +116,14 @@ if ( ! $besecure && ! empty( $_REQUEST['submit-checkout'] ) && is_ssl() ) {
 	$besecure = true;
 }    //be secure anyway since we're already checking out
 
-//action to run extra code for gateways/etc
-do_action( 'pmpro_checkout_preheader' );
+/**
+ * Action to run extra code for gateways/etc.
+ *
+ * @since TBD Added $pmpro_level parameter.
+ *
+ * @param object $pmpro_level The level being purchased.
+ */
+do_action( 'pmpro_checkout_preheader', $pmpro_level );
 
 // We set a global var for add-ons that are expecting it.
 $pmpro_show_discount_code = pmpro_show_discount_code();
@@ -423,9 +429,12 @@ if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
 		 * Filter whether the current checkout should continue.
 		 * Note: This will be deprecated in a future version. Use pmpro_checkout_checks, pmpro_checkout_user_creation_checks, or pmpro_checkout_order_creation_checks instead.
 		 *
+		 * @since TBD Added $pmpro_level parameter.
+		 *
 		 * @param bool $pmpro_continue_registration True if the checkout should continue.
+		 * @param object $pmpro_level The level being purchased.
 		 */
-		$pmpro_continue_registration = apply_filters( "pmpro_registration_checks", true );
+		$pmpro_continue_registration = apply_filters( "pmpro_registration_checks", true, $pmpro_level );
 		if ( ! $pmpro_continue_registration ) {
 			// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
 			pmpro_setMessage( __( 'Checkout checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );
@@ -437,9 +446,12 @@ if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
 		/**
 		 * Filter whether this checkout should proceed to the user creation step.
 		 *
+		 * @since TBD Added $pmpro_level parameter.
+		 *
 		 * @param bool $pmpro_checkout_user_creation_checks True if the checkout should continue.
+		 * @param object $pmpro_level The level being purchased.
 		 */
-		$pmpro_checkout_user_creation_checks = apply_filters( 'pmpro_checkout_user_creation_checks', true );
+		$pmpro_checkout_user_creation_checks = apply_filters( 'pmpro_checkout_user_creation_checks', true, $pmpro_level );
 		if ( ! $pmpro_checkout_user_creation_checks ) {
 			// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
 			pmpro_setMessage( __( 'User creation checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );
@@ -549,9 +561,12 @@ if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
 		/**
 		 * Filter whether this checkout should proceed to the order creation step.
 		 *
+		 * @since TBD Added $pmpro_level parameter.
+		 *
 		 * @param bool $pmpro_checkout_checks True if the checkout should continue.
+		 * @param object $pmpro_level The level being purchased.
 		 */
-		$pmpro_checkout_order_creation_checks = apply_filters( "pmpro_checkout_order_creation_checks", true );
+		$pmpro_checkout_order_creation_checks = apply_filters( "pmpro_checkout_order_creation_checks", true, $pmpro_level );
 		if ( ! $pmpro_checkout_order_creation_checks ) {
 			// If this is false, there should have been an error message set by the filter but just in case, set a generic error message.
 			pmpro_setMessage( __( 'Order creation checks failed.', 'paid-memberships-pro' ), 'pmpro_error' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In 3.0, we added caching to `pmpro_getLevelAtCheckout()` to speed up Add Ons retrieving checkout level information. However, this caching caused issues in edge cases where incorrect level data was retrieved early on page loads.

This PR passes the actual checkout level object to relevant hooks at checkout in lieu of caching the function. This also has the benefit of simplifying Add On code by directly passing checkout levels into functions instead of retrieving them with a function call.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
