### PR TITLE
Improving accessibility of the Add Ons admin screen

### DIFF
--- a/adminpages/addons.php
+++ b/adminpages/addons.php
@@ -160,14 +160,14 @@
 							?>
 							<?php if ( ! empty( $addon['plugin_icon_src'] ) ) { ?>
 								<?php if ( ! empty( $addon['PluginURI'] ) ) { ?>
-									<a target="_blank" href="<?php echo esc_url( $plugin_link ); ?>">
+									<a class="add-on-icon" target="_blank" href="<?php echo esc_url( $plugin_link ); ?>">
 								<?php } ?>
 								<img src="<?php echo esc_url( $addon['plugin_icon_src'] ); ?>" alt="<?php echo esc_attr( $addon['Name'] ); ?>">
 								<?php if ( ! empty( $addon['PluginURI'] ) ) { ?>
 									</a>
 								<?php } ?>
 							<?php } ?>
-							<h5 class="add-on-name">
+							<div class="add-on-name">
 								<?php if ( ! empty( $addon['PluginURI'] ) ) { ?>
 									<a target="_blank" href="<?php echo esc_url( $plugin_link ); ?>">
 								<?php } ?>
@@ -175,7 +175,7 @@
 								<?php if ( ! empty( $addon['PluginURI'] ) ) { ?>
 									</a>
 								<?php } ?>
-							</h5> <!-- end add-on-name -->
+							</div> <!-- end add-on-name -->
 							<div class="add-on-description">
 								<p><?php echo esc_html( $addon['Description'] ); ?></p>
 								<p>
@@ -313,7 +313,7 @@
 									} elseif ( $addon['status'] === 'active' ) {
 										$actions = apply_filters( 'plugin_action_links_' . $plugin_file, array(), $plugin_file, $addon, $addon['status'] );
 										if ( ! empty( $actions ) ) {
-											$action_button = str_replace( '<a ', '<a class="button" ', $actions[0] );
+											$action_button = str_replace( '<a ', '<a class="button" ', reset( $actions ) );
 										} else {
 											$action_button['label'] = __( 'Active', 'paid-memberships-pro' );
 											$action_button['style'] .= ' disabled';
@@ -322,7 +322,7 @@
 
 									if ( is_array( $action_button ) ) {
 										?>
-										<a class="<?php echo esc_attr( $action_button['style'] ); ?>" ><?php echo esc_html( $action_button['label'] ); ?></a>
+										<button class="<?php echo esc_attr( $action_button['style'] ); ?>" ><?php echo esc_html( $action_button['label'] ); ?></button>
 										<?php
 										if ( ! empty( $action_button['hidden_fields'] ) ) {
 											foreach ( $action_button['hidden_fields'] as $name => $value ) {

--- a/css/admin.css
+++ b/css/admin.css
@@ -3057,23 +3057,29 @@ tr.pmpro_alert {
 	overflow: hidden;
 }
 
-#pmpro-admin-add-ons .add-on-item img {
+#pmpro-admin-add-ons .add-on-item .add-on-icon {
 	border: 1px solid var(--pmpro--border--color);
+	display: flex;
 	float: left;
-	max-width: 75px;
+	height: 75px;
+	width: 75px;
+}
+
+#pmpro-admin-add-ons .add-on-item img {
 	padding: 4px;
 }
 
-#pmpro-admin-add-ons .add-on-item h5 {
+#pmpro-admin-add-ons .add-on-item .add-on-name {
 	margin: 0 0 10px 100px;
 	font-size: 16px;
+	font-weight: 700;
 }
 
-#pmpro-admin-add-ons .add-on-item h5 a {
+#pmpro-admin-add-ons .add-on-item .add-on-name a {
 	color: #444;
 }
 
-#pmpro-admin-add-ons .add-on-item h5 a:hover {
+#pmpro-admin-add-ons .add-on-item .add-on-name a:hover {
 	color: #006799;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The install/activate are now HTML "button" elements. This makes them part of the tab order and able to be triggered with keyboard navigation.

This also fixes an issue with skipped heading levels.

Finally, a bug fix where the plugin's action links might be an array with multiple items and for some plugins, named keys (LifterLMS was my test to see this error). The former $actions[0] was causing this error.

This now resets and returns the value of that first element in the array.

Resolves #3266 

