### PR TITLE
Fixing loading payflow gateway

### DIFF
--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1029,7 +1029,7 @@ function pmpro_check_for_deprecated_gateways() {
 	}
 	$default_gateway = get_option( 'pmpro_gateway' );
 
-	$deprecated_gateways = array( 'twocheckout', 'cybersource', 'paypal', 'authorizenet', 'payflow', 'paypalstandard', 'braintree' );
+	$deprecated_gateways = array( 'twocheckout', 'cybersource', 'paypal', 'authorizenet', 'payflowpro', 'paypalstandard', 'braintree' );
 	foreach ( $deprecated_gateways as $deprecated_gateway ) {
 		if ( $default_gateway === $deprecated_gateway || in_array( $deprecated_gateway, $undeprecated_gateways ) ) {
 			require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_' . $deprecated_gateway . '.php' );

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -410,6 +410,32 @@ function pmpro_checkForUpgrades() {
 		pmpro_db_delta();
 		update_option( 'pmpro_db_version', '3.4' );
 	}
+
+	/**
+	 * Version 3.4.3
+	 * Fixing broken Payflow deprecation.
+	 */
+	if ( $pmpro_db_version < 3.403 ) {
+		// Check if there are any Payflow settings.
+		if ( ! empty( get_option( 'pmpro_payflow_partner' ) ) ) {
+			// Get the current list of undeprecated gateways.
+			$undeprecated_gateways = get_option( 'pmpro_undeprecated_gateways' );
+			if ( empty( $undeprecated_gateways ) ) {
+				$undeprecated_gateways = array();
+			} elseif ( is_string( $undeprecated_gateways ) ) {
+				// pmpro_setOption turns this into a comma separated string
+				$undeprecated_gateways = explode( ',', $undeprecated_gateways );
+			}
+
+			// If Payflow isn't in the list, add it.
+			if ( ! in_array( 'payflowpro', $undeprecated_gateways ) ) {
+				$undeprecated_gateways[] = 'payflowpro';
+				update_option( 'pmpro_undeprecated_gateways', $undeprecated_gateways );
+			}
+		}
+
+		update_option( 'pmpro_db_version', '3.403' );
+	}
 }
 
 function pmpro_db_delta() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
PMPro v3.4 marked Payflow as deprecated to prevent new sites from using that gateway. This deprecation also caused existing sites to no longer be able to use Payflow, which was not intentional. This PR adds Payflow back as an option for sites that are already using it

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
