### PR TITLE
User field string value `0` showing blank on members list export

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -446,7 +446,7 @@
 				foreach($extra_columns as $heading => $callback)
 				{
 					$val = call_user_func($callback, $theuser, $heading);
-					$val = !empty($val) ? $val : null;
+					$val = ( is_string( $val ) || ! empty($val) ) ? $val : null;
 					array_push( $csvoutput, pmpro_enclose($val) );
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes an issue where user fields with a string value of `0` would show as blank on the members list CSV export.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set up a checkbox grouped field with multiple options with only labels set (no values)
2. Edit a user and select only the first option (which will have a value of `0`)
3. Export the members list CSV. The `array( 0 )` will be `join()`d to string `'0'`. Before this PR, this would show as an empty cell in the export. After, it will correctly show as `0`.

As a side note, it is highly recommended to set up the grouped checkbox field options in the format `value:label` to avoid values being preset to numbers which could change when options are added or removed from the field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
