### PR TITLE
Make sure the user exists when using pmpro_member.

### DIFF
--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -31,11 +31,16 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		return;
 	}
 
-	// Make sure the user_id is of an existing user.
-	$user = get_userdata( $user_id );
-	if ( ! $user ) {
-		return;
+	// Make sure the user_id is of an existing user when not viewing their own profile.
+	if ( $user_id !== $current_user->ID ) {
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			return;
+		}
+	} else {
+		$user = $current_user;
 	}
+
 
 	// Bail if there's no field attribute.
 	if ( empty( $field ) ) {

--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -26,6 +26,17 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		)
 	);
 
+	// No user_id found, let's bail.
+	if ( ! $user_id ) {
+		return;
+	}
+
+	// Make sure the user_id is of an existing user.
+	$user = get_userdata( $user_id );
+	if ( ! $user ) {
+		return;
+	}
+
 	// Bail if there's no field attribute.
 	if ( empty( $field ) ) {
 		return esc_html__( 'The "field" attribute is required in the pmpro_member shortcode.', 'paid-memberships-pro' );
@@ -155,7 +166,6 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		$r = get_user_meta($user_id, $field, true );
 	} elseif ( in_array( $field, $user_column_fields ) ) {
 		// wp_users column.
-		$user = get_userdata( $user_id );
 		$r    = $user->{$field};
 	} elseif ( $field === 'avatar' ) {
 		// Get the user's avatar.

--- a/shortcodes/pmpro_member.php
+++ b/shortcodes/pmpro_member.php
@@ -31,7 +31,7 @@ function pmpro_member_shortcode( $atts, $content = null, $shortcode_tag = '' ) {
 		return;
 	}
 
-	// Make sure the user_id is of an existing user when not viewing their own profile.
+	// Make sure the user_id is of an existing user when not viewing their own information.
 	if ( $user_id !== $current_user->ID ) {
 		$user = get_userdata( $user_id );
 		if ( ! $user ) {


### PR DESCRIPTION
* BUG FIX: Fixes a warning when the user is logged-out or if an invalid user_id was passed through.

Alternative to #3334.

While most of our `pmpro_` based functions can handle empty `$user_id` values, to save some performance we can check this early on to save resources and time.

The `$user_id` attribute will be set to `0` when someone is logged-out and no parameter is passed in - due to the `$current_user->ID` being the default value, if a non-zero value is passed in we can check that they exist in WordPress. This logic only runs when the logged-in user ID does not match that of the user_id passed in and we can assume they're viewing the content of another WordPress user, so let's make sure they're existing.

This is a bit of logic to help improve performance and avoid warnings as early as possible to save resource time.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. Without this patch add [pmpro_member field='display_name'] to a page.
2. Navigate the page in an incognito window.
3. See debug log file. A warning is logged due attempt to get field from a User with no data.
4. Apply the patch, with the same steps you should see the log file clean. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
