### PR TITLE
pmpro_member shortcode logs a warning if there's no logged in user in…

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -13,6 +13,10 @@
 function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 	global $current_user;
 
+	//Bail if current user is not logged in
+	if ( ! $current_user->exists() ) {
+		return '';
+	}
 	// Get the attributes and their defaults.
 	extract(
 		shortcode_atts(

--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -13,10 +13,6 @@
 function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 	global $current_user;
 
-	//Bail if current user is not logged in
-	if ( ! $current_user->exists() ) {
-		return '';
-	}
 	// Get the attributes and their defaults.
 	extract(
 		shortcode_atts(
@@ -29,6 +25,11 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 			$atts
 		)
 	);
+
+	//Bail if curent user is not logged in and user_id is not set
+	if ( ! $current_user->exists() && ! $user_id ) {
+		return '';
+	}
 
 	// Bail if there's no field attribute.
 	if ( empty( $field ) ) {


### PR DESCRIPTION
… the system

 * Bail early in the case there's no logged in user in the system

![Screenshot 2025-03-10 at 12 27 44 PM](https://github.com/user-attachments/assets/ae624222-3780-47a4-af68-6e0e38a5211e)
![Screenshot 2025-03-10 at 12 27 29 PM](https://github.com/user-attachments/assets/0b48063e-b1ad-49c5-88a4-570573dd580f)



### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If there's no logged in user bail early.

### How to test the changes in this Pull Request:

1. Without this patch add `[pmpro_member field='display_name']` to a page
2. NAvigate the page in an incognito window
3. See debug log file. A warning is logged due attempt to get field from a User with no data.
4. Apply the patch, with the same steps you should see the log file clean.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
