### PR TITLE
Fix warning message when updating a plugin

### DIFF
--- a/includes/addons.php
+++ b/includes/addons.php
@@ -516,8 +516,8 @@ function pmpro_admin_init_updating_plugins() {
 		$slug = str_replace( '.php', '', basename( $plugin ) );
 		$addon = pmpro_getAddonBySlug( $slug );
 		if ( ! empty( $addon ) && pmpro_license_type_is_premium( $addon['License'] ) && ! pmpro_can_download_addon_with_license( $addon['License'] ) ) {
-			$msg = sprintf( __( 'You must enter a valid PMPro %s License Key under Memberships > License to update this Add On.', 'paid-memberships-pro' ), ucwords( $addon['License'] ) );
-			echo '<div class="error"><p>' . html_entity_decode( esc_html( $msg ) ) . '</p></div>';
+			$msg = sprintf( __( 'You must enter a valid PMPro %s License Key in the PMPro Settings to update this Add On.', 'paid-memberships-pro' ), ucwords( $addon['License'] ) );
+			echo '<div class="error"><p>' . esc_html( $msg ) . '</p></div>';
 
 			// can exit WP now
 			exit;

--- a/includes/addons.php
+++ b/includes/addons.php
@@ -516,8 +516,8 @@ function pmpro_admin_init_updating_plugins() {
 		$slug = str_replace( '.php', '', basename( $plugin ) );
 		$addon = pmpro_getAddonBySlug( $slug );
 		if ( ! empty( $addon ) && pmpro_license_type_is_premium( $addon['License'] ) && ! pmpro_can_download_addon_with_license( $addon['License'] ) ) {
-			$msg = sprintf( __( 'You must enter a valid PMPro %s License Key under Settings > PMPro License to update this add on.', 'paid-memberships-pro' ), ucwords( $addon['License'] ) );
-			echo '<div class="error"><p>' . esc_html( $msg ) . '</p></div>';
+			$msg = sprintf( __( 'You must enter a valid PMPro %s License Key under Memberships > License to update this Add On.', 'paid-memberships-pro' ), ucwords( $addon['License'] ) );
+			echo '<div class="error"><p>' . html_entity_decode( esc_html( $msg ) ) . '</p></div>';
 
 			// can exit WP now
 			exit;


### PR DESCRIPTION
* BUG FIX: Fixed a warning message that was encoding the `>` on output as well make the message more clear where the settings are to add a license key to PMPro.

It looks like it wasn't just the `esc_html` causing this, tried various other methods like wp_kses/wp_kses_post - WordPress itself may have been interfering with this message. Decoding the $msg after escaping it works. This will still keep the string safe but just decode allowed characters. `esc_html` will still strip out non-allowed HTML entities.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #3323 

![Screenshot 2025-04-08 at 10 29 10](https://github.com/user-attachments/assets/4bbe119d-3fc6-40f9-8590-275bc2d7d8fd)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->