### PR TITLE
Membership Account Message Functionality

### DIFF
--- a/adminpages/levels/edit-level.php
+++ b/adminpages/levels/edit-level.php
@@ -257,7 +257,7 @@ if (!empty($page_msg)) { ?>
 							<p class="description"><?php
 								printf( 
 									esc_html__( 'This text appears at checkout and on the pricing page if using the %s. Use it to provide a brief overview of the membership level, highlighting key features and benefits to potential members.', 'paid-memberships-pro' ),
-									'<a href="https://www.paidmembershipspro.com/add-ons/pmpro-advanced-levels-shortcode/?utm_source=plugin&utm_medium=pmpro-level-settings&utm_campaign=xxx">' . esc_html__( 'Advanced Levels Page Add On', 'paid-memberships-pro' ) . '</a>' );
+									'<a target="_blank" href="https://www.paidmembershipspro.com/add-ons/pmpro-advanced-levels-shortcode/?utm_source=plugin&utm_medium=pmpro-membershiplevels&utm_campaign=add-ons&utm_content=pmpro-advanced-levels-shortcode">' . esc_html__( 'Advanced Levels Page Add On', 'paid-memberships-pro' ) . '</a>' );
 								?></p>
 						</td>
 					</tr>
@@ -286,7 +286,7 @@ if (!empty($page_msg)) { ?>
             			<th scope="row" valign="top"><label for="membership_account_message"><?php esc_html_e( 'Membership Account Message', 'paid-memberships-pro'); ?></label></th>
             			<td class="pmpro_membership_account_message">
                 			<?php wp_editor( $membership_account_message, 'membership_account_message', array( 'textarea_rows' => 5 ) ); ?>
-                			<p class="description"><?php esc_html_e( 'This message appears only to members of this level in the “My Memberships” section of the account page. Use it to share details about benefits or features specific to this membership level.', 'paid-memberships-pro' ); ?></p>
+                			<p class="description"><?php esc_html_e( 'This message appears only to members of this level in the "My Memberships" section of the account page. Use it to share benefits or link to content specific to this level.', 'paid-memberships-pro' ); ?></p>
            				</td>
         			</tr>
 				</tbody>

--- a/adminpages/levels/edit-level.php
+++ b/adminpages/levels/edit-level.php
@@ -176,6 +176,13 @@ if (!empty($temp_id)) {
 } else {
 	$confirmation_in_email = 0;
 }
+
+// Get the Membership Account Message via meta.
+if ( ! empty( $temp_id ) ) {
+	$membership_account_message = get_pmpro_membership_level_meta( $temp_id, 'membership_account_message', true );
+} else {
+	$membership_account_message = '';
+}
 ?>
 <hr class="wp-header-end">
 <?php if (!empty($level->id)) { ?>
@@ -247,6 +254,11 @@ if (!empty($page_msg)) { ?>
 						<th scope="row" valign="top"><label for="description"><?php esc_html_e('Description', 'paid-memberships-pro'); ?></label></th>
 						<td class="pmpro_description">
 							<?php wp_editor($level->description, 'description', array('textarea_rows' => 5)); ?>
+							<p class="description"><?php
+								printf( 
+									esc_html__( 'This text appears at checkout and on the pricing page if using the %s. Use it to provide a brief overview of the membership level, highlighting key features and benefits to potential members.', 'paid-memberships-pro' ),
+									'<a href="https://www.paidmembershipspro.com/add-ons/pmpro-advanced-levels-shortcode/?utm_source=plugin&utm_medium=pmpro-level-settings&utm_campaign=xxx">' . esc_html__( 'Advanced Levels Page Add On', 'paid-memberships-pro' ) . '</a>' );
+								?></p>
 						</td>
 					</tr>
 					<tr>
@@ -270,6 +282,13 @@ if (!empty($page_msg)) { ?>
 							</p>
 						</td>
 					</tr>
+					<tr>
+            			<th scope="row" valign="top"><label for="membership_account_message"><?php esc_html_e( 'Membership Account Message', 'paid-memberships-pro'); ?></label></th>
+            			<td class="pmpro_membership_account_message">
+                			<?php wp_editor( $membership_account_message, 'membership_account_message', array( 'textarea_rows' => 5 ) ); ?>
+                			<p class="description"><?php esc_html_e( 'This message appears only to members of this level in the “My Memberships” section of the account page. Use it to share details about benefits or features specific to this membership level.', 'paid-memberships-pro' ); ?></p>
+           				</td>
+        			</tr>
 				</tbody>
 			</table>
 			<?php

--- a/adminpages/levels/save-level.php
+++ b/adminpages/levels/save-level.php
@@ -36,6 +36,12 @@ $ml_expiration_number = intval($_REQUEST['expiration_number']);
 $ml_expiration_period = sanitize_text_field($_REQUEST['expiration_period']);
 $ml_categories = array();
 
+if ( ! empty( $_REQUEST['membership_account_message'] ) ) {
+	$ml_membership_account_message = wp_kses( wp_unslash( $_REQUEST['membership_account_message'] ), $allowedposttags );
+} else {
+	$ml_membership_account_message = '';
+}
+
 //reversing disable to allow here
 if(empty($_REQUEST['disable_signups']))
 	$ml_allow_signups = 1;
@@ -141,5 +147,8 @@ if ( isset( $ml_confirmation_in_email ) ) {
 if ( ! empty( $_REQUEST['level_group'] ) ) {
 	pmpro_add_level_to_group( $saveid, (int) $_REQUEST['level_group'] );
 }
+
+// Update the Membership Account Message.
+update_pmpro_membership_level_meta( $saveid, 'membership_account_message', $ml_membership_account_message );
 
 do_action("pmpro_save_membership_level", $saveid);

--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -711,6 +711,21 @@
 
 	}
 
+	#pmpro_account-membership {
+
+		.pmpro_account-membership-message {
+			border-top: 1px solid var(--pmpro--color--border--variation);
+			margin-top: var(--pmpro--base--spacing--large);
+			padding-top: var(--pmpro--base--spacing--large);
+
+			:first-child {
+				margin-top: 0;
+				padding-top: 0;
+			}
+		}
+
+	}
+
 	#pmpro_account-links {
 
 		.pmpro_card_content {

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -717,6 +717,21 @@
 
 	}
 
+	#pmpro_account-membership {
+
+		.pmpro_account-membership-message {
+			border-top: 1px solid var(--pmpro--color--border--variation);
+			margin-top: var(--pmpro--base--spacing--large);
+			padding-top: var(--pmpro--base--spacing--large);
+
+			:first-child {
+				margin-top: 0;
+				padding-top: 0;
+			}
+		}
+
+	}
+
 	#pmpro_account-links {
 
 		.pmpro_card_content {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5042,7 +5042,7 @@ function pmpro_add_level_account_message( $level ) {
 	if ( $membership_account_message ) {
 		?>
 		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-message' ) ); ?>">
-			<?php echo wpautop( wp_kses_post( apply_filters( 'pmpro_account_membership_message', $membership_account_message, $level ) ) ); ?>
+			<?php echo wpautop( wp_kses_post( $membership_account_message ) ); ?>
 		</div>
 		<?php
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5037,7 +5037,7 @@ function pmpro_check_token_order_for_completion( $order_id ) {
 /**
  * Show a message on the account page for a specific membership level.
  */
-function pmpro_add_level_account_message( $level ) {
+function pmpro_display_member_account_level_message( $level ) {
 	$membership_account_message = get_pmpro_membership_level_meta( $level->id, 'membership_account_message', true );
 	if ( $membership_account_message ) {
 		?>
@@ -5047,4 +5047,4 @@ function pmpro_add_level_account_message( $level ) {
 		<?php
 	}
 }
-add_action( 'pmpro_member_account_message', 'pmpro_add_level_account_message' );
+add_action( 'pmpro_membership_account_after_level_card_content', 'pmpro_display_member_account_level_message' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5033,3 +5033,18 @@ function pmpro_check_token_order_for_completion( $order_id ) {
 	// Check the order for completion.
 	return $order->Gateway->check_token_order( $order );
 }
+
+/**
+ * Show a message on the account page for a specific membership level.
+ */
+function pmpro_add_level_account_message( $level ) {
+	$membership_account_message = get_pmpro_membership_level_meta( $level->id, 'membership_account_message', true );
+	if ( $membership_account_message ) {
+		?>
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account-membership-message' ) ); ?>">
+			<?php echo wpautop( wp_kses_post( apply_filters( 'pmpro_account_membership_message', $membership_account_message, $level ) ) ); ?>
+		</div>
+		<?php
+	}
+}
+add_action( 'pmpro_member_account_message', 'pmpro_add_level_account_message' );

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -200,6 +200,18 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 										}
 										?>
 									</ul> <!-- end pmpro_list -->
+									<?php
+										$membership_account_message = get_pmpro_membership_level_meta( $level->id, 'membership_account_message', true );
+										if ( $membership_account_message ) {
+											?>
+											<div id="pmpro_account_membership_message_<?php echo esc_attr( $level->id );?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account_membership_message' ) ); ?>">
+												<?php echo wpautop( wp_kses_post( apply_filters( 'pmpro_account_membership_message', $membership_account_message, $level ) ) ); ?>
+											</div>
+											<?php
+										}
+										
+										do_action( 'pmpro_member_account_message', $level );
+									?>
 								</div> <!-- end pmpro_card_content -->
 
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -201,15 +201,12 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 										?>
 									</ul> <!-- end pmpro_list -->
 									<?php
-										$membership_account_message = get_pmpro_membership_level_meta( $level->id, 'membership_account_message', true );
-										if ( $membership_account_message ) {
-											?>
-											<div id="pmpro_account_membership_message_<?php echo esc_attr( $level->id );?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_account_membership_message' ) ); ?>">
-												<?php echo wpautop( wp_kses_post( apply_filters( 'pmpro_account_membership_message', $membership_account_message, $level ) ) ); ?>
-											</div>
-											<?php
-										}
-										
+										/**
+										 * Hook to add content to the member account message section.
+										 *
+										 * @since TBD
+										 * @param object $level The current level object.
+										 */
 										do_action( 'pmpro_member_account_message', $level );
 									?>
 								</div> <!-- end pmpro_card_content -->

--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -202,12 +202,12 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 									</ul> <!-- end pmpro_list -->
 									<?php
 										/**
-										 * Hook to add content to the member account message section.
+										 * Hook to add content after the default level card content.
 										 *
 										 * @since TBD
 										 * @param object $level The current level object.
 										 */
-										do_action( 'pmpro_member_account_message', $level );
+										do_action( 'pmpro_membership_account_after_level_card_content', $level );
 									?>
 								</div> <!-- end pmpro_card_content -->
 


### PR DESCRIPTION
* ENHANCEMENT: Added logic to now support a "Membership Account Message" content on a per-level basis.

* ENHANCEMENT: Added hook for 'pmpro_member_account_message' which allows developers to show their own information programmatically at the bottom of each membership 'card' on the account page.

* ENHANCEMENT: Added a description to the level's "Description" field to be more clear to members. (TODO: Confirm the UTM arguments are correct).

**Screenshots**
<img width="1336" alt="Screenshot 2025-01-24 at 15 15 44" src="https://github.com/user-attachments/assets/113fcfe1-5d2b-4f86-8193-7a365bed8a69" />
<img width="870" alt="Screenshot 2025-01-24 at 15 15 27" src="https://github.com/user-attachments/assets/c47e997c-aa61-4f37-919f-54eef7eef7a0" />
