### PR TITLE
Fix error handling for password reset invalid/expired keys.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -525,8 +525,8 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 
 							<?php
 						}
-					} elseif ( $location !== 'widget' && ( $action === 'reset_pass' || ( $action === 'rp' && in_array( $_REQUEST['login'], array( 'invalidkey', 'expiredkey' ) ) ) ) ) {
-						// Reset password form.
+  			  } elseif ( $location !== 'widget' && ( $action === 'reset_pass' || ( $action === 'rp' && isset( $_REQUEST['error'] ) && in_array( $_REQUEST['error'], array( 'invalidkey', 'expiredkey' ) ) ) ) ) {
+					// Reset password form.
 						?>
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card pmpro_lost_password_wrap', 'pmpro_lost_password_wrap' ) ); ?>">
 							<?php


### PR DESCRIPTION
Previously, the code relied on 'login' parameter checks for error handling, **which is probably a bad copy-paste**. The code now properly checks the 'error' parameter for invalid or expired keys, ensuring more accurate error handling.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3261.

### How to test the changes in this Pull Request:

1. Check the procedure reported in the issue
2. With the changes in place, the warning is gone
3. Even if you mess up the request changing 'error' to 'error2', no warning.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
