### PR TITLE
Make sure that checkout emails get the expiration date for the right level

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -134,8 +134,6 @@ Total Billed: !!order_total!!
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public function get_email_template_variables() {
-		global $wpdb;
-	
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
@@ -147,11 +145,9 @@ Total Billed: !!order_total!!
 			$confirmation_message = '';
 		}
 
-		$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
-		if( $enddate ) {
-			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
-		} else {
-			$membership_expiration = "";
+		$membership_expiration = '';
+		if( ! empty( $membership_level->enddate ) ) {
+			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $membership_level->enddate)) . "</p>\n";
 		}
 
 		if( $order->getDiscountCode() ) {

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -167,6 +167,11 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			$discount_code = "<p>" . __("Discount Code", 'paid-memberships-pro' ) . ": " . $order->discount_code->code . "</p>\n";
 		}
 
+		$membership_expiration = '';
+		if( ! empty( $membership_level->enddate ) ) {
+			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $membership_level->enddate)) . "</p>\n";
+		}
+
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
 		if ( ! empty( $confirmation_in_email ) ) {
@@ -186,6 +191,7 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 			'order_id' => $order->code,
 			'order_total' => $order->get_formatted_total(),
 			'order_date' => date_i18n( get_option( 'date_format' ), $order->getTimestamp() ),
+			'membership_expiration' => $membership_expiration,
 			'discount_code' => $discount_code,
 		);
 		return $email_template_variables;

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -150,7 +150,6 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public function get_email_template_variables() {
-		global $wpdb;
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
@@ -162,9 +161,8 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 		}
 
 		$membership_expiration = '';
-		$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
-		if( $enddate ) {
-			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
+		if( ! empty( $membership_level->enddate ) ) {
+			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $membership_level->enddate)) . "</p>\n";
 		}
 
 		$discount_code = '';

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -144,7 +144,6 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public function get_email_template_variables() {
-		global $wpdb;
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
@@ -156,9 +155,8 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 		}
 
 		$membership_expiration = '';
-		$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
-		if( $enddate ) {
-			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
+		if( ! empty( $membership_level->enddate ) ) {
+			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $membership_level->enddate)) . "</p>\n";
 		}
 
 		$discount_code = '';

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
@@ -137,7 +137,6 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public function get_email_template_variables() {
-		global $wpdb;
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
@@ -150,9 +149,8 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 			}
 
 		$membership_expiration = '';
-		$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
-		if( $enddate ) {
-			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
+		if( ! empty( $membership_level->enddate ) ) {
+			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $membership_level->enddate)) . "</p>\n";
 		}
 
 		$discount_code = '';

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -141,7 +141,6 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 	 * @return array The email template variables for the email (key => value pairs).
 	 */
 	public function get_email_template_variables() {
-		global $wpdb;
 		$order = $this->order;
 		$user = $this->user;
 		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
@@ -153,9 +152,8 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 		}
 
 		$membership_expiration = '';
-		$enddate = $wpdb->get_var("SELECT UNIX_TIMESTAMP(CONVERT_TZ(enddate, '+00:00', @@global.time_zone)) FROM $wpdb->pmpro_memberships_users WHERE user_id = '" . $user->ID . "' AND status = 'active' LIMIT 1");
-		if( $enddate ) {
-			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $enddate)) . "</p>\n";
+		if( ! empty( $membership_level->enddate ) ) {
+			$membership_expiration = "<p>" . sprintf(__("This membership will expire on %s.", 'paid-memberships-pro' ), date_i18n(get_option('date_format'), $membership_level->enddate)) . "</p>\n";
 		}
 
 		$discount_code = '';

--- a/includes/email.php
+++ b/includes/email.php
@@ -405,10 +405,7 @@ function pmpro_email_templates_send_test() {
 	}
 
 	//send the email
-	error_log( 'pmpro_email_templates_send_test: ' . print_r( $test_email, true ) );
-	error_log( 'pmpro_email_templates_send_test: ' . print_r( $send_email, true ) );
 	$response = call_user_func_array(array($test_email, $send_email), $params);
-	error_log( 'pmpro_email_templates_send_test: ' . print_r( $response, true ) );
 
 	//return the response
 	echo esc_html( $response );

--- a/includes/email.php
+++ b/includes/email.php
@@ -405,7 +405,10 @@ function pmpro_email_templates_send_test() {
 	}
 
 	//send the email
+	error_log( 'pmpro_email_templates_send_test: ' . print_r( $test_email, true ) );
+	error_log( 'pmpro_email_templates_send_test: ' . print_r( $send_email, true ) );
 	$response = call_user_func_array(array($test_email, $send_email), $params);
+	error_log( 'pmpro_email_templates_send_test: ' . print_r( $response, true ) );
 
 	//return the response
 	echo esc_html( $response );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Make sure that we get expiration dates for the newly purchased level when sending checkout emails

### How to test the changes in this Pull Request:
1. Have a level in one group that expires
1. Check out for another level that has a subscription (no expiration)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
