### PR TITLE
Fix race condition with Update Manager

### DIFF
--- a/classes/class-pmpro-admin-activity-email.php
+++ b/classes/class-pmpro-admin-activity-email.php
@@ -256,7 +256,6 @@ class PMPro_Admin_Activity_Email extends PMProEmail {
 									// Get Add On statistics.
 									$all_addons   = 0;
 									$update_addons = 0;
-									require_once( PMPRO_DIR . '/includes/addons.php' );
 									$addons        = pmpro_getAddons();
 									$plugin_info   = get_site_transient( 'update_plugins' );
 									foreach ( $addons as $addon ) {

--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -507,9 +507,6 @@ class PMPro_Wisdom_Integration {
 	 * @return array The list of Add Ons categorized by active, inactive, and update available.
 	 */
 	public function get_addons_info() {
-		// This file only is usually only required when is_admin().
-		require_once( PMPRO_DIR . '/includes/addons.php' );
-		
 		// Build the list of Add Ons data to track.
 		$addons      = pmpro_getAddons();
 		$plugin_info = get_site_transient( 'update_plugins' );

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -9,6 +9,11 @@
  * @since 1.8.5
  */
 function pmpro_setupAddonUpdateInfo() {
+	// Only hook these functions in the WP admin.
+	if ( ! is_admin() ) {
+		return;
+	}
+
 	add_filter( 'plugins_api', 'pmpro_plugins_api', 10, 3 );
 	add_filter( 'pre_set_site_transient_update_plugins', 'pmpro_update_plugins_filter' );
 	add_filter( 'http_request_args', 'pmpro_http_request_args_for_addons', 10, 2 );

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -9,17 +9,12 @@
  * @since 1.8.5
  */
 function pmpro_setupAddonUpdateInfo() {
-	// Only hook these functions in the WP admin.
-	if ( ! is_admin() ) {
-		return;
-	}
-
 	add_filter( 'plugins_api', 'pmpro_plugins_api', 10, 3 );
 	add_filter( 'pre_set_site_transient_update_plugins', 'pmpro_update_plugins_filter' );
 	add_filter( 'http_request_args', 'pmpro_http_request_args_for_addons', 10, 2 );
 	add_action( 'update_option_pmpro_license_key', 'pmpro_reset_update_plugins_cache', 10, 2 );
 }
-add_action( 'init', 'pmpro_setupAddonUpdateInfo' );
+add_action( 'admin_init', 'pmpro_setupAddonUpdateInfo' );
 
 /**
  * Get addon information from PMPro server.

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -177,9 +177,7 @@ if ( is_admin() || defined('WP_CLI') ) {
 }
 
 // load plugin updater
-if ( is_admin() ) {
-	require_once( PMPRO_DIR . '/includes/addons.php' );
-}
+require_once( PMPRO_DIR . '/includes/addons.php' );
 
 /*
 	Definitions


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently in core PMPro, `includes/addons.php` is loaded in 3 places:
- Whenever `is_admin()` is `true` (This is the most common case)
- When sending the Admin Activity email
- When sending telemetry data to Wisdom

In the PMPro Update Manager Add On, a duplicate version of `includes/addons.php` is also sometimes loaded after the `init` hook completes. The duplicate version is only loaded if `function_exists()` returns `false` for one of the `addons.php` functions.

Whenever `is_admin()` is true, core PMPro will load `addons.php` when that plugin is initially loaded, meaning that the Update Manager will never try to load the duplicate version. This is good.

Things get trickier with the other two cases (the Admin Activity email and the telemetry data). In these cases, since the core `addons.php` file is not always loaded before `init`, there is a chance that the Update Manager Add On will load its `addons.php` file. If this happens and core PMPro later sends the Admin Activity email or telemetry data, the core PMPro plugin may also try to load its `addons.php` file which does not have the same `function_exists()` safeguards as the Update Manager Add On. This could in turn trigger a fatal error.

Off the top of my head, there are two straightforward solutions here:
1. Add `function_exists()` checks around all of the function declarations in core PMPro
2. Always load the core `addons.php` file when loading the plugin files

Although the `function_exists()` check feels safe, it feels iffy that it will be a toss-up between which `addons.php` file will be loaded when both PMPro and the Update Manager Add On are active. Instead, ensuring that the core PMPro `addons.php` file is always loaded when possible helps to simplify this logic. The main concern here is around performance issues which this PR resolves by only hooking the functions in this file when `is_admin()` is `true`. Otherwise, all functions will be present, but not "active".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
