### PR TITLE
Support linking to a filtered result via URL attributes on the Add Ons admin screen.

### DIFF
--- a/adminpages/addons.php
+++ b/adminpages/addons.php
@@ -59,7 +59,10 @@
 			</ul>
 			<div class="search-form">
 				<label class="screen-reader-text" for="search-plugins"><?php esc_html_e( 'Search Add Ons', 'paid-memberships-pro' ); ?></label>
-				<input type="search" name="s" id="search-add-ons" data-search="content" class="wp-filter-search" placeholder="<?php esc_attr_e( 'Search Add Ons...', 'paid-memberships-pro' ); ?>">
+				<?php
+					$pmpro_addon_search = isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
+				?>
+				<input type="search" name="s" id="search-add-ons" data-search="content" class="wp-filter-search" placeholder="<?php esc_attr_e( 'Search Add Ons...', 'paid-memberships-pro' ); ?>" value="<?php echo esc_attr( $pmpro_addon_search ); ?>">
 			</div>
 		</div> <!-- end wp-filter -->
 		<br class="clear">
@@ -439,6 +442,12 @@
 
 				// check if we should switch Add On content on page loads
 				$( 'a[data-toggle="view"][href="' + window.location.hash + '"]' ).trigger('click');
+
+				// Check if we should switch Add On content on page loads.
+				var $searchInput = $('#search-add-ons');
+				if ($searchInput.val().length > 0) {
+					$searchInput.trigger('keyup');
+				}
 
 			});
 		</script>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updates the Add Ons admin page to support passing the `s` parameter in the URL. You can pass in a single Add On slug or a query. Examples:

https://pmprokimfork.local/wp-admin/admin.php?page=pmpro-addons&s=restrict+access

https://pmprokimfork.local/wp-admin/admin.php?page=pmpro-addons&s=pmpro-courses

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Added support for passing a search term or Add On slug to pre-filter results on the Memberships > Add Ons admin page using a URL parameter `s`.
