### PR TITLE
Fix so preview of level description in block editor uses line breaks

### DIFF
--- a/blocks/src/single-level-description/edit.js
+++ b/blocks/src/single-level-description/edit.js
@@ -26,7 +26,7 @@ import { Fragment, RawHTML } from '@wordpress/element';
 export default function Edit(props) {
 	const getDescriptionText = (level) => {
 		return pmpro.all_levels_formatted_text[level]
-			? pmpro.all_levels_formatted_text[level].description
+			? pmpro.all_levels_formatted_text[level].formatted_description
 			: null;
 	};
 

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -135,6 +135,7 @@ function pmpro_admin_enqueue_scripts() {
         $all_level_values_and_labels[] = array( 'value' => $level->id, 'label' => $level->name );
 		$level->formatted_price = trim( pmpro_no_quotes( pmpro_getLevelCost( $level, true, true ) ) );
         $level->formatted_expiration = trim( pmpro_no_quotes( pmpro_getLevelExpiration( $level ) ) );
+		$level->formatted_description = apply_filters( 'pmpro_level_description', $level->description, $level );
         $all_levels_formatted_text[$level->id] = $level;
     }
     // Get HTML for empty field group.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When previewing the level description in the editor, line breaks were not being displayed.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
