### PR TITLE
allow single option select2 and remember the value if using ajax

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1003,7 +1003,7 @@ class PMPro_Field {
 
 			//build multi select
 			$r = '<select id="' . esc_attr( $this->id ) . '" name="' . esc_attr( $this->name );
-			if(empty($this->select2options) || !preg_match('/multiple: *false/', $this->select2options)) {
+			if( empty( $this->select2options ) || ! preg_match( '/multiple: *false/', $this->select2options ) ) {
 				// backwards compatible - default to multi-select
 				$r .= '[]" multiple="multiple" ';
 			} else {
@@ -1026,15 +1026,15 @@ class PMPro_Field {
 				$r .= $this->getHTMLAttributes();
 			$r .= '>';
 
-			if(false !== strpos($this->select2options, 'ajax:') && !empty($value) && !empty($value[0]))
+			if( false !== strpos( $this->select2options, 'ajax:' ) && ! empty( $value ) && ! empty( $value[0] ) )
 			{
 				// add selected option(s) if results are fetched remotely
-				if(empty($this->options)) {
+				if( empty( $this->options ) ) {
 					$this->options = [];
 				}
-				foreach($value as $v)
+				foreach( $value as $v )
 				{
-					$this->options[$v] = $v; // we don't know the label so just use value for now
+					$this->options[$v] = $v; // we don't know the label at this point so just use value for now
 				}
 			}
 

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1002,7 +1002,14 @@ class PMPro_Field {
 				$value = array($value);
 
 			//build multi select
-			$r = '<select id="' . esc_attr( $this->id ) . '" name="' . esc_attr( $this->name ) . '[]" multiple="multiple" style="width: 100%" ';
+			$r = '<select id="' . esc_attr( $this->id ) . '" name="' . esc_attr( $this->name );
+			if(empty($this->select2options) || !preg_match('/multiple: *false/', $this->select2options)) {
+				// backwards compatible - default to multi-select
+				$r .= '[]" multiple="multiple" ';
+			} else {
+				$r .= '" ';
+			}
+			$r .= ' style="width: 100%" ';
 			if(isset($this->placeholder)) {
 				$r .= 'placeholder="' . esc_attr($this->placeholder) . '" ';
 				if(empty($this->select2options)) {
@@ -1018,6 +1025,19 @@ class PMPro_Field {
 			if(!empty($this->html_attributes))
 				$r .= $this->getHTMLAttributes();
 			$r .= '>';
+
+			if(false !== strpos($this->select2options, 'ajax:') && !empty($value) && !empty($value[0]))
+			{
+				// add selected option(s) if results are fetched remotely
+				if(empty($this->options)) {
+					$this->options = [];
+				}
+				foreach($value as $v)
+				{
+					$this->options[$v] = $v; // we don't know the label so just use value for now
+				}
+			}
+
 			foreach($this->options as $ovalue => $option)
 			{
 				$r .= '<option value="' . esc_attr($ovalue) . '" ';


### PR DESCRIPTION
DRAFT!  Probably requires some discussion because:

- the documentation says 'multiple' defaults to false - not true for select2 fields
- the `select2options` option is undocumented

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `select2` custom field type allows for options to be fetched via ajax, but when doing this, the value is not preserved because it's not in the options array at the time the field is rendered.

Additionally, select2 defaults to being a multi-select field with no option to remove that.  The fix here is to allow the user to add `multiple: false` in the `select2options` setting making it backwards compatible with existing behaviour.  The documentation says the `multiple` field setting defaults to false, but this has no effect on `select2` fields.

### How to test the `multiple` change

1. create a `select2` field programatically, including an array of options
2. observe that it allows multiple options to be selected
3. in your field's settings, add `"select2options" => " multiple: false "`
4. observe that your field now only allows one option

### How to test the ajax change

1. create a `select2` field programatically with no `options` setting
2. add this setting in the field's parameters:

```
'select2options' => ' ajax: {
    url: "https://run.mocky.io/v3/1cbd61ca-ac99-4c22-a956-7045f790bc87",
},
minimumInputLength: 3 
 ',
```

3. in your field, begin typing "opt" and you should see it populate with data from [this mock](https://run.mocky.io/v3/1cbd61ca-ac99-4c22-a956-7045f790bc87)

### Improvements to this PR:

- should it support setting `multiple:false` in the actual field settings, instead of just `select2options` ?  (not backwards compatible - could break existing installations)
- should it be 2 separate PRs?
- should `select2options` be documented in the public documentation?

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Allow select2 fields to be non-multi-select by specifying " multiple:false " in the select2options field setting
> Allow select2 fields to have selected value preserved when fetching results via ajax
