### PR TITLE
Additional Order Filters

### DIFF
--- a/adminpages/orders-csv.php
+++ b/adminpages/orders-csv.php
@@ -192,17 +192,32 @@ if ( $totals ) {
 }         
 
 if( $l ){            
-    $condition[] = 'o.membership_id IN (' . esc_sql( implode(", ", $l ) ).")";
+    $escaped_levels = array_map(function($s) {
+        return "'" . esc_sql($s) . "'"; // Wrap each value in single quotes and escape it
+    }, $l);            
+    $condition[] = "o.membership_id IN (" . implode(", ", $escaped_levels) . ")";	            
 }
 
 if ( $discount_code ) {
-    $condition[] = 'dc.code_id IN (' . esc_sql( implode(", ", $discount_code ) ).")";
+    $escaped_discount_code = array_map(function($s) {
+        return "'" . esc_sql($s) . "'"; // Wrap each value in single quotes and escape it
+    }, $discount_code);            
+    $condition[] = "o.code_id IN (" . implode(", ", $escaped_discount_code) . ")";			
 } 
 
 if ( $status ) {
-    $condition[] = "o.status IN ('" . esc_sql( implode(", ", $status ) ) . "' )";
+    $escaped_status = array_map(function($s) {
+        return "'" . esc_sql($s) . "'"; // Wrap each value in single quotes and escape it
+    }, $status);            
+    $condition[] = "o.status IN (" . implode(", ", $escaped_status) . ")";
 }         
 
+if( $gateway ) {
+    $escated_gateway = array_map(function($s) {
+        return "'" . esc_sql($s) . "'"; // Wrap each value in single quotes and escape it
+    }, $gateway);            
+    $condition[] = "o.gateway IN (" . implode(", ", $escated_gateway) . ")";
+}       
 
 $condition = implode(" AND ", $condition );
 

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -966,7 +966,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 		$url_params = array(
 			'filter'          => isset( $_REQUEST['filter'] ) ? trim( sanitize_text_field( $_REQUEST['filter'] ) ) : 'all',
 			's'               => isset( $_REQUEST['s'] ) ? sanitize_text_field( $_REQUEST['s'] ) : '',
-			'l'               => isset( $_REQUEST['l'] ) ? sanitize_text_field( $_REQUEST['l'] ) : false,
+			'l'               => isset( $_REQUEST['l'] ) ? array_map( 'intval', $_REQUEST['l'] ) : false,
 			'start-month'     => isset( $_REQUEST['start-month'] ) ? intval( $_REQUEST['start-month'] ) : '1',
 			'start-day'       => isset( $_REQUEST['start-day'] ) ? intval( $_REQUEST['start-day'] ) : '1',
 			'start-year'      => isset( $_REQUEST['start-year'] ) ? intval( $_REQUEST['start-year'] ) : date( 'Y', $now ),
@@ -974,10 +974,14 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 			'end-day'         => isset( $_REQUEST['end-day'] ) ? intval( $_REQUEST['end-day'] ) : date( 'j', $now ),
 			'end-year'        => isset( $_REQUEST['end-year'] ) ? intval( $_REQUEST['end-year'] ) : date( 'Y', $now ),
 			'predefined-date' => isset( $_REQUEST['predefined-date'] ) ? sanitize_text_field( $_REQUEST['predefined-date'] ) : 'This Month',
-			'discount-code'	  => isset( $_REQUEST['discount-code'] ) ? intval( $_REQUEST['discount-code'] ) : false,
-			'status'          => isset( $_REQUEST['status'] ) ? sanitize_text_field( $_REQUEST['status'] ) : '',
+			'discount-code'	  => isset( $_REQUEST['discount-code'] ) ? array_map( 'intval', $_REQUEST['discount-code'] ) : false,
+			'status'          => isset( $_REQUEST['status'] ) ? array_map( 'sanitize_text_field', $_REQUEST['status'] ) : false,
+            'totals'          => isset( $_REQUEST['totals'] ) ? sanitize_text_field( $_REQUEST['totals'] ) : false,
+            'total_min'       => isset( $_REQUEST['total_min'] ) ? intval( $_REQUEST['total_min'] ) : 0,
+            'total_max'       => isset( $_REQUEST['total_max'] ) ? intval( $_REQUEST['total_max'] ) : 0,
 		);
 		$export_url = add_query_arg( $url_params, $export_url );
+        
 		?>
 
 		<?php if ( current_user_can( 'pmpro_orderscsv' ) ) { ?>

--- a/adminpages/orders.php
+++ b/adminpages/orders.php
@@ -979,6 +979,7 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
             'totals'          => isset( $_REQUEST['totals'] ) ? sanitize_text_field( $_REQUEST['totals'] ) : false,
             'total_min'       => isset( $_REQUEST['total_min'] ) ? intval( $_REQUEST['total_min'] ) : 0,
             'total_max'       => isset( $_REQUEST['total_max'] ) ? intval( $_REQUEST['total_max'] ) : 0,
+            'gateway'         => isset( $_REQUEST['gateway'] ) ? array_map( 'sanitize_text_field', $_REQUEST['gateway'] ) : '',
 		);
 		$export_url = add_query_arg( $url_params, $export_url );
         

--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -323,22 +323,18 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 			$condition[] = "o.timestamp BETWEEN '" . esc_sql( $start_date ) . "' AND '" . esc_sql( $end_date ) . "'";
 		} 
 
-        if ( ! $l && $totals ) {
+        if ( $totals ) {
             if(  $totals == 'only-paid' ) {
-                $levels = pmpro_report_get_levels( 'paid' );
-                $condition[] = 'o.membership_id IN (' . esc_sql( $levels ).")";     
+                $condition[] = 'o.total > 0';     
             }    
             if( $totals == 'only-free' ) {
-                $levels = pmpro_report_get_levels( 'free' );
-                $condition[] = 'o.membership_id IN (' . esc_sql( $levels ).")";     
+                $condition[] = 'o.total = 0';     
             }		            
-                   
+            if( $totals == 'custom' ){                    
+                $condition[] = 'o.total BETWEEN '.esc_sql( $total_min ).' AND '.esc_sql( $total_max );               
+            }
 
-		} 
-
-        if( $totals == 'custom' ){                    
-            $condition[] = 'o.total BETWEEN '.esc_sql( $total_min ).' AND '.esc_sql( $total_max );               
-        }
+		}         
         
         if( $l ){            
             $condition[] = 'o.membership_id IN (' . esc_sql( implode(", ", $l ) ).")";
@@ -352,11 +348,6 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 			$condition[] = "o.status IN ('" . esc_sql( implode(", ", $status ) ) . "' )";
 		}         
         
-        // if ( $filter == 'only-paid' ) {
-		// 	$condition = "o.total > 0";
-		// } elseif( $filter == 'only-free' ) {
-		// 	$condition = "o.total = 0";
-		// }
 
         $condition = implode(" AND ", $condition );
 		


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

You can now filter the orders table by selecting:

1. A date
2. Membership Level
3. Discount Code
4. Paid/Free Orders or a custom range (eg $0 - $50)
5. Gateway paid (only for sites with multiple gateways)
6. Order status (success, token, error etc)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

