### PR TITLE
Fixing case where the report called in URL does not exist

### DIFF
--- a/adminpages/reports.php
+++ b/adminpages/reports.php
@@ -13,10 +13,14 @@ require_once( dirname( __FILE__ ) . '/admin_header.php' ); ?>
 <hr class="wp-header-end">
 
 <?php
-// View a single report if requested.
+$report_exists = false;
 if ( ! empty( $_REQUEST[ 'report' ] ) ) {
-	// Get the report we are viewing.
-	$report = sanitize_text_field( $_REQUEST[ 'report' ] ); ?>
+	$report = sanitize_text_field( $_REQUEST[ 'report' ] );
+	$report_function = 'pmpro_report_' . $report . '_page';
+	$report_exists = function_exists( $report_function ) ? true : false;
+}
+
+if ( $report_exists ) { ?>
 	<ul class="subsubsub">
 		<li><a href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-reports' ) ); ?>"><?php esc_html_e('All', 'paid-memberships-pro' ); ?></a></li>
 		<?php
@@ -37,8 +41,8 @@ if ( ! empty( $_REQUEST[ 'report' ] ) ) {
 	<br class="clear" />
 	<?php
 		// View a single report
-		call_user_func( 'pmpro_report_' . $report . '_page' );
-	?>
+		call_user_func( $report_function );
+    ?>
 	<p><a class="button button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-reports' ) );?>"><?php esc_html_e( 'Back to Reports Dashboard', 'paid-memberships-pro' ); ?></a></p>
 
 	<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If a user tries to access a report (via URL attribute) that doesn't actually exist, we would get a fatal error.

This PR makes sure the report slug called exists before trying to load the report function.

### How to test the changes in this Pull Request:

1. Add a non-existent report slug to your URL, like: `/wp-admin/admin.php?page=pmpro-reports&report=nope`
2. See the fatal error.
3. Pull this code and see no error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Prevents a fatal error when accessing a non-existent report in the admin area.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
