### PR TITLE
Removing references to PayPal from the Membership Billing page

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -13,7 +13,7 @@
 ?>
 <div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
 <?php
-	global $wpdb, $current_user, $gateway, $pmpro_msg, $pmpro_msgt, $show_check_payment_instructions, $show_paypal_link, $pmpro_billing_subscription, $pmpro_billing_level;
+	global $wpdb, $current_user, $gateway, $pmpro_msg, $pmpro_msgt, $show_check_payment_instructions, $pmpro_billing_subscription, $pmpro_billing_level;
 	global $bfirstname, $blastname, $baddress1, $baddress2, $bcity, $bstate, $bzipcode, $bcountry, $bemail, $bconfirmemail, $bphone, $CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
 
 	/**
@@ -151,15 +151,6 @@
 					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_payment_instructions' ) ); ?>">
 						<?php echo wp_kses_post( wpautop( wp_unslash( get_option( 'pmpro_instructions' ) ) ) ); ?>
 					</div>
-				</div> <!-- end pmpro_card_content -->
-			</div> <!-- end pmpro_card -->
-		<?php } elseif ( $show_paypal_link ) { ?>
-			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
-				<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_title pmpro_font-large' ) ); ?>">
-					<?php esc_html_e( 'Payment Information', 'paid-memberships-pro' ); ?>
-				</h2>
-				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
-					<p><?php echo wp_kses( __('Your payment subscription is managed by PayPal. Please <a href="https://www.paypal.com">login to PayPal here</a> to update your billing information.', 'paid-memberships-pro' ), array( 'a' => array( 'href' => array() ) ) );?></p>
 				</div> <!-- end pmpro_card_content -->
 			</div> <!-- end pmpro_card -->
 		<?php } elseif ( $gateway != $default_gateway ) {

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -56,13 +56,10 @@ $pmpro_billing_level            = pmpro_getSpecificMembershipLevelForUser( $curr
 $current_user->membership_level = $pmpro_billing_level;
 
 //need to be secure?
-global $besecure, $gateway, $show_paypal_link, $show_check_payment_instructions;
+global $besecure, $gateway, $show_check_payment_instructions;
 if (empty($pmpro_billing_order->gateway)) {
     //no order
     $besecure = false;
-} elseif ($pmpro_billing_order->gateway == "paypalexpress") {
-    $besecure = get_option("pmpro_use_ssl");
-    $show_paypal_link = true;
 } elseif( $pmpro_billing_order->gateway == 'check' ) {
     $show_check_payment_instructions = true;
 } else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Our PayPal gateways no longer support showing the Update Billing Information link from the Membership Account page. The Membership Billing page is also now redirected away from since the PayPal gateway(s) do not declate support for the payment_method_updates gateway method.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Removed references to update subscriptions at PayPal from the Membership Billing page.


> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
