### PR TITLE
Fix admin emails not sending free template

### DIFF
--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -480,21 +480,22 @@
 		 * @param object $user The WordPress user object.
 		 * @param MemberOrder $order The order object that is associated with the checkout.
 		 */
-		function sendCheckoutAdminEmail($user = NULL, $order = NULL)
-		{
-			global $wpdb, $current_user, $discount_code;
-			if(!$user)
+		function sendCheckoutAdminEmail( $user = NULL, $order = NULL ) {
+			global $wpdb, $current_user;
+			if ( ! $user ) {
 				$user = $current_user;
+			}
 			
-			if(!$user)
+			if ( ! $user ) {
 				return false;
+			}
 
 			if ( empty( $order->membership_id ) ) {
 				return false;
 			}
 
 			$email = null;
-			if( !empty( $this->template ) ) {
+			if ( ! empty( $this->template ) ) {
 				switch( $this->template ) {
 					case 'checkout_check_admin':
 						$email = new PMPro_Email_Template_Checkout_Check_Admin( $user, $order );
@@ -507,18 +508,20 @@
 						break;
 				}
 			} else {
-				if( ! empty( $order ) && ! pmpro_isLevelFree( $membership_level ) ) {
+				// Get the membership level for this order, to see if it's a free level.
+				$membership_level =  $order->getMembershipLevel();
+				if ( ! empty( $order ) && ! pmpro_isLevelFree( $membership_level ) ) {
 					if( $order->gateway == "check" ) {
 						$email = new PMPro_Email_Template_Checkout_Check_Admin( $user, $order );
 					} else {
 						$email = new PMPro_Email_Template_Checkout_Paid_Admin( $user, $order );
 					}										
-				} elseif( pmpro_isLevelFree( $membership_level ) ) {
+				} elseif ( pmpro_isLevelFree( $membership_level ) ) {
 					$email = new PMPro_Email_Template_Checkout_Free_Admin( $user, $order );
 				}
 			}
 			//Bail if $email is null
-			if( $email == null ) {
+			if ( $email == null ) { 
 				return false;
 			}
 			return $email->send();


### PR DESCRIPTION
* BUG FIX: Fixed an issue where admin confirmation emails was not sending the "Free" template and was defaulting to "Paid".

* REFACTOR: Applied WPCS to the method `sendCheckoutAdminEmail`.

We were passing a nulled variable $membership_level to each email template class and leveraged the `$order->getMembershipLevel` instead of getting the user level made more sense here (See how it's handled in SendCheckoutEmail as it's slightly different).

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3362, #3349

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?