### PR TITLE
Email template localizations

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
@@ -74,9 +74,9 @@ class PMPro_Email_Template_Admin_Change_Admin extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>An administrator at !!sitename!! has changed a membership level for !!display_name!!.</p>
 
-		<p>!!membership_change!!</p>
+<p>!!membership_change!!</p>
 
-		<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro'  ));
+<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro'  ));
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
@@ -76,7 +76,7 @@ class PMPro_Email_Template_Admin_Change_Admin extends PMPro_Email_Template {
 
 <p>!!membership_change!!</p>
 
-<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro'  ));
+<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change-admin.php
@@ -72,11 +72,11 @@ class PMPro_Email_Template_Admin_Change_Admin extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>An administrator at !!sitename!! has changed a membership level for !!display_name!!.</p>
+		return wp_kses_post( __( '<p>An administrator at !!sitename!! has changed a membership level for !!display_name!!.</p>
 
-<p>!!membership_change!!</p>
+		<p>!!membership_change!!</p>
 
-<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' );
+		<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro'  ));
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-admin-change.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change.php
@@ -74,11 +74,11 @@ class PMPro_Email_Template_Admin_Change  extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>An administrator at !!sitename!! has changed your membership level.</p>
 
-		<p>!!membership_change!!</p>
+<p>!!membership_change!!</p>
 
-		<p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>
+<p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>
 
-		<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-admin-change.php
+++ b/classes/email-templates/class-pmpro-email-template-admin-change.php
@@ -72,13 +72,13 @@ class PMPro_Email_Template_Admin_Change  extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>An administrator at !!sitename!! has changed your membership level.</p>
+		return wp_kses_post( __( '<p>An administrator at !!sitename!! has changed your membership level.</p>
 
-<p>!!membership_change!!</p>
+		<p>!!membership_change!!</p>
 
-<p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>
+		<p>If you did not request this membership change and would like more information please contact us at !!siteemail!!</p>
 
-<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+		<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-billing-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-admin.php
@@ -75,18 +75,18 @@ class PMPro_Email_Template_Billing_Admin extends PMPro_Email_Template {
 
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>The billing information for !!display_name!! at !!sitename!! has been changed.</p>
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>
-				Billing Information:<br />
-				!!billing_address!!
-			</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>
+	Billing Information:<br />
+	!!billing_address!!
+</p>
 
-			<p>
-				!!cardtype!!: !!accountnumber!!<br />
-				Expires: !!expirationmonth!!/!!expirationyear!!
-			</p>
+<p>
+	!!cardtype!!: !!accountnumber!!<br />
+	Expires: !!expirationmonth!!/!!expirationyear!!
+</p>
 
-			<p>Log in to your WordPress dashboard here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your WordPress dashboard here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-billing-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-admin.php
@@ -74,20 +74,19 @@ class PMPro_Email_Template_Billing_Admin extends PMPro_Email_Template {
 	}
 
 	public static function get_default_body() {
-		return wp_kses_post( '<p>The billing information for !!display_name!! at !!sitename!! has been changed.</p>
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>
-	Billing Information:<br />
-	!!billing_address!!
-</p>
+		return wp_kses_post( __( '<p>The billing information for !!display_name!! at !!sitename!! has been changed.</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>
+				Billing Information:<br />
+				!!billing_address!!
+			</p>
 
-<p>
-	!!cardtype!!: !!accountnumber!!<br />
-	Expires: !!expirationmonth!!/!!expirationyear!!
-</p>
+			<p>
+				!!cardtype!!: !!accountnumber!!<br />
+				Expires: !!expirationmonth!!/!!expirationyear!!
+			</p>
 
-<p>Log in to your WordPress dashboard here: !!login_url!!</p>', 'paid-memberships-pro' );
-
+			<p>Log in to your WordPress dashboard here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-billing-failure-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-failure-admin.php
@@ -81,11 +81,11 @@ class PMPro_Email_Template_Billing_Failure_Admin extends PMPro_Email_Template {
 	 * @return string The email body.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>The subscription payment for !!user_login!! for level !!membership_level_name!! at !!sitename!! has failed.</p>
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
+		return wp_kses_post( __( '<p>The subscription payment for !!user_login!! for level !!membership_level_name!! at !!sitename!! has failed.</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
 
-<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-billing-failure-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-failure-admin.php
@@ -82,10 +82,10 @@ class PMPro_Email_Template_Billing_Failure_Admin extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>The subscription payment for !!user_login!! for level !!membership_level_name!! at !!sitename!! has failed.</p>
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
 
-			<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-billing-failure.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-failure.php
@@ -82,7 +82,7 @@ class PMPro_Email_Template_Billing_Failure extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>The current subscription payment for level !!membership_level_name!! at !!sitename!! membership has failed. <strong>Please click the following link to log in and update your billing information to avoid account suspension.</strong><br/> !!login_url!! </p>
-			<p>Account: !!display_name!! (!!user_email!!)</p>', 'paid-memberships-pro' ) );
+<p>Account: !!display_name!! (!!user_email!!)</p>', 'paid-memberships-pro' ) );
 	}
 
 		/**

--- a/classes/email-templates/class-pmpro-email-template-billing-failure.php
+++ b/classes/email-templates/class-pmpro-email-template-billing-failure.php
@@ -81,8 +81,8 @@ class PMPro_Email_Template_Billing_Failure extends PMPro_Email_Template {
 	 * @return string The email body.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>The current subscription payment for level !!membership_level_name!! at !!sitename!! membership has failed. <strong>Please click the following link to log in and update your billing information to avoid account suspension.</strong><br/> !!login_url!! </p>
-<p>Account: !!display_name!! (!!user_email!!)</p>', 'paid-memberships-pro' );
+		return wp_kses_post( __( '<p>The current subscription payment for level !!membership_level_name!! at !!sitename!! membership has failed. <strong>Please click the following link to log in and update your billing information to avoid account suspension.</strong><br/> !!login_url!! </p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>', 'paid-memberships-pro' ) );
 	}
 
 		/**

--- a/classes/email-templates/class-pmpro-email-template-billing.php
+++ b/classes/email-templates/class-pmpro-email-template-billing.php
@@ -83,12 +83,12 @@ class PMPro_Email_Template_Billing extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Your billing information at !!sitename!! has been changed.</p><p>Account: !!display_name!! (!!user_email!!)</p>
 <p>
-Billing Information:<br />
-!!billing_address!!
+	Billing Information:<br />
+	!!billing_address!!
 </p>
 <p>
-!!cardtype!!: !!accountnumber!!<br />
-Expires: !!expirationmonth!!/!!expirationyear!!
+	!!cardtype!!: !!accountnumber!!<br />
+	Expires: !!expirationmonth!!/!!expirationyear!!
 </p>
 <p>If you did not request a billing information change please contact us at !!siteemail!!</p>
 <p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );

--- a/classes/email-templates/class-pmpro-email-template-billing.php
+++ b/classes/email-templates/class-pmpro-email-template-billing.php
@@ -81,17 +81,17 @@ class PMPro_Email_Template_Billing extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Your billing information at !!sitename!! has been changed.</p><p>Account: !!display_name!! (!!user_email!!)</p>
-<p>
-	Billing Information:<br />
-	!!billing_address!!
-</p>
-<p>
-	!!cardtype!!: !!accountnumber!!<br />
-	Expires: !!expirationmonth!!/!!expirationyear!!
-</p>
-<p>If you did not request a billing information change please contact us at !!siteemail!!</p>
-<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+		return wp_kses_post( __( '<p>Your billing information at !!sitename!! has been changed.</p><p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>
+				Billing Information:<br />
+				!!billing_address!!
+			</p>
+			<p>
+				!!cardtype!!: !!accountnumber!!<br />
+				Expires: !!expirationmonth!!/!!expirationyear!!
+			</p>
+			<p>If you did not request a billing information change please contact us at !!siteemail!!</p>
+			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-billing.php
+++ b/classes/email-templates/class-pmpro-email-template-billing.php
@@ -82,16 +82,16 @@ class PMPro_Email_Template_Billing extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Your billing information at !!sitename!! has been changed.</p><p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>
-				Billing Information:<br />
-				!!billing_address!!
-			</p>
-			<p>
-				!!cardtype!!: !!accountnumber!!<br />
-				Expires: !!expirationmonth!!/!!expirationyear!!
-			</p>
-			<p>If you did not request a billing information change please contact us at !!siteemail!!</p>
-			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>
+Billing Information:<br />
+!!billing_address!!
+</p>
+<p>
+!!cardtype!!: !!accountnumber!!<br />
+Expires: !!expirationmonth!!/!!expirationyear!!
+</p>
+<p>If you did not request a billing information change please contact us at !!siteemail!!</p>
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-admin.php
@@ -86,12 +86,12 @@ class PMPro_Email_Template_Cancel_Admin extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>The membership for !!user_login!! at !!sitename!! has been cancelled.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			<p>Start Date: !!startdate!!</p>
-			<p>End Date: !!enddate!!</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Start Date: !!startdate!!</p>
+<p>End Date: !!enddate!!</p>
 
-			<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-admin.php
@@ -84,14 +84,14 @@ class PMPro_Email_Template_Cancel_Admin extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>The membership for !!user_login!! at !!sitename!! has been cancelled.</p>
+		return wp_kses_post( __( '<p>The membership for !!user_login!! at !!sitename!! has been cancelled.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Start Date: !!startdate!!</p>
-<p>End Date: !!enddate!!</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			<p>Start Date: !!startdate!!</p>
+			<p>End Date: !!enddate!!</p>
 
-<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
@@ -81,10 +81,10 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>The payment subscription for !!user_login!! at !!sitename!! has been cancelled.</p>
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			<p>Start Date: !!startdate!!</p>
-			<p>Expiration Date: !!enddate!!</p>', 'paid-memberships-pro' ) );
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Start Date: !!startdate!!</p>
+<p>Expiration Date: !!enddate!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
@@ -80,11 +80,11 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>The payment subscription for !!user_login!! at !!sitename!! has been cancelled.</p>
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Start Date: !!startdate!!</p>
-<p>Expiration Date: !!enddate!!</p>', 'paid-memberships-pro' );
+		return wp_kses_post( __( '<p>The payment subscription for !!user_login!! at !!sitename!! has been cancelled.</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			<p>Start Date: !!startdate!!</p>
+			<p>Expiration Date: !!enddate!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
@@ -85,9 +85,9 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Your payment subscription at !!sitename!! has been cancelled.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			<p>Your access will expire on !!enddate!!.</p>', 'paid-memberships-pro' ) );
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Your access will expire on !!enddate!!.</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
@@ -83,11 +83,11 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Your payment subscription at !!sitename!! has been cancelled.</p>
+		return wp_kses_post( __( '<p>Your payment subscription at !!sitename!! has been cancelled.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Your access will expire on !!enddate!!.</p>', 'paid-memberships-pro' );
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			<p>Your access will expire on !!enddate!!.</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel.php
@@ -83,12 +83,12 @@ class PMPro_Email_Template_Cancel extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Your membership at !!sitename!! has been cancelled.</p>
+		return wp_kses_post( __( '<p>Your membership at !!sitename!! has been cancelled.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
 
-<p>If you did not request this cancellation and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' );
+			<p>If you did not request this cancellation and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-cancel.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel.php
@@ -85,10 +85,10 @@ class PMPro_Email_Template_Cancel extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Your membership at !!sitename!! has been cancelled.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
 
-			<p>If you did not request this cancellation and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ) );
+<p>If you did not request this cancellation and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -95,8 +95,8 @@ class PMPro_Email_Template_Checkout_Check_Admin extends PMPro_Email_Template {
 !!membership_expiration!! !!discount_code!!
 
 <p>
-	Order #!!order_id!! on !!order_date!!<br />
-	Total Billed: !!order_total!!
+Order #!!order_id!! on !!order_date!!<br />
+Total Billed: !!order_total!!
 </p>
 
 <p>Log in to your membership account here: !!login_url!!</p>','paid-memberships-pro' ) ),  $check_gateway_label );

--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -83,23 +83,23 @@ class PMPro_Email_Template_Checkout_Check_Admin extends PMPro_Email_Template {
 	public static function get_default_body() {
 		$check_gateway_label = get_option( 'pmpro_check_gateway_label' ) ? get_option( 'pmpro_check_gateway_label' ) : esc_html__( 'Check', 'paid-memberships-pro' );
 
-		return sprintf( wp_kses_post( '<p>There was a new member checkout at !!sitename!!.</p>
+		return sprintf( wp_kses_post( __( '<p>There was a new member checkout at !!sitename!!.</p>
 
-<p><strong>They have chosen to pay by %s.</strong></p>
+			<p><strong>They have chosen to pay by %s.</strong></p>
 
-<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
+			<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Membership Fee: !!membership_cost!!</p>
-!!membership_expiration!! !!discount_code!!
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			<p>Membership Fee: !!membership_cost!!</p>
+			!!membership_expiration!! !!discount_code!!
 
-<p>
-Order #!!order_id!! on !!order_date!!<br />
-Total Billed: !!order_total!!
-</p>
+			<p>
+			Order #!!order_id!! on !!order_date!!<br />
+			Total Billed: !!order_total!!
+			</p>
 
-<p>Log in to your membership account here: !!login_url!!</p>','paid-memberships-pro' ),  $check_gateway_label );
+			<p>Log in to your membership account here: !!login_url!!</p>','paid-memberships-pro' ) ),  $check_gateway_label );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -85,21 +85,21 @@ class PMPro_Email_Template_Checkout_Check_Admin extends PMPro_Email_Template {
 
 		return sprintf( wp_kses_post( __( '<p>There was a new member checkout at !!sitename!!.</p>
 
-			<p><strong>They have chosen to pay by %s.</strong></p>
+<p><strong>They have chosen to pay by %s.</strong></p>
 
-			<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
+<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			<p>Membership Fee: !!membership_cost!!</p>
-			!!membership_expiration!! !!discount_code!!
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Membership Fee: !!membership_cost!!</p>
+!!membership_expiration!! !!discount_code!!
 
-			<p>
-			Order #!!order_id!! on !!order_date!!<br />
-			Total Billed: !!order_total!!
-			</p>
+<p>
+	Order #!!order_id!! on !!order_date!!<br />
+	Total Billed: !!order_total!!
+</p>
 
-			<p>Log in to your membership account here: !!login_url!!</p>','paid-memberships-pro' ) ),  $check_gateway_label );
+<p>Log in to your membership account here: !!login_url!!</p>','paid-memberships-pro' ) ),  $check_gateway_label );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -83,23 +83,23 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
 
-			!!membership_level_confirmation_message!!
+!!membership_level_confirmation_message!!
 
-			!!instructions!!
+!!instructions!!
 
-			<p>Below are details about your membership account and a receipt for your initial membership order.</p>
+<p>Below are details about your membership account and a receipt for your initial membership order.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			<p>Membership Fee: !!membership_cost!!</p>
-			!!membership_expiration!! !!discount_code!!
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Membership Fee: !!membership_cost!!</p>
+!!membership_expiration!! !!discount_code!!
 
-			<p>
-				Order #!!order_id!! on !!order_date!!<br />
-				Total Billed: !!order_total!!
-			</p>
+<p>
+	Order #!!order_id!! on !!order_date!!<br />
+	Total Billed: !!order_total!!
+</p>
 
-			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -81,25 +81,25 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 	 * @return string The default body for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post('<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
 
-!!membership_level_confirmation_message!!
+			!!membership_level_confirmation_message!!
 
-!!instructions!!
+			!!instructions!!
 
-<p>Below are details about your membership account and a receipt for your initial membership order.</p>
+			<p>Below are details about your membership account and a receipt for your initial membership order.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Membership Fee: !!membership_cost!!</p>
-!!membership_expiration!! !!discount_code!!
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			<p>Membership Fee: !!membership_cost!!</p>
+			!!membership_expiration!! !!discount_code!!
 
-<p>
-	Order #!!order_id!! on !!order_date!!<br />
-	Total Billed: !!order_total!!
-</p>
+			<p>
+				Order #!!order_id!! on !!order_date!!<br />
+				Total Billed: !!order_total!!
+			</p>
 
-<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -83,14 +83,14 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 	 * @return string The email body.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>There was a new member checkout at !!sitename!!.</p>
-<p>Below are details about the new membership account.</p>
+		return wp_kses_post( __( '<p>There was a new member checkout at !!sitename!!.</p>
+			<p>Below are details about the new membership account.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-!!membership_expiration!! !!discount_code!!
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			!!membership_expiration!! !!discount_code!!
 
-<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -84,13 +84,13 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>There was a new member checkout at !!sitename!!.</p>
-			<p>Below are details about the new membership account.</p>
+<p>Below are details about the new membership account.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			!!membership_expiration!! !!discount_code!!
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+!!membership_expiration!! !!discount_code!!
 
-			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -81,13 +81,13 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 	 * @return string The email body.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
-!!membership_level_confirmation_message!!
-<p>Below are details about your membership account.</p>
+		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+			!!membership_level_confirmation_message!!
+			<p>Below are details about your membership account.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-!!membership_expiration!! !!discount_code!!', 'paid-memberships-pro' );
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			!!membership_expiration!! !!discount_code!!', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -82,12 +82,12 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
-			!!membership_level_confirmation_message!!
-			<p>Below are details about your membership account.</p>
+!!membership_level_confirmation_message!!
+<p>Below are details about your membership account.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			!!membership_expiration!! !!discount_code!!', 'paid-memberships-pro' ) );
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+!!membership_expiration!! !!discount_code!!', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
@@ -81,28 +81,28 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>There was a new member checkout at !!sitename!!.</p>
-		<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
+<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
 
-		<p>Account: !!display_name!! (!!user_email!!)</p>
-		<p>Membership Level: !!membership_level_name!!</p>
-		<p>Membership Fee: !!membership_cost!!</p>
-		!!membership_expiration!! !!discount_code!!
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Membership Fee: !!membership_cost!!</p>
+!!membership_expiration!! !!discount_code!!
 
-		<p>
-			Order #!!order_id!! on !!order_date!!<br />
-			Total Billed: !!order_total!!
-		</p>
-		<p>
-			Billing Information:<br />
-			!!billing_address!!
-		</p>
+<p>
+	Order #!!order_id!! on !!order_date!!<br />
+	Total Billed: !!order_total!!
+</p>
+<p>
+	Billing Information:<br />
+	!!billing_address!!
+</p>
 
-		<p>
-			!!cardtype!!: !!accountnumber!!<br />
-			Expires: !!expirationmonth!!/!!expirationyear!!
-		</p>
+<p>
+	!!cardtype!!: !!accountnumber!!<br />
+	Expires: !!expirationmonth!!/!!expirationyear!!
+</p>
 
-		<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
@@ -80,29 +80,29 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 	 * @return string The email body.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>There was a new member checkout at !!sitename!!.</p>
-<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
+		return wp_kses_post( __( '<p>There was a new member checkout at !!sitename!!.</p>
+		<p>Below are details about the new membership account and a receipt for the initial membership order.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
-<p>Membership Fee: !!membership_cost!!</p>
-!!membership_expiration!! !!discount_code!!
+		<p>Account: !!display_name!! (!!user_email!!)</p>
+		<p>Membership Level: !!membership_level_name!!</p>
+		<p>Membership Fee: !!membership_cost!!</p>
+		!!membership_expiration!! !!discount_code!!
 
-<p>
-	Order #!!order_id!! on !!order_date!!<br />
-	Total Billed: !!order_total!!
-</p>
-<p>
-	Billing Information:<br />
-	!!billing_address!!
-</p>
+		<p>
+			Order #!!order_id!! on !!order_date!!<br />
+			Total Billed: !!order_total!!
+		</p>
+		<p>
+			Billing Information:<br />
+			!!billing_address!!
+		</p>
 
-<p>
-	!!cardtype!!: !!accountnumber!!<br />
-	Expires: !!expirationmonth!!/!!expirationyear!!
-</p>
+		<p>
+			!!cardtype!!: !!accountnumber!!<br />
+			Expires: !!expirationmonth!!/!!expirationyear!!
+		</p>
 
-<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+		<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -85,30 +85,30 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 	 * @return string The email body.
 	 */
 	public static function get_default_body() {
-		return  wp_kses_post( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
-		!!membership_level_confirmation_message!!
-		<p>Below are details about your membership account and a receipt for your initial membership order.</p>
-		
-		<p>Account: !!display_name!! (!!user_email!!)</p>
-		<p>Membership Level: !!membership_level_name!!</p>
-		<p>Membership Fee: !!membership_cost!!</p>
-		!!membership_expiration!! !!discount_code!!
-		
-		<p>
-			Order #!!order_id!! on !!order_date!!<br />
-			Total Billed: !!order_total!!
-		</p>
-		<p>
-			Billing Information:<br />
-			!!billing_address!!
-		</p>
-		
-		<p>
-			!!cardtype!!: !!accountnumber!!<br />
-			Expires: !!expirationmonth!!/!!expirationyear!!
-		</p>
-		
-		<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+		return  wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
+			!!membership_level_confirmation_message!!
+			<p>Below are details about your membership account and a receipt for your initial membership order.</p>
+			
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
+			<p>Membership Fee: !!membership_cost!!</p>
+			!!membership_expiration!! !!discount_code!!
+			
+			<p>
+				Order #!!order_id!! on !!order_date!!<br />
+				Total Billed: !!order_total!!
+			</p>
+			<p>
+				Billing Information:<br />
+				!!billing_address!!
+			</p>
+			
+			<p>
+				!!cardtype!!: !!accountnumber!!<br />
+				Expires: !!expirationmonth!!/!!expirationyear!!
+			</p>
+			
+			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -86,29 +86,29 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return  wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Your membership account is now active.</p>
-			!!membership_level_confirmation_message!!
-			<p>Below are details about your membership account and a receipt for your initial membership order.</p>
-			
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
-			<p>Membership Fee: !!membership_cost!!</p>
-			!!membership_expiration!! !!discount_code!!
-			
-			<p>
-				Order #!!order_id!! on !!order_date!!<br />
-				Total Billed: !!order_total!!
-			</p>
-			<p>
-				Billing Information:<br />
-				!!billing_address!!
-			</p>
-			
-			<p>
-				!!cardtype!!: !!accountnumber!!<br />
-				Expires: !!expirationmonth!!/!!expirationyear!!
-			</p>
-			
-			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+!!membership_level_confirmation_message!!
+<p>Below are details about your membership account and a receipt for your initial membership order.</p>
+
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
+<p>Membership Fee: !!membership_cost!!</p>
+!!membership_expiration!! !!discount_code!!
+
+<p>
+	Order #!!order_id!! on !!order_date!!<br />
+	Total Billed: !!order_total!!
+</p>
+<p>
+	Billing Information:<br />
+	!!billing_address!!
+</p>
+
+<p>
+	!!cardtype!!: !!accountnumber!!<br />
+	Expires: !!expirationmonth!!/!!expirationyear!!
+</p>
+
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
@@ -80,18 +80,18 @@ class PMPro_Email_Template_Credit_Card_Expiring extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>The payment method used for your membership at !!sitename!! will expire soon. <strong>Please click the following link to log in and update your billing information to avoid account suspension. !!login_url!!</strong></p>
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>The most recent account information we have on file is:</p>
+		return wp_kses_post( __( '<p>The payment method used for your membership at !!sitename!! will expire soon. <strong>Please click the following link to log in and update your billing information to avoid account suspension. !!login_url!!</strong></p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>The most recent account information we have on file is:</p>
 
-<p>!!billing_name!!</br />
-	!!billing_address!!
-</p>
+			<p>!!billing_name!!</br />
+				!!billing_address!!
+			</p>
 
-<p>
-	!!cardtype!!: !!accountnumber!!<br />
-	Expires: !!expirationmonth!!/!!expirationyear!!
-</p>', 'paid-memberships-pro' );
+			<p>
+				!!cardtype!!: !!accountnumber!!<br />
+				Expires: !!expirationmonth!!/!!expirationyear!!
+			</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
@@ -81,17 +81,17 @@ class PMPro_Email_Template_Credit_Card_Expiring extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>The payment method used for your membership at !!sitename!! will expire soon. <strong>Please click the following link to log in and update your billing information to avoid account suspension. !!login_url!!</strong></p>
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>The most recent account information we have on file is:</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>The most recent account information we have on file is:</p>
 
-			<p>!!billing_name!!</br />
-				!!billing_address!!
-			</p>
+<p>!!billing_name!!</br />
+	!!billing_address!!
+</p>
 
-			<p>
-				!!cardtype!!: !!accountnumber!!<br />
-				Expires: !!expirationmonth!!/!!expirationyear!!
-			</p>', 'paid-memberships-pro' ) );
+<p>
+	!!cardtype!!: !!accountnumber!!<br />
+	Expires: !!expirationmonth!!/!!expirationyear!!
+</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -82,11 +82,11 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Your membership at !!sitename!! has ended.</p>
 
-			<p>Thank you for your support.</p>
+<p>Thank you for your support.</p>
 
-			<p>View our current membership offerings here: !!levels_url!!</p>
+<p>View our current membership offerings here: !!levels_url!!</p>
 
-			<p>Log in to manage your account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to manage your account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -80,13 +80,13 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Your membership at !!sitename!! has ended.</p>
+		return wp_kses_post( __( '<p>Your membership at !!sitename!! has ended.</p>
 
-<p>Thank you for your support.</p>
+			<p>Thank you for your support.</p>
 
-<p>View our current membership offerings here: !!levels_url!!</p>
+			<p>View our current membership offerings here: !!levels_url!!</p>
 
-<p>Log in to manage your account here: !!login_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to manage your account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -82,10 +82,10 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. This is just a reminder that your membership will end on !!enddate!!.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>Membership Level: !!membership_level_name!!</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Membership Level: !!membership_level_name!!</p>
 
-			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -80,12 +80,12 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Thank you for your membership to !!sitename!!. This is just a reminder that your membership will end on !!enddate!!.</p>
+		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. This is just a reminder that your membership will end on !!enddate!!.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>Membership Level: !!membership_level_name!!</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Membership Level: !!membership_level_name!!</p>
 
-<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to your membership account here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
@@ -81,12 +81,12 @@ class PMPro_Email_Template_Payment_Action_Admin extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>A payment at !!sitename!! for !!user_login!! requires additional customer authentication to complete.</p>
-			<p>Below is a copy of the email we sent to !!user_email!! to notify them that they need to complete their payment:</p>
+<p>Below is a copy of the email we sent to !!user_email!! to notify them that they need to complete their payment:</p>
 
-			<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
+<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
 
-			<p>Please complete the verification steps issued by your payment provider at the following link:</p>
-			<p>!!order_url!!</p>', 'paid-memberships-pro' ) );
+<p>Please complete the verification steps issued by your payment provider at the following link:</p>
+<p>!!order_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
@@ -80,13 +80,13 @@ class PMPro_Email_Template_Payment_Action_Admin extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>A payment at !!sitename!! for !!user_login!! requires additional customer authentication to complete.</p>
-<p>Below is a copy of the email we sent to !!user_email!! to notify them that they need to complete their payment:</p>
+		return wp_kses_post( __( '<p>A payment at !!sitename!! for !!user_login!! requires additional customer authentication to complete.</p>
+			<p>Below is a copy of the email we sent to !!user_email!! to notify them that they need to complete their payment:</p>
 
-<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
+			<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
 
-<p>Please complete the verification steps issued by your payment provider at the following link:</p>
-<p>!!order_url!!</p>', 'paid-memberships-pro' );
+			<p>Please complete the verification steps issued by your payment provider at the following link:</p>
+			<p>!!order_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-action.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action.php
@@ -82,8 +82,8 @@ class PMPro_Email_Template_Payment_Action extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
 
-			<p>Please complete the verification steps issued by your payment provider at the following link:</p>
-			<p>!!order_url!!</p>', 'paid-memberships-pro' ) );
+<p>Please complete the verification steps issued by your payment provider at the following link:</p>
+<p>!!order_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-action.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action.php
@@ -80,10 +80,10 @@ class PMPro_Email_Template_Payment_Action extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
+		return wp_kses_post( __( '<p>Customer authentication is required to finish setting up your subscription at !!sitename!!.</p>
 
-<p>Please complete the verification steps issued by your payment provider at the following link:</p>
-<p>!!order_url!!</p>', 'paid-memberships-pro' );
+			<p>Please complete the verification steps issued by your payment provider at the following link:</p>
+			<p>!!order_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-receipt.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-receipt.php
@@ -81,23 +81,23 @@ class PMPro_Email_Template_Payment_Receipt extends PMPro_Email_Template {
 	 */
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Below is a receipt for your most recent membership order.</p>
-			<p>Account: !!display_name!! (!!user_email!!)</p>
-			<p>
-			Order #!!order_id!! on !!order_date!!<br />
-			Total Billed: !!order_total!!
-			</p>
-			<p>
-			Billing Information:<br />
-			!!billing_address!!
-			</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>
+Order #!!order_id!! on !!order_date!!<br />
+Total Billed: !!order_total!!
+</p>
+<p>
+Billing Information:<br />
+!!billing_address!!
+</p>
 
-			<p>
-			!!cardtype!!: !!accountnumber!!<br />
-			Expires: !!expirationmonth!!/!!expirationyear!!
-			</p>
+<p>
+!!cardtype!!: !!accountnumber!!<br />
+Expires: !!expirationmonth!!/!!expirationyear!!
+</p>
 
-			<p>Log in to your membership account here: !!login_url!!</p>
-			<p>To view an online version of this order, click here: !!order_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your membership account here: !!login_url!!</p>
+<p>To view an online version of this order, click here: !!order_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-receipt.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-receipt.php
@@ -80,25 +80,24 @@ class PMPro_Email_Template_Payment_Receipt extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Thank you for your membership to !!sitename!!. Below is a receipt for your most recent membership order.</p>
+		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!. Below is a receipt for your most recent membership order.</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>
+			Order #!!order_id!! on !!order_date!!<br />
+			Total Billed: !!order_total!!
+			</p>
+			<p>
+			Billing Information:<br />
+			!!billing_address!!
+			</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>
-Order #!!order_id!! on !!order_date!!<br />
-Total Billed: !!order_total!!
-</p>
-<p>
-Billing Information:<br />
-!!billing_address!!
-</p>
+			<p>
+			!!cardtype!!: !!accountnumber!!<br />
+			Expires: !!expirationmonth!!/!!expirationyear!!
+			</p>
 
-<p>
-!!cardtype!!: !!accountnumber!!<br />
-Expires: !!expirationmonth!!/!!expirationyear!!
-</p>
-
-<p>Log in to your membership account here: !!login_url!!</p>
-<p>To view an online version of this order, click here: !!order_url!!</p>', 'paid-memberships-pro' );
+			<p>Log in to your membership account here: !!login_url!!</p>
+			<p>To view an online version of this order, click here: !!order_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-reminder.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-reminder.php
@@ -74,11 +74,11 @@ class PMPro_Email_Template_Payment_Reminder extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!.</p>
 
-			<p>This is just a reminder that your !!membership_level_name!! membership will automatically renew on !!renewaldate!!.</p>
+<p>This is just a reminder that your !!membership_level_name!! membership will automatically renew on !!renewaldate!!.</p>
 
-			<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
 
-			<p>If for some reason you do not want to renew your membership you can cancel by clicking here: !!cancel_link!!</p>', 'paid-memberships-pro' ) );
+<p>If for some reason you do not want to renew your membership you can cancel by clicking here: !!cancel_link!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-payment-reminder.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-reminder.php
@@ -72,13 +72,13 @@ class PMPro_Email_Template_Payment_Reminder extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Thank you for your membership to !!sitename!!.</p>
+		return wp_kses_post( __( '<p>Thank you for your membership to !!sitename!!.</p>
 
-<p>This is just a reminder that your !!membership_level_name!! membership will automatically renew on !!renewaldate!!.</p>
+			<p>This is just a reminder that your !!membership_level_name!! membership will automatically renew on !!renewaldate!!.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
+			<p>Account: !!display_name!! (!!user_email!!)</p>
 
-<p>If for some reason you do not want to renew your membership you can cancel by clicking here: !!cancel_link!!</p>', 'paid-memberships-pro' );
+			<p>If for some reason you do not want to renew your membership you can cancel by clicking here: !!cancel_link!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-refund-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-refund-admin.php
@@ -83,13 +83,13 @@ class PMPro_Email_Template_Refund_Admin extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return wp_kses_post( __( '<p>Order #!!order_id!! at !!sitename!! has been refunded.</p>
 
-		<p>Account: !!display_name!! (!!user_email!!)</p>
-		<p>
-			Order #!!order_id!! on !!order_date!!<br />
-			Total Refunded: !!order_total!!
-		</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>
+	Order #!!order_id!! on !!order_date!!<br />
+	Total Refunded: !!order_total!!
+</p>
 
-		<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
+<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-refund-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-refund-admin.php
@@ -81,15 +81,15 @@ class PMPro_Email_Template_Refund_Admin extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return wp_kses_post( '<p>Order #!!order_id!! at !!sitename!! has been refunded.</p>
+		return wp_kses_post( __( '<p>Order #!!order_id!! at !!sitename!! has been refunded.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>
-	Order #!!order_id!! on !!order_date!!<br />
-	Total Refunded: !!order_total!!
-</p>
+		<p>Account: !!display_name!! (!!user_email!!)</p>
+		<p>
+			Order #!!order_id!! on !!order_date!!<br />
+			Total Refunded: !!order_total!!
+		</p>
 
-<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' );
+		<p>Log in to your WordPress admin here: !!login_url!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-refund.php
+++ b/classes/email-templates/class-pmpro-email-template-refund.php
@@ -82,16 +82,16 @@ class PMPro_Email_Template_Refund extends PMPro_Email_Template {
 	public static function get_default_body() {
 		return  wp_kses_post( __( '<p>Order #!!order_id!! at !!sitename!! has been refunded.</p>
 
-		<p>Account: !!display_name!! (!!user_email!!)</p>
-		<p>
-			Order #!!order_id!! on !!order_date!!<br />
-			Total Refunded: !!order_total!!
-		</p>
+<p>Account: !!display_name!! (!!user_email!!)</p>
+<p>
+	Order #!!order_id!! on !!order_date!!<br />
+	Total Refunded: !!order_total!!
+</p>
 
-		<p>Log in to your membership account here: !!login_url!!</p>
-		<p>To view an online version of this order, click here: !!order_url!!</p>
+<p>Log in to your membership account here: !!login_url!!</p>
+<p>To view an online version of this order, click here: !!order_url!!</p>
 
-		<p>If you did not request this refund and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ) );
+<p>If you did not request this refund and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-refund.php
+++ b/classes/email-templates/class-pmpro-email-template-refund.php
@@ -80,18 +80,18 @@ class PMPro_Email_Template_Refund extends PMPro_Email_Template {
 	 * @return string The default body content for the email.
 	 */
 	public static function get_default_body() {
-		return  wp_kses_post( '<p>Order #!!order_id!! at !!sitename!! has been refunded.</p>
+		return  wp_kses_post( __( '<p>Order #!!order_id!! at !!sitename!! has been refunded.</p>
 
-<p>Account: !!display_name!! (!!user_email!!)</p>
-<p>
-	Order #!!order_id!! on !!order_date!!<br />
-	Total Refunded: !!order_total!!
-</p>
+		<p>Account: !!display_name!! (!!user_email!!)</p>
+		<p>
+			Order #!!order_id!! on !!order_date!!<br />
+			Total Refunded: !!order_total!!
+		</p>
 
-<p>Log in to your membership account here: !!login_url!!</p>
-<p>To view an online version of this order, click here: !!order_url!!</p>
+		<p>Log in to your membership account here: !!login_url!!</p>
+		<p>To view an online version of this order, click here: !!order_url!!</p>
 
-<p>If you did not request this refund and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' );
+		<p>If you did not request this refund and would like more information please contact us at !!siteemail!!</p>', 'paid-memberships-pro' ) );
 	}
 
 	/**

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -16,13 +16,13 @@ $pmpro_email_templates_defaults = array(
 	'footer' => array(
 		'subject' => '',
 		'description' => esc_html__( 'Email Footer', 'paid-memberships-pro'),
-		'body' => wp_kses_post( '<p>Respectfully,<br />!!sitename!! </p>', 'paid-memberships-pro' ),
+		'body' => wp_kses_post( __( '<p>Respectfully,<br />!!sitename!! </p>', 'paid-memberships-pro' ) ),
 		'help_text' => esc_html__( 'This is the closing message included in every email sent to members and the site administrator through Paid Memberships Pro.', 'paid-memberships-pro' )
 	),
 	'header' => array(
 		'subject'     => '',
 		'description' => esc_html__( 'Email Header', 'paid-memberships-pro'),
-		'body' => wp_kses_post( '<p>Dear !!header_name!!,</p>', 'paid-memberships-pro' ),
+		'body' => wp_kses_post( __( '<p>Dear !!header_name!!,</p>', 'paid-memberships-pro' ) ),
 		'help_text' => esc_html__( 'This is the opening message included in every email sent to members and the site administrator through Paid Memberships Pro.', 'paid-memberships-pro' )
 	),
 );


### PR DESCRIPTION
* BUG FIX: Return translation functionality to email templates that were mistakenly removed. This reverts back to logic V3.3. 

A nice to have would make these translations even better and avoid email variables getting replaced or being translatable.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?