### PR TITLE
Fixing display names shown in admin checkout emails

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-billing-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-admin.php
@@ -167,7 +167,7 @@ class PMPro_Email_Template_Billing_Admin extends PMPro_Email_Template {
 			'user_login' => $user->user_login,
 			'subject' => $this->get_default_subject(),
 			'user_email' => $user->user_email,
-			'display_name' => $this->get_recipient_name(),
+			'display_name' => $user->display_name,
 			'billing_name' => $order->billing->name,
 			'billing_street' => $order->billing->street,
 			'billing_street2' => $order->billing->street2,

--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -162,8 +162,8 @@ Total Billed: !!order_total!!
 
 		$email_template_variables = array(
 			'subject' => $this->get_default_subject(),
-			'name' => $this->get_recipient_name(),
-			'display_name' => $this->get_recipient_name(),
+			'name' => $user->display_name,
+			'display_name' => $user->display_name,
 			'user_login' => $user->user_login,
 			'membership_id' => $membership_level->id,
 			'membership_level_name' => $membership_level->name,
@@ -211,14 +211,14 @@ Total Billed: !!order_total!!
 
 		return array(
 			'!!subject!!' => esc_html__( 'The subject of the email.', 'paid-memberships-pro' ),
-			'!!name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
-			'!!display_name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
-			'!!user_login!!' => esc_html__( 'The login name of the email recipient.', 'paid-memberships-pro' ),
+			'!!name!!' => esc_html__( 'The name of the purchaser.', 'paid-memberships-pro' ),
+			'!!display_name!!' => esc_html__( 'The name of the purchaser.', 'paid-memberships-pro' ),
+			'!!user_login!!' => esc_html__( 'The login name of the purchaser.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
 			'!!confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
 			'!!membership_cost!!' => esc_html__( 'The cost of the membership level.', 'paid-memberships-pro' ),
-			'!!user_email!!' => esc_html__( 'The email address of the email recipient.', 'paid-memberships-pro' ),
+			'!!user_email!!' => esc_html__( 'The email address of the purchaser.', 'paid-memberships-pro' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -129,14 +129,14 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 
 		return array(
 			'!!subject!!' => esc_html__( 'The subject of the email.', 'paid-memberships-pro' ),
-			'!!name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
-			'!!display_name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
-			'!!user_login!!' => esc_html__( 'The login name of the email recipient.', 'paid-memberships-pro' ),
+			'!!name!!' => esc_html__( 'The name of the purchaser.', 'paid-memberships-pro' ),
+			'!!display_name!!' => esc_html__( 'The name of the purchaser.', 'paid-memberships-pro' ),
+			'!!user_login!!' => esc_html__( 'The login name of the purchaser.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
 			'!!confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
 			'!!membership_cost!!' => esc_html__( 'The cost of the membership level.', 'paid-memberships-pro' ),
-			'!!user_email!!' => esc_html__( 'The email address of the email recipient.', 'paid-memberships-pro' ),
+			'!!user_email!!' => esc_html__( 'The email address of the purchaser.', 'paid-memberships-pro' ),
 			'!!membership_expiration!!' => esc_html__( 'The expiration date of the membership level.', 'paid-memberships-pro' ),
 			'!!discount_code!!' => esc_html__( 'The discount code used for the membership level.', 'paid-memberships-pro' ),
 		);
@@ -175,8 +175,8 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 
 		$email_template_variables = array(
 			'subject' => $this->get_default_subject(),
-			'name' => $this->get_recipient_name(),
-			'display_name' => $this->get_recipient_name(),
+			'name' => $user->display_name,
+			'display_name' => $user->display_name,
 			'user_login' => $user->user_login,
 			'membership_id' => $membership_level->id,
 			'membership_level_name' => $membership_level->name,

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
@@ -162,8 +162,8 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 
 		$email_template_variables = array(
 			'subject' => $this->get_default_subject(),
-			'name' => $this->get_recipient_name(),
-			'display_name' => $this->get_recipient_name(),
+			'name' => $user->display_name,
+			'display_name' => $user->display_name,
 			'user_login' => $user->user_login,
 			'membership_id' => $membership_level->id,
 			'membership_level_name' => $membership_level->name,
@@ -213,14 +213,14 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 
 		return array(
 			'!!subject!!' => esc_html__( 'The subject of the email.', 'paid-memberships-pro' ),
-			'!!name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
-			'!!display_name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
-			'!!user_login!!' => esc_html__( 'The login name of the email recipient.', 'paid-memberships-pro' ),
+			'!!name!!' => esc_html__( 'The name of the purchaser.', 'paid-memberships-pro' ),
+			'!!display_name!!' => esc_html__( 'The name of the purchaser.', 'paid-memberships-pro' ),
+			'!!user_login!!' => esc_html__( 'The login name of the purchaser.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
 			'!!confirmation_message!!' => esc_html__( 'The confirmation message for the membership level.', 'paid-memberships-pro' ),
 			'!!membership_cost!!' => esc_html__( 'The cost of the membership level.', 'paid-memberships-pro' ),
-			'!!user_email!!' => esc_html__( 'The email address of the email recipient.', 'paid-memberships-pro' ),
+			'!!user_email!!' => esc_html__( 'The email address of the purchaser.', 'paid-memberships-pro' ),
 			'!!membership_expiration!!' => esc_html__( 'The expiration date of the membership level.', 'paid-memberships-pro' ),
 			'!!discount_code!!' => esc_html__( 'The discount code used for the membership level.', 'paid-memberships-pro' ),
 			'!!order_id!!' => esc_html__( 'The ID of the order.', 'paid-memberships-pro' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed issue where `!!name!!` and `!!display_name!!` would show the admin's name in admin checkout emails instead of the purchaser's name. Also updated email template variable descriptions to clarify this behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
