### PR TITLE
Show "No Level" for sub with level = 0. + i18n

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
@@ -135,12 +135,22 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 							</strong>
 							<?php
 							// Show warning if the user does not have the level for this subscription.
-							if ( $showing_active_subscriptions && ! in_array( $subscription->get_membership_level_id(), $user_level_ids ) ) {
-								?>
-								<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
-									<?php esc_html_e( 'Membership Ended', 'paid-memberships-pro' ); ?>
-								</span>
-								<?php
+							if ( $showing_active_subscriptions ) {
+                if( $subscription->get_membership_level_id() > 0 ) {
+                  if( ! in_array( $subscription->get_membership_level_id(), $user_level_ids ) ){
+	                  ?>
+                    <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
+                      <?php esc_html_e( 'Membership Ended', 'paid-memberships-pro' ); ?>
+                    </span>
+	                  <?php
+                  }
+                } else {
+	                ?>
+                  <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
+                    <?php esc_html_e( 'No Level', 'paid-memberships-pro' ); ?>
+                  </span>
+	                <?php
+                }
 							}
 
 							// Show warning if the subscription had an error when trying to sync.

--- a/classes/class-pmpro-subscriptions-list-table.php
+++ b/classes/class-pmpro-subscriptions-list-table.php
@@ -523,18 +523,26 @@ class PMPro_Subscriptions_List_Table extends WP_List_Table {
 		} else {
 			esc_html_e( '&#8212;', 'paid-memberships-pro' );
 		}
-
+    
 		// If the subscription is active and the user does not have the level that the subscription is for, show a message.
 		if ( 'active' === $item->get_status() ) {
-			$user_levels    = pmpro_getMembershipLevelsForUser( $item->get_user_id() );
-			$user_level_ids = wp_list_pluck( $user_levels, 'id' );
-			if ( ! in_array( $item->get_membership_level_id(), $user_level_ids ) ) {
-				?>
-				<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
-					<?php esc_html_e( 'Membership Ended', 'paid-memberships-pro' ); ?>
-				</span>
-				<?php
-			}
+      if( $item->get_membership_level_id() > 0 ) {
+        $user_levels    = pmpro_getMembershipLevelsForUser( $item->get_user_id() );
+        $user_level_ids = wp_list_pluck( $user_levels, 'id' );
+        if ( ! in_array( $item->get_membership_level_id(), $user_level_ids ) ) {
+          ?>
+          <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
+            <?php esc_html_e( 'Membership Ended', 'paid-memberships-pro' ); ?>
+          </span>
+          <?php
+        }
+      } else {
+	      ?>
+        <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">
+            <?php esc_html_e( 'No Level', 'paid-memberships-pro' ); ?>
+          </span>
+	      <?php
+      }
 		}
 		
 	}

--- a/classes/class-pmpro-subscriptions-list-table.php
+++ b/classes/class-pmpro-subscriptions-list-table.php
@@ -519,7 +519,7 @@ class PMPro_Subscriptions_List_Table extends WP_List_Table {
 		if ( ! empty( $level ) ) {
 			echo esc_html( $level->name );
 		} elseif ( $item->get_membership_level_id() > 0 ) {
-			echo '['. esc_html( 'deleted', 'paid-memberships-pro' ).']';
+			echo '['. esc_html__( 'deleted', 'paid-memberships-pro' ).']';
 		} else {
 			esc_html_e( '&#8212;', 'paid-memberships-pro' );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When an active sub loses the level id (any reason), the message shown is "Membership Ended", the save we have for membership sub/member level mismatch. Can be more clear: No Level. You will immediately notice there's something weird happening under the hood.

Discussed with David on Slack.

### Before
<img width="656" alt="Screenshot 2025-03-28 at 22 27 05" src="https://github.com/user-attachments/assets/08990dd6-9c7c-4621-aecb-87030055f750" />

### After
<img width="285" alt="Screenshot 2025-03-28 at 22 29 13" src="https://github.com/user-attachments/assets/1aa845a7-3045-42a6-9126-5b5a2b5a3892" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
