### PR TITLE
Fixing HTML in check instructions #3293

### DIFF
--- a/classes/gateways/class.pmprogateway_check.php
+++ b/classes/gateways/class.pmprogateway_check.php
@@ -116,7 +116,7 @@
 				<label for="instructions"><?php esc_html_e('Instructions', 'paid-memberships-pro' );?></label>
 			</th>
 			<td>
-				<textarea id="instructions" name="instructions" rows="3" cols="50" class="large-text"><?php echo wp_kses_post( wpautop(  wp_unslash( $values['instructions'] ) ) ); ?></textarea>
+				<textarea id="instructions" name="instructions" rows="3" cols="50" class="large-text"><?php echo esc_textarea( $values['instructions'] ); ?></textarea>
 				<p class="description"><?php echo esc_html( sprintf( __( 'Instructions for members to follow to complete their purchase when paying with %s. Shown on the membership checkout, confirmation, and order pages.', 'paid-memberships-pro' ), $check_gateway_label ) );?></p>
 			</td>
 		</tr>


### PR DESCRIPTION
Instructions for check payments would save with < p > tags wrapping everything and show it in the admin textarea box after saving

### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3293 by using esc_textarea to properly prep the text for the textarea field

### How to test the changes in this Pull Request:

1. Admin settings go to Payment Gateway
2. Choose check
3. Enter instructions, save

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix issue saving check payment instructions adding unnecessary < p > tags in admin settings