### PR TITLE
[BUGFIXING] Don't strip line breaks in USER FIELDS

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -191,6 +191,16 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		$r = $user_field->displayValue( $r, false );
 	}
 
+	if ( 'textarea' == $user_field->type ) {
+		//Let devs change default wp_kses_post and wpautop behavior.
+		$apply_formatting = 
+			apply_filters( 'pmpro_member_shortcode_text_area_apply_formatting', true, $user_field, $user_id, $field );
+
+		if ( $apply_formatting ) {
+			$r = wp_kses_post( wpautop( $r ) );
+		}
+	}
+
 	// Check for arrays to reformat them.
 	if ( is_array( $r ) ) {
 		$r = implode( ', ', $r );


### PR DESCRIPTION
 * Apply wp_kses_post and wpautop by default to text area user fields.
 * Wrap it among a filter to let devs change this default behavior

<img width="661" alt="Screenshot 2025-02-24 at 2 23 50 PM" src="https://github.com/user-attachments/assets/95929cbd-1548-4107-8afa-cd09cf9e948d" />
<img width="401" alt="Screenshot 2025-02-24 at 2 23 56 PM" src="https://github.com/user-attachments/assets/af9ba53f-933e-4b51-928f-a627a179ecaf" />
<img width="1150" alt="Screenshot 2025-02-24 at 2 24 24 PM" src="https://github.com/user-attachments/assets/7e6495b0-4081-42f4-a06c-b0be5c197a07" />
<img width="526" alt="Screenshot 2025-02-24 at 2 24 41 PM" src="https://github.com/user-attachments/assets/7c2d10b3-af19-4208-84b1-8e76bac59264" />

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Apply to text area user fields by default a wp_kses_post and wpautop functions. Wrap it among a filter to let devs change it if they need or want.

Resolves #3142 .

### How to test the changes in this Pull Request:

1. Create a text area user field make it required at checkout
2. Chckout a level  and fill with a multi line  value like the screenshot attached above
3. Go to a page and add this shortcode  [pmpro_member field="field_name"] 
4. Go to the page and check how it displays.
5. Add a filter callback to `pmpro_member_shortcode_text_area_apply_formatting` and return false. 
6. Go to the page again and check again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
