### PR TITLE
[BUGFIXING] Refund email templates are not formatting order_total value properly.

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-refund-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-refund-admin.php
@@ -174,7 +174,7 @@ class PMPro_Email_Template_Refund_Admin extends PMPro_Email_Template {
 			'membership_id' => $order->membership_id,
 			'membership_level_name' => $level->name,
 			'order_id' => $order->code,
-			'order_total' => $order->total,
+			'order_total' => $order->get_formatted_total(),
 			'order_date' => date_i18n( get_option( 'date_format' ), $order->timestamp ),
 			'refund_date' => date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) ),
 			'billing_name' => $order->billing->name,

--- a/classes/email-templates/class-pmpro-email-template-refund.php
+++ b/classes/email-templates/class-pmpro-email-template-refund.php
@@ -174,7 +174,7 @@ class PMPro_Email_Template_Refund extends PMPro_Email_Template {
 			'membership_id' => $order->membership_id,
 			'membership_level_name' => $level->name,
 			'order_id' => $order->code,
-			'order_total' => $order->total,
+			'order_total' => $order->get_formatted_total(),
 			'order_date' => date_i18n( get_option( 'date_format' ), $order->timestamp ),
 			'refund_date' => date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) ),
 			'billing_name' => $order->billing->name,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/5e99329f-69eb-42e7-8329-34ee5057ff38)
![image](https://github.com/user-attachments/assets/b297cd5a-056a-4898-90bd-791cac210135)



### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Call `get_formatted_total` instead of  raw `total` function to insert to template data.

### How to test the changes in this Pull Request:

1. Without this patch,   refund some orders and check value isn't formatted.
2. After applying this patch check them again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
