### PR TITLE
Fixing warning when level description is empty

### DIFF
--- a/blocks/src/single-level-description/render.php
+++ b/blocks/src/single-level-description/render.php
@@ -5,8 +5,8 @@
 
 // Get the level description.
 $level = pmpro_getLevel( $attributes['selected_membership_level'] );
-$level_description = apply_filters( 'pmpro_level_description', $level->description, $level );
-$level_description = wp_kses_post( $level_description );
+$level_description = isset( $level->description ) ? $level->description : '';
+$level_description = wp_kses_post( apply_filters( 'pmpro_level_description', $level_description, $level ) );
 
 // Return if level description is empty.
 if ( empty( $level_description ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If a level does not have a description, there was a warning generated in the logs / frontend. This resolves the warning but preserves the functionality of the filter.
