### PR TITLE
[ENHANCEMENT] Deprecate pmpro_member_shortcode_access filter

### DIFF
--- a/shortcodes/membership.php
+++ b/shortcodes/membership.php
@@ -80,8 +80,14 @@ function pmpro_shortcode_membership($atts, $content=null, $code="")
 		}
 	}
 
-	// Filter the $hasaccess so we can overwrite this for other add ons.
-	$hasaccess = apply_filters( 'pmpro_member_shortcode_access', $hasaccess, $content, $levels, $delay );
+	/**
+	 * Legacy filter to change the access to the content for the [membership] shortcode. Use the
+	 * pmpro_has_membership_level filter instead.
+	 *
+	 * @deprecated TBD
+	 */
+	$hasaccess = apply_filters_deprecated( 'pmpro_member_shortcode_access',
+		array( $hasaccess, $content, $levels, $delay ), 'TBD', 'pmpro_has_membership_level' );
 
 	//to show or not to show
 	if($hasaccess)


### PR DESCRIPTION
 * Just that deprecate the filter. It's better to use pmpro_has_membership_access_filter instead.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:
Deprecate this filter to use pmpro_has_membership_level instead.  The only place the filter is used is in Approvals Add On and it seems it's a bit problematic when isn't passed any level.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. Install Approvals
2. Add a memberships shortcode without level [membership] some content [/membership]
3. Check debug.log file. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
