### PR TITLE
Logic to add class names based on field ID and passing the field ID to the element param of pmpro_get_element_class so form processing can target

### DIFF
--- a/classes/class-pmpro-field-group.php
+++ b/classes/class-pmpro-field-group.php
@@ -451,6 +451,10 @@ class PMPro_Field_Group {
 				$field->divclass .= "pmpro_form_field pmpro_form_field-" . $field->type;
 				$field->class .= " pmpro_form_input-" . $field->type;
 
+				// Add a class to the field based on the id.
+				$field->divclass .= " pmpro_form_field-" . $field->id;
+				$field->class .= " pmpro_form_input-" . $field->id;
+
 				// Add the required class to field.
 				if ( ! empty( $args['show_required'] ) && ! empty( $field->required ) ) {
 					$field->divclass .= " pmpro_form_field-required";
@@ -463,8 +467,8 @@ class PMPro_Field_Group {
 				}
 
 				// Run the class through the filter.
-				$field->divclass = pmpro_get_element_class( $field->divclass );
-				$field->class = pmpro_get_element_class( $field->class );
+				$field->divclass = pmpro_get_element_class( $field->divclass, $field->id );
+				$field->class = pmpro_get_element_class( $field->class, $field->id );
 
 				?>
 				<div id="<?php echo esc_attr( $field->id );?>_div" <?php if ( ! empty( $field->divclass ) ) { echo 'class="' . esc_attr( $field->divclass ) . '"'; } ?>>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now passing the field ID to the unique "element" parameter of the pmpro_get_element_class so that the checkout processing experience can append the appropriate error class and highlight the "missing" fields by their field ID

Resolves #3131 

![Screenshot 2025-01-10 at 10 59 14 AM](https://github.com/user-attachments/assets/005ee4b4-0854-41fb-a61c-6fe682941f4e)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
