### PR TITLE
[BUGFIXING] Membership Expiring Email Displays Incorrect Membership Level Name with Multiple Levels

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -21,7 +21,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
+	 * @param int $membership_level_id The membership level id of the membership level that expired.
 	 */
 	public function __construct( WP_User $user, int $membership_level_id ) {
 		$this->user = $user;
@@ -138,8 +138,9 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 */
 	public function get_email_template_variables() {
 		global $wpdb;
+		$membership_id = $this->membership_level_id;
 		// If we don't have a level ID, query the user's most recently expired level from the database.
-		if ( empty( $this->membership_id ) ) {
+		if ( empty( $membership_id ) ) {
 			$membership_id = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT membership_id FROM $wpdb->pmpro_memberships_users

--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -13,7 +13,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 *
 	 * @var int
 	 */
-	protected $membership_level_id;
+	protected $membership_id;
 
 	/**
 	 * Constructor.
@@ -21,11 +21,11 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_level_id The membership level id of the membership level that expired.
+	 * @param int $membership_id The membership level id of the membership level that expired.
 	 */
-	public function __construct( WP_User $user, int $membership_level_id ) {
+	public function __construct( WP_User $user, int $membership_id ) {
 		$this->user = $user;
-		$this->membership_level_id = $membership_level_id;
+		$this->membership_level_id = $membership_id;
 	}
 
 	/**
@@ -138,7 +138,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 */
 	public function get_email_template_variables() {
 		global $wpdb;
-		$membership_id = $this->membership_level_id;
+		$membership_id = $this->membership_id;
 		// If we don't have a level ID, query the user's most recently expired level from the database.
 		if ( empty( $membership_id ) ) {
 			$membership_id = $wpdb->get_var(
@@ -152,7 +152,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 				)
 			);
 
-			// If we still don't have a level ID, bail.
+			// If we still don't have a level ID, set it to no level ID.
 			if ( empty( $membership_id ) ) {
 				$membership_id = 0;
 			}

--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -13,7 +13,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 *
 	 * @var int
 	 */
-	protected $membership_id;
+	protected $membership_level_id;
 
 	/**
 	 * Constructor.
@@ -21,11 +21,11 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
+	 * @param int $membership_level_id The membership level id of the membership level that expired.
 	 */
-	public function __construct( WP_User $user, int $membership_id ) {
+	public function __construct( WP_User $user, int $membership_level_id ) {
 		$this->user = $user;
-		$this->membership_level_id = $membership_id;
+		$this->membership_level_id = $membership_level_id;
 	}
 
 	/**
@@ -138,10 +138,10 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 */
 	public function get_email_template_variables() {
 		global $wpdb;
-		$membership_id = $this->membership_id;
+		$membership_level_id = $this->membership_level_id;
 		// If we don't have a level ID, query the user's most recently expired level from the database.
-		if ( empty( $membership_id ) ) {
-			$membership_id = $wpdb->get_var(
+		if ( empty( $membership_level_id ) ) {
+			$membership_level_id = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT membership_id FROM $wpdb->pmpro_memberships_users
 					WHERE user_id = %d
@@ -153,13 +153,13 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 			);
 
 			// If we still don't have a level ID, set it to no level ID.
-			if ( empty( $membership_id ) ) {
-				$membership_id = 0;
+			if ( empty( $membership_level_id ) ) {
+				$membership_level_id = 0;
 			}
 		}
 
 		// Get the membership level object.
-		$membership_level = pmpro_getLevel( $membership_id );
+		$membership_level = pmpro_getLevel( $membership_level_id );
 
 		return array(
 			"subject" => $this->get_default_subject(),

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -139,8 +139,9 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	 */
 	public function get_email_template_variables() {
 		global $wpdb;
+		$membership_id = $this->membership_id;
 		// If we don't have a level ID, query the user's most recently expired level from the database.
-		if ( empty( $this->membership_id ) ) {
+		if ( empty( $membership_id ) ) {
 			$membership_id = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT membership_id FROM $wpdb->pmpro_memberships_users
@@ -160,9 +161,9 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 
 		// Get the membership level object.
 		if ( empty( $membership_id ) ) {
-			$membership_level = pmpro_getMembershipLevelForUser($this->user->ID);
+			$membership_level = pmpro_getMembershipLevelForUser( $this->user->ID );
 		} else {
-			$membership_level = pmpro_getSpecificMembershipLevelForUser($this->user->ID, $membership_id);
+			$membership_level = pmpro_getSpecificMembershipLevelForUser( $this->user->ID, $membership_id );
 		}
 
 		return array(

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -13,7 +13,7 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	 *
 	 * @var int
 	 */
-	protected $membership_id;
+	protected $membership_level_id;
 
 	/**
 	 * Constructor.
@@ -21,11 +21,11 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
+	 * @param int $membership_level_id The membership level id of the membership level that expired.
 	 */
-	public function __construct( WP_User $user, int $membership_id ) {
+	public function __construct( WP_User $user, int $membership_level_id ) {
 		$this->user = $user;
-		$this->membership_id = $membership_id;
+		$this->membership_level_id = $membership_level_id;
 	}
 
 	/**
@@ -139,10 +139,10 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	 */
 	public function get_email_template_variables() {
 		global $wpdb;
-		$membership_id = $this->membership_id;
+		$membership_level_id = $this->membership_level_id;
 		// If we don't have a level ID, query the user's most recently expired level from the database.
-		if ( empty( $membership_id ) ) {
-			$membership_id = $wpdb->get_var(
+		if ( empty( $membership_level_id ) ) {
+			$membership_level_id = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT membership_id FROM $wpdb->pmpro_memberships_users
 					WHERE user_id = %d
@@ -154,16 +154,16 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 			);
 
 			// If we still don't have a level ID, set it to no level ID.
-			if ( empty( $membership_id ) ) {
-				$membership_id = 0;
+			if ( empty( $membership_level_id ) ) {
+				$membership_level_id = 0;
 			}
 		}
 
 		// Get the membership level object.
-		if ( empty( $membership_id ) ) {
+		if ( empty( $membership_level_id ) ) {
 			$membership_level = pmpro_getMembershipLevelForUser( $this->user->ID );
 		} else {
-			$membership_level = pmpro_getSpecificMembershipLevelForUser( $this->user->ID, $membership_id );
+			$membership_level = pmpro_getSpecificMembershipLevelForUser( $this->user->ID, $membership_level_id );
 		}
 
 		return array(

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -153,7 +153,7 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 				)
 			);
 
-			// If we still don't have a level ID, bail.
+			// If we still don't have a level ID, set it to no level ID.
 			if ( empty( $membership_id ) ) {
 				$membership_id = 0;
 			}


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Rely on passed by param membership id to retrieve level name inserted to email data.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3346 

### How to test the changes in this Pull Request:

Follow steps in the issue above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
