### PR TITLE
Avoid call to undefined `supports()` method

### DIFF
--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -340,7 +340,7 @@ if ( isset( $_REQUEST['action'] ) && 'link' === $_REQUEST['action'] ) {
 
 	<?php
 	$gateway_object = $subscription->get_gateway_object();
-	if ( method_exists( $gateway_object, 'supports' ) && $gateway_object->supports( 'subscription_sync' ) ) {
+	if ( ! empty( $gateway_object ) && method_exists( $gateway_object, 'supports' ) && $gateway_object->supports( 'subscription_sync' ) ) {
 	?>
 		<a
 			href="<?php echo ( esc_url( wp_nonce_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $subscription->get_id(), 'update' => '1' ), admin_url('admin.php' ) ), 'update', 'pmpro_subscriptions_nonce'  ) ) ); ?>"

--- a/adminpages/subscriptions.php
+++ b/adminpages/subscriptions.php
@@ -338,7 +338,10 @@ if ( isset( $_REQUEST['action'] ) && 'link' === $_REQUEST['action'] ) {
 		<?php esc_html_e( 'Edit Subscription', 'paid-memberships-pro' ); ?>
 	</a>
 
-	<?php if ( $subscription->get_gateway_object()->supports( 'subscription_sync' ) ) { ?>
+	<?php
+	$gateway_object = $subscription->get_gateway_object();
+	if ( method_exists( $gateway_object, 'supports' ) && $gateway_object->supports( 'subscription_sync' ) ) {
+	?>
 		<a
 			href="<?php echo ( esc_url( wp_nonce_url( add_query_arg( array( 'page' => 'pmpro-subscriptions', 'id' => $subscription->get_id(), 'update' => '1' ), admin_url('admin.php' ) ), 'update', 'pmpro_subscriptions_nonce'  ) ) ); ?>"
 			title="<?php esc_attr_e( 'Sync With Gateway', 'paid-memberships-pro' ); ?>" 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes fatal error on the Subscriptions list table if the gateway object for a subscription does not have a `supports()` method defined.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
