### PR TITLE
Using the discount code set on the level object when set

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -69,6 +69,7 @@ function pmpro_calculate_profile_start_date( $order, $date_format, $filter = tru
 	update_pmpro_membership_order_meta( $order->id, 'checkout_level', $pmpro_level_arr );
 
 	// Save the discount code.
+	// @TODO: Remove this in v4.0. Discount codes should be set on the level object.
 	update_pmpro_membership_order_meta( $order->id, 'checkout_discount_code', $discount_code );
 
 	// Save any files that were uploaded.
@@ -156,6 +157,7 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 	$pmpro_level = (object) $checkout_level_arr;
 
 	// Set $discount_code_id.
+	// @TODO: Remove this in v4.0. Discount codes should be set on the level object.
 	$discount_code = get_pmpro_membership_order_meta( $order->id, 'checkout_discount_code', true );
 	
 	// Set $_REQUEST.
@@ -218,7 +220,13 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 	$enddate = apply_filters( "pmpro_checkout_end_date", $enddate, $order->user_id, $pmpro_level, $startdate );
 
 	// If we have a discount code but not the ID, get the ID.
-	if ( ! empty( $discount_code ) && empty( $discount_code_id ) ) {
+	if ( ! empty( $pmpro_level->discount_code ) ) {
+		$discount_code = $pmpro_level->discount_code;
+		$discount_code_id = empty( $pmpro_level->code_id ) ? $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" ) : $pmpro_level->code_id;
+	} elseif ( ! empty( $discount_code ) && empty( $discount_code_id ) ) {
+		// Throw a doing it wrong warning. If a discount code is being used, it should be set on the level.
+		// @TODO: Remove this in v4.0 along with references to the discount code globals. Discount codes should be set on the level object.
+		_doing_it_wrong( __FUNCTION__, __( 'Discount codes should be set on the $pmpro_level object.', 'paid-memberships-pro' ), 'TBD' );
 		$discount_code_id = $wpdb->get_var( "SELECT id FROM $wpdb->pmpro_discount_codes WHERE code = '" . esc_sql( $discount_code ) . "' LIMIT 1" );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
During asynchronous checkouts, we are currently saving the discount code used at checkout in an order meta field and also on the checkout level object. We have seen issues where those discount codes do not match which may cause discount code uses not to be saved.

To streamline our data storage and avoid duplicate (and potentially conflicting) information, this PR makes the discount code set on the checkout level the source of truth. In a future breaking update, discount code data will only be pulled from the checkout level object when completing checkout.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
