### PR TITLE
Add Turnstile/Recaptcha to the Login Form

### DIFF
--- a/adminpages/securitysettings.php
+++ b/adminpages/securitysettings.php
@@ -28,6 +28,9 @@
 			$nuclear_HTTPS = 0;
 		}
 		pmpro_setOption( "nuclear_HTTPS", $nuclear_HTTPS );
+        if( isset( $_POST['captcha'] ) ) {
+            update_option( 'pmpro_captcha', sanitize_text_field( $_POST['captcha'] ) );
+        }
 
 		/**
 		 * Fires after security settings are saved.
@@ -46,6 +49,7 @@
 	$spamprotection = get_option( 'pmpro_spamprotection' );
 	$use_ssl = get_option( 'pmpro_use_ssl' );
 	$nuclear_HTTPS = get_option( 'pmpro_nuclear_HTTPS' );
+    $captcha = pmpro_captcha();
 
 	// Create an array of plugin files to check.
 	$plugin_files['pmpro-akismet'] = 'pmpro-akismet/pmpro-akismet.php';
@@ -159,6 +163,20 @@
 									<option value="2" <?php if( $spamprotection > 0 ) { ?>selected="selected"<?php } ?>><?php esc_html_e('Yes - Enable Spam Protection', 'paid-memberships-pro' );?></option>
 								</select>
 								<p class="description"><?php printf( esc_html__( 'Block IPs from checkout if there are more than %d failures within %d minutes.', 'paid-memberships-pro' ), (int)PMPRO_SPAM_ACTION_NUM_LIMIT, (int)round(PMPRO_SPAM_ACTION_TIME_LIMIT/60,2) );?></p>
+							</td>
+						</tr>
+                        <tr>
+							<th scope="row" valign="top">
+								<label for="captcha"><?php esc_html_e( 'Use Captcha', 'paid-memberships-pro' );?></label>
+							</th>
+							<td>
+								<select id="captcha" name="captcha">
+									<option value="" <?php selected( $captcha, false ); ?>><?php esc_html_e('No', 'paid-memberships-pro' );?></option>
+									<!-- For reference, removed the Yes - Free memberships only. option -->
+									<option value="recaptcha" <?php selected( $captcha, 'recaptcha', true ); ?>><?php esc_html_e('Use Google reCAPTCHA', 'paid-memberships-pro' );?></option>
+                                    <option value="turnstile" <?php selected( $captcha, 'turnstile', true ); ?>><?php esc_html_e('Use CloudFlare Turnstile', 'paid-memberships-pro' );?></option>
+								</select>
+								<p class="description"><?php printf( esc_html__( 'Protect your Checkout and Login forms with Google reCAPTCHA or CloudFlare Turnstile.', 'paid-memberships-pro' ), (int)PMPRO_SPAM_ACTION_NUM_LIMIT, (int)round(PMPRO_SPAM_ACTION_TIME_LIMIT/60,2) );?></p>
 							</td>
 						</tr>
 						<?php

--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -32,6 +32,22 @@ add_action( 'pmpro_checkout_before_submit_button', 'pmpro_cloudflare_turnstile_g
 add_action( 'pmpro_billing_before_submit_button', 'pmpro_cloudflare_turnstile_get_html' );
 
 /**
+ * Adds Turnstile to the PMPro login form
+ *
+ * @since TBD
+ */
+function pmpro_filter_cloudflare_turnstile_get_html($login_form, $args){
+
+    ob_start();
+    pmpro_cloudflare_turnstile_get_html();
+    $pmpro_turnstile = ob_get_contents();
+    ob_end_clean();
+    return $login_form . $pmpro_turnstile;
+    
+}
+add_filter( 'login_form_middle', 'pmpro_filter_cloudflare_turnstile_get_html', 10, 2 );
+
+/**
  * Registration check to make sure the Turnstile passes.
  *
  * @return void

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5061,3 +5061,32 @@ function pmpro_display_member_account_level_message( $level ) {
 	}
 }
 add_action( 'pmpro_membership_account_after_level_card_content', 'pmpro_display_member_account_level_message' );
+
+/**
+ * Determine which Captcha option has been enabled 
+ */
+function pmpro_captcha(){
+
+    $captcha = get_option( 'pmpro_captcha' );
+
+    if( ! $captcha ) {
+
+        //Backwards compat with the old settings
+        $recaptcha = get_option( 'pmpro_recaptcha' );
+        $turnstile = get_option( 'pmpro_cloudflare_turnstile' );
+        
+        if( $recaptcha && $turnstile ) {
+            //Make reCAPTCHA priority if both are enabled
+            $captcha = 'recaptcha';
+        } else if( $recaptcha ) {
+            $captcha = 'recaptcha';
+        } else if( $turnstile ) {
+            $captcha = 'turnstile';
+        } else {
+            $captcha = '';
+        }
+        
+    }
+
+    return $captcha;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Settings on the Security Page were changed
- Dropdown for reCAPTCHA and Turnstile have been removed
- New dropdown called Use Captcha which allows you to select No, reCAPTCHA or Turnstile

1. reCAPTCHA and Turnstile added to the WP Login Page
2. reCAPTCHA and Turnstile added to the PMPro Login Page
3. reCAPTCHA and Turnstile added to the WP Password Reset Page
4. reCAPTCHA and Turnstile added to the PMPro Password Reset Page

Backwards compatibility added using the pmpro_captcha function
This gives preference to reCAPTCHA if both reCAPTCHA and Turnstile were active

![image](https://github.com/user-attachments/assets/1d088a6e-1984-46ee-bfae-7b13cd421d85)

![image](https://github.com/user-attachments/assets/89d75a41-c0b8-4880-9c7c-77ab36cbaccf)
![image](https://github.com/user-attachments/assets/09ec5720-d21a-438a-955d-621de78a66b8)

![image](https://github.com/user-attachments/assets/541e7319-4a97-4eb6-903e-39bccffa9b3a)
![image](https://github.com/user-attachments/assets/cc7cce2d-001f-4260-af34-fed74e93d835)


### How to test the changes in this Pull Request:

1. Navigate to Memberships > Settings > Security
2. Click on the dropdown for Use Captcha and choose reCAPTCHA or Turnstile
3. Fill in credentials for the Captcha service chosen. 
4. Visit the PMPro and wp-login.php forms. These should show there as well now (and on the PMPro Checkout form as before)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
