### PR TITLE
Stop rendering shortcode in Elementor Editor Mode

### DIFF
--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -3,7 +3,6 @@
 // Include custom settings to restrict Elementor widgets.
 require_once( 'elementor/class-pmpro-elementor.php' );
 
-
 /**
  * Elementor Compatibility
  */
@@ -47,9 +46,35 @@ function pmpro_elementor_get_all_levels() {
 }
 add_action( 'plugins_loaded', 'pmpro_elementor_compatibility', 15 );
 
-
-
+/**
+ * Delete the locally stored elementor cache for levle ID's whenever saving a levle.
+ *
+ * @since TBD
+ * 
+ * @param int $level_id The level ID for the membership level that was saved.
+ */
 function pmpro_elementor_clear_level_cache( $level_id ) {
 	delete_transient( 'pmpro_elementor_levels_cache' );
 }
 add_action( 'pmpro_save_membership_level', 'pmpro_elementor_clear_level_cache' );
+
+/**
+ * Stop rendering shortcodes when in Elementor editor mode.
+ * 
+ * Note: The is_preview_mode() returns false when actually previewing the post or page in Elementor.
+ * This can be treated as "editor mode" where the user is editing the post or page in Elementor.
+ * 
+ * @since TBD
+ * 
+ * @param bool $dont_render Whether to render the shortcode.
+ * @param string $page_name The name of the PMPro page.
+ * @return bool $dont_render Whether to render the shortcode.
+ */
+function pmpro_elementor_stop_rendering_shortcodes( $dont_render, $page_name ) {
+	if ( \Elementor\Plugin::$instance->preview->is_preview_mode() ) {
+		$dont_render = true;
+	}
+
+	return $dont_render;
+}
+add_filter( 'pmpro_dont_render_shortcode', 'pmpro_elementor_stop_rendering_shortcodes', 10, 2 );

--- a/includes/init.php
+++ b/includes/init.php
@@ -72,6 +72,21 @@ function pmpro_wp()
 		{
 			if( ! empty( $post->post_content ) && ( strpos( $post->post_content, "[pmpro_" . $pmpro_page_name . "]" ) !== false || ( function_exists( 'has_block' ) && has_block( 'pmpro/' . $pmpro_page_name . '-page', $post ) ) ) )
 			{
+
+				/**
+				 * Filter to determine if the shortcode should be rendered.
+				 * 
+				 * Use this filter to not render the shortcode when needed. Useful for page builders or similar cases.
+				 * 
+				 * @since TBD
+				 * 
+				 * @param bool $render Whether to render the shortcode. Default is true.
+				 * @param string $pmpro_page_name The name of the PMPro page.
+				 */
+				if ( apply_filters( 'pmpro_dont_render_shortcode', false, $pmpro_page_name ) ) {
+					return;
+				}
+
 				//preheader
 				require_once(PMPRO_DIR . "/preheaders/" . $pmpro_page_name . ".php");
 


### PR DESCRIPTION
* BUG FIX/ENHANCEMENT: Stop rendering shortcodes for PMPro when in the Elementor Editor. This helps avoid unwanted redirects by shortcodes, specifically for core shortcodes.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Install the latest version of Elementor and navigate to the Billing page (or page with [pmpro_billing] shortocde) and edit with Elementor.
2. See that there is an error. (Make sure your admin account doesn't have an active subscription for this test).
3.  Apply this PR and see that the page correctly loads and shows `[pmpro_billing]` without trying to render it.

This PR will affect all PMPro registered shortcodes and pages. This adds a new filter that will allow any page builder or developer to stop rendering the shortcodes in certain cases and should be only used when editing with a page builder and never on the frontend.

Hook into: `pmpro_dont_render_shortcode` 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
