### PR TITLE
Add textarea user fields to wpautop by default.

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1798,6 +1798,24 @@ class PMPro_Field {
 		// Enforce string as output.
 		$output = (string) $output;
 
+		/**
+		 * Filter the field's output before it's displayed to allow wpautop formatting.
+		 * 
+		 * @since TBD
+		 * 
+		 * @param array $field_types The field types to apply wpautop formatting to.
+		 * @param PMPro_Field $field The field object, which can be used to tweak the formatting for more specific fields or based on value.
+		 */
+		if ( in_array( $this->type, apply_filters( 'pmpro_field_wpautop_field_types', array( 'textarea' ), $this ) ) ) {
+			
+			// Add <p> tags for the allowed html filter if it doesn't already exist for the field type.
+			if ( ! isset( $allowed_html['p'] ) ) {
+				$allowed_html['p'] = array();
+			}
+
+			$output = wpautop( $output );
+		}
+
 		if ( $echo ) {
 			echo wp_kses( $output, $allowed_html );
 		} else {


### PR DESCRIPTION
* ENHANCEMENT: Added support for wpautop for textarea fields.

* ENHANCEMNET: Added a filter 'pmpro_field_wpautop_field_types' which takes an array of field types to enable it for and passes through the $field object for more granular checks. See the code sample below.

Alternative to: #3313 

The idea of implementing this inside the `displayValue` method is to ensure that all areas that output a textarea field (be it an Add On, shortcode or custom code) wouldn't have to manually call `wpautop` in these various places. The filter will allow you to opt-out specific field types if not wanted, or if a specific custom CSS class is added to the field. This filter also is to provision should we add other field types in the future such as HTML, WYSIWG or similar fields that may require the `wpautop` formatting.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves: https://github.com/strangerstudios/paid-memberships-pro/issues/3142

### How to test the changes in this Pull Request:

1. Create a textarea field for a member.
2. Enter various text on multiple lines.
3. Use `[pmpro_member field="my_textarea_field"]` and see the output is honored.

I did run various tests of multiple textareas with the filter being used to remove the `wpautop` from specific ones and only apply to ones with a custom class of `my_custom_class`

```
function my_pmpro_example_wpautop( $field_types, $field ) {
	// Remove the field from being wpautop.
	if ( $field->type === 'textarea' ) {
		$field_types = array_diff( $field_types, array( 'textarea' ) );
	}

	// Check if the $field->class contains a specific CSS class to enable wpautop.
	if ( strpos( $field->class, 'my_custom_class' ) !== false ) {
		$field_types[] = $field->type;
	}

	return $field_types;
}
add_filter( 'pmpro_field_wpautop_field_types', 'my_pmpro_example_wpautop', 10, 2 );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
