### PR TITLE
Make sure that the subscription object exists before showing in list table

### DIFF
--- a/classes/class-pmpro-subscriptions-list-table.php
+++ b/classes/class-pmpro-subscriptions-list-table.php
@@ -337,7 +337,9 @@ class PMPro_Subscriptions_List_Table extends WP_List_Table {
 			$subscription_data = array();
 			foreach ( $subscription_ids as $subscription_id ) {
 				$subscription = PMPro_Subscription::get_subscription( $subscription_id );
-				$subscription_data[] = $subscription;
+				if ( ! empty( $subscription ) ) {
+					$subscription_data[] = $subscription;
+				}
 			}
 			return $subscription_data;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If the subscription cannot be retrieved, the list tables will show errors when displaying the row contents. This will prevent the subscription from being shown entirely.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
