### PR TITLE
Update "delete level" confirmation text to match behavior

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -394,7 +394,7 @@
 												$delete_text = esc_html(
 													sprintf(
 														// translators: %s is the Level Name.
-														__( "Are you sure you want to delete membership level %s? All payment subscriptions will be cancelled.", 'paid-memberships-pro' ),
+														__( "Are you sure you want to delete membership level %s? All payment subscriptions for this level will be cancelled.", 'paid-memberships-pro' ),
 														$level->name
 													)
 												);

--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -394,7 +394,7 @@
 												$delete_text = esc_html(
 													sprintf(
 														// translators: %s is the Level Name.
-														__( "Are you sure you want to delete membership level %s? Any gateway subscriptions or third-party connections with a member's account will remain active.", 'paid-memberships-pro' ),
+														__( "Are you sure you want to delete membership level %s? All payment subscriptions will be cancelled.", 'paid-memberships-pro' ),
 														$level->name
 													)
 												);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In PMPro v2.10, there was a PR intending to avoid terminating payment subscriptions for deleted levels, but this change did not work correctly. Since then, subscriptions would still be terminated when a level is deleted even though the "delete level" confirmation message now states that they wouldn't.

This PR reverts the confirmation message to align with the current functionality. In the future, we can revisit this behavior and consider what behavior is truly desired when a level is deleted.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3350

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
