### PR TITLE
Fix for narrow containers for the reset password form

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -632,6 +632,20 @@
 		justify-self: end;
 	}
 
+	#resetpassform .pmpro_cols-2 {
+		container: resetpassform / inline-size;
+	}
+
+	@container resetpassform (max-width: 620px) {
+		#resetpassform .pmpro_cols-2 {
+			flex-direction: column;
+		}
+
+		#resetpassform .pmpro_cols-2 > * {
+			width: 100%;
+		}
+	}
+
 	/**
 	* List Styles
 	*/

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -622,6 +622,20 @@
 		justify-self: end;
 	}
 
+	#resetpassform .pmpro_cols-2 {
+		container: resetpassform / inline-size;
+	}
+
+	@container resetpassform (max-width: 620px) {
+		#resetpassform .pmpro_cols-2 {
+			flex-direction: column;
+		}
+
+		#resetpassform .pmpro_cols-2 > * {
+			width: 100%;
+		}
+	}
+
 	/**
 	* List Styles
 	*/


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves scrunched display for our password reset styling when the container is narrow. Formerly, the Show Password toggle button was breaking to two lines.

![Screenshot 2025-01-23 at 10 34 40 AM](https://github.com/user-attachments/assets/f8e197db-bea7-48e3-9fb5-73cc100b2404)
![Screenshot 2025-02-05 at 4 26 22 PM](https://github.com/user-attachments/assets/abb42c74-8dd1-4cc8-964e-e4f6c8754247)
![Screenshot 2025-02-05 at 4 26 28 PM](https://github.com/user-attachments/assets/7303a448-0083-40bf-bce2-feaaf58f0900)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
This may not need a standalone changelog entry.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
