### PR TITLE
Now supporting level meta with the pmpro_member shortcode field attribute

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -43,6 +43,11 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		'level_cost',
 	);
 
+	// Get a list of membership level meta fields.
+	global $wpdb;
+	$sqlQuery = "SELECT DISTINCT meta_key FROM $wpdb->pmpro_membership_levelmeta";
+	$pmpro_level_meta_fields = $wpdb->get_col( $sqlQuery );
+
 	// Get a list of fields related to the user's subscription.
 	$pmpro_subscription_fields = array(
 		'membership_billing_amount',
@@ -99,7 +104,7 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		'trial_amount',
 	);
 
-	if ( in_array( $field, $pmpro_level_fields ) || in_array( $field, $pmpro_subscription_fields ) ) {
+	if ( in_array( $field, $pmpro_level_fields ) || in_array( $field, $pmpro_subscription_fields ) || in_array( $field, $pmpro_level_meta_fields ) ) {
 		// Fields about the user's membership or subscription.
 		// Get the membership level to show.
 		$membership_level = null;
@@ -138,6 +143,9 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 				$field = str_replace( 'membership_', '', $field );
 				$r     = $membership_level->{$field};
 			}
+		} elseif( in_array( $field, $pmpro_level_meta_fields ) ) {
+			// Membership level meta fields.
+			$r = get_pmpro_membership_level_meta( $membership_level->id, $field, true );
 		} else {
 			// Subscription fields.
 			$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $user_id, $membership_level->id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This is a proposed method to allow our [pmpro_member] shortcode to pull data from the levelmeta table. I don't know if this is the best approach, but we cannot safely "name" the array of keys that "might" be levelmeta. 

An alternative would be to just check it as the "last check" in the else here, convert that to an elseif, and make the else "maybe it's levelmeta"?
https://github.com/strangerstudios/paid-memberships-pro/blob/dev/shortcodes/pmpro_member.php#L141-L151

This is primarily being considered now so that sites can pull the levelmeta-stored Account Message coming in v3.4.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Now supporting any named key in the levelmeta table when using the `[pmpro_member]` shortcode.
