### PR TITLE
Fix the localization path to be correct.

### DIFF
--- a/includes/localization.php
+++ b/includes/localization.php
@@ -5,7 +5,7 @@ function pmpro_load_textdomain() {
 
 	//paths to local (plugin) and global (WP) language files
 	$mofile_local  = dirname( __DIR__ ) . '/languages/' . $mofile;
-	$mofile_global = WP_LANG_DIR . '/plugins/paid-memberships-pro/' . $mofile;
+	$mofile_global = WP_LANG_DIR . '/plugins/' . $mofile;
 
 	unload_textdomain( 'paid-memberships-pro' );
 


### PR DESCRIPTION
* BUG FIX: Updated the localization file location structure. Now it looks for it under `wp-content/languages/plugins/<<file-name>>`

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Delete all translation files from `paid-memberships-pro/languages`
2. Download and add locale files for PMPro to `wp-content/languages/plugins` with the correct file names.
3. See the site is translating.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
