### PR TITLE
Add "Select Country" at the beginning.

### DIFF
--- a/includes/countries.php
+++ b/includes/countries.php
@@ -256,6 +256,6 @@
 	asort($pmpro_countries);
 
 	// Add the blank option at the start of the array, always.
-	$pmpro_countries = array( ''   => __( 'Select country', 'paid-memberships-pro' ) ) + $pmpro_countries;
+	$pmpro_countries = array( ''   => __( 'Select Country', 'paid-memberships-pro' ) ) + $pmpro_countries;
 
 	$pmpro_countries = apply_filters("pmpro_countries", $pmpro_countries);

--- a/includes/countries.php
+++ b/includes/countries.php
@@ -255,4 +255,7 @@
 
 	asort($pmpro_countries);
 
+	// Add the blank option at the start of the array, always.
+	$pmpro_countries = array( ''   => __( 'Select country', 'paid-memberships-pro' ) ) + $pmpro_countries;
+
 	$pmpro_countries = apply_filters("pmpro_countries", $pmpro_countries);


### PR DESCRIPTION
* ENHANCEMENT: Added "Select Country" at the beginning. This is a great fallback if no default country is set instead of choosing the first valid country.

There are some Add Ons that would benefit from this, any that add a country field to checkout, member profiles etc. While it would work to squeeze the "Select country" in anytime we want to use $pmpro_countries, it's best to solve this at it's core, otherwise we will have to constantly squeeze it in everytime we add this (it may not be often but it seems best practice to do this in core). 

This also makes logic around Javascript onchange type of code easier to manage, and work with and also reduces errors as it would default to "Afghanistan" or any filtered value that was the first value of the array when the default country is not detected at all, as well as required field logic to work and not be bypassed because it would default to a non-zero'd value.

One thing to note here, the State Dropdowns Add On added in logic to "Select Country" and squeeze it in when enqueuing the JavaScript files and values/logic, we will need to do an update once this is merged in and released to avoid duplicate "Select country" options. 

This is better as people can still remove it via the `pmpro_countries` filter with custom development whereas squeezing it in here and there doesn't allow developer's to easily remove it.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
