### PR TITLE
Fixing incorrect variable usage and subject line that was not meant to change

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
@@ -90,13 +90,13 @@ class PMPro_Email_Template_Admin_Change_Admin extends PMPro_Email_Template {
 		$user = $this->user;
 		// If the user no longer has a membership level, set the membership_change text to "Membership has been cancelled."
 		if ( ! pmpro_hasMembershipLevel( null,  $this->user->ID ) ) {
-			$membership_changed = __( 'The user\'s membership has been cancelled.', 'paid-memberships-pro' );
+			$membership_change = __( 'The user\'s membership has been cancelled.', 'paid-memberships-pro' );
 		} else {
-			$membership_changed = __( 'You can view the user\'s current memberships from their Edit Member page.', 'paid-memberships-pro' );
+			$membership_change = __( 'You can view the user\'s current memberships from their Edit Member page.', 'paid-memberships-pro' );
 		}
 
 		$email_template_variables = array(
-			'membership_changed' => $membership_changed,
+			'membership_change' => $membership_change,
 			'subject' => $this->get_default_subject(),
 			'name' => $user->display_name,
 			'display_name' => $user->display_name,

--- a/classes/email-templates/class-pmpro-email-template-admin-change.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change.php
@@ -61,7 +61,7 @@ class PMPro_Email_Template_Admin_Change  extends PMPro_Email_Template {
 	 * @return string The default subject for the email.
 	 */
 	public static function get_default_subject() {
-		return __( "Membership for !!header_name!! at !!site_name!! has been changed", "paid-memberships-pro" );
+		return __( "Your membership at !!sitename!! has been changed", "paid-memberships-pro" );
 	}
 
 	/**
@@ -92,13 +92,13 @@ class PMPro_Email_Template_Admin_Change  extends PMPro_Email_Template {
 		$user = $this->user;
 		// If the user no longer has a membership level, set the membership_change text to "Membership has been cancelled."
 		if ( ! pmpro_hasMembershipLevel( null,  $this->user->ID ) ) {
-			$membership_changed = __( 'Your membership has been cancelled.', 'paid-memberships-pro' );
+			$membership_change = __( 'Your membership has been cancelled.', 'paid-memberships-pro' );
 		} else {
-			$membership_changed = __( 'You can view your current memberships by logging in and visiting your membership account page.', 'paid-memberships-pro' );
+			$membership_change = __( 'You can view your current memberships by logging in and visiting your membership account page.', 'paid-memberships-pro' );
 		}
 
 		$email_template_variables = array(
-			'membership_changed' => $membership_changed,
+			'membership_change' => $membership_change,
 			'subject' => $this->get_default_subject(),
 			'name' => $user->display_name, 
 			'display_name' => $user->display_name, 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
A few fixes to incorrect template variable usage. Also putting back the correct subject line for the admin change email sent to the user.
