### PR TITLE
Fixing signups not showing on the last day of memberships report

### DIFF
--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -685,8 +685,7 @@ function pmpro_getCancellations( $period = null, $levels = 'all', $status = arra
 		FROM {$wpdb->pmpro_memberships_users} AS mu1
 		WHERE mu1.status IN('" . implode( "','", array_map( 'esc_sql', $status ) ) . "')
 			AND mu1.enddate >= '" . $startdate . "'
-			AND mu1.enddate <= " . $enddate . '
-		';
+			AND mu1.enddate <= " . $enddate . ' 23:59:59';
 
 	// restrict by level
 	if ( ! empty( $levels ) && $levels != 'all' ) {

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -685,7 +685,7 @@ function pmpro_getCancellations( $period = null, $levels = 'all', $status = arra
 		FROM {$wpdb->pmpro_memberships_users} AS mu1
 		WHERE mu1.status IN('" . implode( "','", array_map( 'esc_sql', $status ) ) . "')
 			AND mu1.enddate >= '" . $startdate . "'
-			AND mu1.enddate <= '" . $enddate . " 23:59:59'";
+			AND mu1.enddate <= '" . $enddate . " 23:59:59' ";
 
 	// restrict by level
 	if ( ! empty( $levels ) && $levels != 'all' ) {

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -686,7 +686,8 @@ function pmpro_getCancellations( $period = null, $levels = 'all', $status = arra
 		FROM {$wpdb->pmpro_memberships_users} AS mu1
 		WHERE mu1.status IN('" . implode( "','", array_map( 'esc_sql', $status ) ) . "')
 			AND mu1.enddate >= '" . $startdate . "'
-			AND mu1.enddate <= '" . $enddate . " 23:59:59' ";
+			AND mu1.enddate <= " . $enddate . '
+		';
 
 	// restrict by level
 	if ( ! empty( $levels ) && $levels != 'all' ) {

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -196,7 +196,7 @@ function pmpro_report_memberships_page() {
 	}
 
 	$sqlQuery .= "WHERE mu.startdate >= '" . esc_sql( $startdate ) . "' ";
-	$sqlQuery .= "AND mu.startdate <= '" . esc_sql( $enddate ) . "' ";
+	$sqlQuery .= "AND mu.startdate <= '" . esc_sql( $enddate ) . " 23:59:59' ";
 
 	if ( ! empty( $l ) ) {
 		$sqlQuery .= 'AND mu.membership_id IN(' . $l . ') '; // $l is already escaped for SQL. See declaration.

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -279,7 +279,8 @@ function pmpro_report_memberships_page() {
 	}
 
 	$sqlQuery .= "AND mu1.enddate >= '" . esc_sql( $startdate ) . "'
-	AND mu1.enddate < '" . esc_sql( $enddate ) . "' ";
+	AND mu1.enddate <= '" . $enddate . " 23:59:59' ";
+
 
 	// restrict by level
 	if ( ! empty( $l ) ) {

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -685,7 +685,7 @@ function pmpro_getCancellations( $period = null, $levels = 'all', $status = arra
 		FROM {$wpdb->pmpro_memberships_users} AS mu1
 		WHERE mu1.status IN('" . implode( "','", array_map( 'esc_sql', $status ) ) . "')
 			AND mu1.enddate >= '" . $startdate . "'
-			AND mu1.enddate <= " . $enddate . ' 23:59:59';
+			AND mu1.enddate <= '" . $enddate . " 23:59:59'";
 
 	// restrict by level
 	if ( ! empty( $levels ) && $levels != 'all' ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Before this fix, the last day of the daily membership report would always show `0`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
