### PR TITLE
Page builder check for shortcodes in admin

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5085,7 +5085,10 @@ function pmpro_is_page_builder_editor() {
         return 'Bricks';
     }
 
+	if ( function_exists( 'Breakdance\\isRequestFromBuilderIframe' ) && Breakdance\isRequestFromBuilderIframe() ) {
+		return 'Breakdance/Oxygen';
+	}
 
-    return false;
+	return false;
 
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5038,3 +5038,54 @@ function pmpro_display_member_account_level_message( $level ) {
 	}
 }
 add_action( 'pmpro_membership_account_after_level_card_content', 'pmpro_display_member_account_level_message' );
+
+/**
+ * Check if the current page is being edited with a page builder.
+ *
+ * @return bool True if the page is being edited with a page builder, false otherwise.
+ */
+function pmpro_is_page_builder_editor() {
+
+	// Check that we are editing a post.
+    global $post;
+    if ( ! $post ) {
+        return false;
+    }
+
+    // Check for Elementor.
+    if ( did_action( 'elementor/loaded' ) && isset( $_GET['elementor-preview'] ) ) {
+        return 'Elementor';
+    }
+
+    // Check for Visual Composer
+    if ( function_exists( 'vchelper' ) ) {
+		$frontendHelper = vchelper('Frontend');
+		if ( $frontendHelper->isVcvFrontend() ) {
+			return 'Visual Composer';
+		}
+    }
+
+    // Check for Beaver Builder, they even use the 'fl_builder' param as their check method.
+    if ( class_exists( 'FLBuilderModel' ) && isset( $_GET['fl_builder'] ) ) {
+        return 'Beaver Builder';
+    }
+
+    // Check for Divi Builder.
+    if ( function_exists( 'et_fb_is_enabled' ) && et_core_is_fb_enabled() ) {
+        return 'Divi';
+    }
+
+    // Check for Fusion Builder (Avada).
+    if ( ( function_exists( 'fusion_is_preview_frame' ) && fusion_is_preview_frame() ) || ( function_exists( 'fusion_is_builder_frame' ) && fusion_is_builder_frame() ) ) {
+        return 'Fusion';
+    }
+
+	// Check for Bricks Builder.
+    if ( function_exists( 'bricks_is_builder' ) && bricks_is_builder() ) {
+        return 'Bricks';
+    }
+
+
+    return false;
+
+}

--- a/includes/init.php
+++ b/includes/init.php
@@ -72,8 +72,11 @@ function pmpro_wp()
 		{
 			if( ! empty( $post->post_content ) && ( strpos( $post->post_content, "[pmpro_" . $pmpro_page_name . "]" ) !== false || ( function_exists( 'has_block' ) && has_block( 'pmpro/' . $pmpro_page_name . '-page', $post ) ) ) )
 			{
-				//preheader
-				require_once(PMPRO_DIR . "/preheaders/" . $pmpro_page_name . ".php");
+				// Do not load preheader if we are in the builder because of the redirects they do causing issues.
+				$editor = pmpro_is_page_builder_editor();
+				if ( ! $editor ) {
+					require_once(PMPRO_DIR . "/preheaders/" . $pmpro_page_name . ".php");
+				}
 
 				//add class to body
 				$pmpro_body_classes[] = "pmpro-" . str_replace("_", "-", $pmpro_page_name);


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves #3213

Check if a page builder is active in the admin before loading the preheader for shortcodes. Uses page builder's internal methods whenever possible, falls back to more simple URL param check for some.

Works with:
* Elementor
* Beaver Builder
* Visual Composer
* Divi
* Avada Fusion
* Bricks Builder

### How to test the changes in this Pull Request:

1. Enable a page builder
2. Edit a page with the [pmpro_billing] (or any shortcode to fully test) in the page builder

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Check if a page builder is active in the admin before loading the preheader for shortcodes
