### PR TITLE
Add != or <> to pmpro_int_compare

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4082,9 +4082,12 @@ function pmpro_check_plugin_version( $plugin_file, $comparison, $version ) {
  * Compare two integers using parameters similar to the version_compare function.
  * This allows us to pass in a comparison character via the notification rules
  * and get a true/false result.
+ *
+ * @since TBD Added support for != and <>.
+ *
  * @param int $a First integer to compare.
  * @param int $b Second integer to compare.
- * @param string $operator Operator to use, e.g. >, <, >=, <=, =.
+ * @param string $operator Operator to use, e.g. >, <, >=, <=, =, !=.
  * @return bool true or false based on the operator passed in. Returns null for invalid operators.
  */
 function pmpro_int_compare( $a, $b, $operator ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4105,6 +4105,10 @@ function pmpro_int_compare( $a, $b, $operator ) {
 		case '==':
 			$r = (int)$a == (int)$b;
 			break;
+		case '!=':
+		case '<>':
+			$r = (int)$a != (int)$b;
+			break;
 		default:
 			$r = null;
 	}


### PR DESCRIPTION
* ENHANCEMENT: Added support for not equals '<>' and '!=' operator for the pmpro_int_compare function.


TL;DR - It makes the pmpro_int_compare function easier to work with in some cases for not equals.

While you could do `pmpro_int_compare( $a, $b, '==' );` and check the inverse of the comparison when wanting to check for "not equals" it makes it easier to work with when allowing the not equals operators in this function.

This makes it a bit easier to expect a true result when using this code and making it a little bit easier to understand.

For example:

```
$operator = '!=';

if ( pmpro_int_compare( $value1, $value2, $operator) {
// Let's do something when it's true
}
```

Let me know if this doesn't make sense.
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?