### PR TITLE
[BUGFIXING] User Fields Incorrectly Marked as Required During Checkout Despite Being Unset Using pmpro_required_user_fields Filter

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5038,3 +5038,37 @@ function pmpro_display_member_account_level_message( $level ) {
 	}
 }
 add_action( 'pmpro_membership_account_after_level_card_content', 'pmpro_display_member_account_level_message' );
+
+/**
+ * Generate required field attributes and labels dynamically, including wrapper classes.
+ *
+ * @param string $field_name The field key from the required fields array.
+ * @param string $field_type The type of the field (text, email, textarea, etc.).
+ * @return array Associative array with 'label', 'input_class', 'input_attr', and 'wrapper_class'.
+ * @since TBD
+ */
+function pmpro_get_required_field_attributes( $field_name, $field_type = 'text' ) {
+	global $pmpro_required_user_fields, $pmpro_required_billing_fields;
+	$is_required = isset( $pmpro_required_user_fields[ $field_name ] )
+		|| isset( $pmpro_required_billing_fields[ $field_name ] );
+
+	// Build the wrapper class dynamically based on field name and type.
+	$base_class = "pmpro_form_field pmpro_form_field-{$field_type} pmpro_form_field-{$field_name}";
+
+	return array(
+		'label' => $is_required ? sprintf(
+			' <span class="%s"><abbr title="%s">*</abbr></span>',
+			esc_attr( pmpro_get_element_class( 'pmpro_asterisk' ) ),
+			esc_attr__( 'Required Field', 'paid-memberships-pro' )
+		) : '',
+		'input_class'   => $is_required ? 'pmpro_form_input-required' : '',
+		'input_attr'    => $is_required ? 'aria-required="true" required' : '',
+		'wrapper_class' => esc_attr( pmpro_get_element_class(
+				$base_class . ( $is_required ? ' pmpro_form_field-required' : '' ), "pmpro_form_field-{$field_name}"
+			)
+		),
+	);
+}
+
+
+

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -140,35 +140,6 @@ jQuery(document).ready(function(){
 		jQuery('input[type=submit]', this).attr('disabled', 'disabled');
 		jQuery('input[type=image]', this).attr('disabled', 'disabled');
 		jQuery('#pmpro_processing_message').css('visibility', 'visible');
-	});	
-
-	jQuery('.pmpro_form_field-required').each(function() {
-		// Check if there's an asterisk already
-		var $firstLabel = jQuery(this).find('.pmpro_form_label').first();
-		var $hasAsterisk = $firstLabel.find('.pmpro_asterisk').length > 0;
-	
-		// If there's no asterisk, add one
-		if ( ! $hasAsterisk ) {
-			$firstLabel.append('<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>');
-		}
-
-		// Add the aria-required="true" attribute to the input.
-		jQuery(this).find('.pmpro_form_input').attr('aria-required', 'true');
-	});
-
-	jQuery('.pmpro_form_input-required').each(function() {
-		// Check if there's an asterisk already
-		var $fieldDiv = jQuery(this).closest('.pmpro_form_field');
-		var $firstLabel = $fieldDiv.find('.pmpro_form_label').first();
-		var $hasAsterisk = $firstLabel.find('.pmpro_asterisk').length > 0;
-
-		// If there's no asterisk, add one
-		if ( ! $hasAsterisk ) {
-			$firstLabel.append('<span class="pmpro_asterisk"> <abbr title="Required Field">*</abbr></span>');
-		}
-
-		// Add the aria-required="true" attribute to the input.
-		jQuery(this).find('.pmpro_form_input').attr('aria-required', 'true');
 	});
 
 	//unhighlight error fields when the user edits them

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -249,13 +249,20 @@ if ( empty( $default_gateway ) ) {
 									<?php
 										// Get discount code from URL parameter, so if the user logs in it will keep it applied.
 										$discount_code_link = ! empty( $discount_code) ? '&pmpro_discount_code=' . $discount_code : '';
+
+										//Retrieve the required field attributes for the username field.
+										$pmpro_username_attr = pmpro_get_required_field_attributes( 'username', 'text' );
 									?>
-
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-username pmpro_form_field-required', 'pmpro_form_field-username' ) ); ?>">
-										<label for="username" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Username', 'paid-memberships-pro' );?></label>
-										<input id="username" name="username" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text pmpro_form_input-required', 'username' ) ); ?>" autocomplete="username" value="<?php echo esc_attr($username); ?>" />
-									</div> <!-- end pmpro_form_field-username -->
-
+									<div class="<?php echo esc_attr( $pmpro_username_attr['wrapper_class'] ); ?>">
+										<label for="username" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+											<?php esc_html_e( 'Username', 'paid-memberships-pro' ); echo $pmpro_username_attr['label']; ?>
+										</label>
+										<input id="username" name="username" type="text"
+											class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'username' ) ) . ' ' . esc_attr( $pmpro_username_attr['input_class'] ); ?>"
+											<?php echo $pmpro_username_attr['input_attr']; ?>
+											autocomplete="username"
+											value="<?php echo esc_attr( $username ); ?>" />
+									</div>
 									<?php do_action( 'pmpro_checkout_after_username' ); ?>
 
 									<?php
@@ -265,30 +272,50 @@ if ( empty( $default_gateway ) ) {
 										 * @param bool $pmpro_checkout_confirm_password, true to require a password confirm field, false to hide.
 										 */
 										$pmpro_checkout_confirm_password = apply_filters( 'pmpro_checkout_confirm_password', true );
+										$pmpro_password_attr = pmpro_get_required_field_attributes( 'password', 'password' );
 
 										echo $pmpro_checkout_confirm_password ? '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ) . '">' : '';
-									?>
 
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-password pmpro_form_field-required' ) ); ?>">
+									?>
+									<div class="<?php echo esc_attr( $pmpro_password_attr['wrapper_class'] ); ?>">
 										<label for="password" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
-											<?php esc_html_e( 'Password', 'paid-memberships-pro' );?>
+											<?php esc_html_e( 'Password', 'paid-memberships-pro' ); echo $pmpro_password_attr['label']; ?>
 										</label>
-										<input type="password" name="password" id="password" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-password pmpro_form_input-required', 'password' ) ); ?>" autocomplete="new-password" spellcheck="false" value="<?php echo esc_attr($password); ?>" />
+										<input type="password" name="password" id="password"
+											class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-password', 'password' ) ) . ' ' . esc_attr( $pmpro_password_attr['input_class'] ); ?>"
+											<?php echo $pmpro_password_attr['input_attr']; ?>
+											autocomplete="new-password" spellcheck="false"
+											value="<?php echo esc_attr( $password ); ?>" />
 										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle' ) ); ?>">
 											<button type="button" class="pmpro_btn pmpro_btn-plain pmpro_btn-password-toggle hide-if-no-js" data-toggle="0">
-												<span class="pmpro_icon pmpro_icon-eye" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg></span>
-													<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle-state' ) ); ?>"><?php esc_html_e( 'Show Password', 'paid-memberships-pro' ); ?></span>
+												<span class="pmpro_icon pmpro_icon-eye" aria-hidden="true">
+													<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="var(--pmpro--color--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye">
+														<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+														<circle cx="12" cy="12" r="3"></circle>
+													</svg>
+												</span>
+												<span class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle-state' ) ); ?>">
+													<?php esc_html_e( 'Show Password', 'paid-memberships-pro' ); ?>
+												</span>
 											</button>
 										</div> <!-- end pmpro_form_field-password-toggle -->
 									</div> <!-- end pmpro_form_field-password -->
 
 									<?php
 										if ( $pmpro_checkout_confirm_password ) {
+											$pmpro_password2_attr = pmpro_get_required_field_attributes( 'password2', 'password' );
+
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-password pmpro_form_field-required', 'pmpro_form_field-password2' ) ); ?>">
-												<label for="password2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Confirm Password', 'paid-memberships-pro' );?></label>
-												<input type="password" name="password2" id="password2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-password pmpro_form_input-required', 'password2' ) ); ?>" autocomplete="new-password" spellcheck="false" value="<?php echo esc_attr($password2); ?>" />
-											</div> <!-- end pmpro_form_field-password2 -->
+												<div class="<?php echo esc_attr( $pmpro_password2_attr['wrapper_class'] ); ?>">
+													<label for="password2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+														<?php esc_html_e( 'Confirm Password', 'paid-memberships-pro' ); echo $pmpro_password2_attr['label']; ?>
+													</label>
+													<input type="password" name="password2" id="password2"
+														class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-password', 'password2' ) ) . ' ' . esc_attr( $pmpro_password2_attr['input_class'] ); ?>"
+														<?php echo $pmpro_password2_attr['input_attr']; ?>
+														autocomplete="new-password" spellcheck="false"
+														value="<?php echo esc_attr( $password2 ); ?>" />
+												</div> <!-- end pmpro_form_field-password2 -->
 											<?php
 										} else {
 											?>
@@ -308,22 +335,35 @@ if ( empty( $default_gateway ) ) {
 										 * @param bool $pmpro_checkout_confirm_email, true to require a email confirm field, false to hide.
 										 */
 										$pmpro_checkout_confirm_email = apply_filters( 'pmpro_checkout_confirm_email', true );
+										$pmpro_bemail_attr = pmpro_get_required_field_attributes( 'bemail', 'email' );
 
 										echo $pmpro_checkout_confirm_email ? '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ) . '">' : '';
 									?>
 
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-email pmpro_form_field-bemail pmpro_form_field-required', 'pmpro_form_field-bemail' ) ); ?>">
-										<label for="bemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Email Address', 'paid-memberships-pro' );?></label>
-										<input id="bemail" name="bemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email pmpro_form_input-required', 'bemail' ) ); ?>" value="<?php echo esc_attr($bemail); ?>" />
-									</div> <!-- end pmpro_form_field-bemail -->
+										<div class="<?php echo esc_attr( $pmpro_bemail_attr['wrapper_class'] ); ?>">
+											<label for="bemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+												<?php esc_html_e( 'Email Address', 'paid-memberships-pro' ); echo $pmpro_bemail_attr['label']; ?>
+											</label>
+											<input id="bemail" name="bemail" type="email"
+												class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'bemail' ) ) . ' ' . esc_attr( $pmpro_bemail_attr['input_class'] ); ?>"
+												<?php echo $pmpro_bemail_attr['input_attr']; ?>
+												value="<?php echo esc_attr( $bemail ); ?>" />
+										</div> <!-- end pmpro_form_field-bemail -->
 
 									<?php
 										if ( $pmpro_checkout_confirm_email ) {
+											$pmpro_bconfirmemail_attr = pmpro_get_required_field_attributes( 'bconfirmemail', 'email' );
+
 											?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-email pmpro_form_field-bconfirmemail pmpro_form_field-required', 'pmpro_form_field-bconfirmemail' ) ); ?>">
-												<label for="bconfirmemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Confirm Email Address', 'paid-memberships-pro' );?></label>
-												<input id="bconfirmemail" name="bconfirmemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email pmpro_form_input-required', 'bconfirmemail' ) ); ?>" value="<?php echo esc_attr($bconfirmemail); ?>" />
-											</div> <!-- end pmpro_form_field-bconfirmemail -->
+												<div class="<?php echo esc_attr( $pmpro_bconfirmemail_attr['wrapper_class'] ); ?>">
+													<label for="bconfirmemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+														<?php esc_html_e( 'Confirm Email Address', 'paid-memberships-pro' ); echo $pmpro_bconfirmemail_attr['label']; ?>
+													</label>
+													<input id="bconfirmemail" name="bconfirmemail" type="email"
+														class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'bconfirmemail' ) ) . ' ' . esc_attr( $pmpro_bconfirmemail_attr['input_class'] ); ?>"
+														<?php echo $pmpro_bconfirmemail_attr['input_attr']; ?>
+														value="<?php echo esc_attr( $bconfirmemail ); ?>" />
+												</div> <!-- end pmpro_form_field-bconfirmemail -->
 											<?php
 										} else {
 											?>
@@ -389,50 +429,119 @@ if ( empty( $default_gateway ) ) {
 							<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e( 'Billing Address', 'paid-memberships-pro' ); ?></h2>
 						</legend>
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields pmpro_cols-2' ) ); ?>">
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-bfirstname', 'pmpro_form_field-bfirstname' ) ); ?>">
-								<label for="bfirstname" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('First Name', 'paid-memberships-pro' );?></label>
-								<input id="bfirstname" name="bfirstname" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bfirstname' ) ); ?>" value="<?php echo esc_attr($bfirstname); ?>" autocomplete="given-name" />
+							<?php
+								$pmpro_bfirstname_attr = pmpro_get_required_field_attributes( 'bfirstname', 'text' );
+							?>
+							<div class="<?php echo esc_attr( $pmpro_bfirstname_attr['wrapper_class'] ); ?>">
+								<label for="bfirstname" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+									<?php esc_html_e( 'First Name', 'paid-memberships-pro' ); echo $pmpro_bfirstname_attr['label']; ?>
+								</label>
+								<input id="bfirstname" name="bfirstname" type="text"
+									class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bfirstname' ) ) . ' ' . esc_attr( $pmpro_bfirstname_attr['input_class'] ); ?>"
+									<?php echo $pmpro_bfirstname_attr['input_attr']; ?>
+									value="<?php echo esc_attr( $bfirstname ); ?>" autocomplete="given-name" />
 							</div> <!-- end pmpro_form_field-bfirstname -->
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-blastname', 'pmpro_form_field-blastname' ) ); ?>">
-								<label for="blastname" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Last Name', 'paid-memberships-pro' );?></label>
-								<input id="blastname" name="blastname" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'blastname' ) ); ?>" value="<?php echo esc_attr($blastname); ?>" autocomplete="family-name" />
+							<?php
+								$pmpro_blastname_attr = pmpro_get_required_field_attributes( 'blastname', 'text' );
+							?>
+							<div class="<?php echo esc_attr( $pmpro_blastname_attr['wrapper_class'] ); ?>">
+								<label for="blastname" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+									<?php esc_html_e( 'Last Name', 'paid-memberships-pro' ); echo $pmpro_blastname_attr['label']; ?>
+								</label>
+								<input id="blastname" name="blastname" type="text"
+									class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'blastname' ) ) . ' ' . esc_attr( $pmpro_blastname_attr['input_class'] ); ?>"
+									<?php echo $pmpro_blastname_attr['input_attr']; ?>
+									value="<?php echo esc_attr( $blastname ); ?>" autocomplete="family-name" />
 							</div> <!-- end pmpro_form_field-blastname -->
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-baddress1', 'pmpro_form_field-baddress1' ) ); ?>">
-								<label for="baddress1" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Address 1', 'paid-memberships-pro' );?></label>
-								<input id="baddress1" name="baddress1" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'baddress1' ) ); ?>" value="<?php echo esc_attr($baddress1); ?>" autocomplete="billing street-address" />
-							</div> <!-- end pmpro_form_field-baddress1 -->
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-baddress2', 'pmpro_form_field-baddress2' ) ); ?>">
-								<label for="baddress2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Address 2', 'paid-memberships-pro' );?></label>
-								<input id="baddress2" name="baddress2" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'baddress2' ) ); ?>" value="<?php echo esc_attr($baddress2); ?>" />
-							</div> <!-- end pmpro_form_field-baddress2 -->
-								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-bcity', 'pmpro_form_field-bcity' ) ); ?>">
-									<label for="bcity" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('City', 'paid-memberships-pro' );?></label>
-									<input id="bcity" name="bcity" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bcity' ) ); ?>" value="<?php echo esc_attr($bcity); ?>" />
+							<?php
+								$pmpro_baddress1_attr = pmpro_get_required_field_attributes( 'baddress1', 'text' );
+							?>
+								<div class="<?php echo esc_attr( $pmpro_baddress1_attr['wrapper_class'] ); ?>">
+									<label for="baddress1" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+										<?php esc_html_e( 'Address 1', 'paid-memberships-pro' ); echo $pmpro_baddress1_attr['label']; ?>
+									</label>
+									<input id="baddress1" name="baddress1" type="text"
+										class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'baddress1' ) ) . ' ' . esc_attr( $pmpro_baddress1_attr['input_class'] ); ?>"
+										<?php echo $pmpro_baddress1_attr['input_attr']; ?>
+										value="<?php echo esc_attr( $baddress1 ); ?>" autocomplete="billing street-address" />
+								</div> <!-- end pmpro_form_field-baddress1 -->
+
+							<?php
+							$pmpro_baddress2_attr = pmpro_get_required_field_attributes( 'baddress2', 'text' );
+							?>
+								<div class="<?php echo esc_attr( $pmpro_baddress2_attr['wrapper_class'] ); ?>">
+									<label for="baddress2" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+										<?php esc_html_e( 'Address 2', 'paid-memberships-pro' ); echo $pmpro_baddress2_attr['label']; ?>
+									</label>
+									<input id="baddress2" name="baddress2" type="text"
+										class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'baddress2' ) ) . ' ' . esc_attr( $pmpro_baddress2_attr['input_class'] ); ?>"
+										<?php echo $pmpro_baddress2_attr['input_attr']; ?>
+										value="<?php echo esc_attr( $baddress2 ); ?>" />
+								</div> <!-- end pmpro_form_field-baddress2 -->
+								<?php
+									$pmpro_bcity_attr = pmpro_get_required_field_attributes( 'bcity', 'text' );
+								?>
+								<div class="<?php echo esc_attr( $pmpro_bcity_attr['wrapper_class'] ); ?>">
+									<label for="bcity" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+										<?php esc_html_e( 'City', 'paid-memberships-pro' ); echo $pmpro_bcity_attr['label']; ?>
+									</label>
+									<input id="bcity" name="bcity" type="text"
+										class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bcity' ) ) . ' ' . esc_attr( $pmpro_bcity_attr['input_class'] ); ?>"
+										<?php echo $pmpro_bcity_attr['input_attr']; ?>
+										value="<?php echo esc_attr( $bcity ); ?>" />
 								</div> <!-- end pmpro_form_field-bcity -->
-								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-bstate', 'pmpro_form_field-bstate' ) ); ?>">
-									<label for="bstate" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('State', 'paid-memberships-pro' );?></label>
-									<input id="bstate" name="bstate" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bstate' ) ); ?>" value="<?php echo esc_attr($bstate); ?>" />
+
+								<?php
+									$pmpro_bstate_attr = pmpro_get_required_field_attributes( 'bstate', 'text' );
+								?>
+								<div class="<?php echo esc_attr( $pmpro_bstate_attr['wrapper_class'] ); ?>">
+									<label for="bstate" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+										<?php esc_html_e( 'State', 'paid-memberships-pro' ); echo $pmpro_bstate_attr['label']; ?>
+									</label>
+									<input id="bstate" name="bstate" type="text"
+										class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bstate' ) ) . ' ' . esc_attr( $pmpro_bstate_attr['input_class'] ); ?>"
+										<?php echo $pmpro_bstate_attr['input_attr']; ?>
+										value="<?php echo esc_attr( $bstate ); ?>" />
 								</div> <!-- end pmpro_form_field-bstate -->
-								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-bzipcode', 'pmpro_form_field-bzipcode' ) ); ?>">
-									<label for="bzipcode" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Postal Code', 'paid-memberships-pro' );?></label>
-									<input id="bzipcode" name="bzipcode" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bzipcode' ) ); ?>" value="<?php echo esc_attr($bzipcode); ?>" autocomplete="billing postal-code" />
+
+								<?php
+									$pmpro_bzipcode_attr = pmpro_get_required_field_attributes( 'bzipcode', 'text' );
+								?>
+								<div class="<?php echo esc_attr( $pmpro_bzipcode_attr['wrapper_class'] ); ?>">
+									<label for="bzipcode" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+										<?php esc_html_e( 'Postal Code', 'paid-memberships-pro' ); echo $pmpro_bzipcode_attr['label']; ?>
+									</label>
+									<input id="bzipcode" name="bzipcode" type="text"
+										class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bzipcode' ) ) . ' ' . esc_attr( $pmpro_bzipcode_attr['input_class'] ); ?>"
+										<?php echo $pmpro_bzipcode_attr['input_attr']; ?>
+										value="<?php echo esc_attr( $bzipcode ); ?>" autocomplete="billing postal-code" />
 								</div> <!-- end pmpro_form_field-bzipcode -->
 							<?php
 								$show_country = apply_filters("pmpro_international_addresses", true);
 								if($show_country) { ?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-select pmpro_form_field-bcountry', 'pmpro_form_field-bcountry' ) ); ?>">
-										<label for="bcountry" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Country', 'paid-memberships-pro' );?></label>
-										<select name="bcountry" id="bcountry" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'bcountry' ) ); ?>" autocomplete="billing country">
-										<?php
-											global $pmpro_countries, $pmpro_default_country;
-											if(!$bcountry) {
-												$bcountry = $pmpro_default_country;
-											}
-											foreach($pmpro_countries as $abbr => $country) { ?>
-												<option value="<?php echo esc_attr( $abbr ) ?>" <?php if($abbr == $bcountry) { ?>selected="selected"<?php } ?>><?php echo esc_html( $country )?></option>
-											<?php } ?>
-										</select>
-									</div> <!-- end pmpro_form_field-bcountry -->
+									<?php
+										$pmpro_bcountry_attr = pmpro_get_required_field_attributes( 'bcountry', 'select' );
+									?>
+										<div class="<?php echo esc_attr( $pmpro_bcountry_attr['wrapper_class'] ); ?>">
+											<label for="bcountry" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+												<?php esc_html_e( 'Country', 'paid-memberships-pro' ); echo $pmpro_bcountry_attr['label']; ?>
+											</label>
+											<select name="bcountry" id="bcountry"
+												class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'bcountry' ) ) . ' ' . esc_attr( $pmpro_bcountry_attr['input_class'] ); ?>"
+												<?php echo $pmpro_bcountry_attr['input_attr']; ?>
+												autocomplete="billing country">
+												<?php
+													global $pmpro_countries, $pmpro_default_country;
+													if ( ! $bcountry ) {
+														$bcountry = $pmpro_default_country;
+													}
+													foreach ( $pmpro_countries as $abbr => $country ) { ?>
+														<option value="<?php echo esc_attr( $abbr ); ?>" <?php selected( $abbr, $bcountry ); ?>>
+															<?php echo esc_html( $country ); ?>
+														</option>
+													<?php } ?>
+											</select>
+										</div> <!-- end pmpro_form_field-bcountry -->
 								<?php } else { ?>
 									<input type="hidden" name="bcountry" id="bcountry" value="<?php echo esc_attr( $pmpro_default_country ); ?>" />
 								<?php } ?>
@@ -446,25 +555,47 @@ if ( empty( $default_gateway ) ) {
 										$bconfirmemail = $current_user->user_email;
 									}
 								}
+
+								$pmpro_bemail_attr = pmpro_get_required_field_attributes( 'bemail', 'email' );
 							?>
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-email pmpro_form_field-bemail', 'pmpro_form_field-bemail' ) ); ?>">
-								<label for="bemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Email Address', 'paid-memberships-pro' );?></label>
-								<input id="bemail" name="bemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'bemail' ) ); ?>" value="<?php echo esc_attr($bemail); ?>" autocomplete="email" />
+							<div class="<?php echo esc_attr( $pmpro_bemail_attr['wrapper_class'] ); ?>">
+								<label for="bemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+									<?php esc_html_e( 'Email Address', 'paid-memberships-pro' ); echo $pmpro_bemail_attr['label']; ?>
+								</label>
+								<input id="bemail" name="bemail" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>"
+									class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'bemail' ) ) . ' ' . esc_attr( $pmpro_bemail_attr['input_class'] ); ?>"
+									<?php echo $pmpro_bemail_attr['input_attr']; ?>
+									value="<?php echo esc_attr( $bemail ); ?>" autocomplete="email" />
 							</div> <!-- end pmpro_form_field-bemail -->
+
 							<?php
 								$pmpro_checkout_confirm_email = apply_filters("pmpro_checkout_confirm_email", true);
-								if($pmpro_checkout_confirm_email) { ?>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-email pmpro_form_field-bconfirmemail', 'pmpro_form_field-bconfirmemail' ) ); ?>">
-										<label for="bconfirmemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Confirm Email', 'paid-memberships-pro' );?></label>
-										<input id="bconfirmemail" name="bconfirmemail" type="<?php echo ($pmpro_email_field_type ? 'email' : 'text'); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'bconfirmemail' ) ); ?>" value="<?php echo esc_attr($bconfirmemail); ?>" autocomplete="email" />
-									</div> <!-- end pmpro_form_field-bconfirmemail -->
+								if($pmpro_checkout_confirm_email) {
+									$pmpro_bconfirmemail_attr = pmpro_get_required_field_attributes( 'bconfirmemail', 'email' );
+							?>
+								<div class="<?php echo esc_attr( $pmpro_bconfirmemail_attr['wrapper_class'] ); ?>">
+									<label for="bconfirmemail" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+										<?php esc_html_e( 'Confirm Email', 'paid-memberships-pro' ); echo $pmpro_bconfirmemail_attr['label']; ?>
+									</label>
+									<input id="bconfirmemail" name="bconfirmemail" type="<?php echo ( $pmpro_email_field_type ? 'email' : 'text' ); ?>"
+										class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-email', 'bconfirmemail' ) ) . ' ' . esc_attr( $pmpro_bconfirmemail_attr['input_class'] ); ?>"
+										<?php echo $pmpro_bconfirmemail_attr['input_attr']; ?>
+										value="<?php echo esc_attr( $bconfirmemail ); ?>" autocomplete="email" />
+								</div> <!-- end pmpro_form_field-bconfirmemail -->
 								<?php } else { ?>
 									<input type="hidden" name="bconfirmemail_copy" value="1" />
 								<?php } ?>
-							<?php } ?>
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_form_field-bphone', 'pmpro_form_field-bphone' ) ); ?>">
-								<label for="bphone" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Phone', 'paid-memberships-pro' );?></label>
-								<input id="bphone" name="bphone" type="text" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bphone' ) ); ?>" value="<?php echo esc_attr(formatPhone($bphone)); ?>" autocomplete="tel" />
+							<?php }
+								$pmpro_bphone_attr = pmpro_get_required_field_attributes( 'bphone', 'text' );
+							?>
+							<div class="<?php echo esc_attr( $pmpro_bphone_attr['wrapper_class'] ); ?>">
+								<label for="bphone" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>">
+									<?php esc_html_e( 'Phone', 'paid-memberships-pro' ); echo $pmpro_bphone_attr['label']; ?>
+								</label>
+								<input id="bphone" name="bphone" type="text"
+									class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'bphone' ) ) . ' ' . esc_attr( $pmpro_bphone_attr['input_class'] ); ?>"
+									<?php echo $pmpro_bphone_attr['input_attr']; ?>
+									value="<?php echo esc_attr( formatPhone( $bphone ) ); ?>" autocomplete="tel" />
 							</div> <!-- end pmpro_form_field-bphone -->
 						</div> <!-- end pmpro_form_fields -->
 					</div> <!-- end pmpro_card_content -->


### PR DESCRIPTION

 * Add a helper function that takes field name and field type and based on globals required fields, that  can be filtered, return an array with values to build the field HTML block
 * Pull values for each field and build the block based on this.
 * Remove jQuery code that add required stuff without take into consideration filtered required fields.

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/46d9388c-60e6-4c33-84d5-43e6563232cf" />
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/9ce710f2-bfb9-4786-95f8-49b165c5e5c7" />


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of adding required css clases, asterisks and aria attributes  after checkout page DOM's load with jQuery, build blocks in the server side bringing the info from  a helper function based on field name, field type and global required fields ( after potentially filtered ).

Resolves #3165 .

### How to test the changes in this Pull Request:

1. Apply the patch 
2. Create a snippet filtering pmpro_required_billing_fields and pmpro_required_user_fields and try setting and unsetting different fields.
3. Observe that required UI stuff is added or not based on filtered required fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
