### PR TITLE
[bugfixing] Add On install button doesn't refresh to show activate ac…

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -865,18 +865,20 @@ const handleActionResponse = (action, responseElement, $actionButton) => {
 
 	// Handle post-install activation prompt
 	if ( action === 'install' ) {
-		const primaryButtons = responseElement.find('.button-primary');
-		if (primaryButtons.length > 0) {
-			const activateButton = primaryButtons[0];
-			const activateButtonHref = activateButton.getAttribute('href');
+		const $primaryButtons = responseElement.find('.button-primary');
+		//Find the activate button and set the action to activate.
+		const $primaryButton = $primaryButtons.filter( function() {
+			return  jQuery(this).attr('href') && jQuery(this).attr('href').indexOf( 'plugins.php?action=activate&plugin=' > 1 );
+		});
 
-			if ( activateButtonHref ) {
-				setTimeout(() => {
-					$actionButton.siblings('input[name="pmproAddOnAdminAction"]').val('activate');
-					$actionButton.siblings('input[name="pmproAddOnAdminActionUrl"]').val(activateButtonHref);
-					$actionButton.html('Activate').removeClass('disabled');
-				}, 1000);
-			}
+		const href = $primaryButton.attr('href');
+
+		if ( href ) {
+			setTimeout(() => {
+				$actionButton.siblings('input[name="pmproAddOnAdminAction"]').val('activate');
+				$actionButton.siblings('input[name="pmproAddOnAdminActionUrl"]').val( href );
+				$actionButton.html('Activate').removeClass('disabled');
+			}, 1000);
 		}
 	}
 };


### PR DESCRIPTION
…tion

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

 * Tweak the  Add On page code and fix the issue that prevented the button to show the activate action.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

 * Tweak the  Add On page code and fix the issue that prevented the button to show the activate action.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
