### PR TITLE
[FEATURE] Add Bricks Support

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -82,20 +82,6 @@ function pmpro_compatibility_checker() {
 add_action( 'plugins_loaded', 'pmpro_compatibility_checker' );
 
 /**
- * Load compatibility files for themes that are loaded in the 'after_setup_theme' hook.
- *
- * @since TBD
- */
-function pmpro_check_theme_compats() {
-	if ( class_exists( 'Bricks\Conditions' ) ) {
-		include_once( PMPRO_DIR . '/includes/compatibility/bricks.php' );
-	}
-}
-add_action( 'after_setup_theme', 'pmpro_check_theme_compats' );
-
-
-
-/**
  * Check whether the requirement is met.
  *
  * @since 2.6.4
@@ -141,6 +127,11 @@ function pmpro_compatibility_checker_themes(){
 			'file' => 'divi.php',
 			'check_type' => 'constant',
 			'check_value' => 'ET_BUILDER_THEME' //Adds support for the Divi theme.
+		),
+		array(
+			'file' => 'bricks.php',
+			'check_type' => 'class',
+			'check_value' => 'Bricks\Conditions'
 		)
 	);
 

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -82,6 +82,20 @@ function pmpro_compatibility_checker() {
 add_action( 'plugins_loaded', 'pmpro_compatibility_checker' );
 
 /**
+ * Load compatibility files for themes that are loaded in the 'after_setup_theme' hook.
+ *
+ * @since TBD
+ */
+function pmpro_check_theme_compats() {
+	if ( class_exists( 'Bricks\Conditions' ) ) {
+		include_once( PMPRO_DIR . '/includes/compatibility/bricks.php' );
+	}
+}
+add_action( 'after_setup_theme', 'pmpro_check_theme_compats' );
+
+
+
+/**
  * Check whether the requirement is met.
  *
  * @since 2.6.4

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -44,55 +44,61 @@ function pmpro_bricks_add_condition_group( $groups ) {
  * @return array The modified condition options.
  */
 function pmpro_bricks_add_custom_condition( $options ) {
+	// All Members
 	$options[] = array(
-		'key'   => 'pmpro_membership_level',
-		'label' => esc_html__( 'PMPro Membership Level', 'paid-memberships-pro' ),
+		'key'   => 'pmpro_membership_level_all_members',
+		'label' => esc_html__( 'All Members', 'paid-memberships-pro' ),
 		'group' => 'pmpro',
 		'compare' => array(
 			'type'        => 'select',
 			'options'     => array(
-				'==' => esc_html__( 'Show content to', 'paid-memberships-pro' ),
-				'!=' => esc_html__( 'Hide content from', 'paid-memberships-pro' ),
+				'==' => esc_html__( 'Show content to All Members', 'paid-memberships-pro' ),
+				'!=' => esc_html__( 'Hide content from All Members', 'paid-memberships-pro' ),
+			),
+			'placeholder' => esc_html__( 'Select Comparison', 'paid-memberships-pro' ),
+		),
+		'value'   => array(
+		),
+	);
+
+	// Show for specific members.
+	$options[] = array(
+		'key'   => 'pmpro_membership_level_specific_levels',
+		'label' => esc_html__( 'Specific Membership Levels', 'paid-memberships-pro' ),
+		'group' => 'pmpro',
+		'compare' => array(
+			'type'        => 'select',
+			'options'     => array(
+				'==' => esc_html__( 'Show content to Specific Membership Levels', 'paid-memberships-pro' ),
+				'!=' => esc_html__( 'Hide content from Specific Membership Levels', 'paid-memberships-pro' ),
 			),
 			'placeholder' => esc_html__( 'Select Comparison', 'paid-memberships-pro' ),
 		),
 		'value'   => array(
 			'type'        => 'select',
-			'options'     => pmpro_bricks_get_membership_levels(),
+			'options'     => wp_list_pluck( pmpro_getAllLevels( true ), 'name', 'id' ),
+			'multiple'    => true,
+		),
+	);
+
+	// Non-members
+	$options[] = array(
+		'key'   => 'pmpro_membership_level_logged_in_users',
+		'label' => esc_html__( 'Logged-in users', 'paid-memberships-pro' ),
+		'group' => 'pmpro',
+		'compare' => array(
+			'type'        => 'select',
+			'options'     => array(
+				'==' => esc_html__( 'Show content to Logged-in users', 'paid-memberships-pro' ),
+				'!=' => esc_html__( 'Hide content from Logged-in users', 'paid-memberships-pro' ),
+			),
+			'placeholder' => esc_html__( 'Select Comparison', 'paid-memberships-pro' ),
+		),
+		'value'   => array(
 		),
 	);
 
 	return $options;
-}
-
-/**
- * Get the membership levels for the PMPro condition.
- *
- * Retrieves all PMPro membership levels and structures them for the Bricks Builder dropdown.
- * Includes a "Non-Members" option for users who are not members.
- *
- * @since TBD
- *
- * @see pmpro_getAllLevels()
- * @return array The membership levels formatted for Bricks conditions.
- */
-function pmpro_bricks_get_membership_levels() {
-	$pmpro_levels = pmpro_getAllLevels( true );
-
-	$levels_options_array = array();
-
-	// Add some custom levels_options_array/values to the level ID array.
-	$levels_options_array[-1] = esc_html__( 'All Members', 'paid-memberships-pro' ); // This gets pushed to the bottom no matter what we do. TODO: Bricks must fix this.
-	$levels_options_array[0] = esc_html__( 'Non Members', 'paid-memberships-pro' );
-
-	// Add the membership levels to the levels_options_array.
-	if ( ! empty( $pmpro_levels ) ) {
-		foreach ( $pmpro_levels as $pmpro_level ) {
-			$levels_options_array[ (int) $pmpro_level->id ] = esc_html( $pmpro_level->name );
-		}
-	};
-
-	return $levels_options_array;
 }
 
 /**
@@ -110,63 +116,35 @@ function pmpro_bricks_get_membership_levels() {
  * @return bool The modified result based on the membership level comparison.
  */
 function pmpro_bricks_condition_result( $result, $condition_key, $condition ) {
-	if ( $condition_key !== 'pmpro_membership_level' ) {
+
+	// Check if the condition is a pmpro_ prefixed condition. If not let's bail.
+	if ( strpos( $condition_key, 'pmpro_' ) !== 0 ) {
 		return $result;
 	}
+	
+	// Set up some default variables here.
+	$comparison = 1;
+	$condition_operator = $condition['compare'];
+	$has_access = false;
 
-	// Get the conditional comparison operator.
-	$compare = '==';
-	if ( isset( $condition['compare'] ) ) {
-		$compare = $condition['compare'];
+	// Check for all members.
+	if ( $condition_key === 'pmpro_membership_level_all_members' ) {
+		$user_value = pmpro_hasMembershipLevel();
+		$has_access = pmpro_int_compare( $user_value, $comparison, $condition_operator );
 	}
 
-	// Get the level ID of the condition.
-	$condition_level_id = '';
-	if ( isset( $condition['value'] ) ) {
-		$condition_level_id = $condition['value'];
+	// Check for logged-in non-members.
+	if ( $condition_key === 'pmpro_membership_level_logged_in_users' ) {
+		$user_value = ! pmpro_hasMembershipLevel();
+		$has_access = pmpro_int_compare( $user_value, $comparison, $condition_operator );
+	}
+	
+	// Check for specific membership levels.
+	if ( $condition_key === 'pmpro_membership_level_specific_levels' ) {
+		$user_value = pmpro_hasMembershipLevel( $condition['value'] );
+		$has_access = pmpro_int_compare( $user_value, $comparison, $condition_operator );
 	}
 
-	// Figure out if the member has the relevant condition.
-	return pmpro_bricks_condition_checker( $condition_level_id, $compare );
-}
-
-/**
- * Helper function to figure out if the condition is met or not.
- *
- * @since TBD
- * 
- * @param string $condition_level_id The level ID to check against.
- * @param string $compare The comparison operator, in this case it's either '==' or '!='.
- * @return boolean $condition_met Whether the condition is met.
- */
-function pmpro_bricks_condition_checker( $condition_level_id, $compare ) {
-
-	// Always cast to an integer, to be safe.
-	$condition_level_id = (int) $condition_level_id;
-
-	if ( $condition_level_id > 0 ) {
-		$user_has_level = pmpro_hasMembershipLevel( $condition_level_id );
-	} elseif ( $condition_level_id === 0 ) {
-		$user_has_level = ! pmpro_hasMembershipLevel();
-	} elseif ( $condition_level_id === -1 ) {
-		$user_has_level = pmpro_hasMembershipLevel();
-	}
-
-	// Compare the condition we're looking for.
-	if ( $compare === '==' ) {
-		$condition_met = $user_has_level;
-	} elseif ( $compare === '!=' ) {
-		$condition_met = ! $user_has_level;
-	}
-
-	/**
-	 * Filter to allow bypassing of the condition check for Bricks Builder condition.
-	 * 
-	 * @since TBD
-	 * 
-	 * @param boolean $condition_met Whether the condition is met.
-	 * @param string $condition_level_id The level ID to check against.
-	 * @param string $compare The comparison operator.
-	 */
-	return apply_filters( 'pmpro_bricks_condition_access', $condition_met, $condition_level_id, $compare );
+	// Return the access to the bricks builder. To filter this, use the `pmpro_has_membership_level` filter.
+	return $has_access;
 }

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -9,7 +9,7 @@
  * @link https://academy.bricksbuilder.io/article/element-conditions/
  */
 
-add_filter( 'bricks/conditions/groups', 'pmpro_bricks_add_condition_group', 5 ); // Lower priority to move to top
+add_filter( 'bricks/conditions/groups', 'pmpro_bricks_add_condition_group' );
 add_filter( 'bricks/conditions/options', 'pmpro_bricks_add_custom_condition' );
 add_filter( 'bricks/conditions/result', 'pmpro_bricks_condition_result', 10, 3 );
 

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -141,6 +141,9 @@ function pmpro_bricks_condition_result( $result, $condition_key, $condition ) {
  */
 function pmpro_bricks_condition_checker( $condition_level_id, $compare ) {
 
+	// Always cast to an integer, to be safe.
+	$condition_level_id = (int) $condition_level_id;
+
 	if ( $condition_level_id > 0 ) {
 		$user_has_level = pmpro_hasMembershipLevel( $condition_level_id );
 	} elseif ( $condition_level_id === 0 ) {

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -102,14 +102,10 @@ function pmpro_bricks_add_custom_condition( $options ) {
 }
 
 /**
- * Check the result of the PMPro membership level condition.
- *
- * Evaluates whether the current user meets the selected membership level condition.
- * Treats non-members as having a level of "0".
+ * Check if the user or member should or should not have access to the content.
  *
  * @since TBD
  *
- * @see pmpro_getMembershipLevelsForUser()
  * @param bool   $result        The existing result.
  * @param string $condition_key The condition key.
  * @param array  $condition     The condition details, including 'compare' and 'value'.

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Bricks Builder Compatibility for Paid Memberships Pro (PMPro).
+ *
+ * @since TBD
+ */
+
+add_filter( 'bricks/conditions/groups', 'pmpro_bricks_add_condition_group', 5 ); // Lower priority to move to top
+add_filter( 'bricks/conditions/options', 'pmpro_bricks_add_custom_condition' );
+add_filter( 'bricks/conditions/result', 'pmpro_bricks_condition_result', 10, 3 );
+
+/**
+ * Add the PMPro condition group to the Bricks condition groups.
+ *
+ * @param array $groups The existing condition groups.
+ * @return array The modified condition groups.
+ */
+function pmpro_bricks_add_condition_group( $groups ) {
+	$new_group = [
+		'name'  => 'pmpro',
+		'label' => esc_html__( 'Paid Memberships Pro', 'paid-memberships-pro' ),
+	];
+
+	array_unshift( $groups, $new_group ); // Insert at the beginning
+
+	return $groups;
+}
+
+/**
+ * Add the PMPro membership level condition to the Bricks conditions.
+ *
+ * @param array $options The existing condition options.
+ * @return array The modified condition options.
+ * @since TBD
+ */
+function pmpro_bricks_add_custom_condition( $options ) {
+	$options[] = [
+		'key'   => 'pmpro_membership_level',
+		'label' => esc_html__( 'PMPro Membership Level', 'paid-memberships-pro' ),
+		'group' => 'pmpro',
+		'compare' => [
+			'type'        => 'select',
+			'options'     =>  [
+				'==' => __( 'Has Membership Level', 'paid-memberships-pro' ),
+				'!=' => __( 'Does Not Have Membership Level', 'paid-memberships-pro' ),
+			],
+			'placeholder' => esc_html__( 'Select Comparison', 'paid-memberships-pro' ),
+		],
+		'value'   => [
+			'type'        => 'select',
+			'options'     => pmpro_bricks_get_membership_levels(),
+		],
+	];
+
+	return $options;
+}
+
+/**
+ * Get the membership levels for the PMPro condition.
+ *
+ * @return array The membership levels.
+ * @since TBD
+ */
+function pmpro_bricks_get_membership_levels() {
+	$pmpro_levels = pmpro_getAllLevels( true );
+
+	$options = [];
+
+	if ( ! empty( $pmpro_levels ) ) {
+		foreach ( $pmpro_levels as $pmpro_level ) {
+			$options[ (string) $pmpro_level->id ] = $pmpro_level->name;
+		}
+	}
+
+	$options['0'] = __( 'Non-Members', 'paid-memberships-pro' );
+
+	return $options;
+}
+
+/**
+ * Check the result of the PMPro membership level condition.
+ *
+ * @param bool $result The existing result.
+ * @param string $condition_key The condition key.
+ * @param array $condition The condition.
+ * @return bool The modified result.
+ * @since TBD
+ */
+function pmpro_bricks_condition_result( $result, $condition_key, $condition ) {
+	if ( $condition_key !== 'pmpro_membership_level' ) {
+		return $result;
+	}
+
+	$compare = isset( $condition['compare'] ) ? $condition['compare'] : '==';
+	$user_value = isset( $condition['value'] ) ? (string) $condition['value'] : '';
+
+	$user_levels = pmpro_getMembershipLevelsForUser( get_current_user_id() );
+
+	// If the user has no levels, treat them as non-members.
+	if ( ! is_array( $user_levels ) ) {
+		$user_levels = [];
+	}
+
+	
+	$user_level_ids = array_map( function( $level ) {
+		return (string) $level->id;
+	}, $user_levels );
+
+	// If the user has no levels, treat them as non-members.
+	if ( empty( $user_level_ids ) ) {
+		$user_level_ids[] = '0'; // Treat non-members as '0'
+	}
+
+	// Initialize the condition met variable.
+	$condition_met = false;
+
+	// Check if the user has the level.
+	$has_level = in_array( $user_value, $user_level_ids );
+
+	//$compare can be either '==' or '!='. Determine if the condition is met based on the compare value.
+	$condition_met = $compare === '==' ? $has_level : ! $has_level;
+
+	return $condition_met;
+}

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -135,7 +135,7 @@ function pmpro_bricks_condition_result( $result, $condition_key, $condition ) {
 
 	// Check for logged-in non-members.
 	if ( $condition_key === 'pmpro_membership_level_logged_in_users' ) {
-		$user_value = ! pmpro_hasMembershipLevel();
+		$user_value = pmpro_hasMembershipLevel( 'L' );
 		$has_access = pmpro_int_compare( $user_value, $comparison, $condition_operator );
 	}
 	

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -2,7 +2,11 @@
 /**
  * Bricks Builder Compatibility for Paid Memberships Pro (PMPro).
  *
+ * Adds custom conditions for Bricks Builder based on PMPro membership levels.
+ *
  * @since TBD
+ *
+ * @link https://academy.bricksbuilder.io/article/element-conditions/
  */
 
 add_filter( 'bricks/conditions/groups', 'pmpro_bricks_add_condition_group', 5 ); // Lower priority to move to top
@@ -12,16 +16,20 @@ add_filter( 'bricks/conditions/result', 'pmpro_bricks_condition_result', 10, 3 )
 /**
  * Add the PMPro condition group to the Bricks condition groups.
  *
+ * Inserts the Paid Memberships Pro (PMPro) condition group at the top of the list.
+ *
+ * @since TBD
+ *
  * @param array $groups The existing condition groups.
  * @return array The modified condition groups.
  */
 function pmpro_bricks_add_condition_group( $groups ) {
-	$new_group = [
+	$new_group = array(
 		'name'  => 'pmpro',
 		'label' => esc_html__( 'Paid Memberships Pro', 'paid-memberships-pro' ),
-	];
+	);
 
-	array_unshift( $groups, $new_group ); // Insert at the beginning
+	array_unshift( $groups, $new_group ); // Insert at the beginning.
 
 	return $groups;
 }
@@ -29,28 +37,32 @@ function pmpro_bricks_add_condition_group( $groups ) {
 /**
  * Add the PMPro membership level condition to the Bricks conditions.
  *
+ * Registers a new condition that allows users to check if a user
+ * has a specific membership level in Paid Memberships Pro (PMPro).
+ *
+ * @since TBD
+ *
  * @param array $options The existing condition options.
  * @return array The modified condition options.
- * @since TBD
  */
 function pmpro_bricks_add_custom_condition( $options ) {
-	$options[] = [
+	$options[] = array(
 		'key'   => 'pmpro_membership_level',
 		'label' => esc_html__( 'PMPro Membership Level', 'paid-memberships-pro' ),
 		'group' => 'pmpro',
-		'compare' => [
+		'compare' => array(
 			'type'        => 'select',
-			'options'     =>  [
-				'==' => __( 'Has Membership Level', 'paid-memberships-pro' ),
-				'!=' => __( 'Does Not Have Membership Level', 'paid-memberships-pro' ),
-			],
+			'options'     => array(
+				'==' => esc_html__( 'Has Membership Level', 'paid-memberships-pro' ),
+				'!=' => esc_html__( 'Does Not Have Membership Level', 'paid-memberships-pro' ),
+			),
 			'placeholder' => esc_html__( 'Select Comparison', 'paid-memberships-pro' ),
-		],
-		'value'   => [
+		),
+		'value'   => array(
 			'type'        => 'select',
 			'options'     => pmpro_bricks_get_membership_levels(),
-		],
-	];
+		),
+	);
 
 	return $options;
 }
@@ -58,21 +70,28 @@ function pmpro_bricks_add_custom_condition( $options ) {
 /**
  * Get the membership levels for the PMPro condition.
  *
- * @return array The membership levels.
+ * Retrieves all PMPro membership levels and structures them for the Bricks Builder dropdown.
+ * Includes a "Non-Members" option for users who are not members.
+ *
  * @since TBD
+ *
+ * @see pmpro_getAllLevels()
+ * @return array The membership levels formatted for Bricks conditions.
  */
 function pmpro_bricks_get_membership_levels() {
 	$pmpro_levels = pmpro_getAllLevels( true );
 
-	$options = [];
+	$options = array();
 
+	// Add the membership levels to the options.
 	if ( ! empty( $pmpro_levels ) ) {
 		foreach ( $pmpro_levels as $pmpro_level ) {
-			$options[ (string) $pmpro_level->id ] = $pmpro_level->name;
+			$options[ (string) $pmpro_level->id ] = esc_html__( $pmpro_level->name );
 		}
 	}
 
-	$options['0'] = __( 'Non-Members', 'paid-memberships-pro' );
+	//Add a non-members option.
+	$options['0'] = esc_html__( 'Non Members', 'paid-memberships-pro' );
 
 	return $options;
 }
@@ -80,45 +99,59 @@ function pmpro_bricks_get_membership_levels() {
 /**
  * Check the result of the PMPro membership level condition.
  *
- * @param bool $result The existing result.
- * @param string $condition_key The condition key.
- * @param array $condition The condition.
- * @return bool The modified result.
+ * Evaluates whether the current user meets the selected membership level condition.
+ * Treats non-members as having a level of "0".
+ *
  * @since TBD
+ *
+ * @see pmpro_getMembershipLevelsForUser()
+ * @param bool   $result        The existing result.
+ * @param string $condition_key The condition key.
+ * @param array  $condition     The condition details, including 'compare' and 'value'.
+ * @return bool The modified result based on the membership level comparison.
  */
 function pmpro_bricks_condition_result( $result, $condition_key, $condition ) {
 	if ( $condition_key !== 'pmpro_membership_level' ) {
 		return $result;
 	}
 
-	$compare = isset( $condition['compare'] ) ? $condition['compare'] : '==';
-	$user_value = isset( $condition['value'] ) ? (string) $condition['value'] : '';
+	$compare = '==';
+	if ( isset( $condition['compare'] ) ) {
+		$compare = $condition['compare'];
+	}
+
+	$user_value = '';
+	if ( isset( $condition['value'] ) ) {
+		$user_value = $condition['value'];
+	}
 
 	$user_levels = pmpro_getMembershipLevelsForUser( get_current_user_id() );
 
 	// If the user has no levels, treat them as non-members.
 	if ( ! is_array( $user_levels ) ) {
-		$user_levels = [];
+		$user_levels = array();
 	}
 
-	
 	$user_level_ids = array_map( function( $level ) {
 		return (string) $level->id;
 	}, $user_levels );
 
 	// If the user has no levels, treat them as non-members.
 	if ( empty( $user_level_ids ) ) {
-		$user_level_ids[] = '0'; // Treat non-members as '0'
+		// Use array_push to add the non-members level to the user level ids.
+		array_push( $user_level_ids, '0' );
 	}
-
-	// Initialize the condition met variable.
-	$condition_met = false;
 
 	// Check if the user has the level.
 	$has_level = in_array( $user_value, $user_level_ids );
 
-	//$compare can be either '==' or '!='. Determine if the condition is met based on the compare value.
-	$condition_met = $compare === '==' ? $has_level : ! $has_level;
+	// Determine if the condition is met based on the compare value.
+	$condition_met = false;
+	if ( $compare === '==' ) {
+		$condition_met = $has_level;
+	} elseif ( $compare === '!=' ) {
+		$condition_met = ! $has_level;
+	}
 
 	return $condition_met;
 }

--- a/includes/compatibility/bricks.php
+++ b/includes/compatibility/bricks.php
@@ -133,6 +133,8 @@ function pmpro_bricks_condition_result( $result, $condition_key, $condition ) {
 /**
  * Helper function to figure out if the condition is met or not.
  *
+ * @since TBD
+ * 
  * @param string $condition_level_id The level ID to check against.
  * @param string $compare The comparison operator, in this case it's either '==' or '!='.
  * @return boolean $condition_met Whether the condition is met.


### PR DESCRIPTION

<img width="366" alt="image" src="https://github.com/user-attachments/assets/d750b0e7-a7be-4564-a05b-9be5ddc84d41" />
<img width="288" alt="image" src="https://github.com/user-attachments/assets/b6808285-d7a5-4cca-a46a-202d9f133550" />


### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

-  Add a new callback function to add compat file on `after_setup_theme` to be able to load Bricks compat file ensurins only loads if Bricks is active.
- Add a compat file that adds a new condition to Bricks builder functionality letting builders add conditions related to users PMPro levels memberships.



### How to test the changes in this Pull Request:

1. In order to test this patch, you have to install Bricks page builder ( I used V 1.10.3 )
2. Create a page, and in that page go to edit with bricks and add an element. 
3. Click conditions icon and look for PAID MEMBERSHIPS PRO group and add a condition. 
4. Conditions are user has a membership level and user does not have level below. In both cases a level can be added in a dropdown below

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
