### PR TITLE
Fixing display value issue for date type user fields stored as YYYY-MM-DD format.

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1677,7 +1677,8 @@ class PMPro_Field {
 					$output = is_numeric( $value ) ? number_format_i18n( $value ) : '';
 					break;
 			case 'date':
-				$output = date_i18n( get_option( 'date_format' ), $value );
+				$timestamp = strtotime( $value );
+				$output = $timestamp ? date_i18n( get_option( 'date_format' ), $timestamp ) : '';
 				break;
 			case 'select':
 			case 'multiselect':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Our date user field type stores the user's information in the format YYYY-MM-DD. The field class' displayValue method, though, was expecting a timestamp.

This update converts the value from usermeta into a timestamp then, if we have a timestamp, sets the field to display in the site's date format. This also resolves cases when the usermeta is empty (was always showing today's date).