### PR TITLE
fix #3385 javascript warning re deprecated event

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -204,8 +204,12 @@ jQuery(document).ready(function(){
 	jQuery("input[name=submit-checkout]").after('<input type="hidden" name="javascriptok" value="1" />');
 	
 	// Keep bottom message box in sync with the top one.
-	jQuery('#pmpro_message').bind("DOMSubtreeModified",function(){
+	let pmpro_msgObserver = new MutationObserver(() => {
 		setTimeout( function(){ pmpro_copyMessageToBottom() }, 200);
+	});
+	pmpro_msgObserver.observe( jQuery('#pmpro_message').get(0), {
+		childList: true,
+		subtree: true
 	});
 	
 	function pmpro_copyMessageToBottom() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Resolves #3385 

### How to test the changes in this Pull Request:

1. Go to the checkout and skip a few required fields, then submit the form
2. Open the browser console and run `jQuery('#pmpro_message').html('test');`
3. Observe that the warning message is changed at both the top and the bottom

### Other information:

See [jQuery issue 5535](https://github.com/jquery/jquery/discussions/5535) for further info.

### Changelog entry

Ensure the checkout error message is shown at top and bottom on newer browsers.

