### PR TITLE
Add new filter for login response messages

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -457,6 +457,17 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 		}
 	}
 
+	/**
+	 * Allow filtering of the form handler success and error messages. 
+	 * This includes the login form, password reset form, and the lost password form messages.
+	 * 
+	 * @since TBD
+	 * 
+	 * @param string $message The displayed message that is related to the form's response.
+	 * @param string $msgt The message type we can check against to know if it's a success or error message - (pmpro_error or pmpro_success).
+	 */
+	$message = wp_kses( apply_filters( 'pmpro_login_forms_handler_response_message', $message, $msgt ), $allowed_html );
+
 	ob_start();
 	?>
 


### PR DESCRIPTION
* ENHANCEMENT: Adding in `pmpro_login_forms_handler_response_message` to allow filtering of success and error messages when logins failed or are successful.

Sample code:
```
function my_test_pmpro_login_message( $message, $msgt ) {
	if ( $msgt == 'pmpro_error' ) {
		$message = 'Whoops! Something went wrong. Please try again.';
	}

	return $message;
}
add_filter( 'pmpro_login_forms_handler_response_message', 'my_test_pmpro_login_message', 10, 2 );
```

Here is the screenshot with the filtered result.
![Screenshot 2025-04-04 at 15 25 36](https://github.com/user-attachments/assets/b0c00a36-32dc-46e0-9cc5-d53308e74008)

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?
