### PR TITLE
[FEATURE] User Avatars

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-user-info.php
@@ -112,8 +112,11 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 			<tr class="form-field">
 				<th scope="row"><label for="last_name"><?php esc_html_e( 'Last Name', 'paid-memberships-pro' ); ?></label></th>
 				<td><input type="text" name="last_name" id="last_name" autocomplete="off" value="<?php echo esc_attr( $last_name ); ?>" <?php echo esc_attr( $disable_fields ); ?>></td>
-			</tr>						
+			</tr>
 			<?php
+			// Show the avatar field.
+			pmpro_display_avatar_field( $user->ID, 'tr' );
+
 			// Only show for new users.
 			if ( empty( $user->ID ) && current_user_can( 'edit_users' ) ) {
 				?>
@@ -307,6 +310,9 @@ class PMPro_Member_Edit_Panel_User_Info extends PMPro_Member_Edit_Panel {
 			// Add other user meta
 			$user_notes = ! empty( $_POST['user_notes'] ) ? sanitize_textarea_field( $_POST['user_notes'] ) : '';
 			update_user_meta( $user_id, 'user_notes', $user_notes );
+
+			// Save the avatar.
+			pmpro_save_avatar_field( $user_id );
 
 			// Set message and redirect if this is a new user.		
 			if ( $update ) {

--- a/includes/avatars.php
+++ b/includes/avatars.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Filter the normal avatar data and show our avatar if set.
+ *
+ * @since TBD
+ *
+ * @param array $args        Arguments passed to get_avatar_data(), after processing.
+ * @param mixed $id_or_email The avatar to retrieve. Accepts a user_id, Gravatar MD5 hash,
+ *                           user email, WP_User object, WP_Post object, or WP_Comment object.
+ * @return array             The filtered avatar data.
+ */
+function pmpro_get_avatar_data( $args, $id_or_email ) {
+	if ( ! empty( $args['force_default'] ) ) {
+		return $args;
+	}
+
+	// Determine if we received an ID or string. Then, set the $user_id variable.
+	if ( is_numeric( $id_or_email ) && 0 < $id_or_email ) {
+		$user_id = (int) $id_or_email;
+	} elseif ( is_object( $id_or_email ) && isset( $id_or_email->user_id ) && 0 < $id_or_email->user_id ) {
+		$user_id = $id_or_email->user_id;
+	} elseif ( is_object( $id_or_email ) && isset( $id_or_email->ID ) && isset( $id_or_email->user_login ) && 0 < $id_or_email->ID ) {
+		$user_id = $id_or_email->ID;
+	} elseif ( is_string( $id_or_email ) && false !== strpos( $id_or_email, '@' ) ) {
+		$_user = get_user_by( 'email', $id_or_email );
+
+		if ( ! empty( $_user ) ) {
+			$user_id = $_user->ID;
+		}
+	}
+
+	if ( empty( $user_id ) ) {
+		return $args;
+	}
+
+	$user_avatar_url = null;
+
+	// Get the user's local avatar from usermeta.
+	$avatar_value = get_user_meta( $user_id, 'pmpro_avatar', true );
+
+	if ( empty( $avatar_value ) ) {
+		// TODO: Maybe try to pull from other avatar plugins.
+	}
+
+	$size = (int) $args['size'];
+
+	// Generate a new size
+	if ( empty( $avatar_value[ 'resized_' . $size ] ) && ! empty( $avatar_value['fullpath'] ) ) {
+
+		$upload_path      = wp_upload_dir();
+		$avatar_full_path = str_replace( $upload_path['baseurl'], $upload_path['basedir'], $avatar_value['fullpath'] );
+		$image            = wp_get_image_editor( $avatar_full_path );
+		$image_sized      = null;
+
+		if ( ! is_wp_error( $image ) ) {
+			$image->resize( $size, $size, true );
+			$image_sized = $image->save();
+		}
+
+		// Deal with original being >= to original image (or lack of sizing ability).
+		if ( empty( $image_sized ) || is_wp_error( $image_sized ) ) {
+			$avatar_value[ 'resized_' . $size ] = $avatar_value['fullpath'];
+		} else {
+			$avatar_value[ 'resized_' . $size ] = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $image_sized['path'] );
+			update_user_meta( $user_id, 'pmpro_avatar', $avatar_value );
+		}
+
+		// Save updated avatar sizes
+		update_user_meta( $user_id, 'pmpro_avatar', $avatar_value );
+
+	} elseif ( ! empty( $avatar_value[ 'resized_' . $size ] ) && substr( $avatar_value[ 'resized_' . $size ], 0, 4 ) != 'http' ) {
+		$avatar_value[ 'resized_' . $size ] = home_url( $avatar_value[ 'resized_' . $size ] );
+	}
+
+	if ( ! empty( $avatar_value[ 'resized_' . $size ] ) && is_ssl() ) {
+		$avatar_value[ 'resized_' . $size ] = str_replace( 'http:', 'https:', $avatar_value[ 'resized_' . $size ] );
+	}
+
+	$user_avatar_url = empty( $avatar_value[ 'resized_' . $size ] ) ? null : $avatar_value[ 'resized_' . $size ];
+
+	if ( $user_avatar_url ) {
+		$args['url'] = $user_avatar_url;
+		$args['found_avatar'] = true;
+	}
+
+	return $args;
+}
+add_filter( 'get_avatar_data', 'pmpro_get_avatar_data', 100, 2 );
+
+/**
+ * Set up the pmpro_avatar user field.
+ *
+ * @since TBD
+ */
+function pmpro_set_up_avatar_field() {
+	// Set up the user field group.
+	$field_group = PMPro_Field_Group::add( 'user_avatar', esc_html__( 'User Avatar', 'paid-memberships-pro' ) );
+
+	// Add the avatar field.
+	$field_group->add_field(
+		new PMPro_Field(
+			'pmpro_avatar',
+			'file',
+			array(
+				'allowed_file_types' => 'png,jpg,jpeg,jpe,gif',
+				'max_file_size' => 1024 * 1024 * 2, // 2MB.
+				'preview' => true,
+				'profile' => false, // Whenever we use this field, we're going to weave it into the user info sections.
+			)
+		)
+	);
+}
+add_action( 'init', 'pmpro_set_up_avatar_field' );
+
+/**
+ * Display the pmpro_avatar field for a user.
+ *
+ * @since TBD
+ *
+ * @param int $user_id The ID of the user to display the avatar for.
+ * @param string $markup Whether to show the field in "div" or "tr" format.
+ */
+function pmpro_display_avatar_field( $user_id, $markup ) {
+	// Get the current field value.
+	$avatar_value = get_user_meta( $user_id, 'pmpro_avatar', true );
+
+	// Show the markup before the label and field.
+	if ( 'tr' === $markup ) {
+		echo '<tr><th>';
+	} else {
+		echo '<div class="pmpro_user_field pmpro_avatar">';
+	}
+
+	// Show the label.
+	echo '<label for="pmpro_avatar">' . esc_html__( 'Profile Picture', 'paid-memberships-pro' ) . '</label>';
+
+	// Show the markup between the label and field.
+	if ( 'tr' === $markup ) {
+		echo '</th><td>';
+	}
+
+	// Display the field.
+	PMPro_Field_Group::get_field( 'pmpro_avatar' )->display( $avatar_value );
+
+	// Show the markup after the field.
+	if ( 'tr' === $markup ) {
+		echo '</td></tr>';
+	} else {
+		echo '</div>';
+	}
+}
+
+/**
+ * Save the pmpro_avatar field for a user.
+ *
+ * @since TBD
+ *
+ * @param int $user_id The ID of the user to save the avatar for.
+ */
+function pmpro_save_avatar_field( $user_id ) {
+	// Before a user switches avatars, we should make sure all custom-sized versions of the previous avatar are unlinked and deleted.
+	$avatar_value = get_user_meta( $user_id, 'pmpro_avatar', true );
+	if ( ! empty($avatar_value ) && is_array( $avatar_value ) ) {
+		$upload_path = wp_upload_dir();
+		foreach ( $avatar_value as $key => $value ) {
+			// Only delete resized images.
+			if ( substr( $key, 0, 8 ) !== 'resized_' ) {
+				continue;
+			}
+
+			// If this is somehow the same file as the fullpath, don't delete it.
+			if ( $value === $avatar_value['fullpath'] ) {
+				continue;
+			}
+
+			// Delete the file.
+			@unlink( str_replace( $upload_path['baseurl'], $upload_path['basedir'], $value ) );
+			unset( $avatar_value[ $key ] );
+		}
+
+		// Save the updated avatar array in case the rest of the update fails.
+		update_user_meta( $user_id, 'pmpro_avatar', $avatar_value );
+	}
+
+	// Save the field.
+	PMPro_Field_Group::get_field( 'pmpro_avatar' )->save_field_for_user( $user_id );
+}

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -1081,6 +1081,11 @@ function pmpro_member_profile_edit_form() {
 		<?php } else {
 			// Save updated profile fields.
 			wp_update_user( $user );
+
+			// Save updated profile picture.
+			pmpro_save_avatar_field( $user->ID );
+
+			// Profile updated message.
 			?>
 			<div role="alert" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message pmpro_success', 'pmpro_success' ) ); ?>">
 				<?php esc_html_e( 'Your profile has been updated.', 'paid-memberships-pro' ); ?>
@@ -1146,6 +1151,10 @@ function pmpro_member_profile_edit_form() {
 										</div>	<!-- end pmpro_form_field -->
 									<?php } ?>
 								</div> <!-- end pmpro_form_fields -->
+								<?php
+								// Show avatar field.
+								pmpro_display_avatar_field( $current_user->ID, 'div' );
+								?>
 							</fieldset> <!-- end pmpro_member_profile_edit-account-information -->
 
 							<?php

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -130,6 +130,7 @@ require_once( PMPRO_DIR . '/includes/spam.php' );					// code to combat spam of 
 require_once( PMPRO_DIR . '/includes/abandoned-signups.php' );		// track users who were created at checkout but did not complete checkout.
 require_once( PMPRO_DIR . '/includes/checkout.php' );		        // Common functions used at checkout.
 require_once( PMPRO_DIR . '/includes/level-groups.php' );		    // Common functions for level groups.
+require_once( PMPRO_DIR . '/includes/avatars.php' );		        // Common functions for avatars.
 
 require_once( PMPRO_DIR . '/includes/xmlrpc.php' );                 // xmlrpc methods
 require_once( PMPRO_DIR . '/includes/rest-api.php' );               // rest API endpoints


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds avatar management to core PMPro.

Currently, avatars can be updated on the user's frontend profile or on the Edit Member page:
![Screenshot 2025-03-24 at 2 57 13 PM](https://github.com/user-attachments/assets/deb2618d-8202-4463-a9ac-aa4d34788a7c)
![Screenshot 2025-03-24 at 2 57 40 PM](https://github.com/user-attachments/assets/efb16dbb-08a4-465f-9ec0-dbcf22f15f57)

Then, when an avatar is retrieved for a user, PMPro will update the avatar to be the uploaded file instead.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
