### PR TITLE
Site change detection: hash current site url and start comparing hashes

### DIFF
--- a/includes/updates/upgrade_3_4_7.php
+++ b/includes/updates/upgrade_3_4_7.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Upgrade to version 3.4.7
+ *
+ * We are encrypting the site url in the database
+ *
+ * @since 3.4.7
+ */
+function pmpro_upgrade_3_4_7() {
+	$current_url_hash = get_option( 'pmpro_last_known_url' );
+
+	// If we don't have a current URL hash yet, set it to the site URL hash.
+	if ( ! empty( $current_url_hash ) ) {
+		// Check if current value was sha256 encoded; if not, encode it.
+		if ( ! preg_match( '/^[a-f0-9]{64}$/', $current_url_hash ) ) {
+			$current_url_hash = hash( 'sha256', $current_url_hash );
+			update_option( 'pmpro_last_known_url', $current_url_hash );
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Previously, if the site change was made using wp-cli search-replace or similar (hosting migration tools working the same way), even the "current_site_url" option saved w/o obfuscation/hashing was updated. Then, the site change was not detected, and the pause mode not triggered.

Now, we are hasing the current site url, and comparing hashes.

### How to test the changes in this Pull Request:

1. Migrate a site using wp search-replace 'old url' 'new url' --all-tables --precise
2. The site change pause mode is not triggering, because the current site url option has been changed as well
3. Now, retrying after upgrading.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
