### PR TITLE
More specific CSS for level-specific account message

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -718,7 +718,7 @@
 			margin-top: var(--pmpro--base--spacing--large);
 			padding-top: var(--pmpro--base--spacing--large);
 
-			:first-child {
+			> *:first-child {
 				margin-top: 0;
 				padding-top: 0;
 			}

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -724,7 +724,7 @@
 			margin-top: var(--pmpro--base--spacing--large);
 			padding-top: var(--pmpro--base--spacing--large);
 
-			:first-child {
+			> *:first-child {
 				margin-top: 0;
 				padding-top: 0;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The previous CSS was targeting any "first child" of another element within the `pmpro_account-membership-message`. This is more specific CSS because we only want to target the VERY FIRST child element inside `pmpro_account-membership-message`, not the first child of all nested elements within.
