### PR TITLE
Fix PHP fatal error if Add On check returns null

### DIFF
--- a/includes/addons.php
+++ b/includes/addons.php
@@ -50,11 +50,19 @@ function pmpro_getAddons() {
 			// error
 			pmpro_setMessage( 'Could not connect to the PMPro License Server to update addon information. Try again later.', 'error' );
 		} elseif ( ! empty( $remote_addons ) && $remote_addons['response']['code'] == 200 ) {
-			// update addons in cache
+			// Update addons in cache.
 			$addons = json_decode( wp_remote_retrieve_body( $remote_addons ), true );
+
+			// If we don't have any addons, bail.
+			if ( empty( $addons ) ) {
+				return array();
+			}
+
+			// Create a short name for each Add On.
 			foreach ( $addons as $key => $value ) {
 				$addons[$key]['ShortName'] = trim( str_replace( array( 'Add On', 'Paid Memberships Pro - ' ), '', $addons[$key]['Title'] ) );
 			}
+
 			// Alphabetize the list by ShortName.
 			$short_names = array_column( $addons, 'ShortName' );
 			array_multisort( $short_names, SORT_ASC, SORT_STRING | SORT_FLAG_CASE, $addons );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We saw the following fatal error on the plugins/updates page if the site fails to retrieve the list of Add Ons:

`An error of type E_ERROR was caused in line 59 of the file /.../wp-content/plugins/paid-memberships-pro/includes/addons.php. Error message: Uncaught TypeError: array_column(): Argument #1 ($array) must be of type array, null given in /.../wp-content/plugins/paid-memberships-pro/includes/addons.php:59
Stack trace:
#0 /.../wp-content/plugins/paid-memberships-pro/includes/addons.php(59): array_column()
#1 /.../wp-content/plugins/paid-memberships-pro/includes/addons.php(265): pmpro_getAddons()
#2 /.../wp-includes/class-wp-hook.php(326): pmpro_update_plugins_filter()
#3 ......`

This PR checks whether `$addons` is empty to avoid passing `null` into `array_column()`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
