### PR TITLE
[BUGFIXING] Header and Footer are logging a warning due te lack of subject when save template on edit template page.

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -200,10 +200,7 @@ function pmpro_email_templates_save_template_data() {
 	}
 
 	$template = sanitize_text_field( $_REQUEST['template'] );
-	$subject = '';
-	if( isset( $_REQUEST['subject'] ) ) {
-		$subject = sanitize_text_field( wp_unslash( $_REQUEST['subject'] ) );
-	}
+	$subject = isset( $_REQUEST['subject'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['subject'] ) ) : '';
 	$body = pmpro_kses( wp_unslash( $_REQUEST['body'] ), 'email' );	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 	//update this template's settings

--- a/includes/email.php
+++ b/includes/email.php
@@ -200,7 +200,10 @@ function pmpro_email_templates_save_template_data() {
 	}
 
 	$template = sanitize_text_field( $_REQUEST['template'] );
-	$subject = sanitize_text_field( wp_unslash( $_REQUEST['subject'] ) );
+	$subject = '';
+	if( isset( $_REQUEST['subject'] ) ) {
+		$subject = sanitize_text_field( wp_unslash( $_REQUEST['subject'] ) );
+	}
 	$body = pmpro_kses( wp_unslash( $_REQUEST['body'] ), 'email' );	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 	//update this template's settings


### PR DESCRIPTION

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/da03d50e-d5da-413c-aa78-b2c71165ac01" />

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### Changes proposed in this Pull Request:

Check the `$_REQUEST['subject']` isset


### How to test the changes in this Pull Request:

1. Without this patch, go to the header or footer email template and save the template.
2. Check the logs.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
