### PR TITLE
Only show global variables for header and footer templates

### DIFF
--- a/adminpages/emailtemplates-edit.php
+++ b/adminpages/emailtemplates-edit.php
@@ -65,6 +65,11 @@
 			esc_html__( 'Global Variables', 'paid-memberships-pro' ) => PMPro_Email_Template::get_base_email_template_variables_with_description(),
 			sprintf( esc_html__( '%s Variables', 'paid-memberships-pro' ), $email_template_class::get_template_name() ) => $email_template_class::get_email_template_variables_with_description(),
 		);
+	} elseif( in_array( $edit, array( 'header', 'footer' ) ) ) {
+		// The header and footer templates are special cases. Just show the globals.
+		$email_variables = array(
+			esc_html__( 'Global Variables', 'paid-memberships-pro' ) => PMPro_Email_Template::get_base_email_template_variables_with_description(),
+		);
 	}
 ?>
 <hr class="wp-header-end">

--- a/adminpages/emailtemplates-edit.php
+++ b/adminpages/emailtemplates-edit.php
@@ -65,7 +65,7 @@
 			esc_html__( 'Global Variables', 'paid-memberships-pro' ) => PMPro_Email_Template::get_base_email_template_variables_with_description(),
 			sprintf( esc_html__( '%s Variables', 'paid-memberships-pro' ), $email_template_class::get_template_name() ) => $email_template_class::get_email_template_variables_with_description(),
 		);
-	} elseif( in_array( $edit, array( 'header', 'footer' ) ) ) {
+	} elseif ( in_array( $edit, array( 'header', 'footer' ) ) ) {
 		// The header and footer templates are special cases. Just show the globals.
 		$email_variables = array(
 			esc_html__( 'Global Variables', 'paid-memberships-pro' ) => PMPro_Email_Template::get_base_email_template_variables_with_description(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now only showing the global email template variables when editing the header and footer templates.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
