### PR TITLE
Fixing showing activate link after installing Add On

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -837,18 +837,21 @@ jQuery(document).ready(function () {
 					// If user just installed, give them the option to activate.
 					// TODO: Also give option to activate after update, but this is harder.
 					if ('install' === action) {
+						// Find the buttons that could be the activate button.
 						var primaryButtons = responseElement.find('.button-primary');
-						if (primaryButtons.length > 0) {
-							var activateButton = primaryButtons[0];
-							var activateButtonHref = activateButton.getAttribute('href');
-							if (activateButtonHref) {
+
+						// Loop through the buttons to find the activate button.
+						for (var i = 0; i < primaryButtons.length; i++) {
+							// If there is a href element beginning with plugins.php?action=activate&plugin=[plugin_slug], then it is very likely the activate button.
+							if ( primaryButtons[i].getAttribute('href') && primaryButtons[i].getAttribute('href').indexOf('plugins.php?action=activate&plugin=') > -1 ) {
 								// Wait 1 second before showing the activate button.
 								setTimeout(function () {
 									button.siblings('input[name="pmproAddOnAdminAction"]').val('activate');
-									button.siblings('input[name="pmproAddOnAdminActionUrl"]').val(activateButtonHref);
+									button.siblings('input[name="pmproAddOnAdminActionUrl"]').val( primaryButtons[i].getAttribute('href') );
 									button.html('Activate');
 									button.removeClass('disabled');
 								}, 1000);
+								break;
 							}
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Alternate to #3254

After installing an Add On via the Memberships > Add Ons page, we try to find an "activate" link to show the user so that they can immediately activate the plugin. This functionality was not working. Upon testing, I found that this may have been due to the Code Snippets having a button with the `.button-primary` class that confused our code in thinking that was the "activate" button.

This PR fixes the issue by specifically looking for a link with `plugins.php?action=activate&plugin=` to greatly increase our chances of finding the correct activation link.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
