### PR TITLE
Minor refactor to Email Template Classes

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
@@ -13,7 +13,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	 *
 	 * @var int
 	 */
-	protected $level_id;
+	protected $membership_level_id;
 
 	/**
 	 * Constructor.
@@ -21,11 +21,11 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $level_id The id of the level that was cancelled.
+	 * @param int $membership_level_id The id of the level that was cancelled.
 	 */
-	public function __construct( WP_User $user,  int $level_id ) {
+	public function __construct( WP_User $user,  int $membership_level_id ) {
 		$this->user = $user;
-		$this->level_id = $level_id;
+		$this->membership_level_id = $membership_level_id;
 	}
 
 	/**
@@ -145,7 +145,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	 */
 	public function get_email_template_variables() {
 		$user = $this->user;
-		$level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $this->level_id );
+		$level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $this->membership_level_id );
 
 		$email_template_variables = array(
 			'name' => $user->display_name,

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php
@@ -9,7 +9,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	protected $user;
 
 	/**
-	 *  The level id object of the level that was cancelled.
+	 *  The level ID of the level that was cancelled.
 	 *
 	 * @var int
 	 */
@@ -21,7 +21,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date_Admin extends PMPro_Email
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_level_id The id of the level that was cancelled.
+	 * @param int $membership_level_id The ID of the level that was cancelled.
 	 */
 	public function __construct( WP_User $user,  int $membership_level_id ) {
 		$this->user = $user;

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
@@ -14,9 +14,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	 *
 	 * @var int
 	 */
-	protected $level_id;
-
-
+	protected $membership_level_id;
 
 	/**
 	 * Constructor.
@@ -24,11 +22,11 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $level_id The id of the level that was cancelled.
+	 * @param int $membership_level_id The id of the level that was cancelled.
 	 */
-	public function __construct( WP_User $user,  int $level_id ) {
+	public function __construct( WP_User $user,  int $membership_level_id ) {
 		$this->user = $user;
-		$this->level_id = $level_id;
+		$this->membership_level_id = $membership_level_id;
 	}
 
 	/**
@@ -142,7 +140,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	 */
 	public function get_email_template_variables() {
 		$user = $this->user;
-		$level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $this->level_id );
+		$level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $this->membership_level_id );
 
 		$email_template_variables = array(
 			'name' => $user->display_name,

--- a/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php
@@ -10,7 +10,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	protected $user;
 
 	/**
-	 *  The level id object of the level that was cancelled.
+	 *  The level ID of the level that was cancelled.
 	 *
 	 * @var int
 	 */
@@ -22,7 +22,7 @@ class PMPro_Email_Template_Cancel_On_Next_Payment_Date extends PMPro_Email_Templ
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_level_id The id of the level that was cancelled.
+	 * @param int $membership_level_id The ID of the level that was cancelled.
 	 */
 	public function __construct( WP_User $user,  int $membership_level_id ) {
 		$this->user = $user;

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -15,7 +15,6 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 	 */
 	protected $order;
 
-
 	/**
 	 * Constructor.
 	 *

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -16,7 +16,7 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 	protected $order;
 
 
-		/**
+	/**
 	 * Constructor.
 	 *
 	 * @since 3.4

--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -9,7 +9,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	protected $user;
 
 	/**
-	 * The membership level that expired.
+	 * The membership level ID that expired.
 	 *
 	 * @var int
 	 */
@@ -21,7 +21,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
+	 * @param int $membership_id The membership level ID of the membership level that expired.
 	 */
 	public function __construct( WP_User $user, int $membership_level_id ) {
 		$this->user = $user;

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -9,7 +9,7 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	protected $user;
 
 	/**
-	 * The membership level that expired.
+	 * The membership level ID of the membership level that is expiring soon.
 	 *
 	 * @var int
 	 */
@@ -21,7 +21,7 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
+	 * @param int $membership_id The membership level ID of the membership level that is expiring soon.
 	 */
 	public function __construct( WP_User $user, int $membership_id ) {
 		$this->user = $user;

--- a/classes/email-templates/class-pmpro-email-template-membership-recurring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-recurring.php
@@ -13,8 +13,7 @@ class PMPro_Email_Template_Membership_Recurring extends PMPro_Email_Template {
 	 *
 	 * @since 3.4
 	 *
-	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
+	 * @param PMPro_Subscription $subscription_obj The PMPro subscription object.
 	 */
 	public function __construct( PMPro_Subscription $subscription_obj ) {
 		$this->subscription_obj = $subscription_obj;

--- a/classes/email-templates/class-pmpro-email-template-membership-recurring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-recurring.php
@@ -2,7 +2,7 @@
 class PMPro_Email_Template_Membership_Recurring extends PMPro_Email_Template {
 
 	/**
-	 * The user object of the user to send the email to.
+	 * The subscription object relating to this transaction.
 	 *
 	 * @var PMPro_Subscription
 	 */

--- a/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
@@ -20,7 +20,6 @@ class PMPro_Email_Template_Payment_Action_Admin extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
 	 * @param string $order_url The URL of the order.
 	 */
 	public function __construct( WP_User $user, string $order_url ) {

--- a/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action-admin.php
@@ -11,6 +11,7 @@ class PMPro_Email_Template_Payment_Action_Admin extends PMPro_Email_Template {
 	/**
 	 * The URL of the order.
 	 * 
+	 * @var string
 	 */
 	protected $order_url;
 

--- a/classes/email-templates/class-pmpro-email-template-payment-action.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action.php
@@ -20,7 +20,6 @@ class PMPro_Email_Template_Payment_Action extends PMPro_Email_Template {
 	 * @since 3.4
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
-	 * @param int $membership_id The membership level id of the membership level that expired.
 	 * @param string $order_url The URL of the order.
 	 */
 	public function __construct( WP_User $user, string $order_url ) {

--- a/classes/email-templates/class-pmpro-email-template-payment-action.php
+++ b/classes/email-templates/class-pmpro-email-template-payment-action.php
@@ -11,6 +11,7 @@ class PMPro_Email_Template_Payment_Action extends PMPro_Email_Template {
 	/**
 	 * The URL of the order.
 	 * 
+	 * @var string
 	 */
 	protected $order_url;
 

--- a/classes/email-templates/class-pmpro-email-template-refund-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-refund-admin.php
@@ -9,7 +9,7 @@ class PMPro_Email_Template_Refund_Admin extends PMPro_Email_Template {
 	protected $user;
 
 	/**
-	 * The {@link MemberOrder} object of the order that was updated.
+	 * The {@link MemberOrder} object of the order that was refunded.
 	 *
 	 * @var MemberOrder
 	 */

--- a/classes/email-templates/class-pmpro-email-template-refund.php
+++ b/classes/email-templates/class-pmpro-email-template-refund.php
@@ -9,7 +9,7 @@ class PMPro_Email_Template_Refund extends PMPro_Email_Template {
 	protected $user;
 
 	/**
-	 * The {@link MemberOrder} object of the order that was updated.
+	 * The {@link MemberOrder} object of the order that was refunded.
 	 *
 	 * @var MemberOrder
 	 */

--- a/includes/email.php
+++ b/includes/email.php
@@ -376,11 +376,11 @@ function pmpro_email_templates_send_test() {
 			break;
 		case 'payment_action':
 			$send_email = 'sendPaymentActionRequiredEmail';
-			$params = array($test_user, $test_order, "http://www.example-notification-url.com/not-a-real-site");
+			$params = array( $test_user, $test_order, get_option( 'siteurl' ) );
 			break;
 		case 'payment_action_admin':
 			$send_email = 'sendPaymentActionRequiredAdminEmail';
-			$params = array($test_user, $test_order, "http://www.example-notification-url.com/not-a-real-site");
+			$params = array( $test_user, $test_order, get_option( 'siteurl' ) );
 			break;
 		case 'refund':
 			$send_email = 'sendRefundedEmail';
@@ -396,7 +396,7 @@ function pmpro_email_templates_send_test() {
       break;
 		case 'credit_card_expiring':
 			$send_email = 'sendCreditCardExpiringEmail';
-			$params = array($test_user, $test_order,  "http://www.example-notification-url.com/not-a-real-site");
+			$params = array( $test_user, $test_order );
 			break;
 		default:
 			$send_email = 'sendEmail';


### PR DESCRIPTION
* REFACTOR: Refactored variables to be more descriptive while working with the code.
* REFACTOR: Changes made to incorrect doc blocks values or descriptions.
* ENHANCEMENT: Changed static value of the !!order_url!! "http://www.example-notification-url.com/not-a-real-site" to pull in the site's URL instead when sending test emails.

This relies on PR to be merged in -> https://github.com/strangerstudios/paid-memberships-pro/pull/3347/. The `sendCreditCardExpiringEmail` email does not take the order URL parameter and is removed in this PR.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?