### PR TITLE
Allowing for subscription transaction IDs up to 64 characters

### DIFF
--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -401,6 +401,15 @@ function pmpro_checkForUpgrades() {
 		pmpro_db_delta();
 		update_option( 'pmpro_db_version', '3.3' );
 	}
+
+	/**
+	 * Version 3.4
+	 * Allowing subscription transaction IDs up to 64 characters.
+	 */
+	if ( $pmpro_db_version < 3.4 ) {
+		pmpro_db_delta();
+		update_option( 'pmpro_db_version', '3.4' );
+	}
 }
 
 function pmpro_db_delta() {
@@ -492,7 +501,7 @@ function pmpro_db_delta() {
 		  `gateway` varchar(64) NOT NULL,
 		  `gateway_environment` varchar(64) NOT NULL,
 		  `payment_transaction_id` varchar(64) NOT NULL,
-		  `subscription_transaction_id` varchar(32) NOT NULL,
+		  `subscription_transaction_id` varchar(64) NOT NULL,
 		  `timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 		  `affiliate_id` varchar(32) NOT NULL,
 		  `affiliate_subid` varchar(32) NOT NULL,
@@ -642,7 +651,7 @@ function pmpro_db_delta() {
 			`membership_level_id` int(11) unsigned NOT NULL,
 			`gateway` varchar(64) NOT NULL,
 			`gateway_environment` varchar(64) NOT NULL,
-			`subscription_transaction_id` varchar(32) NOT NULL,
+			`subscription_transaction_id` varchar(64) NOT NULL,
 			`status` varchar(20) NOT NULL DEFAULT 'active',
 			`startdate` datetime DEFAULT NULL,
 			`enddate` datetime DEFAULT NULL,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Some gateways, such as Square, have subscription transaction IDs that are longer than 32 characters. This PR bumps our limit to 64 characters which matches the limit that we already have on payment transaction IDs.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
