### PR TITLE
[Bugfixing] Checkout check template misses confirmation message and discount code variables.

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -140,7 +140,7 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			'!!user_login!!' => esc_html__( 'The login name of the email recipient.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'!!confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
+			'!!membership_level_confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
 			'!!membership_cost!!' => esc_html__( 'The cost of the membership level.', 'paid-memberships-pro' ),
 			'!!user_email!!' => esc_html__( 'The email address of the email recipient.', 'paid-memberships-pro' ),
 			'!!membership_expiration!!' => esc_html__( 'The expiration date of the membership level.', 'paid-memberships-pro' ),
@@ -162,13 +162,16 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		$discount_code = "";
+		if( $order->getDiscountCode() ) {
+			$discount_code = "<p>" . __("Discount Code", 'paid-memberships-pro' ) . ": " . $order->discount_code->code . "</p>\n";
+		}
 
+		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
-			if ( ! empty( $confirmation_in_email ) ) {
-				$confirmation_message = $membership_level->confirmation;
-			} else {
-				$confirmation_message = '';
-			}
+		if ( ! empty( $confirmation_in_email ) ) {
+			$confirmation_message = $membership_level->confirmation;
+		}
 
 		$email_template_variables = array(
 			'subject' => $this->get_default_subject(),
@@ -177,17 +180,16 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			'user_login' => $user->user_login,
 			'membership_id' => $membership_level->id,
 			'membership_level_name' => $membership_level->name,
-			'confirmation_message' => $confirmation_message,
+			'membership_level_confirmation_message' => $confirmation_message,
 			'membership_cost' => pmpro_getLevelCost($membership_level),
 			'user_email' => $user->user_email,
 			'order_id' => $order->code,
 			'order_total' => $order->get_formatted_total(),
 			'order_date' => date_i18n( get_option( 'date_format' ), $order->getTimestamp() ),
+			'discount_code' => $discount_code,
 		);
-
 		return $email_template_variables;
 	}
-
 }
 
 /**

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -128,7 +128,7 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 			'!!user_login!!' => esc_html__( 'The login name of the email recipient.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'!!confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
+			'!!membership_level_confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
 			'!!membership_cost!!' => esc_html__( 'The cost of the membership level.', 'paid-memberships-pro' ),
 			'!!user_email!!' => esc_html__( 'The email address of the email recipient.', 'paid-memberships-pro' ),
 			'!!membership_expiration!!' => esc_html__( 'The expiration date of the membership level.', 'paid-memberships-pro' ),

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -146,12 +146,11 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
 
+		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
-			if ( ! empty( $confirmation_in_email ) ) {
-				$confirmation_message = $membership_level->confirmation;
-			} else {
-				$confirmation_message = '';
-			}
+		if ( ! empty( $confirmation_in_email ) ) {
+			$confirmation_message = $membership_level->confirmation;
+		}
 
 		$membership_expiration = '';
 		$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
@@ -222,7 +221,7 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 			'!!user_login!!' => esc_html__( 'The login name of the email recipient.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'!!confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
+			'!!membership_level_confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
 			'!!membership_cost!!' => esc_html__( 'The cost of the membership level.', 'paid-memberships-pro' ),
 			'!!user_email!!' => esc_html__( 'The email address of the email recipient.', 'paid-memberships-pro' ),
 			'!!membership_expiration!!' => esc_html__( 'The expiration date of the membership level.', 'paid-memberships-pro' ),


### PR DESCRIPTION
### All Submissions:
<img width="655" alt="image" src="https://github.com/user-attachments/assets/6a6277c0-6298-460f-8d41-521b0af6234f" />
<img width="666" alt="image" src="https://github.com/user-attachments/assets/93130e9f-c594-4148-a970-659706fff98b" />


* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixed membership_level_confirmation_message variable in checkout check template. Also fixed for free and paid templates how membership_level_confirmation_message is documented.

### How to test the changes in this Pull Request:

1. Payment gateway must be pay by check
2. Checkout for a paid level.
3. See email sent to the user
4. Check again the template after applying the patch. membership_level_confirmation_message and discount code should be either blank or properly rendered.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
