### PR TITLE
Styling password toggle when minimal design setting is active; fixing capitalization of password toggle so PHP matches JS

### DIFF
--- a/css/frontend/base.css
+++ b/css/frontend/base.css
@@ -373,6 +373,31 @@ button[type="button"]#other_discount_code_toggle:focus {
 	min-height: 30px;
 }
 
+/* Special Fields */
+.pmpro_form_field-password-toggle button,
+.pmpro_form_field-password-toggle button:hover,
+.pmpro_form_field-password-toggle button:focus,
+.pmpro_form_field-password-toggle button:active {
+	align-items: center;
+	background: transparent;
+	border: none;
+	box-shadow: none;
+	box-sizing: border-box;
+	color: var(--pmpro--color--contrast);
+	display: flex;
+	flex-direction: row;
+	gap: calc( var(--pmpro--base--spacing--small) / 2 );
+	line-height: 1;
+	margin: 0;
+	min-height: 1px;
+	padding: 0;
+}
+
+.pmpro_form_field-password-toggle button:focus,
+.pmpro_form_field-password-toggle button:active {
+	color: var(--pmpro--color--contrast);
+}
+
 /* Hide the Edge "reveal password" native button */
 .wp-pwd input::-ms-reveal {
 	display: none;

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -38,8 +38,8 @@ function pmpro_enqueue_scripts() {
 				'discount_code_passed_in' => !empty( $_REQUEST['pmpro_discount_code'] ) && !empty( $_REQUEST['discount_code'] ),
 				'sensitiveCheckoutRequestVars' => pmpro_get_sensitive_checkout_request_vars(),
 				'update_nonce' => apply_filters( 'pmpro_update_nonce_at_checkout', false ),
-				'hide_password_text' =>  __( 'Hide password', 'paid-memberships-pro' ),
-				'show_password_text' =>  __( 'Show password', 'paid-memberships-pro' ),
+				'hide_password_text' =>  __( 'Hide Password', 'paid-memberships-pro' ),
+				'show_password_text' =>  __( 'Show Password', 'paid-memberships-pro' ),
 			)
 		);
 		wp_enqueue_script( 'pmpro_checkout' );
@@ -80,8 +80,8 @@ function pmpro_enqueue_scripts() {
 				'pmpro_login_page' => 'changepassword',
 				'strength_indicator_text' => __( 'Strength Indicator', 'paid-memberships-pro' ),
 				'allow_weak_passwords' => $allow_weak_passwords,
-				'hide_password_text' =>  __( 'Hide password', 'paid-memberships-pro' ),
-				'show_password_text' =>  __( 'Show password', 'paid-memberships-pro' )
+				'hide_password_text' =>  __( 'Hide Password', 'paid-memberships-pro' ),
+				'show_password_text' =>  __( 'Show Password', 'paid-memberships-pro' )
 			)
 		);
 		wp_enqueue_script( 'pmpro_login' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updates the minimal style option to provide very basic styling for the password toggle buttons.

Also a small fix to the capitalization of the button text. Before, the PHP was using title case but the JS was using sentence case so it swapped when you clicked to toggle. 

### Screenshots

Before
![Screenshot 2025-04-08 at 6 34 47 AM](https://github.com/user-attachments/assets/04b93058-2519-4b36-969e-29808bd88996)

After
![Screenshot 2025-04-08 at 6 34 30 AM](https://github.com/user-attachments/assets/679a7345-f4e2-4f83-834c-b4be2122fc97)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX/ENHANCEMENT: Basic styling for password visibility toggle when a site is using the minimal global style setting.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
