### PR TITLE
Fix depends issue for radio buttons

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1414,8 +1414,8 @@ class PMPro_Field {
 							$binds[] = "#" . esc_html( $field_id );
 							break;
 						case 'radio':
-							$checks_escaped[] = "jQuery('#" . esc_html( $field_id ) . " input[type=radio][value=" . esc_js( $check['value'] ) . "]:checked').length > 0";
-							$binds[] = "#" . esc_html( $field_id ) . " input[type=radio][name=" . esc_js( $field_id ) . "]";
+							$checks_escaped[] = "jQuery('input[name=\"" . esc_js( $field_id ) . "\"][value=\"" . esc_js( $check['value'] ) . "\"]:checked').length > 0";
+							$binds[] = "input[type=radio][name=\"" . esc_js( $field_id ) . "\"]";
 							break;
 						default:
 							$checks_escaped[] = "jQuery('#" . esc_html( $field_id ) . "').val() == " . json_encode( $check['value'] ) . " || jQuery.inArray( jQuery('#" . esc_html( $field_id ) . "').val(), " . json_encode( $check['value'] ) . ") > -1";


### PR DESCRIPTION
* BUG FIX: Fixed an issue where `depends` was not working with radio buttons.

The generated JQuery is set to target the input name instead of the field ID. When multiple radio options are added the radio ID is `field_id_x` and increments accordingly. This follows logic of the grouped checkboxes logic as the structure of the radio buttons are similar to this.

Also moved to `esc_js` instead to match that of other generated conditionals.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3365.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
