### PR TITLE
Test email variables 3166

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -303,7 +303,7 @@
 				return false;
 			
 			$email = new PMPro_Email_Template_Cancel( $user, $old_level_id );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -327,7 +327,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Cancel_Admin( $user, $old_level_id );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -348,7 +348,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Cancel_On_Next_Payment_Date( $user, $level_id );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -379,7 +379,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin( $user, $level_id );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -399,7 +399,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Refund( $user, $order );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -419,7 +419,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Refund_Admin( $user, $order );
-			$email->send();
+			return $email->send();
 
 		}
 
@@ -472,7 +472,7 @@
 			if( $email == null ) {
 				return false;
 			}
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -503,7 +503,7 @@
 					case 'checkout_free_admin':
 						$email = new PMPro_Email_Template_Checkout_Free_Admin( $user, $order );
 						break;
-					case 'checkout_paid':
+					case 'checkout_paid_admin':
 						$email = new PMPro_Email_Template_Checkout_Paid_Admin( $user, $order );
 						break;
 				}
@@ -522,7 +522,7 @@
 			if( $email == null ) {
 				return false;
 			}
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -545,7 +545,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Billing( $user, $order );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -568,7 +568,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Billing_Admin( $user, $order );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -586,7 +586,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Billing_Failure( $user, $order );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -604,7 +604,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Billing_Failure_Admin( $user, $order );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -653,7 +653,7 @@
 			}
 
 			$email = new PMPro_Email_Template_Payment_Receipt( $user, $order );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -731,7 +731,7 @@
 
 			$email = new PMPro_Email_Template_Membership_Expired( $user, $membership_id );
 
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -755,7 +755,7 @@
 			}
 						
 			$email = new PMPro_Email_Template_Membership_Expiring( $user, $membership_id );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -773,7 +773,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Admin_Change( $user );
-			$email->send();
+			return $email->send();
 		}
 		
 		/**
@@ -791,7 +791,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Admin_Change_Admin( $user );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -839,7 +839,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Payment_Action( $user, $order_url );
-			$email->send();
+			return $email->send();
 
 		}
 
@@ -868,7 +868,7 @@
 				return false;
 
 			$email = new PMPro_Email_Template_Payment_Action_Admin( $user, $order_url );
-			$email->send();
+			return $email->send();
 		}
 
 		/**
@@ -884,7 +884,7 @@
 				return false;
 			}
 			$email = new PMPro_Email_Template_Payment_Reminder( $subscription_obj );
-			$email->send();
+			return $email->send();
 		}
 
 		/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -138,6 +138,9 @@ class PMPro_Email_Template_Checkout_Check_Admin extends PMPro_Email_Template {
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		if ( empty( $membership_level ) ) {
+			$membership_level = pmpro_getLevel( $order->membership_id );
+		}
 
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
 		if ( ! empty( $confirmation_in_email ) ) {

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -188,7 +188,7 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			'order_total' => $order->get_formatted_total(),
 			'order_date' => date_i18n( get_option( 'date_format' ), $order->getTimestamp() ),
 			'discount_code' => $discount_code,
-			'instructions' => get_option( 'pmpro_instructions' ),
+			'instructions' => wp_kses_post( wpautop( wp_unslash( get_option( 'pmpro_instructions' ) ) ) ),
 		);
 		return $email_template_variables;
 	}

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -148,6 +148,7 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			'!!order_id!!' => esc_html__( 'The ID of the order.', 'paid-memberships-pro' ),
 			'!!order_date!!' => esc_html__( 'The date of the order.', 'paid-memberships-pro' ),
 			'!!order_total!!' => esc_html__( 'The total cost of the order.', 'paid-memberships-pro' ),
+			'!!instructions!!' => esc_html__( 'Instructions to the customer on how to pay.', 'paid-memberships-pro' ),
 		);
 	}
 
@@ -187,6 +188,7 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			'order_total' => $order->get_formatted_total(),
 			'order_date' => date_i18n( get_option( 'date_format' ), $order->getTimestamp() ),
 			'discount_code' => $discount_code,
+			'instructions' => get_option( 'pmpro_instructions' ),
 		);
 		return $email_template_variables;
 	}

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -173,6 +173,10 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		if ( empty( $membership_level ) ) {
+			$membership_level = pmpro_getLevel( $order->membership_id );
+		}
+
 		$discount_code = "";
 		if( $order->getDiscountCode() ) {
 			$discount_code = "<p>" . __("Discount Code", 'paid-memberships-pro' ) . ": " . $order->discount_code->code . "</p>\n";

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -156,6 +156,9 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		if ( empty( $membership_level ) ) {
+			$membership_level = pmpro_getLevel( $order->membership_id );
+		}
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -147,7 +147,7 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 		global $wpdb;
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		$membership_level = $user->membership_level;
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -152,7 +152,10 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = $user->membership_level;
+		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		if ( empty( $membership_level ) ) {
+			$membership_level = pmpro_getLevel( $order->membership_id );
+		}
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
@@ -144,6 +144,9 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		if ( empty( $membership_level ) ) {
+			$membership_level = pmpro_getLevel( $order->membership_id );
+		}
 
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
 			if ( ! empty( $confirmation_in_email ) ) {

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -144,7 +144,7 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 		global $wpdb;
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		$membership_level = $user->membership_level;
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -148,7 +148,10 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = $user->membership_level;
+		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
+		if ( empty( $membership_level ) ) {
+			$membership_level = pmpro_getLevel( $order->membership_id );
+		}
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-payment-reminder.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-reminder.php
@@ -115,11 +115,11 @@ class PMPro_Email_Template_Payment_Reminder extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'membership_level_name' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
-			'renewaldate' => esc_html__( 'The date of the next payment date.', 'paid-memberships-pro' ),
-			'display_name' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
-			'user_email' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
-			'cancel_link' => esc_html__( 'The link to cancel the subscription.', 'paid-memberships-pro' ),
+			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
+			'!!renewaldate!!' => esc_html__( 'The date of the next payment date.', 'paid-memberships-pro' ),
+			'!!display_name!!' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
+			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
+			'!!cancel_link!!' => esc_html__( 'The link to cancel the subscription.', 'paid-memberships-pro' ),
 		);
 	}
 

--- a/includes/email.php
+++ b/includes/email.php
@@ -313,7 +313,7 @@ function pmpro_email_templates_send_test() {
 	switch($test_email->template) {
 		case 'cancel':
 			$send_email = 'sendCancelEmail';
-			$params = array($test_user,$test_user->membership_level->id);
+			$params = array($test_user, $test_user->membership_level->id);
 			break;
 		case 'cancel_admin':
 			$send_email = 'sendCancelAdminEmail';

--- a/includes/email.php
+++ b/includes/email.php
@@ -337,7 +337,6 @@ function pmpro_email_templates_send_test() {
 		case 'checkout_check':
 		case 'checkout_free':
 		case 'checkout_paid':
-			_log( $test_email->template );
 			$send_email = 'sendCheckoutEmail';
 			$params = array($test_user, $test_order);
 			break;

--- a/includes/email.php
+++ b/includes/email.php
@@ -296,13 +296,12 @@ function pmpro_email_templates_send_test() {
 
 	$test_user = $current_user;
 
-
-	//test subscription object
-	$test_subscription = new PMPro_Subscription( array( 'user_id' => $test_user->ID, 'membership_level_id' => $test_user->membership_level->id, 'next_payment_date' => date( 'Y-m-d', strtotime( '+1 month' )  ) )  );
-
 	// Grab the first membership level defined as a "test level" to use
 	$all_levels = pmpro_getAllLevels( true);
 	$test_user->membership_level = array_pop( $all_levels );
+
+	//test subscription object
+	$test_subscription = new PMPro_Subscription( array( 'user_id' => $test_user->ID, 'membership_level_id' => $test_user->membership_level->id, 'next_payment_date' => date( 'Y-m-d', strtotime( '+1 month' )  ) )  );
 
 	//add notice to email body
 	add_filter('pmpro_email_body', 'pmpro_email_templates_test_body', 10, 2);
@@ -314,11 +313,11 @@ function pmpro_email_templates_send_test() {
 	switch($test_email->template) {
 		case 'cancel':
 			$send_email = 'sendCancelEmail';
-			$params = array($test_user);
+			$params = array($test_user,$test_user->membership_level->id);
 			break;
 		case 'cancel_admin':
 			$send_email = 'sendCancelAdminEmail';
-			$params = array($current_user, $current_user->membership_level->id);
+			$params = array($test_user, $test_user->membership_level->id);
 			break;
 		case 'cancel_on_next_payment_date':
 		case 'cancel_on_next_payment_date_admin':
@@ -338,6 +337,7 @@ function pmpro_email_templates_send_test() {
 		case 'checkout_check':
 		case 'checkout_free':
 		case 'checkout_paid':
+			_log( $test_email->template );
 			$send_email = 'sendCheckoutEmail';
 			$params = array($test_user, $test_order);
 			break;
@@ -406,6 +406,8 @@ function pmpro_email_templates_send_test() {
 
 	//send the email
 	$response = call_user_func_array(array($test_email, $send_email), $params);
+
+	_log( $response, 'test email response from ' . $send_email );
 
 	//return the response
 	echo esc_html( $response );

--- a/includes/email.php
+++ b/includes/email.php
@@ -407,8 +407,6 @@ function pmpro_email_templates_send_test() {
 	//send the email
 	$response = call_user_func_array(array($test_email, $send_email), $params);
 
-	_log( $response, 'test email response from ' . $send_email );
-
 	//return the response
 	echo esc_html( $response );
 	exit;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes issues from #3166 
Fixes issues with test template email sending returning as "failed" in admin
Adding missing membership level data in checkout free/paid email templates
Adding missing template variable !!instructions!!

### How to test the changes in this Pull Request:

1. Go to any of the Email templates and send a test

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fixed test emails where data was empty as per #3166 
* All test emails were returning as "failed" in admin because they did not return the send() method result as the ajax response
* Including missing membership level data in checkout free/paid email templates
* Added missing template variable for !!instructions!! for check payments email

