### PR TITLE
Fixing membership report "vs cancel" and "vs expiration", add table below chart

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -187,25 +187,16 @@ function pmpro_report_memberships_page() {
 	// testing or live data
 	$gateway_environment = get_option( "pmpro_gateway_environment");
 
-	// get data
-	if (
-		$type === 'signup_v_cancel' ||
-		$type === 'signup_v_expiration' ||
-		$type === 'signup_v_all'
-	) {
-		$sqlQuery = "SELECT $date_function(mu.startdate) as date, COUNT(DISTINCT mu.user_id) as signups
-		FROM $wpdb->pmpro_memberships_users mu ";
+	// Get signups.
+	$sqlQuery = "SELECT $date_function(mu.startdate) as date, COUNT(DISTINCT mu.user_id) as signups
+	FROM $wpdb->pmpro_memberships_users mu ";
 
-		if ( ! empty( $discount_code ) ) {
-			$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON mu.user_id = dc.user_id ";
-		}
-
-		$sqlQuery .= "WHERE mu.startdate >= '" . esc_sql( $startdate ) . "' ";
-
-		if ( ! empty( $enddate ) ) {
-			$sqlQuery .= "AND mu.startdate <= '" . esc_sql( $enddate ) . "' ";
-		}
+	if ( ! empty( $discount_code ) ) {
+		$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON mu.user_id = dc.user_id ";
 	}
+
+	$sqlQuery .= "WHERE mu.startdate >= '" . esc_sql( $startdate ) . "' ";
+	$sqlQuery .= "AND mu.startdate <= '" . esc_sql( $enddate ) . "' ";
 
 	if ( ! empty( $l ) ) {
 		$sqlQuery .= 'AND mu.membership_id IN(' . $l . ') '; // $l is already escaped for SQL. See declaration.
@@ -219,35 +210,30 @@ function pmpro_report_memberships_page() {
 
 	$dates = $wpdb->get_results( $sqlQuery );
 
-	// fill in blanks in dates
+	// Build array of dates to track.
+	// We are doing this after getting the signup data in case annual is selected so that we know the first year we have data for.
 	$cols = array();
 	if ( $period == 'daily' ) {
 		$lastday = date_i18n( 't', strtotime( $startdate, current_time( 'timestamp' ) ) );
 
 		for ( $i = 1; $i <= $lastday; $i++ ) {
-			// Signups vs. Cancellations, Expirations, or All
-			if ( $type === 'signup_v_cancel' || $type === 'signup_v_expiration' || $type === 'signup_v_all' ) {
-				$cols[ $i ]          = new stdClass();
-				$cols[ $i ]->signups = 0;
-				foreach ( $dates as $day => $date ) {
-					if ( $date->date == $i ) {
-						$cols[ $i ]->signups = $date->signups;
-					}
+			$cols[ $i ]          = new stdClass();
+			$cols[ $i ]->signups = 0;
+			foreach ( $dates as $day => $date ) {
+				if ( $date->date == $i ) {
+					$cols[ $i ]->signups = $date->signups;
 				}
 			}
 		}
 	} elseif ( $period == 'monthly' ) {
 		for ( $i = 1; $i < 13; $i++ ) {
-			// Signups vs. Cancellations, Expirations, or All
-			if ( $type === 'signup_v_cancel' || $type === 'signup_v_expiration' || $type === 'signup_v_all' ) {
-				$cols[ $i ]          = new stdClass();
-				$cols[ $i ]->date    = $i;
-				$cols[ $i ]->signups = 0;
-				foreach ( $dates as $date ) {
-					if ( $date->date == $i ) {
-						$cols[ $i ]->date    = $date->date;
-						$cols[ $i ]->signups = $date->signups;
-					}
+			$cols[ $i ]          = new stdClass();
+			$cols[ $i ]->date    = $i;
+			$cols[ $i ]->signups = 0;
+			foreach ( $dates as $date ) {
+				if ( $date->date == $i ) {
+					$cols[ $i ]->date    = $date->date;
+					$cols[ $i ]->signups = $date->signups;
 				}
 			}
 		}
@@ -261,16 +247,13 @@ function pmpro_report_memberships_page() {
 		}
 
 		for ( $i = $first_year; $i <= $thisyear; $i++ ) {
-			// Signups vs. Cancellations, Expirations, or All
-			if ( $type === 'signup_v_cancel' || $type === 'signup_v_expiration' || $type === 'signup_v_all' ) {
-				$cols[ $i ]          = new stdClass();
-				$cols[ $i ]->date    = $i;
-				$cols[ $i ]->signups = 0;
-				foreach ( $dates as $date ) {
-					if ( $date->date == $i ) {
-						$cols[ $i ]->date    = $date->date;
-						$cols[ $i ]->signups = $date->signups;
-					}
+			$cols[ $i ]          = new stdClass();
+			$cols[ $i ]->date    = $i;
+			$cols[ $i ]->signups = 0;
+			foreach ( $dates as $date ) {
+				if ( $date->date == $i ) {
+					$cols[ $i ]->date    = $date->date;
+					$cols[ $i ]->signups = $date->signups;
 				}
 			}
 		}
@@ -279,58 +262,56 @@ function pmpro_report_memberships_page() {
 	$dates = ( ! empty( $cols ) ) ? $cols : $dates;
 
 	// Signups vs. all
-	if ( $type === 'signup_v_cancel' || $type === 'signup_v_expiration' || $type === 'signup_v_all' ) {
-		$sqlQuery = "SELECT $date_function(mu1.modified) as date, COUNT(DISTINCT mu1.user_id) as cancellations
-		FROM $wpdb->pmpro_memberships_users mu1 ";
+	$sqlQuery = "SELECT $date_function(mu1.modified) as date, COUNT(DISTINCT mu1.user_id) as cancellations
+	FROM $wpdb->pmpro_memberships_users mu1 ";
 
-		// restrict by discount code
-		if ( ! empty( $discount_code ) ) {
-			$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON mu1.user_id = dc.user_id ";
-		}
+	// restrict by discount code
+	if ( ! empty( $discount_code ) ) {
+		$sqlQuery .= "LEFT JOIN $wpdb->pmpro_discount_codes_uses dc ON mu1.user_id = dc.user_id ";
+	}
 
-		if ( $type === 'signup_v_cancel' ) {
-			$sqlQuery .= "WHERE mu1.status IN('inactive','cancelled','admin_cancelled') ";
-		} elseif ( $type === 'signup_v_expiration' ) {
-			$sqlQuery .= "WHERE mu1.status IN('expired') ";
+	if ( $type === 'signup_v_cancel' ) {
+		$sqlQuery .= "WHERE mu1.status IN('inactive','cancelled','admin_cancelled') ";
+	} elseif ( $type === 'signup_v_expiration' ) {
+		$sqlQuery .= "WHERE mu1.status IN('expired') ";
+	} else {
+		$sqlQuery .= "WHERE mu1.status IN('inactive','expired','cancelled','admin_cancelled') ";
+	}
+
+	$sqlQuery .= "AND mu1.enddate >= '" . esc_sql( $startdate ) . "'
+	AND mu1.enddate < '" . esc_sql( $enddate ) . "' ";
+
+	// restrict by level
+	if ( ! empty( $l ) ) {
+		$sqlQuery .= 'AND mu1.membership_id IN(' . $l . ') '; // $l is already escaped for SQL. See declaration.
+	}
+
+	if ( ! empty( $discount_code ) ) {
+		$sqlQuery .= "AND dc.code_id = '" . esc_sql( $discount_code ) . "' ";
+	}
+
+	$sqlQuery .= ' GROUP BY date ORDER BY date ';
+
+	/**
+	 * Filter query to get cancellation numbers in signups vs cancellations detailed report.
+	 *
+	 * @since 1.8.8
+	 *
+	 * @param string $sqlQuery The current SQL
+	 * @param string $type report type
+	 * @param string $startdate Start Date in YYYY-MM-DD format
+	 * @param string $enddate End Date in YYYY-MM-DD format
+	 * @param int $l Level ID
+	 */
+	$sqlQuery = apply_filters( 'pmpro_reports_signups_sql', $sqlQuery, $type, $startdate, $enddate, $l );
+
+	$cdates = $wpdb->get_results( $sqlQuery, OBJECT_K );
+
+	foreach ( $dates as $day => &$date ) {
+		if ( ! empty( $cdates ) && ! empty( $cdates[ $day ] ) ) {
+			$date->cancellations = $cdates[ $day ]->cancellations;
 		} else {
-			$sqlQuery .= "WHERE mu1.status IN('inactive','expired','cancelled','admin_cancelled') ";
-		}
-
-		$sqlQuery .= "AND mu1.enddate >= '" . esc_sql( $startdate ) . "'
-		AND mu1.enddate < '" . esc_sql( $enddate ) . "' ";
-
-		// restrict by level
-		if ( ! empty( $l ) ) {
-			$sqlQuery .= 'AND mu1.membership_id IN(' . $l . ') '; // $l is already escaped for SQL. See declaration.
-		}
-
-		if ( ! empty( $discount_code ) ) {
-			$sqlQuery .= "AND dc.code_id = '" . esc_sql( $discount_code ) . "' ";
-		}
-
-		$sqlQuery .= ' GROUP BY date ORDER BY date ';
-
-		/**
-		 * Filter query to get cancellation numbers in signups vs cancellations detailed report.
-		 *
-		 * @since 1.8.8
-		 *
-		 * @param string $sqlQuery The current SQL
-		 * @param string $type report type
-		 * @param string $startdate Start Date in YYYY-MM-DD format
-		 * @param string $enddate End Date in YYYY-MM-DD format
-		 * @param int $l Level ID
-		 */
-		$sqlQuery = apply_filters( 'pmpro_reports_signups_sql', $sqlQuery, $type, $startdate, $enddate, $l );
-
-		$cdates = $wpdb->get_results( $sqlQuery, OBJECT_K );
-
-		foreach ( $dates as $day => &$date ) {
-			if ( ! empty( $cdates ) && ! empty( $cdates[ $day ] ) ) {
-				$date->cancellations = $cdates[ $day ]->cancellations;
-			} else {
-				$date->cancellations = 0;
-			}
+			$date->cancellations = 0;
 		}
 	}
 
@@ -489,8 +470,17 @@ function pmpro_report_memberships_page() {
 		function drawVisualization() {
 
 			var data = google.visualization.arrayToDataTable([
-			<?php if ( $type === 'signup_v_all' ) : // Signups vs. all cancellations ?>
-				['<?php echo esc_html( $date_function ); ?>', 'Signups', 'All Cancellations'],
+				<?php
+				// Get the label for the "cancellations" index.
+				if ( $type === 'signup_v_cancel' ) {
+					$cancellations_label = __( 'Cancellations', 'paid-memberships-pro' );
+				} elseif ( $type === 'signup_v_expiration' ) {
+					$cancellations_label = __( 'Expirations', 'paid-memberships-pro' );
+				} else {
+					$cancellations_label = __( 'All Cancellations', 'paid-memberships-pro' );
+				}
+				?>
+				['<?php echo esc_html( $date_function ); ?>', '<?php echo esc_html( __( 'Signups', 'paid-memberships-pro' ) ) ?>', '<?php echo esc_html( $cancellations_label ); ?>'],
 				<?php foreach ( $dates as $key => $value ) { ?>
 				['<?php
 					if ( $period == 'monthly' ) {
@@ -503,42 +493,6 @@ function pmpro_report_memberships_page() {
 					?>
 				', <?php echo esc_html( $value->signups ); ?>, <?php echo esc_html( $value->cancellations ); ?>],
 				<?php } ?>
-			<?php endif; ?>
-
-			<?php if ( $type === 'signup_v_cancel' ) : // Signups vs. cancellations ?>
-				['<?php echo esc_html( $date_function ); ?>', 'Signups', 'Cancellations'],
-				<?php foreach ( $dates as $key => $value ) { ?>
-				['
-					<?php
-					if ( $period == 'monthly' ) {
-						echo esc_html( date_i18n( 'M', mktime( 0, 0, 0, $value->date, 2 ) ) );
-					} elseif ( $period == 'daily' ) {
-						echo esc_html( $key );
-					} else {
-						echo esc_html( $value->date );
-					}
-					?>
-				', <?php echo esc_html( $value->signups ); ?>, <?php echo esc_html( $value->cancellations ); ?>],
-				<?php } ?>
-			<?php endif; ?>
-
-			<?php if ( $type === 'signup_v_expiration' ) : // Signups vs. expirations ?>
-				['<?php echo esc_html( $date_function ); ?>', 'Signups', 'Expirations'],
-				<?php foreach ( $dates as $key => $value ) { ?>
-				['
-					<?php
-					if ( $period == 'monthly' ) {
-						echo esc_html( date_i18n( 'M', mktime( 0, 0, 0, $value->date, 2 ) ) );
-					} elseif ( $period == 'daily' ) {
-						echo esc_html( $key );
-					} else {
-						echo esc_html( $value->date );
-					}
-					?>
-				', <?php echo esc_html( $value->signups ); ?>, <?php echo esc_html( $value->cancellations ); ?>],
-				<?php } ?>
-			<?php endif; ?>
-
 			]);
 
 			var options = {
@@ -570,6 +524,44 @@ function pmpro_report_memberships_page() {
 	</script>
 
 	</form>
+	<?php
+	// Show a table with all of the raw data.
+	?>
+	<table class="widefat">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Date', 'paid-memberships-pro' ); ?></th>
+				<th><?php esc_html_e( 'Signups', 'paid-memberships-pro' ); ?></th>
+				<th><?php echo esc_html( $cancellations_label ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php
+			foreach ( $dates as $key => $value ) {
+				?>
+				<tr>
+					<td><?php
+						if ( $period == 'monthly' ) {
+							echo esc_html( date_i18n( 'M', mktime( 0, 0, 0, $value->date, 2 ) ) );
+						} elseif ( $period == 'daily' ) {
+							echo esc_html( $key );
+						} else {
+							echo esc_html( $value->date );
+						}
+						?></td>
+					<td><?php echo esc_html( $value->signups ); ?></td>
+					<td><?php echo esc_html( $value->cancellations ); ?></td>
+				</tr>
+				<?php
+			}
+			?>
+			<tr>
+				<td><strong><?php esc_html_e( 'Total', 'paid-memberships-pro' ); ?></strong></td>
+				<td><strong><?php echo esc_html( array_sum( wp_list_pluck( $dates, 'signups' ) ) ); ?></strong></td>
+				<td><strong><?php echo esc_html( array_sum( wp_list_pluck( $dates, 'cancellations' ) ) ); ?></strong></td>
+			</tr>
+		</tbody>
+	</table>
 	<?php
 }
 

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -527,41 +527,45 @@ function pmpro_report_memberships_page() {
 	<?php
 	// Show a table with all of the raw data.
 	?>
-	<table class="widefat">
-		<thead>
-			<tr>
-				<th><?php esc_html_e( 'Date', 'paid-memberships-pro' ); ?></th>
-				<th><?php esc_html_e( 'Signups', 'paid-memberships-pro' ); ?></th>
-				<th><?php echo esc_html( $cancellations_label ); ?></th>
-			</tr>
-		</thead>
-		<tbody>
-			<?php
-			foreach ( $dates as $key => $value ) {
-				?>
+	<div class="pmpro_table_area">
+		<table class="widefat striped">
+			<thead>
 				<tr>
-					<td><?php
-						if ( $period == 'monthly' ) {
-							echo esc_html( date_i18n( 'M', mktime( 0, 0, 0, $value->date, 2 ) ) );
-						} elseif ( $period == 'daily' ) {
-							echo esc_html( $key );
-						} else {
-							echo esc_html( $value->date );
-						}
-						?></td>
-					<td><?php echo esc_html( $value->signups ); ?></td>
-					<td><?php echo esc_html( $value->cancellations ); ?></td>
+					<th><?php esc_html_e( 'Date', 'paid-memberships-pro' ); ?></th>
+					<th><?php esc_html_e( 'Signups', 'paid-memberships-pro' ); ?></th>
+					<th><?php echo esc_html( $cancellations_label ); ?></th>
 				</tr>
+			</thead>
+			<tbody>
 				<?php
-			}
-			?>
-			<tr>
-				<td><strong><?php esc_html_e( 'Total', 'paid-memberships-pro' ); ?></strong></td>
-				<td><strong><?php echo esc_html( array_sum( wp_list_pluck( $dates, 'signups' ) ) ); ?></strong></td>
-				<td><strong><?php echo esc_html( array_sum( wp_list_pluck( $dates, 'cancellations' ) ) ); ?></strong></td>
-			</tr>
-		</tbody>
-	</table>
+					foreach ( $dates as $key => $value ) {
+					?>
+					<tr>
+						<th scope="row"><?php
+							if ( $period == 'monthly' ) {
+								echo esc_html( date_i18n( 'F Y', mktime( 0, 0, 0, $value->date, 2 ) ) );
+							} elseif ( $period == 'daily' ) {
+								echo esc_html( $key );
+							} else {
+								echo esc_html( $value->date );
+							}
+							?></th>
+						<td><?php echo esc_html( $value->signups ); ?></td>
+						<td><?php echo esc_html( $value->cancellations ); ?></td>
+					</tr>
+					<?php
+				}
+				?>
+			</tbody>
+			<tfoot>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Total', 'paid-memberships-pro' ); ?></th>
+					<th><?php echo esc_html( array_sum( wp_list_pluck( $dates, 'signups' ) ) ); ?></th>
+					<th><?php echo esc_html( array_sum( wp_list_pluck( $dates, 'cancellations' ) ) ); ?></th>
+				</tr>
+			</tfoot>
+		</table>
+	</div>
 	<?php
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -3377,6 +3377,14 @@ button.pmpro_report_th_closed:before {
 	width: 100%;
 }
 
+.pmpro_table_area table {
+	max-width: 900px;
+}
+
+.pmpro_table_area tfoot th {
+	font-weight: 700;
+}
+
 /**
  * Dashboard admin page
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The "Signups vs. Cancellations" and "Signups vs. Expirations" reports have been broken since v3.0. This PR:
1. Fixes those reports (See abstraction in `function drawVisualization()`. The issue was JS errors caused by `['` and `<?php` being on new lines in the deleted code)
2. Removes unnecessary `if ( $type === 'signup_v_cancel' || $type === 'signup_v_expiration' || $type === 'signup_v_all' ) {` conditions that always evaluate to `true` (resulting indentation changes is most of the diff)
3. Adds the raw report data in a table under the chart.

![Screenshot 2025-01-17 at 1 53 22 PM](https://github.com/user-attachments/assets/9ff9c975-59ed-4208-817d-1352fe7938b0)

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
