### PR TITLE
[ENHANCEMENT] Add support to test email templates from Add Ons

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -399,12 +399,19 @@ function pmpro_email_templates_send_test() {
 			$params = array($test_user, $test_order,  "http://www.example-notification-url.com/not-a-real-site");
 			break;
 		default:
-			$send_email = 'sendEmail';
-			$params = array();
+			$send_email = apply_filters( 'pmpro_email_template_send_test_email', 'sendEmail', $test_email->template );
+			$params = apply_filters( 'pmpro_email_template_send_test_email_params', array(), $test_email->template );
 	}
 
-	//send the email
-	$response = call_user_func_array(array($test_email, $send_email), $params);
+	//send the email. Let's see if the $send_email exists in the PMProEmail class or we need to look for more wide
+	if ( method_exists( $test_email, $send_email ) ) {
+		$response = call_user_func_array( [$test_email, $send_email], $params );
+	} elseif ( function_exists( $send_email ) ) {
+		$response = call_user_func_array( $send_email, $params );
+	} else {
+		//Should we throw an error or log something here ?
+		$response = false;
+	}
 
 	//return the response
 	echo esc_html( $response );


### PR DESCRIPTION
<img width="665" alt="image" src="https://github.com/user-attachments/assets/41c727dd-9a08-406e-a8aa-625d8fdb9e65" />
![image](https://github.com/user-attachments/assets/e8c89dd4-7e04-4bfa-8b41-e6a70a721afe)


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

 * In the `pmpro_email_templates_send_test` function, filter `$send_email` and `$params` variables to let Add Ons run their own sendMail test function. Besides  call PMProEmail class methods, allow to call global available functions in order to call plugins functions.

Resolves several plugin having issues to test email templates

### How to test the changes in this Pull Request:

1. In order to reproduce follow steps  here -> https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/issues/5
2. 
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
