### PR TITLE
Fix fatal error for PHP 5.6

### DIFF
--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -233,7 +233,7 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 												__( 'No <a %1$s>Discount Codes</a> were used %2$s.', 'paid-memberships-pro' ),
 												'style="color:#1A688B;" target="_blank" href="' . esc_url( admin_url( 'admin.php?page=pmpro-discountcodes' ) ) . '"',
 												esc_html( $term )
-											),
+											)
 										);
 										?>
 									</p>


### PR DESCRIPTION
* BUG FIX: Fixes a minor issue for PHP 5.6 with the admin activity email class.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?