### PR TITLE
Add in churned user win-back email

### DIFF
--- a/adminpages/emailsettings.php
+++ b/adminpages/emailsettings.php
@@ -33,6 +33,8 @@
 		
 		pmpro_setOption("email_member_notification");
 		
+		pmpro_setOption("churned_email_days", null, 'intval');
+		
 		//assume success
 		$msg = true;
 		$msgt = "Your email settings have been updated.";		
@@ -48,6 +50,8 @@
 	$email_admin_billing = get_option( "pmpro_email_admin_billing");	
 	
 	$email_member_notification = get_option( "pmpro_email_member_notification");
+	
+	$churned_email_days = get_option("pmpro_churned_email_days", 30);
 	
 	if(empty($from_email))
 	{
@@ -184,6 +188,18 @@
 							<input type="checkbox" id="email_member_notification" name="email_member_notification" value="1" <?php if(!empty($email_member_notification)) { ?>checked="checked"<?php } ?> />
 							<label for="email_member_notification"><?php esc_html_e('Default WP notification email.', 'paid-memberships-pro' );?></label>
 							<p class="description"><?php esc_html_e( 'Recommended: Leave unchecked. Members will still get an email confirmation from PMPro after checkout.', 'paid-memberships-pro' ); ?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row" valign="top">
+							<label for="churned_email_days"><?php esc_html_e("Churned Member Email Delay", "paid-memberships-pro" );?>:</label>
+						</th>
+						<td>
+							<input type="number" id="churned_email_days" name="churned_email_days" value="<?php echo esc_attr($churned_email_days); ?>" min="1" max="365" class="small-text" /> <?php esc_html_e("days", "paid-memberships-pro" );?>
+							<p class="description">
+								<?php esc_html_e( "Number of days after a membership expires before sending a win-back email to churned members.", "paid-memberships-pro" ); ?>
+								<?php printf( esc_html__( 'You can %scustomize or disable this email%s from the Email Templates page.', 'paid-memberships-pro' ), '<a href="' . esc_url( admin_url( 'admin.php?page=pmpro-emailtemplates' ) ) . '">', '</a>' ); ?>
+							</p>
 						</td>
 					</tr>
 				</tbody>

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -731,6 +731,27 @@
 			$email = new PMPro_Email_Template_Membership_Expired( $user, $membership_id );
 			return $email->send();
 		}
+		
+		/**
+		 * Send the member a churned email 30 days after their membership has expired.
+		 *
+		 * @param object $user The WordPress user object.
+		 * @param int $membership_id The member's membership level ID.
+		 * @return bool Whether the email was sent successfully.
+		 */
+		function sendMembershipChurnedEmail( $user = NULL, $membership_id = NULL ) {
+			global $current_user;
+			if( !$user ) {
+				$user = $current_user;
+			}
+			//Bail if still we don't have a user.
+			if( !$user ) {
+				return false;
+			}
+
+			$email = new PMPro_Email_Template_Membership_Churned( $user, $membership_id );
+			return $email->send();
+		}
 
 		/**
 		 * Send the member an email when their membership has ended.

--- a/classes/email-templates/class-pmpro-email-template-membership-churned.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-churned.php
@@ -1,0 +1,193 @@
+<?php
+class PMPro_Email_Template_Membership_Churned extends PMPro_Email_Template {
+
+	/**
+	 * The user object of the user to send the email to.
+	 *
+	 * @var WP_User
+	 */
+	protected $user;
+
+	/**
+	 * The membership level that expired.
+	 *
+	 * @var int
+	 */
+	protected $membership_level_id;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WP_User $user The user object of the user to send the email to.
+	 * @param int $membership_id The membership level id of the membership level that expired.
+	 */
+	public function __construct( WP_User $user, int $membership_level_id ) {
+		$this->user = $user;
+		$this->membership_level_id = $membership_level_id;
+	}
+
+	/**
+	 * Get the email template slug.
+	 *
+	 * @return string The email template slug.
+	 */
+	public static function get_template_slug() {
+		return 'membership_churned';
+	}
+
+	/**
+	 * Get the "nice name" of the email template.
+	 *
+	 * @return string The "nice name" of the email template.
+	 */
+	public static function get_template_name() {
+		return esc_html__( 'Membership Churned', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get "help text" to display to the admin when editing the email template.
+	 *
+	 * @return string The "help text" to display to the admin when editing the email template.
+	 */
+	public static function get_template_description() {
+		$days = intval(get_option("pmpro_churned_email_days", 30));
+		/* translators: %d: number of days after membership expiration */
+		return sprintf(esc_html__( 'This email is sent to former members %d days after their membership expires (churned members).', 'paid-memberships-pro' ), $days);
+	}
+
+	/**
+	 * Get the default subject for the email.
+	 *
+	 * @return string The default subject for the email.
+	 */
+	public static function get_default_subject() {
+		return esc_html__( 'We miss you at !!sitename!! - Special offer inside', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the default body content for the email.
+	 *
+	 * @return string The default body content for the email.
+	 */
+	public static function get_default_body() {
+		$days = intval(get_option("pmpro_churned_email_days", 30));
+		
+		// Convert days to friendly text with flexible ranges
+		$time_period = '';
+		if ($days <= 7) {
+			$time_period = 'a week';
+		} elseif ($days <= 14) {
+			$time_period = 'two weeks';
+		} elseif ($days <= 31) {
+			$time_period = 'a month';
+		} elseif ($days <= 62) {
+			$time_period = 'two months';
+		} elseif ($days <= 93) {
+			$time_period = 'three months';
+		} elseif ($days <= 186) {
+			$time_period = 'six months';
+		} elseif ($days <= 366) {
+			$time_period = 'a year';
+		} else {
+			$time_period = 'some time';
+		}
+		
+		return wp_kses_post( sprintf( __( '<p>Hi !!display_name!!,</p>
+
+<p>We noticed it has been %s since your membership at !!sitename!! expired, and we would love to have you back.</p>
+
+<p>We value your past membership and would like to offer you the opportunity to rejoin our community.</p>
+
+<p>View our current membership offerings here: !!levels_url!!</p>
+
+<p>Log in to manage your account here: !!login_url!!</p>
+
+<p>Thank you for considering rejoining us!</p>', 'paid-memberships-pro' ), $time_period ) );
+	}
+
+	/**
+	 * Get the email address to send the email to.
+	 *
+	 * @return string The email address to send the email to.
+	 */
+	public function get_recipient_email() {
+		return $this->user->user_email;
+	}
+
+	/**
+	 * Get the name of the email recipient.
+	 *
+	 * @return string The name of the email recipient.
+	 */
+	public function get_recipient_name() {
+		return $this->user->display_name;
+	}
+
+
+	/**
+	 * Get the email template variables for the email paired with a description of the variable.
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public static function get_email_template_variables_with_description() {
+		return array(
+			'!!display_name!!' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
+			'!!user_login!!' => esc_html__( 'The username of the user.', 'paid-memberships-pro' ),
+			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
+			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
+			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
+		);
+	}
+
+	/**
+	 * Get the email template variables for the email.
+	 *
+	 * @return array The email template variables for the email (key => value pairs).
+	 */
+	public function get_email_template_variables() {
+		global $wpdb;
+		// If we don't have a level ID, query the user's most recently expired level from the database.
+		if ( empty( $this->membership_id ) ) {
+			$membership_id = $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT membership_id FROM $wpdb->pmpro_memberships_users
+					WHERE user_id = %d
+					AND status = 'expired'
+					ORDER BY enddate DESC
+					LIMIT 1",
+					$this->user->ID
+				)
+			);
+
+			// If we still don't have a level ID, bail.
+			if ( empty( $membership_id ) ) {
+				$membership_id = 0;
+			}
+		}
+
+		// Get the membership level object.
+		$membership_level = pmpro_getLevel( $membership_id );
+
+		return array(
+			"subject" => $this->get_default_subject(),
+			"name" => $this->user->display_name,
+			"display_name" => $this->user->display_name,
+			"user_login" => $this->user->user_login,
+			"user_email" => $this->user->user_email,
+			"membership_id" => ( ! empty( $membership_level ) && ! empty( $membership_level->id ) ) ? $membership_level->id : 0,
+			"membership_level_name" => ( ! empty( $membership_level ) && ! empty( $membership_level->name ) ) ? $membership_level->name : '[' . esc_html( 'deleted', 'paid-memberships-pro' ) . ']',
+		);
+	}
+}
+
+/**
+ * Register the email template.
+ *
+ * @param array $email_templates The email templates (template slug => email template class name)
+ * @return array The modified email templates array.
+ */
+function pmpro_email_templates_membership_churned( $email_templates ) {
+	$email_templates['membership_churned'] = 'PMPro_Email_Template_Membership_Churned';
+	return $email_templates;
+}
+add_filter( 'pmpro_email_templates', 'pmpro_email_templates_membership_churned' );

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -32,6 +32,10 @@ function pmpro_get_crons() {
 			'interval'  => 'daily',
 			'timestamp' => strtotime( '10:30:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ),
 		],
+		'pmpro_cron_churned_emails'               => [
+			'interval'  => 'daily',
+			'timestamp' => strtotime( '11:00:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ),
+		],
 		'pmpro_license_check_key'                  => [
 			'interval' => 'monthly',
 		],

--- a/includes/email.php
+++ b/includes/email.php
@@ -366,6 +366,10 @@ function pmpro_email_templates_send_test() {
 			$send_email = 'sendInvoiceEmail';
 			$params = array($test_user, $test_order);
 			break;
+		case 'membership_churned';
+			$send_email = 'sendMembershipChurnedEmail';
+			$params = array($test_user, $test_order->membership_id );
+			break;
 		case 'membership_expired';
 			$send_email = 'sendMembershipExpiredEmail';
 			$params = array($test_user, $test_order->membership_id );

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -78,6 +78,7 @@ require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template-b
 require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template-billing-failure-admin.php' ); // billing failure email template
 require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date.php' ); //cancel auto renewals email template
 require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template-cancel-on-next-payment-date-admin.php' ); //cancel auto renewals admin email template
+require_once( PMPRO_DIR . '/classes/email-templates/class-pmpro-email-template-membership-churned.php' ); //churned member email template
 
 require_once( PMPRO_DIR . '/includes/filters.php' );                // filters, hacks, etc, moved into the plugin
 require_once( PMPRO_DIR . '/includes/reports.php' );                // load reports for admin (reports may also include tracking code, etc)

--- a/scheduled/churnedemails.php
+++ b/scheduled/churnedemails.php
@@ -1,0 +1,2 @@
+<?php
+	die( 'You may no longer trigger this cron directly. Trigger the pmpro_cron_churned_emails hook via WP-Cron.' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a new "Churned Member Win-Back Email" feature that sends an email to former members a configurable number of days after their membership expires. This helps site owners re-engage with former members and potentially win them back.

Key changes:
- Added a new email template `membership_churned` that gets sent to former members
- Added a setting in the Email Settings page to configure the number of days after expiration (default 30)
- Created a daily cron job that finds members whose memberships expired exactly N days ago
- Only sends the email once per expired membership (tracked via user meta)

### How to test the changes in this Pull Request:

1. Set up a membership site with at least one member
2. Let that member's membership expire (or manually set the status to 'expired' in the database)
3. Change the `pmpro_churned_email_days` setting to a smaller value for testing (e.g., 1 day)
4. Wait for the daily cron to run, or manually trigger it for testing
5. Verify the member receives the "We miss you" email

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added a new "Churned Member Win-Back Email" feature that sends an email to former members a configurable number of days after their membership expires. Site owners can customize the email content and the number of days after expiration before sending.