### PR TITLE
Always trim select values for dropdowns (fix issue #3378)

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1107,7 +1107,7 @@ function pmpro_load_user_fields_from_settings() {
                         $parts = explode( ':', $settings_option );
                         $options[trim( $parts[0] )] = trim( $parts[1] );
                     } else {
-                        $options[] = $settings_option;
+                        $options[] = trim( $settings_option );
                     }
                 }
             } else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves #3378. See the error report and how to reploduce.
Also, we were already trimming for values like `IT:Italy  ` => `IT:Italy`. Not trimming for values like "`Italy  `".
The trailing spaces causes _matching_ issue, fixed by this PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
