### PR TITLE
PHP Warnings generated when editing a page containing the Membership …

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -337,18 +337,20 @@ function pmpro_isLevelExpiringSoon( &$level ) {
 
 function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
 	// initial payment
+	$pmpro_initial_payment = isset( $level->initial_payment ) ? $level->initial_payment : 0;
 	if ( ! $short ) {
-		$r = sprintf( __( 'The price for membership is <strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $level->initial_payment ) );
+		$r = sprintf( __( 'The price for membership is <strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $pmpro_initial_payment ) );
 	} else {
 		if ( pmpro_isLevelFree( $level ) ) {
 			$r = '<strong>' . __('Free', 'paid-memberships-pro' ) . '</strong>';
 		} else {
-			$r = sprintf( __( '<strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $level->initial_payment ) );
+			$r = sprintf( __( '<strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $pmpro_initial_payment ) );
 		}
 	}
 
 	// recurring part
-	if ( (float)$level->billing_amount > 0 ) {
+	$pmpro_billing_amount = isset( $level->billing_amount ) ? $level->billing_amount : 0;
+	if ( (float) $pmpro_billing_amount > 0 ) {
 		if ( $level->billing_limit > 1 ) {
 			if ( $level->cycle_number == '1' ) {
 				$r .= sprintf( __( ' and then <strong>%1$s per %2$s for %3$d more %4$s</strong>.', 'paid-memberships-pro' ), pmpro_formatPrice( $level->billing_amount ), pmpro_translate_billing_period( $level->cycle_period ), $level->billing_limit, pmpro_translate_billing_period( $level->cycle_period, $level->billing_limit ) );
@@ -388,7 +390,8 @@ function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
 	$r .= ' ';
 
 	// trial part
-	if ( $level->trial_limit ) {
+	$pmpro_trial_limit = isset( $level->trial_limit ) ? $level->trial_limit : 0;
+	if ( $pmpro_trial_limit > 0 ) {
 		if ( (float)$level->trial_amount == 0 ) {
 			if ( $level->trial_limit == '1' ) {
 				$r .= ' ' . __( 'After your initial payment, your first payment is Free.', 'paid-memberships-pro' );
@@ -527,8 +530,8 @@ function pmpro_getLevelsCost( &$levels, $tags = true, $short = false ) {
 }
 
 function pmpro_getLevelExpiration( &$level ) {
-
-	if ( $level->expiration_number ) {
+	$pmpro_expiration_number = isset( $level->expiration_number ) ? $level->expiration_number : 0;
+	if ( $pmpro_expiration_number ) {
 		$expiration_text = sprintf( __( 'Membership expires after %1$d %2$s.', 'paid-memberships-pro' ), $level->expiration_number, pmpro_translate_billing_period( $level->expiration_period, $level->expiration_number ) );
 	} else {
 		$expiration_text = '';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -337,9 +337,10 @@ function pmpro_isLevelExpiringSoon( &$level ) {
 
 function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
 	//Bail if no level
-	if ( ! isset( $level )  ||  $level->id === 0 ) {
+	if ( empty( $level ) ) {
 		return '';
 	}
+
 	// initial payment
 	if ( ! $short ) {
 		$r = sprintf( __( 'The price for membership is <strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $level->initial_payment ) );
@@ -352,7 +353,7 @@ function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
 	}
 
 	// recurring part
-	if ( (float) $level->billing_amount > 0 ) {
+	if ( (float)$level->billing_amount > 0 ) {
 		if ( $level->billing_limit > 1 ) {
 			if ( $level->cycle_number == '1' ) {
 				$r .= sprintf( __( ' and then <strong>%1$s per %2$s for %3$d more %4$s</strong>.', 'paid-memberships-pro' ), pmpro_formatPrice( $level->billing_amount ), pmpro_translate_billing_period( $level->cycle_period ), $level->billing_limit, pmpro_translate_billing_period( $level->cycle_period, $level->billing_limit ) );
@@ -532,9 +533,10 @@ function pmpro_getLevelsCost( &$levels, $tags = true, $short = false ) {
 
 function pmpro_getLevelExpiration( &$level ) {
 	//Bail if no level
-	if ( empty( $level ) ||  $level->id === 0 ) {
+	if ( empty( $level ) ) {
 		return '';
 	}
+
 	if ( $level->expiration_number ) {
 		$expiration_text = sprintf( __( 'Membership expires after %1$d %2$s.', 'paid-memberships-pro' ), $level->expiration_number, pmpro_translate_billing_period( $level->expiration_period, $level->expiration_number ) );
 	} else {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -336,21 +336,23 @@ function pmpro_isLevelExpiringSoon( &$level ) {
 
 
 function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
+	//Bail if no level
+	if ( ! isset( $level )  ||  $level->id === 0 ) {
+		return '';
+	}
 	// initial payment
-	$pmpro_initial_payment = isset( $level->initial_payment ) ? $level->initial_payment : 0;
 	if ( ! $short ) {
-		$r = sprintf( __( 'The price for membership is <strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $pmpro_initial_payment ) );
+		$r = sprintf( __( 'The price for membership is <strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $level->initial_payment ) );
 	} else {
 		if ( pmpro_isLevelFree( $level ) ) {
 			$r = '<strong>' . __('Free', 'paid-memberships-pro' ) . '</strong>';
 		} else {
-			$r = sprintf( __( '<strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $pmpro_initial_payment ) );
+			$r = sprintf( __( '<strong>%s</strong> now', 'paid-memberships-pro' ), pmpro_formatPrice( $level->initial_payment ) );
 		}
 	}
 
 	// recurring part
-	$pmpro_billing_amount = isset( $level->billing_amount ) ? $level->billing_amount : 0;
-	if ( (float) $pmpro_billing_amount > 0 ) {
+	if ( (float) $level->billing_amount > 0 ) {
 		if ( $level->billing_limit > 1 ) {
 			if ( $level->cycle_number == '1' ) {
 				$r .= sprintf( __( ' and then <strong>%1$s per %2$s for %3$d more %4$s</strong>.', 'paid-memberships-pro' ), pmpro_formatPrice( $level->billing_amount ), pmpro_translate_billing_period( $level->cycle_period ), $level->billing_limit, pmpro_translate_billing_period( $level->cycle_period, $level->billing_limit ) );
@@ -390,8 +392,7 @@ function pmpro_getLevelCost( &$level, $tags = true, $short = false ) {
 	$r .= ' ';
 
 	// trial part
-	$pmpro_trial_limit = isset( $level->trial_limit ) ? $level->trial_limit : 0;
-	if ( $pmpro_trial_limit > 0 ) {
+	if ( $level->trial_limit ) {
 		if ( (float)$level->trial_amount == 0 ) {
 			if ( $level->trial_limit == '1' ) {
 				$r .= ' ' . __( 'After your initial payment, your first payment is Free.', 'paid-memberships-pro' );
@@ -530,8 +531,11 @@ function pmpro_getLevelsCost( &$levels, $tags = true, $short = false ) {
 }
 
 function pmpro_getLevelExpiration( &$level ) {
-	$pmpro_expiration_number = isset( $level->expiration_number ) ? $level->expiration_number : 0;
-	if ( $pmpro_expiration_number ) {
+	//Bail if no level
+	if ( empty( $level ) ||  $level->id === 0 ) {
+		return '';
+	}
+	if ( $level->expiration_number ) {
 		$expiration_text = sprintf( __( 'Membership expires after %1$d %2$s.', 'paid-memberships-pro' ), $level->expiration_number, pmpro_translate_billing_period( $level->expiration_period, $level->expiration_number ) );
 	} else {
 		$expiration_text = '';

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -16,6 +16,14 @@ global $discount_code, $username, $password, $password2, $bfirstname, $blastname
 
 $pmpro_levels = pmpro_getAllLevels();
 
+//If global $pmpro_level is null, let's instantiate a dummy level object to avoid errors.
+if ( ! isset( $pmpro_level ) ) {
+	$pmpro_level = new PMPro_Membership_Level();
+	$pmpro_level->id = 0;
+	$pmpro_level->name = 'Invalid Level';
+	$pmpro_level->description = $pmpro_level->name;
+}
+
 /**
  * Filter to set if PMPro uses email or text as the type for email field inputs.
  *
@@ -38,13 +46,11 @@ if ( empty( $default_gateway ) ) {
 
 	<?php do_action( 'pmpro_checkout_before_form' ); ?>
 
-	<?php $pmpro_level_id = isset( $pmpro_level->id ) ? $pmpro_level->id : ''; //Let's get the id here so we avoid warning in those pages where the level isn't defined ?>
+	<section id="pmpro_level-<?php echo intval( $pmpro_level->id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_checkout_gateway_class, 'pmpro_level-' . $pmpro_level->id ) ); ?>">
 
-	<section id="pmpro_level-<?php echo intval( $pmpro_level_id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_checkout_gateway_class, 'pmpro_level-' . $pmpro_level_id ) ); ?>">
+		<form id="pmpro_form" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form' ) ); ?>" action="<?php if(!empty($_REQUEST['review'])) echo esc_url( pmpro_url("checkout", "?pmpro_level=" . $pmpro_level->id ) ); ?>" method="post">
 
-		<form id="pmpro_form" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form' ) ); ?>" action="<?php if(!empty($_REQUEST['review'])) echo esc_url( pmpro_url("checkout", "?pmpro_level=" . $pmpro_level_id ) ); ?>" method="post">
-
-			<input type="hidden" id="pmpro_level" name="pmpro_level" value="<?php echo esc_attr( $pmpro_level_id ) ?>" />
+			<input type="hidden" id="pmpro_level" name="pmpro_level" value="<?php echo esc_attr( $pmpro_level->id ) ?>" />
 			<input type="hidden" id="checkjavascript" name="checkjavascript" value="1" />
 			<?php if ($discount_code && $pmpro_review) { ?>
 				<input class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_alter_price', 'pmpro_discount_code' ) ); ?>" id="pmpro_discount_code" name="pmpro_discount_code" type="hidden" value="<?php echo esc_attr($discount_code) ?>" />
@@ -75,11 +81,10 @@ if ( empty( $default_gateway ) ) {
 						<p class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_name_text' ) );?>">
 							<?php
 							// Tell the user which level they are signing up for.
-							$pmpro_level_name = isset( $pmpro_level->name ) ? $pmpro_level->name : '';
-							printf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level_name ) . '</strong>' );
+							printf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level->name ) . '</strong>' );
 							// If a level will be removed with this purchase, let them know that too.
 							// First off, get the group for this level and check if it allows a user to have multiple levels.
-							$group_id = pmpro_get_group_id_for_level( $pmpro_level_id );
+							$group_id = pmpro_get_group_id_for_level( $pmpro_level->id );
 							$group    = pmpro_get_level_group( $group_id );
 							if ( ! empty( $group ) && empty( $group->allow_multiple_selections ) ) {
 								// Get all of the user's current membership levels.
@@ -113,8 +118,7 @@ if ( empty( $default_gateway ) ) {
 							 * @param string $description The level description.
 							 * @param object $pmpro_level The PMPro Level object.
 							 */
-							$pmpro_level_description = isset( $pmpro_level->description ) ? $pmpro_level->description : '';
-							$level_description = apply_filters('pmpro_level_description', $pmpro_level_description, $pmpro_level);
+							$level_description = apply_filters( 'pmpro_level_description', $pmpro_level->description, $pmpro_level );
 							if ( ! empty( $level_description ) ) { ?>
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_description_text' ) );?>">
 									<?php echo wp_kses_post( $level_description ); ?>
@@ -317,7 +321,7 @@ if ( empty( $default_gateway ) ) {
 						</div> <!-- end pmpro_card_content -->
 						<?php if ( ! $skip_account_fields ) { ?>
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
-								<?php esc_html_e('Already have an account?', 'paid-memberships-pro' );?> <a href="<?php echo esc_url( wp_login_url( apply_filters( 'pmpro_checkout_login_redirect', pmpro_url("checkout", "?pmpro_level=" . $pmpro_level_id . $discount_code_link) ) ) ); ?>"><?php esc_html_e('Log in here', 'paid-memberships-pro' ); ?></a>
+								<?php esc_html_e('Already have an account?', 'paid-memberships-pro' );?> <a href="<?php echo esc_url( wp_login_url( apply_filters( 'pmpro_checkout_login_redirect', pmpro_url("checkout", "?pmpro_level=" . $pmpro_level->id . $discount_code_link) ) ) ); ?>"><?php esc_html_e('Log in here', 'paid-memberships-pro' ); ?></a>
 							</div> <!-- end pmpro_card_actions -->
 						<?php } ?>
 					</div> <!-- end pmpro_card -->

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -22,7 +22,18 @@ if ( ! isset( $pmpro_level ) ) {
 	$pmpro_level->id = 0;
 	$pmpro_level->name = 'Invalid Level';
 	$pmpro_level->description = $pmpro_level->name;
-}
+	$pmpro_level->confirmation = '';
+	$pmpro_level->initial_payment = 0;
+	$pmpro_level->billing_amount = 0;
+	$pmpro_level->cycle_number = 0;
+	$pmpro_level->cycle_period = '';
+	$pmpro_level->billing_limit = 0;
+	$pmpro_level->trial_amount = 0;
+	$pmpro_level->trial_limit = 0;
+	$pmpro_level->allow_signups = 0;
+	$pmpro_level->expiration_number = 0;
+	$pmpro_level->expiration_period = '';
+ }
 
 /**
  * Filter to set if PMPro uses email or text as the type for email field inputs.

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -38,11 +38,13 @@ if ( empty( $default_gateway ) ) {
 
 	<?php do_action( 'pmpro_checkout_before_form' ); ?>
 
-	<section id="pmpro_level-<?php echo intval( $pmpro_level->id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_checkout_gateway_class, 'pmpro_level-' . $pmpro_level->id ) ); ?>">
+	<?php $pmpro_level_id = isset( $pmpro_level->id ) ? $pmpro_level->id : ''; //Let's get the id here so we avoid warning in those pages where the level isn't defined ?>
 
-		<form id="pmpro_form" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form' ) ); ?>" action="<?php if(!empty($_REQUEST['review'])) echo esc_url( pmpro_url("checkout", "?pmpro_level=" . $pmpro_level->id) ); ?>" method="post">
+	<section id="pmpro_level-<?php echo intval( $pmpro_level_id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_checkout_gateway_class, 'pmpro_level-' . $pmpro_level_id ) ); ?>">
 
-			<input type="hidden" id="pmpro_level" name="pmpro_level" value="<?php echo esc_attr($pmpro_level->id) ?>" />
+		<form id="pmpro_form" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form' ) ); ?>" action="<?php if(!empty($_REQUEST['review'])) echo esc_url( pmpro_url("checkout", "?pmpro_level=" . $pmpro_level_id ) ); ?>" method="post">
+
+			<input type="hidden" id="pmpro_level" name="pmpro_level" value="<?php echo esc_attr( $pmpro_level_id ) ?>" />
 			<input type="hidden" id="checkjavascript" name="checkjavascript" value="1" />
 			<?php if ($discount_code && $pmpro_review) { ?>
 				<input class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_alter_price', 'pmpro_discount_code' ) ); ?>" id="pmpro_discount_code" name="pmpro_discount_code" type="hidden" value="<?php echo esc_attr($discount_code) ?>" />
@@ -73,11 +75,11 @@ if ( empty( $default_gateway ) ) {
 						<p class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_name_text' ) );?>">
 							<?php
 							// Tell the user which level they are signing up for.
-							printf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level->name ) . '</strong>' );
-
+							$pmpro_level_name = isset( $pmpro_level->name ) ? $pmpro_level->name : '';
+							printf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level_name ) . '</strong>' );
 							// If a level will be removed with this purchase, let them know that too.
 							// First off, get the group for this level and check if it allows a user to have multiple levels.
-							$group_id = pmpro_get_group_id_for_level( $pmpro_level->id );
+							$group_id = pmpro_get_group_id_for_level( $pmpro_level_id );
 							$group    = pmpro_get_level_group( $group_id );
 							if ( ! empty( $group ) && empty( $group->allow_multiple_selections ) ) {
 								// Get all of the user's current membership levels.
@@ -111,7 +113,8 @@ if ( empty( $default_gateway ) ) {
 							 * @param string $description The level description.
 							 * @param object $pmpro_level The PMPro Level object.
 							 */
-							$level_description = apply_filters('pmpro_level_description', $pmpro_level->description, $pmpro_level);
+							$pmpro_level_description = isset( $pmpro_level->description ) ? $pmpro_level->description : '';
+							$level_description = apply_filters('pmpro_level_description', $pmpro_level_description, $pmpro_level);
 							if ( ! empty( $level_description ) ) { ?>
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_description_text' ) );?>">
 									<?php echo wp_kses_post( $level_description ); ?>
@@ -314,7 +317,7 @@ if ( empty( $default_gateway ) ) {
 						</div> <!-- end pmpro_card_content -->
 						<?php if ( ! $skip_account_fields ) { ?>
 							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
-								<?php esc_html_e('Already have an account?', 'paid-memberships-pro' );?> <a href="<?php echo esc_url( wp_login_url( apply_filters( 'pmpro_checkout_login_redirect', pmpro_url("checkout", "?pmpro_level=" . $pmpro_level->id . $discount_code_link) ) ) ); ?>"><?php esc_html_e('Log in here', 'paid-memberships-pro' ); ?></a>
+								<?php esc_html_e('Already have an account?', 'paid-memberships-pro' );?> <a href="<?php echo esc_url( wp_login_url( apply_filters( 'pmpro_checkout_login_redirect', pmpro_url("checkout", "?pmpro_level=" . $pmpro_level_id . $discount_code_link) ) ) ); ?>"><?php esc_html_e('Log in here', 'paid-memberships-pro' ); ?></a>
 							</div> <!-- end pmpro_card_actions -->
 						<?php } ?>
 					</div> <!-- end pmpro_card -->

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -20,19 +20,18 @@ $pmpro_levels = pmpro_getAllLevels();
 if ( ! isset( $pmpro_level ) ) {
 	$pmpro_level = new PMPro_Membership_Level();
 	$pmpro_level->id = 0;
-	$pmpro_level->name = 'Invalid Level';
+	$pmpro_level->name = __( 'Invalid Level', 'paid-memberships-pro' );
 	$pmpro_level->description = $pmpro_level->name;
 	$pmpro_level->confirmation = '';
 	$pmpro_level->initial_payment = 0;
 	$pmpro_level->billing_amount = 0;
 	$pmpro_level->cycle_number = 0;
-	$pmpro_level->cycle_period = '';
+	$pmpro_level->cycle_period = 'Month';
 	$pmpro_level->billing_limit = 0;
 	$pmpro_level->trial_amount = 0;
 	$pmpro_level->trial_limit = 0;
-	$pmpro_level->allow_signups = 0;
 	$pmpro_level->expiration_number = 0;
-	$pmpro_level->expiration_period = '';
+	$pmpro_level->expiration_period = 'Month';
  }
 
 /**
@@ -93,6 +92,7 @@ if ( empty( $default_gateway ) ) {
 							<?php
 							// Tell the user which level they are signing up for.
 							printf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level->name ) . '</strong>' );
+
 							// If a level will be removed with this purchase, let them know that too.
 							// First off, get the group for this level and check if it allows a user to have multiple levels.
 							$group_id = pmpro_get_group_id_for_level( $pmpro_level->id );


### PR DESCRIPTION
…Checkout Form block

 * In several places, check for null before get properties due warnings reported
 
 
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/fab1924b-37a0-4a86-b4b2-a32e2890810d" />

<img width="1128" alt="Screenshot 2025-02-07 at 1 02 52 PM" src="https://github.com/user-attachments/assets/264440ed-5fbd-4200-85b5-287c6e363515" />
<img width="1134" alt="Screenshot 2025-02-07 at 1 03 08 PM" src="https://github.com/user-attachments/assets/9d6aa1cd-c422-4b47-8ffb-5e7ed00ecdd5" />
<img width="1121" alt="Screenshot 2025-02-07 at 1 03 31 PM" src="https://github.com/user-attachments/assets/9dc8a482-6fc5-4cc0-9c98-85953b502d03" />


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Before all calls described as problematic in the bug report check if the object is null and assign either an empty for strings or 0 for integers if that's the case.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3270 

### How to test the changes in this Pull Request:

Enable WP debug in wp-config.php 
define('WP_DEBUG', true);
define('WP_DEBUG_LOG', true);
define('WP_DEBUG_DISPLAY', false);
@ini_set('display_errors', 0);

See the file log is full of these warnings ( are described in the bug ) and check again after apply the patch.

Also worth to do some checkouts to see everything go smooth

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
