### PR TITLE
Action Scheduler Cron (2 of 2)

### DIFF
--- a/classes/class-pmpro-action-scheduler.php
+++ b/classes/class-pmpro-action-scheduler.php
@@ -63,6 +63,11 @@ class PMPro_Action_Scheduler {
 	 */
 	public function __construct() {
 
+		// Check if Action Scheduler is installed and activated.
+		if ( ! class_exists( \ActionScheduler::class ) ) {
+			return;
+		}
+
 		// Add custom hooks for quarter-hourly, hourly, daily and weekly tasks.
 		add_action( 'action_scheduler_init', array( $this, 'add_recurring_hooks' ) );
 

--- a/classes/class-pmpro-action-scheduler.php
+++ b/classes/class-pmpro-action-scheduler.php
@@ -1,0 +1,699 @@
+<?php
+/**
+ *
+ * Paid Memberships Pro — Action Scheduler (AS).
+ *
+ * This class provides methods to schedule, manage, and execute tasks asynchronously, and is both a replacement
+ * for older wp-cron based tasks and a more efficient and performant way to handle background and asynchronous tasks in WordPress.
+ *
+ * Keep in mind that: tasks are always handled asynchronously;
+ * Queued tasks are not guaranteed to run immediately;
+ * Action Scheduler always processes tasks in batches with potentially different sizes.
+ *
+ * @package pmpro_plugin
+ * @subpackage classes
+ * @since 3.5
+ */
+
+class PMPro_Action_Scheduler {
+
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var PMPro_Action_Scheduler
+	 * @access protected
+	 * @since 3.5
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Callback for batch size/concurrent batches filter when paused.
+	 *
+	 * @var callable|null
+	 * @access protected
+	 */
+	protected $batch_size_callback = null;
+
+	/**
+	 * The default queue threshold for async tasks.
+	 * This is the maximum number of async tasks that can be queued before a delay is added to the next task.
+	 * This is to prevent taxing the server with too many tasks that have to be run.
+	 * The default is 250 tasks.
+	 */
+	public static $pmpro_as_queue_limit = 250;
+
+	/**
+	 * Get the queue limit for async tasks.
+	 *
+	 * @return int The maximum number of tasks that can be queued before a delay is added.
+	 * @access public
+	 * @since 3.5
+	 */
+	public static function get_pmpro_as_queue_limit() {
+		/**
+		 * Filter the queue limit for async tasks.
+		 *
+		 * @param int $queue_limit The default queue limit.
+		 */
+		return apply_filters( 'pmpro_action_scheduler_queue_limit', self::$pmpro_as_queue_limit );
+	}
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+
+		// Add custom hooks for quarter-hourly, hourly, daily and weekly tasks.
+		add_action( 'action_scheduler_init', array( $this, 'add_recurring_hooks' ) );
+
+		// Handle the monthly
+		add_action( 'pmpro_trigger_monthly', array( $this, 'handle_monthly_tasks' ) );
+
+		// Add dummy callbacks for scheduled tasks that may not have a handler.
+		add_action( 'action_scheduler_init', array( $this, 'add_dummy_callbacks' ) );
+
+		// Handle the pause status of PMPro by pausing Action Scheduler.
+		add_action( 'pmpro_pause_status_changed', array( $this, 'pause_as_queue' ) );
+
+		// Add late filters to modify the AS batch size and time limit.
+		add_filter( 'action_scheduler_queue_runner_batch_size', array( $this, 'modify_batch_size' ), 999 );
+		add_filter( 'action_scheduler_queue_runner_time_limit', array( $this, 'modify_batch_time_limit' ), 999 );
+	}
+
+	/**
+	 * Get the single instance of the class.
+	 *
+	 * @return PMPro_Action_Scheduler
+	 * @access public
+	 * @since 3.5
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Prevent the instance from being cloned.
+	 *
+	 * @access protected
+	 * @since 3.5
+	 * @return void
+	 * @throws WP_Error If the instance is cloned.
+	 */
+	protected function __clone() {
+		throw new WP_Error( 'pmpro_action_scheduler_warning', __( 'Action Scheduler instance cannot be cloned', 'paid-memberships-pro' ) );
+	}
+
+	/**
+	 * Prevent the instance from being unserialized.
+	 *
+	 * @access protected
+	 * @since 3.5
+	 * @return void
+	 * @throws WP_Error If the instance is unserialized.
+	 */
+	protected function __wakeup() {
+		throw new WP_Error( 'pmpro_action_scheduler_warning', __( 'Action Scheduler instance cannot be unserialized', 'paid-memberships-pro' ) );
+	}
+
+	/**
+	 * Check if AS has an existing task in the pending or completed queue
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string         $hook The hook name for the task.
+	 * @param array          $args Arguments passed to the task hook.
+	 * @param string         $group The group the task belongs to.
+	 * @param boolean        $pending True to check pending tasks, false to check completed tasks.
+	 * @param string|boolean $timestamp Optional timestamp to compare with task date.
+	 * @return bool True if an existing task is found, false otherwise.
+	 */
+	public function has_existing_task( $hook, $args = array(), $group = '', $pending = true, $timestamp = false ) {
+		$status = $pending ? ActionScheduler_Store::STATUS_PENDING : ActionScheduler_Store::STATUS_COMPLETE;
+
+		$query_args = array(
+			'hook'   => $hook,
+			'args'   => $args,
+			'group'  => $group,
+			'status' => $status,
+		);
+
+		// If we are looking for a task that's not in the future, we must provide a timestamp.
+		if ( ! $pending && $timestamp ) {
+			$query_args['date']         = $timestamp;
+			$query_args['date_compare'] = '>=';
+		} elseif ( ! $pending ) {
+			$query_args['date']         = current_time( 'mysql' );
+			$query_args['date_compare'] = '<=';
+		}
+
+		$results = as_get_scheduled_actions( $query_args );
+		return ! empty( $results );
+	}
+
+	/**
+	 * Get the count of AS items currently queued for a group
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string $group The task group name.
+	 * @return int The number of tasks in the queue.
+	 */
+	public static function count_existing_tasks_for_group( $group ) {
+		$search_args = array(
+			'group'  => $group,
+			'status' => ActionScheduler_Store::STATUS_PENDING,
+		);
+		return count( as_get_scheduled_actions( $search_args ) );
+	}
+
+	/**
+	 * Check if a task exists in the queue of tasks before adding it; and maybe add a queue delay.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string          $hook The hook for the task.
+	 * @param mixed           $args The data being passed to the task hook.
+	 * @param string          $group The group this task should be assigned to. Default is 'pmpro_async_tasks'.
+	 * @param int|string|null $timestamp An pmpro_strtotime datetime or human-readable string.
+	 * @param boolean         $run_asap Whether to bypass the count delay and run async asap.
+	 * @return void
+	 */
+	public function maybe_add_task( $hook, $args, $group = 'pmpro_async_tasks', $timestamp = null, $run_asap = false ) {
+		// Convert human-readable string to timestamp if needed.
+		if ( ! is_null( $timestamp ) && ! is_int( $timestamp ) ) {
+			$converted = $this->pmpro_strtotime( $timestamp );
+			if ( $converted !== false ) {
+				$timestamp = $converted;
+			} else {
+				$timestamp = null;
+			}
+		}
+		// Check for a task in the queue matching this task exactly (hook, args, group).
+		if ( $this->has_existing_task( $hook, $args, $group ) ) {
+			return;
+		}
+
+		// We're going to add a timestamp
+		if ( null === $timestamp && false === $run_asap ) {
+			$task_count = self::count_existing_tasks_for_group( $group );
+			// If we have more than self::get_pmpro_as_queue() tasks in the queue, add a delay to the task.
+			// This will space out tasks and prevent overwhelming the server if the tasking is heavy.
+			if ( $task_count > self::get_pmpro_as_queue_limit() ) {
+				$delay     = $task_count - self::get_pmpro_as_queue_limit();
+				$timestamp = $this->pmpro_strtotime( "+{$delay} seconds" );
+			} else {
+				// Less than self::get_pmpro_as_queue() tasks in the queue, queue this task immediately.
+				$timestamp = $this->pmpro_strtotime( 'now' );
+			}
+		}
+
+		// If we are running this task immediately, we need to use the async queue.
+		if ( $run_asap ) {
+			return as_enqueue_async_action( $hook, $args, $group );
+		}
+		// If we have a timestamp, we will schedule the task for the time provided.
+		if ( null !== $timestamp ) {
+			return as_schedule_single_action( $timestamp, $hook, $args, $group );
+		}
+	}
+
+	/**
+	 * Maybe add a recurring task (if not exists)
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string   $hook The hook for the task.
+	 * @param int|null $interval_in_seconds The interval in seconds this recurring task should run.
+	 * @param int|null $first_run_datetime An pmpro_strtotime datetime in the future this task should first run.
+	 * @param string   $group The group this task should be assigned to.
+	 * @return void
+	 */
+	public function maybe_add_recurring_task( $hook, $interval_in_seconds = null, $first_run_datetime = null, $group = 'pmpro_recurring_tasks' ) {
+		if ( ! $this->has_existing_task( $hook, array(), $group ) ) {
+			// Make sure first run datetime has been set.
+			$first_run_datetime = $first_run_datetime ?: $this->pmpro_strtotime( 'now +5 minutes' );
+			// Schedule this task in the future, and make it recurring.
+			if ( ! empty( $interval_in_seconds ) ) {
+				return as_schedule_recurring_action( $first_run_datetime, $interval_in_seconds, $hook, array(), $group );
+			} else {
+				throw new WP_Error( 'pmpro_action_scheduler_warning', __( 'An interval is required to queue an Action Scheduler recurring task.', 'paid-memberships-pro' ) );
+			}
+		}
+	}
+
+	/**
+	 * Add the ability to store custom messages with Action Scheduler's logs when running a task.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string $hook The hook name.
+	 * @param string $status The status of the action.
+	 * @param string $message The log message to add.
+	 * @return void
+	 */
+	public static function add_task_log( $hook, $status, $message = '' ) {
+		if ( empty( $hook ) || empty( $message ) ) {
+			// If we don't have a message or hook, we can't log anything.
+			return;
+		}
+		// We have to use ActionScheduler::store()->find_action() to get the action ID.
+		// This is because the action ID is not available in the context of the task.
+		$action_id = ActionScheduler::store()->find_action( $hook, array( 'status' => ActionScheduler_Store::STATUS_RUNNING ) );
+
+		if ( empty( $action_id ) ) {
+			// If we don't have an action ID, we can't log anything.
+			return;
+		}
+		// Log the message with the action ID when running a task.
+		ActionScheduler::logger()->log( $action_id, $message );
+	}
+
+	/**
+	 * List all tasks in the queue for a given group.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string $group The task group name.
+	 * @return array The list of tasks in the queue.
+	 */
+	public static function list_tasks_by_group( $group ) {
+		return as_get_scheduled_actions( array( 'group' => $group ) );
+	}
+
+	/**
+	 * List all tasks in the queue for a given hook.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string $hook The task hook name.
+	 * @return array The list of tasks in the queue.
+	 */
+	public static function list_tasks_by_hook( $hook ) {
+		return as_get_scheduled_actions( array( 'hook' => $hook ) );
+	}
+
+	/**
+	 * Clear all tasks in the queue matching the given hook, args, and/or group.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param string|null $hook  The hook name for the task.
+	 * @param array       $args  The arguments for the task.
+	 * @param string|null $group The group the task belongs to.
+	 * @param string      $status The status of the task to delete (default: 'completed').
+	 * @return int Number of tasks deleted.
+	 * @throws WP_Error If no parameters are provided.
+	 */
+	public static function remove_actions( $hook = null, $args = array(), $group = null, $status = 'completed' ) {
+
+		// For cases where we're filtering by args or group only
+		$search_args = array(
+			'status'   => self::get_as_status( $status ),
+			'per_page' => 100, // Process in batches
+		);
+
+		if ( ! empty( $hook ) ) {
+			$search_args['hook'] = $hook;
+		}
+
+		if ( ! empty( $args ) ) {
+			$search_args['args'] = $args;
+		}
+
+		if ( ! empty( $group ) ) {
+			$search_args['group'] = $group;
+		}
+
+		$count             = 0;
+		$deleted_something = true;
+
+		// Continue deleting in batches until no more actions are found
+		while ( $deleted_something ) {
+			$deleted_something = false;
+			$actions           = as_get_scheduled_actions( $search_args, 'ids' );
+
+			if ( ! empty( $actions ) && is_array( $actions ) ) {
+				foreach ( $actions as $action_id ) {
+					ActionScheduler::store()->delete_action( $action_id );
+					++$count;
+					$deleted_something = true;
+				}
+			} else {
+				break;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Registers PMPro recurring scheduled hooks and ensures they are scheduled if not already.
+	 *
+	 * The following hooks are scheduled via Action Scheduler, using the 'pmpro_recurring_tasks' group:
+	 * - pmpro_schedule_quarter_hourly: Runs every 15 minutes.
+	 * - pmpro_schedule_hourly: Runs every hour.
+	 * - pmpro_schedule_daily: Runs daily at 10:30am.
+	 * - pmpro_schedule_weekly: Runs every Sunday at 8:00am.
+	 * - pmpro_trigger_monthly: Runs on the first day of each month at 8:00am.
+	 *
+	 * Filters:
+	 * - `pmpro_action_scheduler_recurring_schedules`: Modify or extend the recurring schedule definitions.
+	 *
+	 * Notes:
+	 * - Each hook gets a dummy callback (see `add_dummy_callbacks()`) to prevent logging failures for unhandled actions.
+	 * - The `pmpro_trigger_monthly` task is handled by `handle_monthly_tasks()` and automatically reschedules itself.
+	 *
+	 * @access public
+	 * @since 3.5
+	 */
+	public function add_recurring_hooks() {
+		$schedules = apply_filters(
+			'pmpro_action_scheduler_recurring_schedules',
+			array(
+				array(
+					'hook'     => 'pmpro_schedule_quarter_hourly',
+					'interval' => 15 * MINUTE_IN_SECONDS,
+					'start'    => $this->pmpro_strtotime( 'now +15 minutes' ),
+				),
+				array(
+					'hook'     => 'pmpro_schedule_hourly',
+					'interval' => HOUR_IN_SECONDS,
+					'start'    => $this->pmpro_strtotime( 'now +1 hour' ),
+				),
+				array(
+					'hook'     => 'pmpro_schedule_daily',
+					'interval' => DAY_IN_SECONDS,
+					'start'    => $this->pmpro_strtotime( 'tomorrow 10:30am' ),
+				),
+				array(
+					'hook'     => 'pmpro_schedule_weekly',
+					'interval' => WEEK_IN_SECONDS,
+					'start'    => $this->pmpro_strtotime( 'next sunday 8:00am' ),
+				),
+			)
+		);
+
+		foreach ( $schedules as $schedule ) {
+			if ( ! empty( $schedule['hook'] ) && ! empty( $schedule['interval'] ) ) {
+				$this->maybe_add_recurring_task(
+					$schedule['hook'],
+					$schedule['interval'],
+					! empty( $schedule['start'] ) ? $schedule['start'] : null,
+					'pmpro_recurring_tasks'
+				);
+			}
+		}
+
+		// Schedule the first instance of our monthly action if none exists.
+		if ( ! $this->has_existing_task( 'pmpro_trigger_monthly', array(), 'pmpro_recurring_tasks' ) ) {
+			$first = $this->pmpro_strtotime( 'first day of next month 8:00am' );
+			as_schedule_single_action( $first, 'pmpro_trigger_monthly', array(), 'pmpro_recurring_tasks' );
+		}
+	}
+
+	/**
+	 * Add dummy callbacks for our scheduled tasks to prevent AS from logging failed actions.
+	 *
+	 * This ensures that scheduled hooks without real handlers do not trigger "no callback" errors in the Action Scheduler log.
+	 *
+	 * NOTE: If you are using a custom schedule, you will need to add a dummy callback for it here.
+	 *
+	 * Filters:
+	 * - `pmpro_action_scheduler_recurring_schedules`: Allows you to modify or extend the list of recurring hooks needing dummy callbacks.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return void
+	 */
+	public function add_dummy_callbacks() {
+		$schedules = apply_filters(
+			'pmpro_action_scheduler_recurring_schedules',
+			array(
+				array( 'hook' => 'pmpro_schedule_quarter_hourly' ),
+				array( 'hook' => 'pmpro_schedule_hourly' ),
+				array( 'hook' => 'pmpro_schedule_daily' ),
+				array( 'hook' => 'pmpro_schedule_weekly' ),
+			)
+		);
+
+		// Add dummy callbacks for the scheduled tasks.
+		// This is to prevent PHP notices when the tasks are run.
+		foreach ( $schedules as $schedule ) {
+			if ( ! empty( $schedule['hook'] ) ) {
+				add_action(
+					$schedule['hook'],
+					function () use ( $schedule ) {
+						PMPro_Action_Scheduler::add_task_log( $schedule['hook'], 'info', 'PMPro: Dummy callback executed for ' . $schedule['hook'] . ' scheduled hook.' );
+						return;
+					}
+				);
+			}
+		}
+
+		// Ensure our custom monthly task also has a fallback callback.
+		add_action(
+			'pmpro_trigger_monthly',
+			function () {
+				PMPro_Action_Scheduler::add_task_log( 'pmpro_trigger_monthly', 'info', 'PMPro: Dummy callback executed for monthly scheduled hook.' );
+				return;
+			}
+		);
+	}
+
+	/**
+	 * Handle the monthly schedule and reschedule the next instance.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return void
+	 */
+	public function handle_monthly_tasks() {
+		// Run any logic needed for monthly jobs here.
+		do_action( 'pmpro_schedule_monthly' );
+
+		// Schedule the next run for exactly one calendar month from now.
+		$next_month = $this->pmpro_strtotime( 'first day of next month 8:00am' );
+		as_schedule_single_action( $next_month, 'pmpro_trigger_monthly', array(), 'pmpro_recurring_tasks' );
+	}
+
+	/**
+	 * Suspend or resume Action Scheduler. Happens automatically if pmpro_is_paused() is true.
+	 *
+	 * This method adds filters to Action Scheduler's queue runner
+	 * to set the batch size and concurrent batches to 0.
+	 *
+	 * @return void
+	 */
+	public function pause_as_queue() {
+
+		// Initialize the callback only if not already set
+		if ( $this->batch_size_callback === null ) {
+			$this->batch_size_callback = function ( $batch_size, $context ) {
+				return 0;
+			};
+		}
+		$callback = $this->batch_size_callback;
+
+		// If PMPro is paused, add our filters
+		if ( pmpro_is_paused() ) {
+			add_filter( 'action_scheduler_queue_runner_batch_size', $callback, 999, 2 );
+			add_filter( 'action_scheduler_queue_runner_concurrent_batches', $callback, 999, 2 );
+		}
+
+		// Add listener for pause/unpause status changes
+		add_action(
+			'pmpro_as_pause_status_changed',
+			function ( $is_paused ) use ( $callback ) {
+				if ( $is_paused ) {
+					add_filter( 'action_scheduler_queue_runner_batch_size', $callback, 999, 2 );
+					add_filter( 'action_scheduler_queue_runner_concurrent_batches', $callback, 999, 2 );
+				} else {
+					remove_filter( 'action_scheduler_queue_runner_batch_size', $callback, 999 );
+					remove_filter( 'action_scheduler_queue_runner_concurrent_batches', $callback, 999 );
+				}
+			},
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Action scheduler claims a batch of actions to process in each request. It keeps the batch
+	 * fairly small (by default, 25) in order to prevent errors, like memory exhaustion.
+	 *
+	 * This method increases or decreases it so that more/less actions are processed in each queue, which speeds up the
+	 * overall queue processing time due to latency in requests and the minimum 1 minute between each
+	 * queue being processed.
+	 *
+	 * You can also set this to a different value using the pmpro_action_scheduler_batch_size filter.
+	 *
+	 * For more details on Action Scheduler batch sizes, see: https://actionscheduler.org/perf/#increasing-batch-size
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param int $batch_size The current batch size.
+	 * @return int Modified batch size.
+	 */
+	public function modify_batch_size( $batch_size ) {
+
+		// If we are on Pantheon, we can set it to 50.
+		if ( defined( 'PANTHEON_ENVIRONMENT' ) ) {
+			$batch_size = 50;
+			// If we are on WP Engine, we should set it to 20.
+		} elseif ( defined( 'WP_ENGINE' ) ) {
+			$batch_size = 20;
+		}
+
+		/**
+		 * Public filter for adjusting the batch size in Action Scheduler.
+		 *
+		 * @param int $batch_size The batch size.
+		 */
+		$batch_size = apply_filters( 'pmpro_action_scheduler_batch_size', $batch_size );
+
+		return $batch_size;
+	}
+
+
+	/**
+	 * Modify the default time limit for processing a batch of actions.
+	 *
+	 * Action Scheduler provides a default of 30 seconds in which to process actions.
+	 * We can increase this for hosts like Pantheon and WP Engine.
+	 *
+	 * You can also set this to a different value using the pmpro_action_scheduler_time_limit_seconds filter.
+	 *
+	 * For more details on the Action Scheduler time limit, see: https://actionscheduler.org/perf/#increasing-time-limit
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @param int $time_limit The current time limit in seconds.
+	 * @return int Modified time limit in seconds.
+	 */
+	public function modify_batch_time_limit( $time_limit ) {
+
+		// Set sensible defaults based on known environment limits.
+		// If we are on Pantheon, we can set it to 120.
+		if ( defined( 'PANTHEON_ENVIRONMENT' ) ) {
+			$time_limit = 120;
+			// If we are on WP Engine, we can set it to 60.
+		} elseif ( defined( 'WP_ENGINE' ) ) {
+			$time_limit = 60;
+		}
+
+		/**
+		 * Public filter for adjusting the time limit for Action Scheduler batches.
+		 *
+		 * @param int $time_limit The time limit in seconds.
+		 */
+		$time_limit = apply_filters( 'pmpro_action_scheduler_time_limit_seconds', $time_limit );
+
+		return $time_limit;
+	}
+
+	/**
+	 * Map text $status to the Action Scheduler status.
+	 *
+	 * Accepts fuzzy matches for the following statuses: queue, queued, waiting, pending | error, failed | in-progress, running, processing | completed, complete, done.
+	 *
+	 * @access private
+	 * @since 3.5
+	 * @param string $status The text status to map to AS status.
+	 * @return string The mapped status.
+	 */
+	public static function get_as_status( $status ) {
+		// Map a text $status to the Action Scheduler status.
+		switch ( $status ) {
+			case 'queue':
+			case 'queued':
+			case 'waiting':
+			case 'pending':
+				$status = ActionScheduler_Store::STATUS_PENDING;
+				break;
+			case 'error':
+			case 'failed':
+				$status = ActionScheduler_Store::STATUS_FAILED;
+				break;
+			case 'in-progress':
+			case 'running':
+			case 'processing':
+				$status = ActionScheduler_Store::STATUS_RUNNING;
+				break;
+			case 'completed':
+			case 'complete':
+			case 'done':
+			default:
+				$status = ActionScheduler_Store::STATUS_COMPLETE;
+		}
+		return $status;
+	}
+
+	/**
+	 * Convert a relative or absolute time string into a timestamp using the site's timezone.
+	 *
+	 * @access private
+	 * @since 3.5
+	 * @param string $time_string A string like "+10 minutes" or "tomorrow 5pm".
+	 * @return int UTC timestamp adjusted to the WordPress timezone.
+	 */
+	private function pmpro_strtotime( $time_string ) {
+		$timezone = wp_timezone();
+		$datetime = new DateTimeImmutable( 'now', $timezone );
+		$modified = $datetime->modify( $time_string );
+		return $modified->getTimestamp();
+	}
+
+	/**
+	 * Pause Action Scheduler.
+	 *
+	 * Sets the 'pmpro_paused' option to true and fires the 'pmpro_pause_status_changed' action.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return void
+	 */
+	public static function pause() {
+		update_option( 'pmpro_as_paused', true );
+		/**
+		 * Fires when PMPro pause status is changed.
+		 *
+		 * @param bool $is_paused Whether PMPro is paused.
+		 */
+		do_action( 'pmpro_as_pause_status_changed', true );
+	}
+
+	/**
+	 * Unpause Action Scheduler.
+	 *
+	 * Sets the 'pmpro_as_paused' option to false and fires the 'pmpro_as_pause_status_changed' action.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return void
+	 */
+	public static function unpause() {
+		update_option( 'pmpro_as_paused', false );
+		/**
+		 * Fires when PMPro pause status is changed.
+		 *
+		 * @param bool $is_paused Whether PMPro is paused.
+		 */
+		do_action( 'pmpro_as_pause_status_changed', false );
+	}
+
+	/**
+	 * Check if Action Scheduler is paused.
+	 *
+	 * Returns the value of the 'pmpro_as_paused' option as a boolean.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return bool True if paused, false otherwise.
+	 */
+	public static function is_paused() {
+		return (bool) get_option( 'pmpro_as_paused', false );
+	}
+}

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -65,6 +65,10 @@ class PMPro_Site_Health {
 					'label' => __( 'Cron Job Status', 'paid-memberships-pro' ),
 					'value' => self::get_cron_jobs(),
 				],
+				'pmpro-action-scheduler' => [
+					'label' => __( 'Action Scheduler Enabled', 'paid-memberships-pro' ),
+					'value' => self::get_action_scheduler_state(),
+				],
 				'pmpro-gateway'              => [
 					'label' => __( 'Payment Gateway', 'paid-memberships-pro' ),
 					'value' => self::get_gateway(),
@@ -419,6 +423,34 @@ class PMPro_Site_Health {
 		}
 
 		return implode( " | \n", $cron_information );
+	}
+
+	/**
+	 * Get the action scheduler state.
+	 *
+	 * @access public
+	 * @since 3.5
+	 *
+	 * @return string The action scheduler state.
+	 */
+	public function get_action_scheduler_state() {
+		if ( ! class_exists( 'ActionScheduler' ) ) {
+			return __( 'Not Installed', 'paid-memberships-pro' );
+		}
+
+		if ( ! ActionScheduler::is_enabled() ) {
+			return __( 'Disabled', 'paid-memberships-pro' );
+		}
+
+		if ( ! ActionScheduler::is_installed() ) {
+			return __( 'Not Installed', 'paid-memberships-pro' );
+		}
+
+		if ( ! ActionScheduler::is_ready() ) {
+			return __( 'Not Ready', 'paid-memberships-pro' );
+		}
+
+		return __( 'Enabled', 'paid-memberships-pro' );
 	}
 
 	/**

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -21,9 +21,6 @@ function pmpro_get_crons() {
 			'interval'  => 'hourly',
 			'timestamp' => current_time( 'timestamp' ) + 1,
 		),
-		'pmpro_cron_credit_card_expiring_warnings' => array(
-			'interval' => 'monthly',
-		),
 		'pmpro_cron_admin_activity_email'          => array(
 			'interval'  => 'daily',
 			'timestamp' => strtotime( '10:30:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ),

--- a/includes/crons.php
+++ b/includes/crons.php
@@ -13,32 +13,32 @@
  * @return array The list of registered crons for Paid Memberships Pro.
  */
 function pmpro_get_crons() {
-	$crons = [
-		'pmpro_cron_expire_memberships'            => [
+	$crons = array(
+		'pmpro_cron_expire_memberships'            => array(
 			'interval' => 'hourly',
-		],
-		'pmpro_cron_expiration_warnings'           => [
+		),
+		'pmpro_cron_expiration_warnings'           => array(
 			'interval'  => 'hourly',
 			'timestamp' => current_time( 'timestamp' ) + 1,
-		],
-		'pmpro_cron_credit_card_expiring_warnings' => [
+		),
+		'pmpro_cron_credit_card_expiring_warnings' => array(
 			'interval' => 'monthly',
-		],
-		'pmpro_cron_admin_activity_email'          => [
+		),
+		'pmpro_cron_admin_activity_email'          => array(
 			'interval'  => 'daily',
 			'timestamp' => strtotime( '10:30:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ),
-		],
-		'pmpro_cron_delete_tmp'          => [
+		),
+		'pmpro_cron_delete_tmp'                    => array(
 			'interval'  => 'daily',
 			'timestamp' => strtotime( '10:30:00' ) - ( get_option( 'gmt_offset' ) * HOUR_IN_SECONDS ),
-		],
-		'pmpro_license_check_key'                  => [
+		),
+		'pmpro_license_check_key'                  => array(
 			'interval' => 'monthly',
-		],
-		'pmpro_cron_recurring_payment_reminders'  => [
+		),
+		'pmpro_cron_recurring_payment_reminders'   => array(
 			'interval' => 'hourly',
-		],
-	];
+		),
+	);
 
 	/**
 	 * Allow filtering the list of registered crons for Paid Memberships Pro.
@@ -60,7 +60,7 @@ function pmpro_get_crons() {
 		}
 
 		if ( empty( $cron['args'] ) ) {
-			$cron['args'] = [];
+			$cron['args'] = array();
 		}
 
 		$crons[ $hook ] = $cron;
@@ -84,11 +84,12 @@ function pmpro_maybe_schedule_crons() {
 
 /**
  * Clear all PMPro related crons.
+ *
  * @since 2.8.1
  */
-function pmpro_clear_crons() {	
+function pmpro_clear_crons() {
 	$crons = array_keys( pmpro_get_crons() );
-	foreach( $crons as $cron ) {
+	foreach ( $crons as $cron ) {
 		wp_clear_scheduled_hook( $cron );
 	}
 }
@@ -110,7 +111,7 @@ function pmpro_handle_schedule_crons_on_cron_ready_check( $pre ) {
 	return $pre;
 }
 
-add_filter( 'pre_get_ready_cron_jobs', 'pmpro_handle_schedule_crons_on_cron_ready_check' );
+// add_filter( 'pre_get_ready_cron_jobs', 'pmpro_handle_schedule_crons_on_cron_ready_check' );
 
 /**
  * Schedule a periodic event unless one with the same hook is already scheduled.
@@ -131,7 +132,7 @@ add_filter( 'pre_get_ready_cron_jobs', 'pmpro_handle_schedule_crons_on_cron_read
  *
  * @return bool|WP_Error True when an event is scheduled, WP_Error on failure, and false if the event was already scheduled.
  */
-function pmpro_maybe_schedule_event( $timestamp, $recurrence, $hook, $args = [] ) {
+function pmpro_maybe_schedule_event( $timestamp, $recurrence, $hook, $args = array() ) {
 	$next = wp_next_scheduled( $hook, $args );
 
 	if ( empty( $next ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3900,11 +3900,17 @@ function pmpro_getOrderStatuses( $force = false ) {
  * those rows are marked as inactive.
  *
  * @since 1.9.4.4
+ * @deprecated 3.5 Use PMPro_Membership_Level::fix_inactive_memberships() and PMPro_Membership_Level::resolve_duplicate_active_rows() instead.
+ * 
+ * @return void
  */
 function pmpro_cleanup_memberships_users_table() {
+	_deprecated_function( __METHOD__, '3.5', 'PMPro_Membership_Level::fix_inactive_memberships()' );
+	_deprecated_function( __METHOD__, '3.5', 'PMPro_Membership_Level::resolve_duplicate_active_rows()' );
+
 	global $wpdb;
 
-	// fix rows for levels that don't exists
+	// Fix rows for levels that don't exist
 	$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users mu
 					LEFT JOIN $wpdb->pmpro_membership_levels l ON mu.membership_id = l.id
 				SET mu.status = 'inactive'
@@ -3912,7 +3918,7 @@ function pmpro_cleanup_memberships_users_table() {
 					AND l.id IS NULL";
 	$wpdb->query( $sqlQuery );
 
-	// fix rows where there is more than one active status for the same user/level
+	// Fix rows where there is more than one active status for the same user/level
 	$sqlQuery = "UPDATE $wpdb->pmpro_memberships_users t1
 					INNER JOIN (SELECT mu1.id as id
 				FROM $wpdb->pmpro_memberships_users mu1, $wpdb->pmpro_memberships_users mu2
@@ -3924,7 +3930,7 @@ function pmpro_cleanup_memberships_users_table() {
 				GROUP BY mu1.id
 				ORDER BY mu1.user_id, mu1.id DESC) t2
 				ON t1.id = t2.id
-				SET status = 'inactive'";
+				SET t1.status = 'inactive'";
 	$wpdb->query( $sqlQuery );
 }
 

--- a/includes/lib/action-scheduler/README.md
+++ b/includes/lib/action-scheduler/README.md
@@ -1,0 +1,35 @@
+# Action Scheduler - Job Queue for WordPress [![Build Status](https://travis-ci.org/woocommerce/action-scheduler.png?branch=master)](https://travis-ci.org/woocommerce/action-scheduler) [![codecov](https://codecov.io/gh/woocommerce/action-scheduler/branch/master/graph/badge.svg)](https://codecov.io/gh/woocommerce/action-scheduler)
+
+Action Scheduler is a scalable, traceable job queue for background processing large sets of actions in WordPress. It's specially designed to be distributed in WordPress plugins.
+
+Action Scheduler works by triggering an action hook to run at some time in the future. Each hook can be scheduled with unique data, to allow callbacks to perform operations on that data. The hook can also be scheduled to run on one or more occasions.
+
+Think of it like an extension to `do_action()` which adds the ability to delay and repeat a hook.
+
+## Battle-Tested Background Processing
+
+Every month, Action Scheduler processes millions of payments for [Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/), webhooks for [WooCommerce](https://wordpress.org/plugins/woocommerce/), as well as emails and other events for a range of other plugins.
+
+It's been seen on live sites processing queues in excess of 50,000 jobs and doing resource intensive operations, like processing payments and creating orders, at a sustained rate of over 10,000 / hour without negatively impacting normal site operations.
+
+This is all on infrastructure and WordPress sites outside the control of the plugin author.
+
+If your plugin needs background processing, especially of large sets of tasks, Action Scheduler can help.
+
+## Learn More
+
+To learn more about how to Action Scheduler works, and how to use it in your plugin, check out the docs on [ActionScheduler.org](https://actionscheduler.org).
+
+There you will find:
+
+* [Usage guide](https://actionscheduler.org/usage/): instructions on installing and using Action Scheduler
+* [WP CLI guide](https://actionscheduler.org/wp-cli/): instructions on running Action Scheduler at scale via WP CLI
+* [API Reference](https://actionscheduler.org/api/): complete reference guide for all API functions
+* [Administration Guide](https://actionscheduler.org/admin/): guide to managing scheduled actions via the administration screen
+* [Guide to Background Processing at Scale](https://actionscheduler.org/perf/): instructions for running Action Scheduler at scale via the default WP Cron queue runner
+
+## Credits
+
+Action Scheduler is developed and maintained by [Automattic](http://automattic.com/) with significant early development completed by [Flightless](https://flightless.us/).
+
+Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.

--- a/includes/lib/action-scheduler/action-scheduler.php
+++ b/includes/lib/action-scheduler/action-scheduler.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Plugin Name: Action Scheduler
+ * Plugin URI: https://actionscheduler.org
+ * Description: A robust scheduling library for use in WordPress plugins.
+ * Author: Automattic
+ * Author URI: https://automattic.com/
+ * Version: 3.9.2
+ * License: GPLv3
+ * Requires at least: 6.5
+ * Tested up to: 6.7
+ * Requires PHP: 7.1
+ *
+ * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @package ActionScheduler
+ */
+
+if ( ! function_exists( 'action_scheduler_register_3_dot_9_dot_2' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
+
+	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
+		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
+		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
+	}
+
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_9_dot_2', 0, 0 ); // WRCS: DEFINED_VERSION.
+
+	// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+	/**
+	 * Registers this version of Action Scheduler.
+	 */
+	function action_scheduler_register_3_dot_9_dot_2() { // WRCS: DEFINED_VERSION.
+		$versions = ActionScheduler_Versions::instance();
+		$versions->register( '3.9.2', 'action_scheduler_initialize_3_dot_9_dot_2' ); // WRCS: DEFINED_VERSION.
+	}
+
+	// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
+	/**
+	 * Initializes this version of Action Scheduler.
+	 */
+	function action_scheduler_initialize_3_dot_9_dot_2() { // WRCS: DEFINED_VERSION.
+		// A final safety check is required even here, because historic versions of Action Scheduler
+		// followed a different pattern (in some unusual cases, we could reach this point and the
+		// ActionScheduler class is already defined—so we need to guard against that).
+		if ( ! class_exists( 'ActionScheduler', false ) ) {
+			require_once __DIR__ . '/classes/abstracts/ActionScheduler.php';
+			ActionScheduler::init( __FILE__ );
+		}
+	}
+
+	// Support usage in themes - load this version if no plugin has loaded a version yet.
+	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
+		action_scheduler_initialize_3_dot_9_dot_2(); // WRCS: DEFINED_VERSION.
+		do_action( 'action_scheduler_pre_theme_init' );
+		ActionScheduler_Versions::initialize_latest_version();
+	}
+}

--- a/includes/lib/action-scheduler/changelog.txt
+++ b/includes/lib/action-scheduler/changelog.txt
@@ -1,0 +1,187 @@
+*** Changelog ***
+
+= 3.9.2 - 2025-02-03 =
+* Fixed fatal errors by moving version info methods to a new class and deprecating conflicting ones in ActionScheduler_Versions
+
+= 3.9.1 - 2025-01-21 =
+* A number of new WP CLI commands have been added, making it easier to manage actions in the terminal and from scripts.
+* New wp action-scheduler source command to help determine how Action Scheduler is being loaded.
+* Additional information about the active instance of Action Scheduler is now available in the Help pull-down drawer.
+* Make some other nullable parameters explicitly nullable.
+* Set option value to `no` rather than deleting.
+
+= 3.9.0 - 2024-11-14 =  
+* Minimum required version of PHP is now 7.1.  
+* Performance improvements for the `as_pending_actions_due()` function.  
+* Existing filter hook `action_scheduler_claim_actions_order_by` enhanced to provide callbacks with additional information.  
+* Improved compatibility with PHP 8.4, specifically by making implicitly nullable parameters explicitly nullable.  
+* A large number of coding standards-enhancements, to help reduce friction when submitting plugins to marketplaces and plugin directories. Special props @crstauf for this effort.  
+* Minor documentation tweaks and improvements.
+
+= 3.8.2 - 2024-09-12 =
+* Add missing parameter to the `pre_as_enqueue_async_action` hook.
+* Bump minimum PHP version to 7.0.
+* Bump minimum WordPress version to 6.4.
+* Make the batch size adjustable during processing.
+
+= 3.8.1 - 2024-06-20 =
+* Fix typos.
+* Improve the messaging in our unidentified action exceptions.
+
+= 3.8.0 - 2024-05-22 =
+* Documentation - Fixed typos in perf.md.
+* Update - We now require WordPress 6.3 or higher.
+* Update - We now require PHP 7.0 or higher.
+
+= 3.7.4 - 2024-04-05 =
+* Give a clear description of how the $unique parameter works.
+* Preserve the tab field if set.
+* Tweak - WP 6.5 compatibility.
+
+= 3.7.3 - 2024-03-20 =
+* Do not iterate over all of GET when building form in list table.
+* Fix a few issues reported by PCP (Plugin Check Plugin).
+* Try to save actions as unique even when the store doesn't support it.
+* Tweak - WP 6.4 compatibility.
+* Update "Tested up to" tag to WordPress 6.5.
+* update version in package-lock.json.
+
+= 3.7.2 - 2024-02-14 =
+* No longer user variables in `_n()` translation function.
+
+= 3.7.1 - 2023-12-13 =
+* update semver to 5.7.2 because of a security vulnerability in 5.7.1.
+
+= 3.7.0 - 2023-11-20 =
+* Important: starting with this release, Action Scheduler follows an L-2 version policy (WordPress, and consequently PHP).
+* Add extended indexes for hook_status_scheduled_date_gmt and status_scheduled_date_gmt.
+* Catch and log exceptions thrown when actions can't be created, e.g. under a corrupt database schema.
+* Tweak - WP 6.4 compatibility.
+* Update unit tests for upcoming dependency version policy.
+* make sure hook action_scheduler_failed_execution can access original exception object.
+* mention dependency version policy in usage.md.
+
+= 3.6.4 - 2023-10-11 =
+* Performance improvements when bulk cancelling actions.
+* Dev-related fixes.
+
+= 3.6.3 - 2023-09-13 =
+* Use `_doing_it_wrong` in initialization check.
+
+= 3.6.2 - 2023-08-09 =
+* Add guidance about passing arguments.
+* Atomic option locking.
+* Improve bulk delete handling.
+* Include database error in the exception message.
+* Tweak - WP 6.3 compatibility.
+
+= 3.6.1 - 2023-06-14 =
+* Document new optional `$priority` arg for various API functions.
+* Document the new `--exclude-groups` WP CLI option.
+* Document the new `action_scheduler_init` hook.
+* Ensure actions within each claim are executed in the expected order.
+* Fix incorrect text domain.
+* Remove SHOW TABLES usage when checking if tables exist.
+
+= 3.6.0 - 2023-05-10 =
+* Add $unique parameter to function signatures.
+* Add a cast-to-int for extra safety before forming new DateTime object.
+* Add a hook allowing exceptions for consistently failing recurring actions.
+* Add action priorities.
+* Add init hook.
+* Always raise the time limit.
+* Bump minimatch from 3.0.4 to 3.0.8.
+* Bump yaml from 2.2.1 to 2.2.2.
+* Defensive coding relating to gaps in declared schedule types.
+* Do not process an action if it cannot be set to `in-progress`.
+* Filter view labels (status names) should be translatable | #919.
+* Fix WPCLI progress messages.
+* Improve data-store initialization flow.
+* Improve error handling across all supported PHP versions.
+* Improve logic for flushing the runtime cache.
+* Support exclusion of multiple groups.
+* Update lint-staged and Node/NPM requirements.
+* add CLI clean command.
+* add CLI exclude-group filter.
+* exclude past-due from list table all filter count.
+* throwing an exception if as_schedule_recurring_action interval param is not of type integer.
+
+= 3.5.4 - 2023-01-17 =
+* Add pre filters during action registration.
+* Async scheduling.
+* Calculate timeouts based on total actions.
+* Correctly order the parameters for `ActionScheduler_ActionFactory`'s calls to `single_unique`.
+* Fetch action in memory first before releasing claim to avoid deadlock.
+* PHP 8.2: declare property to fix creation of dynamic property warning.
+* PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead".
+* Prevent `undefined variable` warning for `$num_pastdue_actions`.
+
+= 3.5.3 - 2022-11-09 =
+* Query actions with partial match.
+
+= 3.5.2 - 2022-09-16 =
+* Fix - erroneous 3.5.1 release.
+
+= 3.5.1 - 2022-09-13 =
+* Maintenance on A/S docs.
+* fix: PHP 8.2 deprecated notice.
+
+= 3.5.0 - 2022-08-25 =
+* Add - The active view link within the "Tools > Scheduled Actions" screen is now clickable.
+* Add - A warning when there are past-due actions.
+* Enhancement - Added the ability to schedule unique actions via an atomic operation.
+* Enhancement - Improvements to cache invalidation when processing batches (when running on WordPress 6.0+).
+* Enhancement - If a recurring action is found to be consistently failing, it will stop being rescheduled.
+* Enhancement - Adds a new "Past Due" view to the scheduled actions list table.
+
+= 3.4.2 - 2022-06-08 =
+* Fix - Change the include for better linting.
+* Fix - update: Added Action scheduler completed action hook.
+
+= 3.4.1 - 2022-05-24 =
+* Fix - Change the include for better linting.
+* Fix - Fix the documented return type.
+
+= 3.4.0 - 2021-10-29 =
+* Enhancement - Number of items per page can now be set for the Scheduled Actions view (props @ovidiul). #771
+* Fix - Do not lower the max_execution_time if it is already set to 0 (unlimited) (props @barryhughes). #755
+* Fix - Avoid triggering autoloaders during the version resolution process (props @olegabr). #731 & #776
+* Dev - ActionScheduler_wcSystemStatus PHPCS fixes (props @ovidiul). #761
+* Dev - ActionScheduler_DBLogger.php PHPCS fixes (props @ovidiul). #768
+* Dev - Fixed phpcs for ActionScheduler_Schedule_Deprecated (props @ovidiul). #762
+* Dev - Improve actions table indices (props @glagonikas). #774 & #777
+* Dev - PHPCS fixes for ActionScheduler_DBStore.php (props @ovidiul). #769 & #778
+* Dev - PHPCS Fixes for ActionScheduler_Abstract_ListTable (props @ovidiul). #763 & #779
+* Dev - Adds new filter action_scheduler_claim_actions_order_by to allow tuning of the claim query (props @glagonikas). #773
+* Dev - PHPCS fixes for ActionScheduler_WpPostStore class (props @ovidiul). #780
+
+= 3.3.0 - 2021-09-15 =
+* Enhancement - Adds as_has_scheduled_action() to provide a performant way to test for existing actions. #645
+* Fix - Improves compatibility with environments where NO_ZERO_DATE is enabled. #519
+* Fix - Adds safety checks to guard against errors when our database tables cannot be created. #645
+* Dev - Now supports queries that use multiple statuses. #649
+* Dev - Minimum requirements for WordPress and PHP bumped (to 5.2 and 5.6 respectively). #723
+
+= 3.2.1 - 2021-06-21 =
+* Fix - Add extra safety/account for different versions of AS and different loading patterns. #714
+* Fix - Handle hidden columns (Tools → Scheduled Actions) | #600.
+
+= 3.2.0 - 2021-06-03 =
+* Fix - Add "no ordering" option to as_next_scheduled_action().
+* Fix - Add secondary scheduled date checks when claiming actions (DBStore) | #634.
+* Fix - Add secondary scheduled date checks when claiming actions (wpPostStore) | #634.
+* Fix - Adds a new index to the action table, reducing the potential for deadlocks (props: @glagonikas).
+* Fix - Fix unit tests infrastructure and adapt tests to PHP 8.
+* Fix - Identify in-use data store.
+* Fix - Improve test_migration_is_scheduled.
+* Fix - PHP notice on list table.
+* Fix - Speed up clean up and batch selects.
+* Fix - Update pending dependencies.
+* Fix - [PHP 8.0] Only pass action arg values through to do_action_ref_array().
+* Fix - [PHP 8] Set the PHP version to 7.1 in composer.json for PHP 8 compatibility.
+* Fix - add is_initialized() to docs.
+* Fix - fix file permissions.
+* Fix - fixes #664 by replacing __ with esc_html__.
+
+= 3.1.6 - 2020-05-12 =
+* Change log starts.

--- a/includes/lib/action-scheduler/classes/ActionScheduler_ActionClaim.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_ActionClaim.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Class ActionScheduler_ActionClaim
+ */
+class ActionScheduler_ActionClaim {
+	/**
+	 * Claim ID.
+	 *
+	 * @var string
+	 */
+	private $id = '';
+
+	/**
+	 * Claimed action IDs.
+	 *
+	 * @var int[]
+	 */
+	private $action_ids = array();
+
+	/**
+	 * Construct.
+	 *
+	 * @param string $id Claim ID.
+	 * @param int[]  $action_ids Action IDs.
+	 */
+	public function __construct( $id, array $action_ids ) {
+		$this->id         = $id;
+		$this->action_ids = $action_ids;
+	}
+
+	/**
+	 * Get claim ID.
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+
+	/**
+	 * Get IDs of claimed actions.
+	 */
+	public function get_actions() {
+		return $this->action_ids;
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_ActionFactory.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_ActionFactory.php
@@ -1,0 +1,378 @@
+<?php
+
+/**
+ * Class ActionScheduler_ActionFactory
+ */
+class ActionScheduler_ActionFactory {
+
+	/**
+	 * Return stored actions for given params.
+	 *
+	 * @param string                        $status The action's status in the data store.
+	 * @param string                        $hook The hook to trigger when this action runs.
+	 * @param array                         $args Args to pass to callbacks when the hook is triggered.
+	 * @param ActionScheduler_Schedule|null $schedule The action's schedule.
+	 * @param string                        $group A group to put the action in.
+	 * phpcs:ignore Squiz.Commenting.FunctionComment.ExtraParamComment
+	 * @param int                           $priority The action priority.
+	 *
+	 * @return ActionScheduler_Action An instance of the stored action.
+	 */
+	public function get_stored_action( $status, $hook, array $args = array(), ?ActionScheduler_Schedule $schedule = null, $group = '' ) {
+		// The 6th parameter ($priority) is not formally declared in the method signature to maintain compatibility with
+		// third-party subclasses created before this param was added.
+		$priority = func_num_args() >= 6 ? (int) func_get_arg( 5 ) : 10;
+
+		switch ( $status ) {
+			case ActionScheduler_Store::STATUS_PENDING:
+				$action_class = 'ActionScheduler_Action';
+				break;
+			case ActionScheduler_Store::STATUS_CANCELED:
+				$action_class = 'ActionScheduler_CanceledAction';
+				if ( ! is_null( $schedule ) && ! is_a( $schedule, 'ActionScheduler_CanceledSchedule' ) && ! is_a( $schedule, 'ActionScheduler_NullSchedule' ) ) {
+					$schedule = new ActionScheduler_CanceledSchedule( $schedule->get_date() );
+				}
+				break;
+			default:
+				$action_class = 'ActionScheduler_FinishedAction';
+				break;
+		}
+
+		$action_class = apply_filters( 'action_scheduler_stored_action_class', $action_class, $status, $hook, $args, $schedule, $group );
+
+		$action = new $action_class( $hook, $args, $schedule, $group );
+		$action->set_priority( $priority );
+
+		/**
+		 * Allow 3rd party code to change the instantiated action for a given hook, args, schedule and group.
+		 *
+		 * @param ActionScheduler_Action   $action The instantiated action.
+		 * @param string                   $hook The instantiated action's hook.
+		 * @param array                    $args The instantiated action's args.
+		 * @param ActionScheduler_Schedule $schedule The instantiated action's schedule.
+		 * @param string                   $group The instantiated action's group.
+		 * @param int                      $priority The action priority.
+		 */
+		return apply_filters( 'action_scheduler_stored_action_instance', $action, $hook, $args, $schedule, $group, $priority );
+	}
+
+	/**
+	 * Enqueue an action to run one time, as soon as possible (rather a specific scheduled time).
+	 *
+	 * This method creates a new action using the NullSchedule. In practice, this results in an action scheduled to
+	 * execute "now". Therefore, it will generally run as soon as possible but is not prioritized ahead of other actions
+	 * that are already past-due.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param string $group A group to put the action in.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function async( $hook, $args = array(), $group = '' ) {
+		return $this->async_unique( $hook, $args, $group, false );
+	}
+
+	/**
+	 * Same as async, but also supports $unique param.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether to ensure the action is unique.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function async_unique( $hook, $args = array(), $group = '', $unique = true ) {
+		$schedule = new ActionScheduler_NullSchedule();
+		$action   = new ActionScheduler_Action( $hook, $args, $schedule, $group );
+		return $unique ? $this->store_unique_action( $action, $unique ) : $this->store( $action );
+	}
+
+	/**
+	 * Create single action.
+	 *
+	 * @param string $hook  The hook to trigger when this action runs.
+	 * @param array  $args  Args to pass when the hook is triggered.
+	 * @param int    $when  Unix timestamp when the action will run.
+	 * @param string $group A group to put the action in.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function single( $hook, $args = array(), $when = null, $group = '' ) {
+		return $this->single_unique( $hook, $args, $when, $group, false );
+	}
+
+	/**
+	 * Create single action only if there is no pending or running action with same name and params.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param int    $when Unix timestamp when the action will run.
+	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether action scheduled should be unique.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function single_unique( $hook, $args = array(), $when = null, $group = '', $unique = true ) {
+		$date     = as_get_datetime_object( $when );
+		$schedule = new ActionScheduler_SimpleSchedule( $date );
+		$action   = new ActionScheduler_Action( $hook, $args, $schedule, $group );
+		return $unique ? $this->store_unique_action( $action ) : $this->store( $action );
+	}
+
+	/**
+	 * Create the first instance of an action recurring on a given interval.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param int    $first Unix timestamp for the first run.
+	 * @param int    $interval Seconds between runs.
+	 * @param string $group A group to put the action in.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function recurring( $hook, $args = array(), $first = null, $interval = null, $group = '' ) {
+		return $this->recurring_unique( $hook, $args, $first, $interval, $group, false );
+	}
+
+	/**
+	 * Create the first instance of an action recurring on a given interval only if there is no pending or running action with same name and params.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param int    $first Unix timestamp for the first run.
+	 * @param int    $interval Seconds between runs.
+	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether action scheduled should be unique.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function recurring_unique( $hook, $args = array(), $first = null, $interval = null, $group = '', $unique = true ) {
+		if ( empty( $interval ) ) {
+			return $this->single_unique( $hook, $args, $first, $group, $unique );
+		}
+		$date     = as_get_datetime_object( $first );
+		$schedule = new ActionScheduler_IntervalSchedule( $date, $interval );
+		$action   = new ActionScheduler_Action( $hook, $args, $schedule, $group );
+		return $unique ? $this->store_unique_action( $action ) : $this->store( $action );
+	}
+
+	/**
+	 * Create the first instance of an action recurring on a Cron schedule.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param int    $base_timestamp The first instance of the action will be scheduled
+	 *        to run at a time calculated after this timestamp matching the cron
+	 *        expression. This can be used to delay the first instance of the action.
+	 * @param int    $schedule A cron definition string.
+	 * @param string $group A group to put the action in.
+	 *
+	 * @return int The ID of the stored action.
+	 */
+	public function cron( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '' ) {
+		return $this->cron_unique( $hook, $args, $base_timestamp, $schedule, $group, false );
+	}
+
+
+	/**
+	 * Create the first instance of an action recurring on a Cron schedule only if there is no pending or running action with same name and params.
+	 *
+	 * @param string $hook The hook to trigger when this action runs.
+	 * @param array  $args Args to pass when the hook is triggered.
+	 * @param int    $base_timestamp The first instance of the action will be scheduled
+	 *        to run at a time calculated after this timestamp matching the cron
+	 *        expression. This can be used to delay the first instance of the action.
+	 * @param int    $schedule A cron definition string.
+	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether action scheduled should be unique.
+	 *
+	 * @return int The ID of the stored action.
+	 **/
+	public function cron_unique( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '', $unique = true ) {
+		if ( empty( $schedule ) ) {
+			return $this->single_unique( $hook, $args, $base_timestamp, $group, $unique );
+		}
+		$date     = as_get_datetime_object( $base_timestamp );
+		$cron     = CronExpression::factory( $schedule );
+		$schedule = new ActionScheduler_CronSchedule( $date, $cron );
+		$action   = new ActionScheduler_Action( $hook, $args, $schedule, $group );
+		return $unique ? $this->store_unique_action( $action ) : $this->store( $action );
+	}
+
+	/**
+	 * Create a successive instance of a recurring or cron action.
+	 *
+	 * Importantly, the action will be rescheduled to run based on the current date/time.
+	 * That means when the action is scheduled to run in the past, the next scheduled date
+	 * will be pushed forward. For example, if a recurring action set to run every hour
+	 * was scheduled to run 5 seconds ago, it will be next scheduled for 1 hour in the
+	 * future, which is 1 hour and 5 seconds from when it was last scheduled to run.
+	 *
+	 * Alternatively, if the action is scheduled to run in the future, and is run early,
+	 * likely via manual intervention, then its schedule will change based on the time now.
+	 * For example, if a recurring action set to run every day, and is run 12 hours early,
+	 * it will run again in 24 hours, not 36 hours.
+	 *
+	 * This slippage is less of an issue with Cron actions, as the specific run time can
+	 * be set for them to run, e.g. 1am each day. In those cases, and entire period would
+	 * need to be missed before there was any change is scheduled, e.g. in the case of an
+	 * action scheduled for 1am each day, the action would need to run an entire day late.
+	 *
+	 * @param ActionScheduler_Action $action The existing action.
+	 *
+	 * @return string The ID of the stored action
+	 * @throws InvalidArgumentException If $action is not a recurring action.
+	 */
+	public function repeat( $action ) {
+		$schedule = $action->get_schedule();
+		$next     = $schedule->get_next( as_get_datetime_object() );
+
+		if ( is_null( $next ) || ! $schedule->is_recurring() ) {
+			throw new InvalidArgumentException( __( 'Invalid action - must be a recurring action.', 'action-scheduler' ) );
+		}
+
+		$schedule_class = get_class( $schedule );
+		$new_schedule   = new $schedule( $next, $schedule->get_recurrence(), $schedule->get_first_date() );
+		$new_action     = new ActionScheduler_Action( $action->get_hook(), $action->get_args(), $new_schedule, $action->get_group() );
+		$new_action->set_priority( $action->get_priority() );
+		return $this->store( $new_action );
+	}
+
+	/**
+	 * Creates a scheduled action.
+	 *
+	 * This general purpose method can be used in place of specific methods such as async(),
+	 * async_unique(), single() or single_unique(), etc.
+	 *
+	 * @internal Not intended for public use, should not be overridden by subclasses.
+	 *
+	 * @param array $options {
+	 *     Describes the action we wish to schedule.
+	 *
+	 *     @type string     $type      Must be one of 'async', 'cron', 'recurring', or 'single'.
+	 *     @type string     $hook      The hook to be executed.
+	 *     @type array      $arguments Arguments to be passed to the callback.
+	 *     @type string     $group     The action group.
+	 *     @type bool       $unique    If the action should be unique.
+	 *     @type int        $when      Timestamp. Indicates when the action, or first instance of the action in the case
+	 *                                 of recurring or cron actions, becomes due.
+	 *     @type int|string $pattern   Recurrence pattern. This is either an interval in seconds for recurring actions
+	 *                                 or a cron expression for cron actions.
+	 *     @type int        $priority  Lower values means higher priority. Should be in the range 0-255.
+	 * }
+	 *
+	 * @return int The action ID. Zero if there was an error scheduling the action.
+	 */
+	public function create( array $options = array() ) {
+		$defaults = array(
+			'type'      => 'single',
+			'hook'      => '',
+			'arguments' => array(),
+			'group'     => '',
+			'unique'    => false,
+			'when'      => time(),
+			'pattern'   => null,
+			'priority'  => 10,
+		);
+
+		$options = array_merge( $defaults, $options );
+
+		// Cron/recurring actions without a pattern are treated as single actions (this gives calling code the ability
+		// to use functions like as_schedule_recurring_action() to schedule recurring as well as single actions).
+		if ( ( 'cron' === $options['type'] || 'recurring' === $options['type'] ) && empty( $options['pattern'] ) ) {
+			$options['type'] = 'single';
+		}
+
+		switch ( $options['type'] ) {
+			case 'async':
+				$schedule = new ActionScheduler_NullSchedule();
+				break;
+
+			case 'cron':
+				$date     = as_get_datetime_object( $options['when'] );
+				$cron     = CronExpression::factory( $options['pattern'] );
+				$schedule = new ActionScheduler_CronSchedule( $date, $cron );
+				break;
+
+			case 'recurring':
+				$date     = as_get_datetime_object( $options['when'] );
+				$schedule = new ActionScheduler_IntervalSchedule( $date, $options['pattern'] );
+				break;
+
+			case 'single':
+				$date     = as_get_datetime_object( $options['when'] );
+				$schedule = new ActionScheduler_SimpleSchedule( $date );
+				break;
+
+			default:
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log( "Unknown action type '{$options['type']}' specified when trying to create an action for '{$options['hook']}'." );
+				return 0;
+		}
+
+		$action = new ActionScheduler_Action( $options['hook'], $options['arguments'], $schedule, $options['group'] );
+		$action->set_priority( $options['priority'] );
+
+		$action_id = 0;
+		try {
+			$action_id = $options['unique'] ? $this->store_unique_action( $action ) : $this->store( $action );
+		} catch ( Exception $e ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log(
+				sprintf(
+					/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
+					__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
+					$options['hook'],
+					$e->getMessage()
+				)
+			);
+		}
+		return $action_id;
+	}
+
+	/**
+	 * Save action to database.
+	 *
+	 * @param ActionScheduler_Action $action Action object to save.
+	 *
+	 * @return int The ID of the stored action
+	 */
+	protected function store( ActionScheduler_Action $action ) {
+		$store = ActionScheduler_Store::instance();
+		return $store->save_action( $action );
+	}
+
+	/**
+	 * Store action if it's unique.
+	 *
+	 * @param ActionScheduler_Action $action Action object to store.
+	 *
+	 * @return int ID of the created action. Will be 0 if action was not created.
+	 */
+	protected function store_unique_action( ActionScheduler_Action $action ) {
+		$store = ActionScheduler_Store::instance();
+		if ( method_exists( $store, 'save_unique_action' ) ) {
+			return $store->save_unique_action( $action );
+		} else {
+			/**
+			 * Fallback to non-unique action if the store doesn't support unique actions.
+			 * We try to save the action as unique, accepting that there might be a race condition.
+			 * This is likely still better than giving up on unique actions entirely.
+			 */
+			$existing_action_id = (int) $store->find_action(
+				$action->get_hook(),
+				array(
+					'args'   => $action->get_args(),
+					'status' => ActionScheduler_Store::STATUS_PENDING,
+					'group'  => $action->get_group(),
+				)
+			);
+			if ( $existing_action_id > 0 ) {
+				return 0;
+			}
+			return $store->save_action( $action );
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_AdminView.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_AdminView.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * Class ActionScheduler_AdminView
+ *
+ * @codeCoverageIgnore
+ */
+class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
+
+	/**
+	 * Instance.
+	 *
+	 * @var null|self
+	 */
+	private static $admin_view = null;
+
+	/**
+	 * Screen ID.
+	 *
+	 * @var string
+	 */
+	private static $screen_id = 'tools_page_action-scheduler';
+
+	/**
+	 * ActionScheduler_ListTable instance.
+	 *
+	 * @var ActionScheduler_ListTable
+	 */
+	protected $list_table;
+
+	/**
+	 * Get instance.
+	 *
+	 * @return ActionScheduler_AdminView
+	 * @codeCoverageIgnore
+	 */
+	public static function instance() {
+
+		if ( empty( self::$admin_view ) ) {
+			$class            = apply_filters( 'action_scheduler_admin_view_class', 'ActionScheduler_AdminView' );
+			self::$admin_view = new $class();
+		}
+
+		return self::$admin_view;
+	}
+
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
+
+			if ( class_exists( 'WooCommerce' ) ) {
+				add_action( 'woocommerce_admin_status_content_action-scheduler', array( $this, 'render_admin_ui' ) );
+				add_action( 'woocommerce_system_status_report', array( $this, 'system_status_report' ) );
+				add_filter( 'woocommerce_admin_status_tabs', array( $this, 'register_system_status_tab' ) );
+			}
+
+			add_action( 'admin_menu', array( $this, 'register_menu' ) );
+			add_action( 'admin_notices', array( $this, 'maybe_check_pastdue_actions' ) );
+			add_action( 'current_screen', array( $this, 'add_help_tabs' ) );
+		}
+	}
+
+	/**
+	 * Print system status report.
+	 */
+	public function system_status_report() {
+		$table = new ActionScheduler_wcSystemStatus( ActionScheduler::store() );
+		$table->render();
+	}
+
+	/**
+	 * Registers action-scheduler into WooCommerce > System status.
+	 *
+	 * @param array $tabs An associative array of tab key => label.
+	 * @return array $tabs An associative array of tab key => label, including Action Scheduler's tabs
+	 */
+	public function register_system_status_tab( array $tabs ) {
+		$tabs['action-scheduler'] = __( 'Scheduled Actions', 'action-scheduler' );
+
+		return $tabs;
+	}
+
+	/**
+	 * Include Action Scheduler's administration under the Tools menu.
+	 *
+	 * A menu under the Tools menu is important for backward compatibility (as that's
+	 * where it started), and also provides more convenient access than the WooCommerce
+	 * System Status page, and for sites where WooCommerce isn't active.
+	 */
+	public function register_menu() {
+		$hook_suffix = add_submenu_page(
+			'tools.php',
+			__( 'Scheduled Actions', 'action-scheduler' ),
+			__( 'Scheduled Actions', 'action-scheduler' ),
+			'manage_options',
+			'action-scheduler',
+			array( $this, 'render_admin_ui' )
+		);
+		add_action( 'load-' . $hook_suffix, array( $this, 'process_admin_ui' ) );
+	}
+
+	/**
+	 * Triggers processing of any pending actions.
+	 */
+	public function process_admin_ui() {
+		$this->get_list_table();
+	}
+
+	/**
+	 * Renders the Admin UI
+	 */
+	public function render_admin_ui() {
+		$table = $this->get_list_table();
+		$table->display_page();
+	}
+
+	/**
+	 * Get the admin UI object and process any requested actions.
+	 *
+	 * @return ActionScheduler_ListTable
+	 */
+	protected function get_list_table() {
+		if ( null === $this->list_table ) {
+			$this->list_table = new ActionScheduler_ListTable( ActionScheduler::store(), ActionScheduler::logger(), ActionScheduler::runner() );
+			$this->list_table->process_actions();
+		}
+
+		return $this->list_table;
+	}
+
+	/**
+	 * Action: admin_notices
+	 *
+	 * Maybe check past-due actions, and print notice.
+	 *
+	 * @uses $this->check_pastdue_actions()
+	 */
+	public function maybe_check_pastdue_actions() {
+
+		// Filter to prevent checking actions (ex: inappropriate user).
+		if ( ! apply_filters( 'action_scheduler_check_pastdue_actions', current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
+
+		// Get last check transient.
+		$last_check = get_transient( 'action_scheduler_last_pastdue_actions_check' );
+
+		// If transient exists, we're within interval, so bail.
+		if ( ! empty( $last_check ) ) {
+			return;
+		}
+
+		// Perform the check.
+		$this->check_pastdue_actions();
+	}
+
+	/**
+	 * Check past-due actions, and print notice.
+	 */
+	protected function check_pastdue_actions() {
+
+		// Set thresholds.
+		$threshold_seconds = (int) apply_filters( 'action_scheduler_pastdue_actions_seconds', DAY_IN_SECONDS );
+		$threshold_min     = (int) apply_filters( 'action_scheduler_pastdue_actions_min', 1 );
+
+		// Set fallback value for past-due actions count.
+		$num_pastdue_actions = 0;
+
+		// Allow third-parties to preempt the default check logic.
+		$check = apply_filters( 'action_scheduler_pastdue_actions_check_pre', null );
+
+		// If no third-party preempted and there are no past-due actions, return early.
+		if ( ! is_null( $check ) ) {
+			return;
+		}
+
+		// Scheduled actions query arguments.
+		$query_args = array(
+			'date'     => as_get_datetime_object( time() - $threshold_seconds ),
+			'status'   => ActionScheduler_Store::STATUS_PENDING,
+			'per_page' => $threshold_min,
+		);
+
+		// If no third-party preempted, run default check.
+		if ( is_null( $check ) ) {
+			$store               = ActionScheduler_Store::instance();
+			$num_pastdue_actions = (int) $store->query_actions( $query_args, 'count' );
+
+			// Check if past-due actions count is greater than or equal to threshold.
+			$check = ( $num_pastdue_actions >= $threshold_min );
+			$check = (bool) apply_filters( 'action_scheduler_pastdue_actions_check', $check, $num_pastdue_actions, $threshold_seconds, $threshold_min );
+		}
+
+		// If check failed, set transient and abort.
+		if ( ! boolval( $check ) ) {
+			$interval = apply_filters( 'action_scheduler_pastdue_actions_check_interval', round( $threshold_seconds / 4 ), $threshold_seconds );
+			set_transient( 'action_scheduler_last_pastdue_actions_check', time(), $interval );
+
+			return;
+		}
+
+		$actions_url = add_query_arg(
+			array(
+				'page'   => 'action-scheduler',
+				'status' => 'past-due',
+				'order'  => 'asc',
+			),
+			admin_url( 'tools.php' )
+		);
+
+		// Print notice.
+		echo '<div class="notice notice-warning"><p>';
+		printf(
+			wp_kses(
+				// translators: 1) is the number of affected actions, 2) is a link to an admin screen.
+				_n(
+					'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due action</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
+					'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due actions</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
+					$num_pastdue_actions,
+					'action-scheduler'
+				),
+				array(
+					'strong' => array(),
+					'a'      => array(
+						'href'   => true,
+						'target' => true,
+					),
+				)
+			),
+			absint( $num_pastdue_actions ),
+			esc_attr( esc_url( $actions_url ) )
+		);
+		echo '</p></div>';
+
+		// Facilitate third-parties to evaluate and print notices.
+		do_action( 'action_scheduler_pastdue_actions_extra_notices', $query_args );
+	}
+
+	/**
+	 * Provide more information about the screen and its data in the help tab.
+	 */
+	public function add_help_tabs() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || self::$screen_id !== $screen->id ) {
+			return;
+		}
+
+		$as_version       = ActionScheduler_Versions::instance()->latest_version();
+		$as_source        = ActionScheduler_SystemInformation::active_source();
+		$as_source_path   = ActionScheduler_SystemInformation::active_source_path();
+		$as_source_markup = sprintf( '<code>%s</code>', esc_html( $as_source_path ) );
+
+		if ( ! empty( $as_source ) ) {
+			$as_source_markup = sprintf(
+				'%s: <abbr title="%s">%s</abbr>',
+				ucfirst( $as_source['type'] ),
+				esc_attr( $as_source_path ),
+				esc_html( $as_source['name'] )
+			);
+		}
+
+		$screen->add_help_tab(
+			array(
+				'id'      => 'action_scheduler_about',
+				'title'   => __( 'About', 'action-scheduler' ),
+				'content' =>
+					// translators: %s is the Action Scheduler version.
+					'<h2>' . sprintf( __( 'About Action Scheduler %s', 'action-scheduler' ), $as_version ) . '</h2>' .
+					'<p>' .
+						__( 'Action Scheduler is a scalable, traceable job queue for background processing large sets of actions. Action Scheduler works by triggering an action hook to run at some time in the future. Scheduled actions can also be scheduled to run on a recurring schedule.', 'action-scheduler' ) .
+					'</p>' .
+					'<h3>' . esc_html__( 'Source', 'action-scheduler' ) . '</h3>' .
+					'<p>' .
+						esc_html__( 'Action Scheduler is currently being loaded from the following location. This can be useful when debugging, or if requested by the support team.', 'action-scheduler' ) .
+					'</p>' .
+					'<p>' . $as_source_markup . '</p>' .
+					'<h3>' . esc_html__( 'WP CLI', 'action-scheduler' ) . '</h3>' .
+					'<p>' .
+						sprintf(
+							/* translators: %1$s is WP CLI command (not translatable) */
+							esc_html__( 'WP CLI commands are available: execute %1$s for a list of available commands.', 'action-scheduler' ),
+							'<code>wp help action-scheduler</code>'
+						) .
+					'</p>',
+			)
+		);
+
+		$screen->add_help_tab(
+			array(
+				'id'      => 'action_scheduler_columns',
+				'title'   => __( 'Columns', 'action-scheduler' ),
+				'content' =>
+					'<h2>' . __( 'Scheduled Action Columns', 'action-scheduler' ) . '</h2>' .
+					'<ul>' .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Hook', 'action-scheduler' ), __( 'Name of the action hook that will be triggered.', 'action-scheduler' ) ) .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Status', 'action-scheduler' ), __( 'Action statuses are Pending, Complete, Canceled, Failed', 'action-scheduler' ) ) .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Arguments', 'action-scheduler' ), __( 'Optional data array passed to the action hook.', 'action-scheduler' ) ) .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Group', 'action-scheduler' ), __( 'Optional action group.', 'action-scheduler' ) ) .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Recurrence', 'action-scheduler' ), __( 'The action\'s schedule frequency.', 'action-scheduler' ) ) .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Scheduled', 'action-scheduler' ), __( 'The date/time the action is/was scheduled to run.', 'action-scheduler' ) ) .
+					sprintf( '<li><strong>%1$s</strong>: %2$s</li>', __( 'Log', 'action-scheduler' ), __( 'Activity log for the action.', 'action-scheduler' ) ) .
+					'</ul>',
+			)
+		);
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -1,0 +1,93 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ActionScheduler_AsyncRequest_QueueRunner class.
+ */
+class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
+
+	/**
+	 * Data store for querying actions
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	protected $store;
+
+	/**
+	 * Prefix for ajax hooks
+	 *
+	 * @var string
+	 */
+	protected $prefix = 'as';
+
+	/**
+	 * Action for ajax hooks
+	 *
+	 * @var string
+	 */
+	protected $action = 'async_request_queue_runner';
+
+	/**
+	 * Initiate new async request.
+	 *
+	 * @param ActionScheduler_Store $store Store object.
+	 */
+	public function __construct( ActionScheduler_Store $store ) {
+		parent::__construct();
+		$this->store = $store;
+	}
+
+	/**
+	 * Handle async requests
+	 *
+	 * Run a queue, and maybe dispatch another async request to run another queue
+	 * if there are still pending actions after completing a queue in this request.
+	 */
+	protected function handle() {
+		do_action( 'action_scheduler_run_queue', 'Async Request' ); // run a queue in the same way as WP Cron, but declare the Async Request context.
+
+		$sleep_seconds = $this->get_sleep_seconds();
+
+		if ( $sleep_seconds ) {
+			sleep( $sleep_seconds );
+		}
+
+		$this->maybe_dispatch();
+	}
+
+	/**
+	 * If the async request runner is needed and allowed to run, dispatch a request.
+	 */
+	public function maybe_dispatch() {
+		if ( ! $this->allow() ) {
+			return;
+		}
+
+		$this->dispatch();
+		ActionScheduler_QueueRunner::instance()->unhook_dispatch_async_request();
+	}
+
+	/**
+	 * Only allow async requests when needed.
+	 *
+	 * Also allow 3rd party code to disable running actions via async requests.
+	 */
+	protected function allow() {
+
+		if ( ! has_action( 'action_scheduler_run_queue' ) || ActionScheduler::runner()->has_maximum_concurrent_batches() || ! $this->store->has_pending_actions_due() ) {
+			$allow = false;
+		} else {
+			$allow = true;
+		}
+
+		return apply_filters( 'action_scheduler_allow_async_request_runner', $allow );
+	}
+
+	/**
+	 * Chaining async requests can crash MySQL. A brief sleep call in PHP prevents that.
+	 */
+	protected function get_sleep_seconds() {
+		return apply_filters( 'action_scheduler_async_request_sleep_seconds', 5, $this );
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_Compatibility.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_Compatibility.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Class ActionScheduler_Compatibility
+ */
+class ActionScheduler_Compatibility {
+	/**
+	 * Converts a shorthand byte value to an integer byte value.
+	 *
+	 * Wrapper for wp_convert_hr_to_bytes(), moved to load.php in WordPress 4.6 from media.php
+	 *
+	 * @link https://secure.php.net/manual/en/function.ini-get.php
+	 * @link https://secure.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+	 *
+	 * @param string $value A (PHP ini) byte value, either shorthand or ordinary.
+	 * @return int An integer byte value.
+	 */
+	public static function convert_hr_to_bytes( $value ) {
+		if ( function_exists( 'wp_convert_hr_to_bytes' ) ) {
+			return wp_convert_hr_to_bytes( $value );
+		}
+
+		$value = strtolower( trim( $value ) );
+		$bytes = (int) $value;
+
+		if ( false !== strpos( $value, 'g' ) ) {
+			$bytes *= GB_IN_BYTES;
+		} elseif ( false !== strpos( $value, 'm' ) ) {
+			$bytes *= MB_IN_BYTES;
+		} elseif ( false !== strpos( $value, 'k' ) ) {
+			$bytes *= KB_IN_BYTES;
+		}
+
+		// Deal with large (float) values which run into the maximum integer size.
+		return min( $bytes, PHP_INT_MAX );
+	}
+
+	/**
+	 * Attempts to raise the PHP memory limit for memory intensive processes.
+	 *
+	 * Only allows raising the existing limit and prevents lowering it.
+	 *
+	 * Wrapper for wp_raise_memory_limit(), added in WordPress v4.6.0
+	 *
+	 * @return bool|int|string The limit that was set or false on failure.
+	 */
+	public static function raise_memory_limit() {
+		if ( function_exists( 'wp_raise_memory_limit' ) ) {
+			return wp_raise_memory_limit( 'admin' );
+		}
+
+		$current_limit     = @ini_get( 'memory_limit' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$current_limit_int = self::convert_hr_to_bytes( $current_limit );
+
+		if ( -1 === $current_limit_int ) {
+			return false;
+		}
+
+		$wp_max_limit       = WP_MAX_MEMORY_LIMIT;
+		$wp_max_limit_int   = self::convert_hr_to_bytes( $wp_max_limit );
+		$filtered_limit     = apply_filters( 'admin_memory_limit', $wp_max_limit );
+		$filtered_limit_int = self::convert_hr_to_bytes( $filtered_limit );
+
+		// phpcs:disable WordPress.PHP.IniSet.memory_limit_Blacklisted
+		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+
+		if ( -1 === $filtered_limit_int || ( $filtered_limit_int > $wp_max_limit_int && $filtered_limit_int > $current_limit_int ) ) {
+			if ( false !== @ini_set( 'memory_limit', $filtered_limit ) ) {
+				return $filtered_limit;
+			} else {
+				return false;
+			}
+		} elseif ( -1 === $wp_max_limit_int || $wp_max_limit_int > $current_limit_int ) {
+			if ( false !== @ini_set( 'memory_limit', $wp_max_limit ) ) {
+				return $wp_max_limit;
+			} else {
+				return false;
+			}
+		}
+
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
+	 * Attempts to raise the PHP timeout for time intensive processes.
+	 *
+	 * Only allows raising the existing limit and prevents lowering it. Wrapper for wc_set_time_limit(), when available.
+	 *
+	 * @param int $limit The time limit in seconds.
+	 */
+	public static function raise_time_limit( $limit = 0 ) {
+		$limit              = (int) $limit;
+		$max_execution_time = (int) ini_get( 'max_execution_time' );
+
+		// If the max execution time is already set to zero (unlimited), there is no reason to make a further change.
+		if ( 0 === $max_execution_time ) {
+			return;
+		}
+
+		// Whichever of $max_execution_time or $limit is higher is the amount by which we raise the time limit.
+		$raise_by = 0 === $limit || $limit > $max_execution_time ? $limit : $max_execution_time;
+
+		if ( function_exists( 'wc_set_time_limit' ) ) {
+			wc_set_time_limit( $raise_by );
+		} elseif ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved
+			@set_time_limit( $raise_by ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_DataController.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_DataController.php
@@ -1,0 +1,201 @@
+<?php
+
+use Action_Scheduler\Migration\Controller;
+
+/**
+ * Class ActionScheduler_DataController
+ *
+ * The main plugin/initialization class for the data stores.
+ *
+ * Responsible for hooking everything up with WordPress.
+ *
+ * @package Action_Scheduler
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_DataController {
+	/** Action data store class name. */
+	const DATASTORE_CLASS = 'ActionScheduler_DBStore';
+
+	/** Logger data store class name. */
+	const LOGGER_CLASS = 'ActionScheduler_DBLogger';
+
+	/** Migration status option name. */
+	const STATUS_FLAG = 'action_scheduler_migration_status';
+
+	/** Migration status option value. */
+	const STATUS_COMPLETE = 'complete';
+
+	/** Migration minimum required PHP version. */
+	const MIN_PHP_VERSION = '5.5';
+
+	/**
+	 * Instance.
+	 *
+	 * @var ActionScheduler_DataController
+	 */
+	private static $instance;
+
+	/**
+	 * Sleep time in seconds.
+	 *
+	 * @var int
+	 */
+	private static $sleep_time = 0;
+
+	/**
+	 * Tick count required for freeing memory.
+	 *
+	 * @var int
+	 */
+	private static $free_ticks = 50;
+
+	/**
+	 * Get a flag indicating whether the migration environment dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function dependencies_met() {
+		$php_support = version_compare( PHP_VERSION, self::MIN_PHP_VERSION, '>=' );
+		return $php_support && apply_filters( 'action_scheduler_migration_dependencies_met', true );
+	}
+
+	/**
+	 * Get a flag indicating whether the migration is complete.
+	 *
+	 * @return bool Whether the flag has been set marking the migration as complete
+	 */
+	public static function is_migration_complete() {
+		return get_option( self::STATUS_FLAG ) === self::STATUS_COMPLETE;
+	}
+
+	/**
+	 * Mark the migration as complete.
+	 */
+	public static function mark_migration_complete() {
+		update_option( self::STATUS_FLAG, self::STATUS_COMPLETE );
+	}
+
+	/**
+	 * Unmark migration when a plugin is de-activated. Will not work in case of silent activation, for example in an update.
+	 * We do this to mitigate the bug of lost actions which happens if there was an AS 2.x to AS 3.x migration in the past, but that plugin is now
+	 * deactivated and the site was running on AS 2.x again.
+	 */
+	public static function mark_migration_incomplete() {
+		delete_option( self::STATUS_FLAG );
+	}
+
+	/**
+	 * Set the action store class name.
+	 *
+	 * @param string $class Classname of the store class.
+	 *
+	 * @return string
+	 */
+	public static function set_store_class( $class ) {
+		return self::DATASTORE_CLASS;
+	}
+
+	/**
+	 * Set the action logger class name.
+	 *
+	 * @param string $class Classname of the logger class.
+	 *
+	 * @return string
+	 */
+	public static function set_logger_class( $class ) {
+		return self::LOGGER_CLASS;
+	}
+
+	/**
+	 * Set the sleep time in seconds.
+	 *
+	 * @param integer $sleep_time The number of seconds to pause before resuming operation.
+	 */
+	public static function set_sleep_time( $sleep_time ) {
+		self::$sleep_time = (int) $sleep_time;
+	}
+
+	/**
+	 * Set the tick count required for freeing memory.
+	 *
+	 * @param integer $free_ticks The number of ticks to free memory on.
+	 */
+	public static function set_free_ticks( $free_ticks ) {
+		self::$free_ticks = (int) $free_ticks;
+	}
+
+	/**
+	 * Free memory if conditions are met.
+	 *
+	 * @param int $ticks Current tick count.
+	 */
+	public static function maybe_free_memory( $ticks ) {
+		if ( self::$free_ticks && 0 === $ticks % self::$free_ticks ) {
+			self::free_memory();
+		}
+	}
+
+	/**
+	 * Reduce memory footprint by clearing the database query and object caches.
+	 */
+	public static function free_memory() {
+		if ( 0 < self::$sleep_time ) {
+			/* translators: %d: amount of time */
+			\WP_CLI::warning( sprintf( _n( 'Stopped the insanity for %d second', 'Stopped the insanity for %d seconds', self::$sleep_time, 'action-scheduler' ), self::$sleep_time ) );
+			sleep( self::$sleep_time );
+		}
+
+		\WP_CLI::warning( __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
+
+		/**
+		 * Globals.
+		 *
+		 * @var $wpdb            \wpdb
+		 * @var $wp_object_cache \WP_Object_Cache
+		 */
+		global $wpdb, $wp_object_cache;
+
+		$wpdb->queries = array();
+
+		if ( ! is_a( $wp_object_cache, 'WP_Object_Cache' ) ) {
+			return;
+		}
+
+		$wp_object_cache->group_ops      = array();
+		$wp_object_cache->stats          = array();
+		$wp_object_cache->memcache_debug = array();
+		$wp_object_cache->cache          = array();
+
+		if ( is_callable( array( $wp_object_cache, '__remoteset' ) ) ) {
+			call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important!
+		}
+	}
+
+	/**
+	 * Connect to table datastores if migration is complete.
+	 * Otherwise, proceed with the migration if the dependencies have been met.
+	 */
+	public static function init() {
+		if ( self::is_migration_complete() ) {
+			add_filter( 'action_scheduler_store_class', array( 'ActionScheduler_DataController', 'set_store_class' ), 100 );
+			add_filter( 'action_scheduler_logger_class', array( 'ActionScheduler_DataController', 'set_logger_class' ), 100 );
+			add_action( 'deactivate_plugin', array( 'ActionScheduler_DataController', 'mark_migration_incomplete' ) );
+		} elseif ( self::dependencies_met() ) {
+			Controller::init();
+		}
+
+		add_action( 'action_scheduler/progress_tick', array( 'ActionScheduler_DataController', 'maybe_free_memory' ) );
+	}
+
+	/**
+	 * Singleton factory.
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new static();
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * ActionScheduler DateTime class.
+ *
+ * This is a custom extension to DateTime that
+ */
+class ActionScheduler_DateTime extends DateTime {
+
+	/**
+	 * UTC offset.
+	 *
+	 * Only used when a timezone is not set. When a timezone string is
+	 * used, this will be set to 0.
+	 *
+	 * @var int
+	 */
+	protected $utcOffset = 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+
+	/**
+	 * Get the unix timestamp of the current object.
+	 *
+	 * Missing in PHP 5.2 so just here so it can be supported consistently.
+	 *
+	 * @return int
+	 */
+	#[\ReturnTypeWillChange]
+	public function getTimestamp() {
+		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
+	}
+
+	/**
+	 * Set the UTC offset.
+	 *
+	 * This represents a fixed offset instead of a timezone setting.
+	 *
+	 * @param string|int $offset UTC offset value.
+	 */
+	public function setUtcOffset( $offset ) {
+		$this->utcOffset = intval( $offset ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	}
+
+	/**
+	 * Returns the timezone offset.
+	 *
+	 * @return int
+	 * @link http://php.net/manual/en/datetime.getoffset.php
+	 */
+	#[\ReturnTypeWillChange]
+	public function getOffset() {
+		return $this->utcOffset ? $this->utcOffset : parent::getOffset(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+	}
+
+	/**
+	 * Set the TimeZone associated with the DateTime
+	 *
+	 * @param DateTimeZone $timezone Timezone object.
+	 *
+	 * @return static
+	 * @link http://php.net/manual/en/datetime.settimezone.php
+	 */
+	#[\ReturnTypeWillChange]
+	public function setTimezone( $timezone ) {
+		$this->utcOffset = 0; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		parent::setTimezone( $timezone );
+
+		return $this;
+	}
+
+	/**
+	 * Get the timestamp with the WordPress timezone offset added or subtracted.
+	 *
+	 * @since  3.0.0
+	 * @return int
+	 */
+	public function getOffsetTimestamp() {
+		return $this->getTimestamp() + $this->getOffset();
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_Exception.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * ActionScheduler Exception Interface.
+ *
+ * Facilitates catching Exceptions unique to Action Scheduler.
+ *
+ * @package ActionScheduler
+ * @since 2.1.0
+ */
+interface ActionScheduler_Exception {}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_FatalErrorMonitor.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Class ActionScheduler_FatalErrorMonitor
+ */
+class ActionScheduler_FatalErrorMonitor {
+
+	/**
+	 * ActionScheduler_ActionClaim instance.
+	 *
+	 * @var ActionScheduler_ActionClaim
+	 */
+	private $claim = null;
+
+	/**
+	 * ActionScheduler_Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $store = null;
+
+	/**
+	 * Current action's ID.
+	 *
+	 * @var int
+	 */
+	private $action_id = 0;
+
+	/**
+	 * Construct.
+	 *
+	 * @param ActionScheduler_Store $store Action store.
+	 */
+	public function __construct( ActionScheduler_Store $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * Start monitoring.
+	 *
+	 * @param ActionScheduler_ActionClaim $claim Claimed actions.
+	 */
+	public function attach( ActionScheduler_ActionClaim $claim ) {
+		$this->claim = $claim;
+		add_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
+		add_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0, 1 );
+		add_action( 'action_scheduler_after_execute', array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'untrack_action' ), 0, 0 );
+	}
+
+	/**
+	 * Stop monitoring.
+	 */
+	public function detach() {
+		$this->claim = null;
+		$this->untrack_action();
+		remove_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
+		remove_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0 );
+		remove_action( 'action_scheduler_after_execute', array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_execution_ignored', array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_failed_execution', array( $this, 'untrack_action' ), 0 );
+	}
+
+	/**
+	 * Track specified action.
+	 *
+	 * @param int $action_id Action ID to track.
+	 */
+	public function track_current_action( $action_id ) {
+		$this->action_id = $action_id;
+	}
+
+	/**
+	 * Un-track action.
+	 */
+	public function untrack_action() {
+		$this->action_id = 0;
+	}
+
+	/**
+	 * Handle unexpected shutdown.
+	 */
+	public function handle_unexpected_shutdown() {
+		$error = error_get_last();
+
+		if ( $error ) {
+			if ( in_array( $error['type'], array( E_ERROR, E_PARSE, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ), true ) ) {
+				if ( ! empty( $this->action_id ) ) {
+					$this->store->mark_failure( $this->action_id );
+					do_action( 'action_scheduler_unexpected_shutdown', $this->action_id, $error );
+				}
+			}
+
+			$this->store->release_claim( $this->claim );
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_InvalidActionException.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_InvalidActionException.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * InvalidAction Exception.
+ *
+ * Used for identifying actions that are invalid in some way.
+ *
+ * @package ActionScheduler
+ */
+class ActionScheduler_InvalidActionException extends \InvalidArgumentException implements ActionScheduler_Exception {
+
+	/**
+	 * Create a new exception when the action's schedule cannot be fetched.
+	 *
+	 * @param string $action_id The action ID with bad args.
+	 * @param mixed  $schedule  Passed schedule.
+	 * @return static
+	 */
+	public static function from_schedule( $action_id, $schedule ) {
+		$message = sprintf(
+			/* translators: 1: action ID 2: schedule */
+			__( 'Action [%1$s] has an invalid schedule: %2$s', 'action-scheduler' ),
+			$action_id,
+			var_export( $schedule, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		);
+
+		return new static( $message );
+	}
+
+	/**
+	 * Create a new exception when the action's args cannot be decoded to an array.
+	 *
+	 * @param string $action_id The action ID with bad args.
+	 * @param mixed  $args      Passed arguments.
+	 * @return static
+	 */
+	public static function from_decoding_args( $action_id, $args = array() ) {
+		$message = sprintf(
+			/* translators: 1: action ID 2: arguments */
+			__( 'Action [%1$s] has invalid arguments. It cannot be JSON decoded to an array. $args = %2$s', 'action-scheduler' ),
+			$action_id,
+			var_export( $args, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		);
+
+		return new static( $message );
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_ListTable.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_ListTable.php
@@ -1,0 +1,675 @@
+<?php
+
+/**
+ * Implements the admin view of the actions.
+ *
+ * @codeCoverageIgnore
+ */
+class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
+
+	/**
+	 * The package name.
+	 *
+	 * @var string
+	 */
+	protected $package = 'action-scheduler';
+
+	/**
+	 * Columns to show (name => label).
+	 *
+	 * @var array
+	 */
+	protected $columns = array();
+
+	/**
+	 * Actions (name => label).
+	 *
+	 * @var array
+	 */
+	protected $row_actions = array();
+
+	/**
+	 * The active data stores
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	protected $store;
+
+	/**
+	 * A logger to use for getting action logs to display
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	protected $logger;
+
+	/**
+	 * A ActionScheduler_QueueRunner runner instance (or child class)
+	 *
+	 * @var ActionScheduler_QueueRunner
+	 */
+	protected $runner;
+
+	/**
+	 * Bulk actions. The key of the array is the method name of the implementation.
+	 * Example: bulk_<key>(array $ids, string $sql_in).
+	 *
+	 * See the comments in the parent class for further details
+	 *
+	 * @var array
+	 */
+	protected $bulk_actions = array();
+
+	/**
+	 * Flag variable to render our notifications, if any, once.
+	 *
+	 * @var bool
+	 */
+	protected static $did_notification = false;
+
+	/**
+	 * Array of seconds for common time periods, like week or month, alongside an internationalised string representation, i.e. "Day" or "Days"
+	 *
+	 * @var array
+	 */
+	private static $time_periods;
+
+	/**
+	 * Sets the current data store object into `store->action` and initialises the object.
+	 *
+	 * @param ActionScheduler_Store       $store Store object.
+	 * @param ActionScheduler_Logger      $logger Logger object.
+	 * @param ActionScheduler_QueueRunner $runner Runner object.
+	 */
+	public function __construct( ActionScheduler_Store $store, ActionScheduler_Logger $logger, ActionScheduler_QueueRunner $runner ) {
+
+		$this->store  = $store;
+		$this->logger = $logger;
+		$this->runner = $runner;
+
+		$this->table_header = __( 'Scheduled Actions', 'action-scheduler' );
+
+		$this->bulk_actions = array(
+			'delete' => __( 'Delete', 'action-scheduler' ),
+		);
+
+		$this->columns = array(
+			'hook'        => __( 'Hook', 'action-scheduler' ),
+			'status'      => __( 'Status', 'action-scheduler' ),
+			'args'        => __( 'Arguments', 'action-scheduler' ),
+			'group'       => __( 'Group', 'action-scheduler' ),
+			'recurrence'  => __( 'Recurrence', 'action-scheduler' ),
+			'schedule'    => __( 'Scheduled Date', 'action-scheduler' ),
+			'log_entries' => __( 'Log', 'action-scheduler' ),
+		);
+
+		$this->sort_by = array(
+			'schedule',
+			'hook',
+			'group',
+		);
+
+		$this->search_by = array(
+			'hook',
+			'args',
+			'claim_id',
+		);
+
+		$request_status = $this->get_request_status();
+
+		if ( empty( $request_status ) ) {
+			$this->sort_by[] = 'status';
+		} elseif ( in_array( $request_status, array( 'in-progress', 'failed' ), true ) ) {
+			$this->columns  += array( 'claim_id' => __( 'Claim ID', 'action-scheduler' ) );
+			$this->sort_by[] = 'claim_id';
+		}
+
+		$this->row_actions = array(
+			'hook' => array(
+				'run'    => array(
+					'name' => __( 'Run', 'action-scheduler' ),
+					'desc' => __( 'Process the action now as if it were run as part of a queue', 'action-scheduler' ),
+				),
+				'cancel' => array(
+					'name'  => __( 'Cancel', 'action-scheduler' ),
+					'desc'  => __( 'Cancel the action now to avoid it being run in future', 'action-scheduler' ),
+					'class' => 'cancel trash',
+				),
+			),
+		);
+
+		self::$time_periods = array(
+			array(
+				'seconds' => YEAR_IN_SECONDS,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s year', '%s years', 'action-scheduler' ),
+			),
+			array(
+				'seconds' => MONTH_IN_SECONDS,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s month', '%s months', 'action-scheduler' ),
+			),
+			array(
+				'seconds' => WEEK_IN_SECONDS,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s week', '%s weeks', 'action-scheduler' ),
+			),
+			array(
+				'seconds' => DAY_IN_SECONDS,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s day', '%s days', 'action-scheduler' ),
+			),
+			array(
+				'seconds' => HOUR_IN_SECONDS,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s hour', '%s hours', 'action-scheduler' ),
+			),
+			array(
+				'seconds' => MINUTE_IN_SECONDS,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s minute', '%s minutes', 'action-scheduler' ),
+			),
+			array(
+				'seconds' => 1,
+				/* translators: %s: amount of time */
+				'names'   => _n_noop( '%s second', '%s seconds', 'action-scheduler' ),
+			),
+		);
+
+		parent::__construct(
+			array(
+				'singular' => 'action-scheduler',
+				'plural'   => 'action-scheduler',
+				'ajax'     => false,
+			)
+		);
+
+		add_screen_option(
+			'per_page',
+			array(
+				'default' => $this->items_per_page,
+			)
+		);
+
+		add_filter( 'set_screen_option_' . $this->get_per_page_option_name(), array( $this, 'set_items_per_page_option' ), 10, 3 );
+		set_screen_options();
+	}
+
+	/**
+	 * Handles setting the items_per_page option for this screen.
+	 *
+	 * @param mixed  $status Default false (to skip saving the current option).
+	 * @param string $option Screen option name.
+	 * @param int    $value  Screen option value.
+	 * @return int
+	 */
+	public function set_items_per_page_option( $status, $option, $value ) {
+		return $value;
+	}
+	/**
+	 * Convert an interval of seconds into a two part human friendly string.
+	 *
+	 * The WordPress human_time_diff() function only calculates the time difference to one degree, meaning
+	 * even if an action is 1 day and 11 hours away, it will display "1 day". This function goes one step
+	 * further to display two degrees of accuracy.
+	 *
+	 * Inspired by the Crontrol::interval() function by Edward Dale: https://wordpress.org/plugins/wp-crontrol/
+	 *
+	 * @param int $interval A interval in seconds.
+	 * @param int $periods_to_include Depth of time periods to include, e.g. for an interval of 70, and $periods_to_include of 2, both minutes and seconds would be included. With a value of 1, only minutes would be included.
+	 * @return string A human friendly string representation of the interval.
+	 */
+	private static function human_interval( $interval, $periods_to_include = 2 ) {
+
+		if ( $interval <= 0 ) {
+			return __( 'Now!', 'action-scheduler' );
+		}
+
+		$output           = '';
+		$num_time_periods = count( self::$time_periods );
+
+		for ( $time_period_index = 0, $periods_included = 0, $seconds_remaining = $interval; $time_period_index < $num_time_periods && $seconds_remaining > 0 && $periods_included < $periods_to_include; $time_period_index++ ) {
+
+			$periods_in_interval = floor( $seconds_remaining / self::$time_periods[ $time_period_index ]['seconds'] );
+
+			if ( $periods_in_interval > 0 ) {
+				if ( ! empty( $output ) ) {
+					$output .= ' ';
+				}
+				$output            .= sprintf( translate_nooped_plural( self::$time_periods[ $time_period_index ]['names'], $periods_in_interval, 'action-scheduler' ), $periods_in_interval );
+				$seconds_remaining -= $periods_in_interval * self::$time_periods[ $time_period_index ]['seconds'];
+				$periods_included++;
+			}
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Returns the recurrence of an action or 'Non-repeating'. The output is human readable.
+	 *
+	 * @param ActionScheduler_Action $action Action object.
+	 *
+	 * @return string
+	 */
+	protected function get_recurrence( $action ) {
+		$schedule = $action->get_schedule();
+		if ( $schedule->is_recurring() && method_exists( $schedule, 'get_recurrence' ) ) {
+			$recurrence = $schedule->get_recurrence();
+
+			if ( is_numeric( $recurrence ) ) {
+				/* translators: %s: time interval */
+				return sprintf( __( 'Every %s', 'action-scheduler' ), self::human_interval( $recurrence ) );
+			} else {
+				return $recurrence;
+			}
+		}
+
+		return __( 'Non-repeating', 'action-scheduler' );
+	}
+
+	/**
+	 * Serializes the argument of an action to render it in a human friendly format.
+	 *
+	 * @param array $row The array representation of the current row of the table.
+	 *
+	 * @return string
+	 */
+	public function column_args( array $row ) {
+		if ( empty( $row['args'] ) ) {
+			return apply_filters( 'action_scheduler_list_table_column_args', '', $row );
+		}
+
+		$row_html = '<ul>';
+		foreach ( $row['args'] as $key => $value ) {
+			$row_html .= sprintf( '<li><code>%s => %s</code></li>', esc_html( var_export( $key, true ) ), esc_html( var_export( $value, true ) ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		}
+		$row_html .= '</ul>';
+
+		return apply_filters( 'action_scheduler_list_table_column_args', $row_html, $row );
+	}
+
+	/**
+	 * Prints the logs entries inline. We do so to avoid loading Javascript and other hacks to show it in a modal.
+	 *
+	 * @param array $row Action array.
+	 * @return string
+	 */
+	public function column_log_entries( array $row ) {
+
+		$log_entries_html = '<ol>';
+
+		$timezone = new DateTimezone( 'UTC' );
+
+		foreach ( $row['log_entries'] as $log_entry ) {
+			$log_entries_html .= $this->get_log_entry_html( $log_entry, $timezone );
+		}
+
+		$log_entries_html .= '</ol>';
+
+		return $log_entries_html;
+	}
+
+	/**
+	 * Prints the logs entries inline. We do so to avoid loading Javascript and other hacks to show it in a modal.
+	 *
+	 * @param ActionScheduler_LogEntry $log_entry Log entry object.
+	 * @param DateTimezone             $timezone Timestamp.
+	 * @return string
+	 */
+	protected function get_log_entry_html( ActionScheduler_LogEntry $log_entry, DateTimezone $timezone ) {
+		$date = $log_entry->get_date();
+		$date->setTimezone( $timezone );
+		return sprintf( '<li><strong>%s</strong><br/>%s</li>', esc_html( $date->format( 'Y-m-d H:i:s O' ) ), esc_html( $log_entry->get_message() ) );
+	}
+
+	/**
+	 * Only display row actions for pending actions.
+	 *
+	 * @param array  $row         Row to render.
+	 * @param string $column_name Current row.
+	 *
+	 * @return string
+	 */
+	protected function maybe_render_actions( $row, $column_name ) {
+		if ( 'pending' === strtolower( $row['status_name'] ) ) {
+			return parent::maybe_render_actions( $row, $column_name );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Renders admin notifications
+	 *
+	 * Notifications:
+	 *  1. When the maximum number of tasks are being executed simultaneously.
+	 *  2. Notifications when a task is manually executed.
+	 *  3. Tables are missing.
+	 */
+	public function display_admin_notices() {
+		global $wpdb;
+
+		if ( ( is_a( $this->store, 'ActionScheduler_HybridStore' ) || is_a( $this->store, 'ActionScheduler_DBStore' ) ) && apply_filters( 'action_scheduler_enable_recreate_data_store', true ) ) {
+			$table_list = array(
+				'actionscheduler_actions',
+				'actionscheduler_logs',
+				'actionscheduler_groups',
+				'actionscheduler_claims',
+			);
+
+			$found_tables = $wpdb->get_col( "SHOW TABLES LIKE '{$wpdb->prefix}actionscheduler%'" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			foreach ( $table_list as $table_name ) {
+				if ( ! in_array( $wpdb->prefix . $table_name, $found_tables, true ) ) {
+					$this->admin_notices[] = array(
+						'class'   => 'error',
+						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).', 'action-scheduler' ),
+					);
+					$this->recreate_tables();
+					parent::display_admin_notices();
+
+					return;
+				}
+			}
+		}
+
+		if ( $this->runner->has_maximum_concurrent_batches() ) {
+			$claim_count           = $this->store->get_claim_count();
+			$this->admin_notices[] = array(
+				'class'   => 'updated',
+				'message' => sprintf(
+					/* translators: %s: amount of claims */
+					_n(
+						'Maximum simultaneous queues already in progress (%s queue). No additional queues will begin processing until the current queues are complete.',
+						'Maximum simultaneous queues already in progress (%s queues). No additional queues will begin processing until the current queues are complete.',
+						$claim_count,
+						'action-scheduler'
+					),
+					$claim_count
+				),
+			);
+		} elseif ( $this->store->has_pending_actions_due() ) {
+
+			$async_request_lock_expiration = ActionScheduler::lock()->get_expiration( 'async-request-runner' );
+
+			// No lock set or lock expired.
+			if ( false === $async_request_lock_expiration || $async_request_lock_expiration < time() ) {
+				$in_progress_url = add_query_arg( 'status', 'in-progress', remove_query_arg( 'status' ) );
+				/* translators: %s: process URL */
+				$async_request_message = sprintf( __( 'A new queue has begun processing. <a href="%s">View actions in-progress &raquo;</a>', 'action-scheduler' ), esc_url( $in_progress_url ) );
+			} else {
+				/* translators: %d: seconds */
+				$async_request_message = sprintf( __( 'The next queue will begin processing in approximately %d seconds.', 'action-scheduler' ), $async_request_lock_expiration - time() );
+			}
+
+			$this->admin_notices[] = array(
+				'class'   => 'notice notice-info',
+				'message' => $async_request_message,
+			);
+		}
+
+		$notification = get_transient( 'action_scheduler_admin_notice' );
+
+		if ( is_array( $notification ) ) {
+			delete_transient( 'action_scheduler_admin_notice' );
+
+			$action           = $this->store->fetch_action( $notification['action_id'] );
+			$action_hook_html = '<strong><code>' . $action->get_hook() . '</code></strong>';
+
+			if ( 1 === absint( $notification['success'] ) ) {
+				$class = 'updated';
+				switch ( $notification['row_action_type'] ) {
+					case 'run':
+						/* translators: %s: action HTML */
+						$action_message_html = sprintf( __( 'Successfully executed action: %s', 'action-scheduler' ), $action_hook_html );
+						break;
+					case 'cancel':
+						/* translators: %s: action HTML */
+						$action_message_html = sprintf( __( 'Successfully canceled action: %s', 'action-scheduler' ), $action_hook_html );
+						break;
+					default:
+						/* translators: %s: action HTML */
+						$action_message_html = sprintf( __( 'Successfully processed change for action: %s', 'action-scheduler' ), $action_hook_html );
+						break;
+				}
+			} else {
+				$class = 'error';
+				/* translators: 1: action HTML 2: action ID 3: error message */
+				$action_message_html = sprintf( __( 'Could not process change for action: "%1$s" (ID: %2$d). Error: %3$s', 'action-scheduler' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
+			}
+
+			$action_message_html = apply_filters( 'action_scheduler_admin_notice_html', $action_message_html, $action, $notification );
+
+			$this->admin_notices[] = array(
+				'class'   => $class,
+				'message' => $action_message_html,
+			);
+		}
+
+		parent::display_admin_notices();
+	}
+
+	/**
+	 * Prints the scheduled date in a human friendly format.
+	 *
+	 * @param array $row The array representation of the current row of the table.
+	 *
+	 * @return string
+	 */
+	public function column_schedule( $row ) {
+		return $this->get_schedule_display_string( $row['schedule'] );
+	}
+
+	/**
+	 * Get the scheduled date in a human friendly format.
+	 *
+	 * @param ActionScheduler_Schedule $schedule Action's schedule.
+	 * @return string
+	 */
+	protected function get_schedule_display_string( ActionScheduler_Schedule $schedule ) {
+
+		$schedule_display_string = '';
+
+		if ( is_a( $schedule, 'ActionScheduler_NullSchedule' ) ) {
+			return __( 'async', 'action-scheduler' );
+		}
+
+		if ( ! method_exists( $schedule, 'get_date' ) || ! $schedule->get_date() ) {
+			return '0000-00-00 00:00:00';
+		}
+
+		$next_timestamp = $schedule->get_date()->getTimestamp();
+
+		$schedule_display_string .= $schedule->get_date()->format( 'Y-m-d H:i:s O' );
+		$schedule_display_string .= '<br/>';
+
+		if ( gmdate( 'U' ) > $next_timestamp ) {
+			/* translators: %s: date interval */
+			$schedule_display_string .= sprintf( __( ' (%s ago)', 'action-scheduler' ), self::human_interval( gmdate( 'U' ) - $next_timestamp ) );
+		} else {
+			/* translators: %s: date interval */
+			$schedule_display_string .= sprintf( __( ' (%s)', 'action-scheduler' ), self::human_interval( $next_timestamp - gmdate( 'U' ) ) );
+		}
+
+		return $schedule_display_string;
+	}
+
+	/**
+	 * Bulk delete.
+	 *
+	 * Deletes actions based on their ID. This is the handler for the bulk delete. It assumes the data
+	 * properly validated by the callee and it will delete the actions without any extra validation.
+	 *
+	 * @param int[]  $ids Action IDs.
+	 * @param string $ids_sql Inherited and unused.
+	 */
+	protected function bulk_delete( array $ids, $ids_sql ) {
+		foreach ( $ids as $id ) {
+			try {
+				$this->store->delete_action( $id );
+			} catch ( Exception $e ) {
+				// A possible reason for an exception would include a scenario where the same action is deleted by a
+				// concurrent request.
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log(
+					sprintf(
+						/* translators: 1: action ID 2: exception message. */
+						__( 'Action Scheduler was unable to delete action %1$d. Reason: %2$s', 'action-scheduler' ),
+						$id,
+						$e->getMessage()
+					)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Implements the logic behind running an action. ActionScheduler_Abstract_ListTable validates the request and their
+	 * parameters are valid.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	protected function row_action_cancel( $action_id ) {
+		$this->process_row_action( $action_id, 'cancel' );
+	}
+
+	/**
+	 * Implements the logic behind running an action. ActionScheduler_Abstract_ListTable validates the request and their
+	 * parameters are valid.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	protected function row_action_run( $action_id ) {
+		$this->process_row_action( $action_id, 'run' );
+	}
+
+	/**
+	 * Force the data store schema updates.
+	 */
+	protected function recreate_tables() {
+		if ( is_a( $this->store, 'ActionScheduler_HybridStore' ) ) {
+			$store = $this->store;
+		} else {
+			$store = new ActionScheduler_HybridStore();
+		}
+		add_action( 'action_scheduler/created_table', array( $store, 'set_autoincrement' ), 10, 2 );
+
+		$store_schema  = new ActionScheduler_StoreSchema();
+		$logger_schema = new ActionScheduler_LoggerSchema();
+		$store_schema->register_tables( true );
+		$logger_schema->register_tables( true );
+
+		remove_action( 'action_scheduler/created_table', array( $store, 'set_autoincrement' ), 10 );
+	}
+	/**
+	 * Implements the logic behind processing an action once an action link is clicked on the list table.
+	 *
+	 * @param int    $action_id Action ID.
+	 * @param string $row_action_type The type of action to perform on the action.
+	 */
+	protected function process_row_action( $action_id, $row_action_type ) {
+		try {
+			switch ( $row_action_type ) {
+				case 'run':
+					$this->runner->process_action( $action_id, 'Admin List Table' );
+					break;
+				case 'cancel':
+					$this->store->cancel_action( $action_id );
+					break;
+			}
+			$success       = 1;
+			$error_message = '';
+		} catch ( Exception $e ) {
+			$success       = 0;
+			$error_message = $e->getMessage();
+		}
+
+		set_transient( 'action_scheduler_admin_notice', compact( 'action_id', 'success', 'error_message', 'row_action_type' ), 30 );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function prepare_items() {
+		$this->prepare_column_headers();
+
+		$per_page = $this->get_items_per_page( $this->get_per_page_option_name(), $this->items_per_page );
+
+		$query = array(
+			'per_page' => $per_page,
+			'offset'   => $this->get_items_offset(),
+			'status'   => $this->get_request_status(),
+			'orderby'  => $this->get_request_orderby(),
+			'order'    => $this->get_request_order(),
+			'search'   => $this->get_request_search_query(),
+		);
+
+		/**
+		 * Change query arguments to query for past-due actions.
+		 * Past-due actions have the 'pending' status and are in the past.
+		 * This is needed because registering 'past-due' as a status is overkill.
+		 */
+		if ( 'past-due' === $this->get_request_status() ) {
+			$query['status'] = ActionScheduler_Store::STATUS_PENDING;
+			$query['date']   = as_get_datetime_object();
+		}
+
+		$this->items = array();
+
+		$total_items = $this->store->query_actions( $query, 'count' );
+
+		$status_labels = $this->store->get_status_labels();
+
+		foreach ( $this->store->query_actions( $query ) as $action_id ) {
+			try {
+				$action = $this->store->fetch_action( $action_id );
+			} catch ( Exception $e ) {
+				continue;
+			}
+			if ( is_a( $action, 'ActionScheduler_NullAction' ) ) {
+				continue;
+			}
+			$this->items[ $action_id ] = array(
+				'ID'          => $action_id,
+				'hook'        => $action->get_hook(),
+				'status_name' => $this->store->get_status( $action_id ),
+				'status'      => $status_labels[ $this->store->get_status( $action_id ) ],
+				'args'        => $action->get_args(),
+				'group'       => $action->get_group(),
+				'log_entries' => $this->logger->get_logs( $action_id ),
+				'claim_id'    => $this->store->get_claim_id( $action_id ),
+				'recurrence'  => $this->get_recurrence( $action ),
+				'schedule'    => $action->get_schedule(),
+			);
+		}
+
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => ceil( $total_items / $per_page ),
+			)
+		);
+	}
+
+	/**
+	 * Prints the available statuses so the user can click to filter.
+	 */
+	protected function display_filter_by_status() {
+		$this->status_counts = $this->store->action_counts() + $this->store->extra_action_counts();
+		parent::display_filter_by_status();
+	}
+
+	/**
+	 * Get the text to display in the search box on the list table.
+	 */
+	protected function get_search_box_button_text() {
+		return __( 'Search hook, args and claim ID', 'action-scheduler' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function get_per_page_option_name() {
+		return str_replace( '-', '_', $this->screen->id ) . '_per_page';
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_LogEntry.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_LogEntry.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Class ActionScheduler_LogEntry
+ */
+class ActionScheduler_LogEntry {
+
+	/**
+	 * Action's ID for log entry.
+	 *
+	 * @var int $action_id
+	 */
+	protected $action_id = '';
+
+	/**
+	 * Log entry's message.
+	 *
+	 * @var string $message
+	 */
+	protected $message = '';
+
+	/**
+	 * Log entry's date.
+	 *
+	 * @var Datetime $date
+	 */
+	protected $date;
+
+	/**
+	 * Constructor
+	 *
+	 * @param mixed    $action_id Action ID.
+	 * @param string   $message   Message.
+	 * @param Datetime $date      Datetime object with the time when this log entry was created. If this parameter is
+	 *                            not provided a new Datetime object (with current time) will be created.
+	 */
+	public function __construct( $action_id, $message, $date = null ) {
+		/*
+		 * ActionScheduler_wpCommentLogger::get_entry() previously passed a 3rd param of $comment->comment_type
+		 * to ActionScheduler_LogEntry::__construct(), goodness knows why, and the Follow-up Emails plugin
+		 * hard-codes loading its own version of ActionScheduler_wpCommentLogger with that out-dated method,
+		 * goodness knows why, so we need to guard against that here instead of using a DateTime type declaration
+		 * for the constructor's 3rd param of $date and causing a fatal error with older versions of FUE.
+		 */
+		if ( null !== $date && ! is_a( $date, 'DateTime' ) ) {
+			_doing_it_wrong( __METHOD__, 'The third parameter must be a valid DateTime instance, or null.', '2.0.0' );
+			$date = null;
+		}
+
+		$this->action_id = $action_id;
+		$this->message   = $message;
+		$this->date      = $date ? $date : new Datetime();
+	}
+
+	/**
+	 * Returns the date when this log entry was created
+	 *
+	 * @return Datetime
+	 */
+	public function get_date() {
+		return $this->date;
+	}
+
+	/**
+	 * Get action ID of log entry.
+	 */
+	public function get_action_id() {
+		return $this->action_id;
+	}
+
+	/**
+	 * Get log entry message.
+	 */
+	public function get_message() {
+		return $this->message;
+	}
+}
+

--- a/includes/lib/action-scheduler/classes/ActionScheduler_NullLogEntry.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_NullLogEntry.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Class ActionScheduler_NullLogEntry
+ */
+class ActionScheduler_NullLogEntry extends ActionScheduler_LogEntry {
+
+	/**
+	 * Construct.
+	 *
+	 * @param string $action_id Action ID.
+	 * @param string $message   Log entry.
+	 */
+	public function __construct( $action_id = '', $message = '' ) {
+		// nothing to see here.
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_OptionLock.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_OptionLock.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Provide a way to set simple transient locks to block behaviour
+ * for up-to a given duration.
+ *
+ * Class ActionScheduler_OptionLock
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_OptionLock extends ActionScheduler_Lock {
+
+	/**
+	 * Set a lock using options for a given amount of time (60 seconds by default).
+	 *
+	 * Using an autoloaded option avoids running database queries or other resource intensive tasks
+	 * on frequently triggered hooks, like 'init' or 'shutdown'.
+	 *
+	 * For example, ActionScheduler_QueueRunner->maybe_dispatch_async_request() uses a lock to avoid
+	 * calling ActionScheduler_QueueRunner->has_maximum_concurrent_batches() every time the 'shutdown',
+	 * hook is triggered, because that method calls ActionScheduler_QueueRunner->store->get_claim_count()
+	 * to find the current number of claims in the database.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @bool True if lock value has changed, false if not or if set failed.
+	 */
+	public function set( $lock_type ) {
+		global $wpdb;
+
+		$lock_key            = $this->get_key( $lock_type );
+		$existing_lock_value = $this->get_existing_lock( $lock_type );
+		$new_lock_value      = $this->new_lock_value( $lock_type );
+
+		// The lock may not exist yet, or may have been deleted.
+		if ( empty( $existing_lock_value ) ) {
+			return (bool) $wpdb->insert(
+				$wpdb->options,
+				array(
+					'option_name'  => $lock_key,
+					'option_value' => $new_lock_value,
+					'autoload'     => 'no',
+				)
+			);
+		}
+
+		if ( $this->get_expiration_from( $existing_lock_value ) >= time() ) {
+			return false;
+		}
+
+		// Otherwise, try to obtain the lock.
+		return (bool) $wpdb->update(
+			$wpdb->options,
+			array( 'option_value' => $new_lock_value ),
+			array(
+				'option_name'  => $lock_key,
+				'option_value' => $existing_lock_value,
+			)
+		);
+	}
+
+	/**
+	 * If a lock is set, return the timestamp it was set to expiry.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool|int False if no lock is set, otherwise the timestamp for when the lock is set to expire.
+	 */
+	public function get_expiration( $lock_type ) {
+		return $this->get_expiration_from( $this->get_existing_lock( $lock_type ) );
+	}
+
+	/**
+	 * Given the lock string, derives the lock expiration timestamp (or false if it cannot be determined).
+	 *
+	 * @param string $lock_value String containing a timestamp, or pipe-separated combination of unique value and timestamp.
+	 *
+	 * @return false|int
+	 */
+	private function get_expiration_from( $lock_value ) {
+		$lock_string = explode( '|', $lock_value );
+
+		// Old style lock?
+		if ( count( $lock_string ) === 1 && is_numeric( $lock_string[0] ) ) {
+			return (int) $lock_string[0];
+		}
+
+		// New style lock?
+		if ( count( $lock_string ) === 2 && is_numeric( $lock_string[1] ) ) {
+			return (int) $lock_string[1];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the key to use for storing the lock in the transient
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return string
+	 */
+	protected function get_key( $lock_type ) {
+		return sprintf( 'action_scheduler_lock_%s', $lock_type );
+	}
+
+	/**
+	 * Supplies the existing lock value, or an empty string if not set.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 *
+	 * @return string
+	 */
+	private function get_existing_lock( $lock_type ) {
+		global $wpdb;
+
+		// Now grab the existing lock value, if there is one.
+		return (string) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
+				$this->get_key( $lock_type )
+			)
+		);
+	}
+
+	/**
+	 * Supplies a lock value consisting of a unique value and the current timestamp, which are separated by a pipe
+	 * character.
+	 *
+	 * Example: (string) "649de012e6b262.09774912|1688068114"
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 *
+	 * @return string
+	 */
+	private function new_lock_value( $lock_type ) {
+		return uniqid( '', true ) . '|' . ( time() + $this->get_duration( $lock_type ) );
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_QueueCleaner.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_QueueCleaner.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * Class ActionScheduler_QueueCleaner
+ */
+class ActionScheduler_QueueCleaner {
+
+	/**
+	 * The batch size.
+	 *
+	 * @var int
+	 */
+	protected $batch_size;
+
+	/**
+	 * ActionScheduler_Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $store = null;
+
+	/**
+	 * 31 days in seconds.
+	 *
+	 * @var int
+	 */
+	private $month_in_seconds = 2678400;
+
+	/**
+	 * Default list of statuses purged by the cleaner process.
+	 *
+	 * @var string[]
+	 */
+	private $default_statuses_to_purge = array(
+		ActionScheduler_Store::STATUS_COMPLETE,
+		ActionScheduler_Store::STATUS_CANCELED,
+	);
+
+	/**
+	 * ActionScheduler_QueueCleaner constructor.
+	 *
+	 * @param ActionScheduler_Store|null $store      The store instance.
+	 * @param int                        $batch_size The batch size.
+	 */
+	public function __construct( ?ActionScheduler_Store $store = null, $batch_size = 20 ) {
+		$this->store      = $store ? $store : ActionScheduler_Store::instance();
+		$this->batch_size = $batch_size;
+	}
+
+	/**
+	 * Default queue cleaner process used by queue runner.
+	 *
+	 * @return array
+	 */
+	public function delete_old_actions() {
+		/**
+		 * Filter the minimum scheduled date age for action deletion.
+		 *
+		 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
+		 */
+		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
+
+		try {
+			$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
+		} catch ( Exception $e ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* Translators: %s is the exception message. */
+					esc_html__( 'It was not possible to determine a valid cut-off time: %s.', 'action-scheduler' ),
+					esc_html( $e->getMessage() )
+				),
+				'3.5.5'
+			);
+
+			return array();
+		}
+
+		/**
+		 * Filter the statuses when cleaning the queue.
+		 *
+		 * @param string[] $default_statuses_to_purge Action statuses to clean.
+		 */
+		$statuses_to_purge = (array) apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
+
+		return $this->clean_actions( $statuses_to_purge, $cutoff, $this->get_batch_size() );
+	}
+
+	/**
+	 * Delete selected actions limited by status and date.
+	 *
+	 * @param string[] $statuses_to_purge List of action statuses to purge. Defaults to canceled, complete.
+	 * @param DateTime $cutoff_date Date limit for selecting actions. Defaults to 31 days ago.
+	 * @param int|null $batch_size Maximum number of actions per status to delete. Defaults to 20.
+	 * @param string   $context Calling process context. Defaults to `old`.
+	 * @return array Actions deleted.
+	 */
+	public function clean_actions( array $statuses_to_purge, DateTime $cutoff_date, $batch_size = null, $context = 'old' ) {
+		$batch_size = ! is_null( $batch_size ) ? $batch_size : $this->batch_size;
+		$cutoff     = ! is_null( $cutoff_date ) ? $cutoff_date : as_get_datetime_object( $this->month_in_seconds . ' seconds ago' );
+		$lifespan   = time() - $cutoff->getTimestamp();
+
+		if ( empty( $statuses_to_purge ) ) {
+			$statuses_to_purge = $this->default_statuses_to_purge;
+		}
+
+		$deleted_actions = array();
+
+		foreach ( $statuses_to_purge as $status ) {
+			$actions_to_delete = $this->store->query_actions(
+				array(
+					'status'           => $status,
+					'modified'         => $cutoff,
+					'modified_compare' => '<=',
+					'per_page'         => $batch_size,
+					'orderby'          => 'none',
+				)
+			);
+
+			$deleted_actions = array_merge( $deleted_actions, $this->delete_actions( $actions_to_delete, $lifespan, $context ) );
+		}
+
+		return $deleted_actions;
+	}
+
+	/**
+	 * Delete actions.
+	 *
+	 * @param int[]  $actions_to_delete List of action IDs to delete.
+	 * @param int    $lifespan Minimum scheduled age in seconds of the actions being deleted.
+	 * @param string $context Context of the delete request.
+	 * @return array Deleted action IDs.
+	 */
+	private function delete_actions( array $actions_to_delete, $lifespan = null, $context = 'old' ) {
+		$deleted_actions = array();
+
+		if ( is_null( $lifespan ) ) {
+			$lifespan = $this->month_in_seconds;
+		}
+
+		foreach ( $actions_to_delete as $action_id ) {
+			try {
+				$this->store->delete_action( $action_id );
+				$deleted_actions[] = $action_id;
+			} catch ( Exception $e ) {
+				/**
+				 * Notify 3rd party code of exceptions when deleting a completed action older than the retention period
+				 *
+				 * This hook provides a way for 3rd party code to log or otherwise handle exceptions relating to their
+				 * actions.
+				 *
+				 * @param int $action_id The scheduled actions ID in the data store
+				 * @param Exception $e The exception thrown when attempting to delete the action from the data store
+				 * @param int $lifespan The retention period, in seconds, for old actions
+				 * @param int $count_of_actions_to_delete The number of old actions being deleted in this batch
+				 * @since 2.0.0
+				 */
+				do_action( "action_scheduler_failed_{$context}_action_deletion", $action_id, $e, $lifespan, count( $actions_to_delete ) );
+			}
+		}
+		return $deleted_actions;
+	}
+
+	/**
+	 * Unclaim pending actions that have not been run within a given time limit.
+	 *
+	 * When called by ActionScheduler_Abstract_QueueRunner::run_cleanup(), the time limit passed
+	 * as a parameter is 10x the time limit used for queue processing.
+	 *
+	 * @param int $time_limit The number of seconds to allow a queue to run before unclaiming its pending actions. Default 300 (5 minutes).
+	 */
+	public function reset_timeouts( $time_limit = 300 ) {
+		$timeout = apply_filters( 'action_scheduler_timeout_period', $time_limit );
+
+		if ( $timeout < 0 ) {
+			return;
+		}
+
+		$cutoff           = as_get_datetime_object( $timeout . ' seconds ago' );
+		$actions_to_reset = $this->store->query_actions(
+			array(
+				'status'           => ActionScheduler_Store::STATUS_PENDING,
+				'modified'         => $cutoff,
+				'modified_compare' => '<=',
+				'claimed'          => true,
+				'per_page'         => $this->get_batch_size(),
+				'orderby'          => 'none',
+			)
+		);
+
+		foreach ( $actions_to_reset as $action_id ) {
+			$this->store->unclaim_action( $action_id );
+			do_action( 'action_scheduler_reset_action', $action_id );
+		}
+	}
+
+	/**
+	 * Mark actions that have been running for more than a given time limit as failed, based on
+	 * the assumption some uncatchable and unloggable fatal error occurred during processing.
+	 *
+	 * When called by ActionScheduler_Abstract_QueueRunner::run_cleanup(), the time limit passed
+	 * as a parameter is 10x the time limit used for queue processing.
+	 *
+	 * @param int $time_limit The number of seconds to allow an action to run before it is considered to have failed. Default 300 (5 minutes).
+	 */
+	public function mark_failures( $time_limit = 300 ) {
+		$timeout = apply_filters( 'action_scheduler_failure_period', $time_limit );
+
+		if ( $timeout < 0 ) {
+			return;
+		}
+
+		$cutoff           = as_get_datetime_object( $timeout . ' seconds ago' );
+		$actions_to_reset = $this->store->query_actions(
+			array(
+				'status'           => ActionScheduler_Store::STATUS_RUNNING,
+				'modified'         => $cutoff,
+				'modified_compare' => '<=',
+				'per_page'         => $this->get_batch_size(),
+				'orderby'          => 'none',
+			)
+		);
+
+		foreach ( $actions_to_reset as $action_id ) {
+			$this->store->mark_failure( $action_id );
+			do_action( 'action_scheduler_failed_action', $action_id, $timeout );
+		}
+	}
+
+	/**
+	 * Do all of the cleaning actions.
+	 *
+	 * @param int $time_limit The number of seconds to use as the timeout and failure period. Default 300 (5 minutes).
+	 */
+	public function clean( $time_limit = 300 ) {
+		$this->delete_old_actions();
+		$this->reset_timeouts( $time_limit );
+		$this->mark_failures( $time_limit );
+	}
+
+	/**
+	 * Get the batch size for cleaning the queue.
+	 *
+	 * @return int
+	 */
+	protected function get_batch_size() {
+		/**
+		 * Filter the batch size when cleaning the queue.
+		 *
+		 * @param int $batch_size The number of actions to clean in one batch.
+		 */
+		return absint( apply_filters( 'action_scheduler_cleanup_batch_size', $this->batch_size ) );
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_QueueRunner.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_QueueRunner.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * Class ActionScheduler_QueueRunner
+ */
+class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
+	const WP_CRON_HOOK = 'action_scheduler_run_queue';
+
+	const WP_CRON_SCHEDULE = 'every_minute';
+
+	/**
+	 * ActionScheduler_AsyncRequest_QueueRunner instance.
+	 *
+	 * @var ActionScheduler_AsyncRequest_QueueRunner
+	 */
+	protected $async_request;
+
+	/**
+	 * ActionScheduler_QueueRunner instance.
+	 *
+	 * @var ActionScheduler_QueueRunner
+	 */
+	private static $runner = null;
+
+	/**
+	 * Number of processed actions.
+	 *
+	 * @var int
+	 */
+	private $processed_actions_count = 0;
+
+	/**
+	 * Get instance.
+	 *
+	 * @return ActionScheduler_QueueRunner
+	 * @codeCoverageIgnore
+	 */
+	public static function instance() {
+		if ( empty( self::$runner ) ) {
+			$class        = apply_filters( 'action_scheduler_queue_runner_class', 'ActionScheduler_QueueRunner' );
+			self::$runner = new $class();
+		}
+
+		return self::$runner;
+	}
+
+	/**
+	 * ActionScheduler_QueueRunner constructor.
+	 *
+	 * @param ActionScheduler_Store|null                    $store Store object.
+	 * @param ActionScheduler_FatalErrorMonitor|null        $monitor Monitor object.
+	 * @param ActionScheduler_QueueCleaner|null             $cleaner Cleaner object.
+	 * @param ActionScheduler_AsyncRequest_QueueRunner|null $async_request Async request runner object.
+	 */
+	public function __construct( ?ActionScheduler_Store $store = null, ?ActionScheduler_FatalErrorMonitor $monitor = null, ?ActionScheduler_QueueCleaner $cleaner = null, ?ActionScheduler_AsyncRequest_QueueRunner $async_request = null ) {
+		parent::__construct( $store, $monitor, $cleaner );
+
+		if ( is_null( $async_request ) ) {
+			$async_request = new ActionScheduler_AsyncRequest_QueueRunner( $this->store );
+		}
+
+		$this->async_request = $async_request;
+	}
+
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+
+		add_filter( 'cron_schedules', array( self::instance(), 'add_wp_cron_schedule' ) ); // phpcs:ignore WordPress.WP.CronInterval.CronSchedulesInterval
+
+		// Check for and remove any WP Cron hook scheduled by Action Scheduler < 3.0.0, which didn't include the $context param.
+		$next_timestamp = wp_next_scheduled( self::WP_CRON_HOOK );
+		if ( $next_timestamp ) {
+			wp_unschedule_event( $next_timestamp, self::WP_CRON_HOOK );
+		}
+
+		$cron_context = array( 'WP Cron' );
+
+		if ( ! wp_next_scheduled( self::WP_CRON_HOOK, $cron_context ) ) {
+			$schedule = apply_filters( 'action_scheduler_run_schedule', self::WP_CRON_SCHEDULE );
+			wp_schedule_event( time(), $schedule, self::WP_CRON_HOOK, $cron_context );
+		}
+
+		add_action( self::WP_CRON_HOOK, array( self::instance(), 'run' ) );
+		$this->hook_dispatch_async_request();
+	}
+
+	/**
+	 * Hook check for dispatching an async request.
+	 */
+	public function hook_dispatch_async_request() {
+		add_action( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
+	}
+
+	/**
+	 * Unhook check for dispatching an async request.
+	 */
+	public function unhook_dispatch_async_request() {
+		remove_action( 'shutdown', array( $this, 'maybe_dispatch_async_request' ) );
+	}
+
+	/**
+	 * Check if we should dispatch an async request to process actions.
+	 *
+	 * This method is attached to 'shutdown', so is called frequently. To avoid slowing down
+	 * the site, it mitigates the work performed in each request by:
+	 * 1. checking if it's in the admin context and then
+	 * 2. haven't run on the 'shutdown' hook within the lock time (60 seconds by default)
+	 * 3. haven't exceeded the number of allowed batches.
+	 *
+	 * The order of these checks is important, because they run from a check on a value:
+	 * 1. in memory - is_admin() maps to $GLOBALS or the WP_ADMIN constant
+	 * 2. in memory - transients use autoloaded options by default
+	 * 3. from a database query - has_maximum_concurrent_batches() run the query
+	 *    $this->store->get_claim_count() to find the current number of claims in the DB.
+	 *
+	 * If all of these conditions are met, then we request an async runner check whether it
+	 * should dispatch a request to process pending actions.
+	 */
+	public function maybe_dispatch_async_request() {
+		// Only start an async queue at most once every 60 seconds.
+		if (
+			is_admin()
+			&& ! ActionScheduler::lock()->is_locked( 'async-request-runner' )
+			&& ActionScheduler::lock()->set( 'async-request-runner' )
+		) {
+			$this->async_request->maybe_dispatch();
+		}
+	}
+
+	/**
+	 * Process actions in the queue. Attached to self::WP_CRON_HOOK i.e. 'action_scheduler_run_queue'
+	 *
+	 * The $context param of this method defaults to 'WP Cron', because prior to Action Scheduler 3.0.0
+	 * that was the only context in which this method was run, and the self::WP_CRON_HOOK hook had no context
+	 * passed along with it. New code calling this method directly, or by triggering the self::WP_CRON_HOOK,
+	 * should set a context as the first parameter. For an example of this, refer to the code seen in
+	 *
+	 * @see ActionScheduler_AsyncRequest_QueueRunner::handle()
+	 *
+	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
+	 *        Generally, this should be capitalised and not localised as it's a proper noun.
+	 * @return int The number of actions processed.
+	 */
+	public function run( $context = 'WP Cron' ) {
+		ActionScheduler_Compatibility::raise_memory_limit();
+		ActionScheduler_Compatibility::raise_time_limit( $this->get_time_limit() );
+		do_action( 'action_scheduler_before_process_queue' );
+		$this->run_cleanup();
+
+		$this->processed_actions_count = 0;
+		if ( false === $this->has_maximum_concurrent_batches() ) {
+			do {
+				$batch_size                     = apply_filters( 'action_scheduler_queue_runner_batch_size', 25 );
+				$processed_actions_in_batch     = $this->do_batch( $batch_size, $context );
+				$this->processed_actions_count += $processed_actions_in_batch;
+			} while ( $processed_actions_in_batch > 0 && ! $this->batch_limits_exceeded( $this->processed_actions_count ) ); // keep going until we run out of actions, time, or memory.
+		}
+
+		do_action( 'action_scheduler_after_process_queue' );
+		return $this->processed_actions_count;
+	}
+
+	/**
+	 * Process a batch of actions pending in the queue.
+	 *
+	 * Actions are processed by claiming a set of pending actions then processing each one until either the batch
+	 * size is completed, or memory or time limits are reached, defined by @see $this->batch_limits_exceeded().
+	 *
+	 * @param int    $size The maximum number of actions to process in the batch.
+	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
+	 *                        Generally, this should be capitalised and not localised as it's a proper noun.
+	 * @return int The number of actions processed.
+	 */
+	protected function do_batch( $size = 100, $context = '' ) {
+		$claim = $this->store->stake_claim( $size );
+		$this->monitor->attach( $claim );
+		$processed_actions = 0;
+
+		foreach ( $claim->get_actions() as $action_id ) {
+			// bail if we lost the claim.
+			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $claim->get_id() ), true ) ) {
+				break;
+			}
+			$this->process_action( $action_id, $context );
+			$processed_actions++;
+
+			if ( $this->batch_limits_exceeded( $processed_actions + $this->processed_actions_count ) ) {
+				break;
+			}
+		}
+		$this->store->release_claim( $claim );
+		$this->monitor->detach();
+		$this->clear_caches();
+		return $processed_actions;
+	}
+
+	/**
+	 * Flush the cache if possible (intended for use after a batch of actions has been processed).
+	 *
+	 * This is useful because running large batches can eat up memory and because invalid data can accrue in the
+	 * runtime cache, which may lead to unexpected results.
+	 */
+	protected function clear_caches() {
+		/*
+		 * Calling wp_cache_flush_runtime() lets us clear the runtime cache without invalidating the external object
+		 * cache, so we will always prefer this method (as compared to calling wp_cache_flush()) when it is available.
+		 *
+		 * However, this function was only introduced in WordPress 6.0. Additionally, the preferred way of detecting if
+		 * it is supported changed in WordPress 6.1 so we use two different methods to decide if we should utilize it.
+		 */
+		$flushing_runtime_cache_explicitly_supported = function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' );
+		$flushing_runtime_cache_implicitly_supported = ! function_exists( 'wp_cache_supports' ) && function_exists( 'wp_cache_flush_runtime' );
+
+		if ( $flushing_runtime_cache_explicitly_supported || $flushing_runtime_cache_implicitly_supported ) {
+			wp_cache_flush_runtime();
+		} elseif (
+			! wp_using_ext_object_cache()
+			/**
+			 * When an external object cache is in use, and when wp_cache_flush_runtime() is not available, then
+			 * normally the cache will not be flushed after processing a batch of actions (to avoid a performance
+			 * penalty for other processes).
+			 *
+			 * This filter makes it possible to override this behavior and always flush the cache, even if an external
+			 * object cache is in use.
+			 *
+			 * @since 1.0
+			 *
+			 * @param bool $flush_cache If the cache should be flushed.
+			 */
+			|| apply_filters( 'action_scheduler_queue_runner_flush_cache', false )
+		) {
+			wp_cache_flush();
+		}
+	}
+
+	/**
+	 * Add schedule to WP cron.
+	 *
+	 * @param array<string, array<string, int|string>> $schedules Schedules.
+	 * @return array<string, array<string, int|string>>
+	 */
+	public function add_wp_cron_schedule( $schedules ) {
+		$schedules['every_minute'] = array(
+			'interval' => 60, // in seconds.
+			'display'  => __( 'Every minute', 'action-scheduler' ),
+		);
+
+		return $schedules;
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_SystemInformation.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_SystemInformation.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Provides information about active and registered instances of Action Scheduler.
+ */
+class ActionScheduler_SystemInformation {
+	/**
+	 * Returns information about the plugin or theme which contains the current active version
+	 * of Action Scheduler.
+	 *
+	 * If this cannot be determined, or if Action Scheduler is being loaded via some other
+	 * method, then it will return an empty array. Otherwise, if populated, the array will
+	 * look like the following:
+	 *
+	 *     [
+	 *         'type' => 'plugin', # or 'theme'
+	 *         'name' => 'Name',
+	 *     ]
+	 *
+	 * @return array
+	 */
+	public static function active_source(): array {
+		$plugins      = get_plugins();
+		$plugin_files = array_keys( $plugins );
+
+		foreach ( $plugin_files as $plugin_file ) {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . dirname( $plugin_file );
+			$plugin_file = trailingslashit( WP_PLUGIN_DIR ) . $plugin_file;
+
+			if ( 0 !== strpos( dirname( __DIR__ ), $plugin_path ) ) {
+				continue;
+			}
+
+			$plugin_data = get_plugin_data( $plugin_file );
+
+			if ( ! is_array( $plugin_data ) || empty( $plugin_data['Name'] ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'plugin',
+				'name' => $plugin_data['Name'],
+			);
+		}
+
+		$themes = (array) search_theme_directories();
+
+		foreach ( $themes as $slug => $data ) {
+			$needle = trailingslashit( $data['theme_root'] ) . $slug . '/';
+
+			if ( 0 !== strpos( __FILE__, $needle ) ) {
+				continue;
+			}
+
+			$theme = wp_get_theme( $slug );
+
+			if ( ! is_object( $theme ) || ! is_a( $theme, \WP_Theme::class ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'theme',
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				'name' => $theme->Name,
+			);
+		}
+
+		return array();
+	}
+
+	/**
+	 * Returns the directory path for the currently active installation of Action Scheduler.
+	 *
+	 * @return string
+	 */
+	public static function active_source_path(): string {
+		return trailingslashit( dirname( __DIR__ ) );
+	}
+
+	/**
+	 * Get registered sources.
+	 *
+	 * It is not always possible to obtain this information. For instance, if earlier versions (<=3.9.0) of
+	 * Action Scheduler register themselves first, then the necessary data about registered sources will
+	 * not be available.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_sources() {
+		$versions = ActionScheduler_Versions::instance();
+		return method_exists( $versions, 'get_sources' ) ? $versions->get_sources() : array();
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_Versions.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_Versions.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Class ActionScheduler_Versions
+ */
+class ActionScheduler_Versions {
+	/**
+	 * ActionScheduler_Versions instance.
+	 *
+	 * @var ActionScheduler_Versions
+	 */
+	private static $instance = null;
+
+	/**
+	 * Versions.
+	 *
+	 * @var array<string, callable>
+	 */
+	private $versions = array();
+
+	/**
+	 * Registered sources.
+	 *
+	 * @var array<string, string>
+	 */
+	private $sources = array();
+
+	/**
+	 * Register version's callback.
+	 *
+	 * @param string   $version_string          Action Scheduler version.
+	 * @param callable $initialization_callback Callback to initialize the version.
+	 */
+	public function register( $version_string, $initialization_callback ) {
+		if ( isset( $this->versions[ $version_string ] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+		$backtrace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+		$source    = $backtrace[0]['file'];
+
+		$this->versions[ $version_string ] = $initialization_callback;
+		$this->sources[ $source ]          = $version_string;
+		return true;
+	}
+
+	/**
+	 * Get all versions.
+	 */
+	public function get_versions() {
+		return $this->versions;
+	}
+
+	/**
+	 * Get registered sources.
+	 *
+	 * Use with caution: this method is only available as of Action Scheduler's 3.9.1
+	 * release and, owing to the way Action Scheduler is loaded, it's possible that the
+	 * class definition used at runtime will belong to an earlier version.
+	 *
+	 * @since 3.9.1
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_sources() {
+		return $this->sources;
+	}
+
+	/**
+	 * Get latest version registered.
+	 */
+	public function latest_version() {
+		$keys = array_keys( $this->versions );
+		if ( empty( $keys ) ) {
+			return false;
+		}
+		uasort( $keys, 'version_compare' );
+		return end( $keys );
+	}
+
+	/**
+	 * Get callback for latest registered version.
+	 */
+	public function latest_version_callback() {
+		$latest = $this->latest_version();
+
+		if ( empty( $latest ) || ! isset( $this->versions[ $latest ] ) ) {
+			return '__return_null';
+		}
+
+		return $this->versions[ $latest ];
+	}
+
+	/**
+	 * Get instance.
+	 *
+	 * @return ActionScheduler_Versions
+	 * @codeCoverageIgnore
+	 */
+	public static function instance() {
+		if ( empty( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function initialize_latest_version() {
+		$self = self::instance();
+		call_user_func( $self->latest_version_callback() );
+	}
+
+	/**
+	 * Returns information about the plugin or theme which contains the current active version
+	 * of Action Scheduler.
+	 *
+	 * If this cannot be determined, or if Action Scheduler is being loaded via some other
+	 * method, then it will return an empty array. Otherwise, if populated, the array will
+	 * look like the following:
+	 *
+	 *     [
+	 *         'type' => 'plugin', # or 'theme'
+	 *         'name' => 'Name',
+	 *     ]
+	 *
+	 * @deprecated 3.9.2 Use ActionScheduler_SystemInformation::active_source().
+	 *
+	 * @return array
+	 */
+	public function active_source(): array {
+		_deprecated_function( __METHOD__, '3.9.2', 'ActionScheduler_SystemInformation::active_source()' );
+		return ActionScheduler_SystemInformation::active_source();
+	}
+
+	/**
+	 * Returns the directory path for the currently active installation of Action Scheduler.
+	 *
+	 * @deprecated 3.9.2 Use ActionScheduler_SystemInformation::active_source_path().
+	 *
+	 * @return string
+	 */
+	public function active_source_path(): string {
+		_deprecated_function( __METHOD__, '3.9.2', 'ActionScheduler_SystemInformation::active_source_path()' );
+		return ActionScheduler_SystemInformation::active_source_path();
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_WPCommentCleaner.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_WPCommentCleaner.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * Class ActionScheduler_WPCommentCleaner
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_WPCommentCleaner {
+
+	/**
+	 * Post migration hook used to cleanup the WP comment table.
+	 *
+	 * @var string
+	 */
+	protected static $cleanup_hook = 'action_scheduler/cleanup_wp_comment_logs';
+
+	/**
+	 * An instance of the ActionScheduler_wpCommentLogger class to interact with the comments table.
+	 *
+	 * This instance should only be used as an interface. It should not be initialized.
+	 *
+	 * @var ActionScheduler_wpCommentLogger
+	 */
+	protected static $wp_comment_logger = null;
+
+	/**
+	 * The key used to store the cached value of whether there are logs in the WP comment table.
+	 *
+	 * @var string
+	 */
+	protected static $has_logs_option_key = 'as_has_wp_comment_logs';
+
+	/**
+	 * Initialize the class and attach callbacks.
+	 */
+	public static function init() {
+		if ( empty( self::$wp_comment_logger ) ) {
+			self::$wp_comment_logger = new ActionScheduler_wpCommentLogger();
+		}
+
+		add_action( self::$cleanup_hook, array( __CLASS__, 'delete_all_action_comments' ) );
+
+		// While there are orphaned logs left in the comments table, we need to attach the callbacks which filter comment counts.
+		add_action( 'pre_get_comments', array( self::$wp_comment_logger, 'filter_comment_queries' ), 10, 1 );
+		add_action( 'wp_count_comments', array( self::$wp_comment_logger, 'filter_comment_count' ), 20, 2 ); // run after WC_Comments::wp_count_comments() to make sure we exclude order notes and action logs.
+		add_action( 'comment_feed_where', array( self::$wp_comment_logger, 'filter_comment_feed' ), 10, 2 );
+
+		// Action Scheduler may be displayed as a Tools screen or WooCommerce > Status administration screen.
+		add_action( 'load-tools_page_action-scheduler', array( __CLASS__, 'register_admin_notice' ) );
+		add_action( 'load-woocommerce_page_wc-status', array( __CLASS__, 'register_admin_notice' ) );
+	}
+
+	/**
+	 * Determines if there are log entries in the wp comments table.
+	 *
+	 * Uses the flag set on migration completion set by @see self::maybe_schedule_cleanup().
+	 *
+	 * @return boolean Whether there are scheduled action comments in the comments table.
+	 */
+	public static function has_logs() {
+		return 'yes' === get_option( self::$has_logs_option_key );
+	}
+
+	/**
+	 * Schedules the WP Post comment table cleanup to run in 6 months if it's not already scheduled.
+	 * Attached to the migration complete hook 'action_scheduler/migration_complete'.
+	 */
+	public static function maybe_schedule_cleanup() {
+		$has_logs = 'no';
+
+		$args = array(
+			'type'   => ActionScheduler_wpCommentLogger::TYPE,
+			'number' => 1,
+			'fields' => 'ids',
+		);
+
+		if ( (bool) get_comments( $args ) ) {
+			$has_logs = 'yes';
+
+			if ( ! as_next_scheduled_action( self::$cleanup_hook ) ) {
+				as_schedule_single_action( gmdate( 'U' ) + ( 6 * MONTH_IN_SECONDS ), self::$cleanup_hook );
+			}
+		}
+
+		update_option( self::$has_logs_option_key, $has_logs, true );
+	}
+
+	/**
+	 * Delete all action comments from the WP Comments table.
+	 */
+	public static function delete_all_action_comments() {
+		global $wpdb;
+
+		$wpdb->delete(
+			$wpdb->comments,
+			array(
+				'comment_type'  => ActionScheduler_wpCommentLogger::TYPE,
+				'comment_agent' => ActionScheduler_wpCommentLogger::AGENT,
+			)
+		);
+
+		update_option( self::$has_logs_option_key, 'no', true );
+	}
+
+	/**
+	 * Registers admin notices about the orphaned action logs.
+	 */
+	public static function register_admin_notice() {
+		add_action( 'admin_notices', array( __CLASS__, 'print_admin_notice' ) );
+	}
+
+	/**
+	 * Prints details about the orphaned action logs and includes information on where to learn more.
+	 */
+	public static function print_admin_notice() {
+		$next_cleanup_message        = '';
+		$next_scheduled_cleanup_hook = as_next_scheduled_action( self::$cleanup_hook );
+
+		if ( $next_scheduled_cleanup_hook ) {
+			/* translators: %s: date interval */
+			$next_cleanup_message = sprintf( __( 'This data will be deleted in %s.', 'action-scheduler' ), human_time_diff( gmdate( 'U' ), $next_scheduled_cleanup_hook ) );
+		}
+
+		$notice = sprintf(
+			/* translators: 1: next cleanup message 2: github issue URL */
+			__( 'Action Scheduler has migrated data to custom tables; however, orphaned log entries exist in the WordPress Comments table. %1$s <a href="%2$s">Learn more &raquo;</a>', 'action-scheduler' ),
+			$next_cleanup_message,
+			'https://github.com/woocommerce/action-scheduler/issues/368'
+		);
+
+		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
+	}
+}

--- a/includes/lib/action-scheduler/classes/ActionScheduler_wcSystemStatus.php
+++ b/includes/lib/action-scheduler/classes/ActionScheduler_wcSystemStatus.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Class ActionScheduler_wcSystemStatus
+ */
+class ActionScheduler_wcSystemStatus {
+
+	/**
+	 * The active data stores
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	protected $store;
+
+	/**
+	 * Constructor method for ActionScheduler_wcSystemStatus.
+	 *
+	 * @param ActionScheduler_Store $store Active store object.
+	 *
+	 * @return void
+	 */
+	public function __construct( $store ) {
+		$this->store = $store;
+	}
+
+	/**
+	 * Display action data, including number of actions grouped by status and the oldest & newest action in each status.
+	 *
+	 * Helpful to identify issues, like a clogged queue.
+	 */
+	public function render() {
+		$action_counts     = $this->store->action_counts();
+		$status_labels     = $this->store->get_status_labels();
+		$oldest_and_newest = $this->get_oldest_and_newest( array_keys( $status_labels ) );
+
+		$this->get_template( $status_labels, $action_counts, $oldest_and_newest );
+	}
+
+	/**
+	 * Get oldest and newest scheduled dates for a given set of statuses.
+	 *
+	 * @param array $status_keys Set of statuses to find oldest & newest action for.
+	 * @return array
+	 */
+	protected function get_oldest_and_newest( $status_keys ) {
+
+		$oldest_and_newest = array();
+
+		foreach ( $status_keys as $status ) {
+			$oldest_and_newest[ $status ] = array(
+				'oldest' => '&ndash;',
+				'newest' => '&ndash;',
+			);
+
+			if ( 'in-progress' === $status ) {
+				continue;
+			}
+
+			$oldest_and_newest[ $status ]['oldest'] = $this->get_action_status_date( $status, 'oldest' );
+			$oldest_and_newest[ $status ]['newest'] = $this->get_action_status_date( $status, 'newest' );
+		}
+
+		return $oldest_and_newest;
+	}
+
+	/**
+	 * Get oldest or newest scheduled date for a given status.
+	 *
+	 * @param string $status Action status label/name string.
+	 * @param string $date_type Oldest or Newest.
+	 * @return DateTime
+	 */
+	protected function get_action_status_date( $status, $date_type = 'oldest' ) {
+
+		$order = 'oldest' === $date_type ? 'ASC' : 'DESC';
+
+		$action = $this->store->query_actions(
+			array(
+				'claimed'  => false,
+				'status'   => $status,
+				'per_page' => 1,
+				'order'    => $order,
+			)
+		);
+
+		if ( ! empty( $action ) ) {
+			$date_object = $this->store->get_date( $action[0] );
+			$action_date = $date_object->format( 'Y-m-d H:i:s O' );
+		} else {
+			$action_date = '&ndash;';
+		}
+
+		return $action_date;
+	}
+
+	/**
+	 * Get oldest or newest scheduled date for a given status.
+	 *
+	 * @param array $status_labels Set of statuses to find oldest & newest action for.
+	 * @param array $action_counts Number of actions grouped by status.
+	 * @param array $oldest_and_newest Date of the oldest and newest action with each status.
+	 */
+	protected function get_template( $status_labels, $action_counts, $oldest_and_newest ) {
+		$as_version   = ActionScheduler_Versions::instance()->latest_version();
+		$as_datastore = get_class( ActionScheduler_Store::instance() );
+		?>
+
+		<table class="wc_status_table widefat" cellspacing="0">
+			<thead>
+				<tr>
+					<th colspan="5" data-export-label="Action Scheduler"><h2><?php esc_html_e( 'Action Scheduler', 'action-scheduler' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows details of Action Scheduler.', 'action-scheduler' ) ); ?></h2></th>
+				</tr>
+				<tr>
+					<td colspan="2" data-export-label="Version"><?php esc_html_e( 'Version:', 'action-scheduler' ); ?></td>
+					<td colspan="3"><?php echo esc_html( $as_version ); ?></td>
+				</tr>
+				<tr>
+					<td colspan="2" data-export-label="Data store"><?php esc_html_e( 'Data store:', 'action-scheduler' ); ?></td>
+					<td colspan="3"><?php echo esc_html( $as_datastore ); ?></td>
+				</tr>
+				<tr>
+					<td><strong><?php esc_html_e( 'Action Status', 'action-scheduler' ); ?></strong></td>
+					<td class="help">&nbsp;</td>
+					<td><strong><?php esc_html_e( 'Count', 'action-scheduler' ); ?></strong></td>
+					<td><strong><?php esc_html_e( 'Oldest Scheduled Date', 'action-scheduler' ); ?></strong></td>
+					<td><strong><?php esc_html_e( 'Newest Scheduled Date', 'action-scheduler' ); ?></strong></td>
+				</tr>
+			</thead>
+			<tbody>
+				<?php
+				foreach ( $action_counts as $status => $count ) {
+					// WC uses the 3rd column for export, so we need to display more data in that (hidden when viewed as part of the table) and add an empty 2nd column.
+					printf(
+						'<tr><td>%1$s</td><td>&nbsp;</td><td>%2$s<span style="display: none;">, Oldest: %3$s, Newest: %4$s</span></td><td>%3$s</td><td>%4$s</td></tr>',
+						esc_html( $status_labels[ $status ] ),
+						esc_html( number_format_i18n( $count ) ),
+						esc_html( $oldest_and_newest[ $status ]['oldest'] ),
+						esc_html( $oldest_and_newest[ $status ]['newest'] )
+					);
+				}
+				?>
+			</tbody>
+		</table>
+
+		<?php
+	}
+
+	/**
+	 * Is triggered when invoking inaccessible methods in an object context.
+	 *
+	 * @param string $name Name of method called.
+	 * @param array  $arguments Parameters to invoke the method with.
+	 *
+	 * @return mixed
+	 * @link https://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.methods
+	 */
+	public function __call( $name, $arguments ) {
+		switch ( $name ) {
+			case 'print':
+				_deprecated_function( __CLASS__ . '::print()', '2.2.4', __CLASS__ . '::render()' );
+				return call_user_func_array( array( $this, 'render' ), $arguments );
+		}
+
+		return null;
+	}
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Cancel_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Cancel_Command.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+use function \WP_CLI\Utils\get_flag_value;
+
+/**
+ * WP-CLI command: action-scheduler action cancel
+ */
+class Cancel_Command extends \ActionScheduler_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$hook          = '';
+		$group         = get_flag_value( $this->assoc_args, 'group', '' );
+		$callback_args = get_flag_value( $this->assoc_args, 'args', null );
+		$all           = get_flag_value( $this->assoc_args, 'all', false );
+
+		if ( ! empty( $this->args[0] ) ) {
+			$hook = $this->args[0];
+		}
+
+		if ( ! empty( $callback_args ) ) {
+			$callback_args = json_decode( $callback_args, true );
+		}
+
+		if ( $all ) {
+			$this->cancel_all( $hook, $callback_args, $group );
+			return;
+		}
+
+		$this->cancel_single( $hook, $callback_args, $group );
+	}
+
+	/**
+	 * Cancel single action.
+	 *
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $callback_args Args that would have been passed to the job.
+	 * @param string $group The group the job is assigned to.
+	 * @return void
+	 */
+	protected function cancel_single( $hook, $callback_args, $group ) {
+		if ( empty( $hook ) ) {
+			\WP_CLI::error( __( 'Please specify hook of action to cancel.', 'action-scheduler' ) );
+		}
+
+		try {
+			$result = as_unschedule_action( $hook, $callback_args, $group );
+		} catch ( \Exception $e ) {
+			$this->print_error( $e, false );
+		}
+
+		if ( null === $result ) {
+			$e = new \Exception( __( 'Unable to cancel scheduled action: check the logs.', 'action-scheduler' ) );
+			$this->print_error( $e, false );
+		}
+
+		$this->print_success( false );
+	}
+
+	/**
+	 * Cancel all actions.
+	 *
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $callback_args Args that would have been passed to the job.
+	 * @param string $group The group the job is assigned to.
+	 * @return void
+	 */
+	protected function cancel_all( $hook, $callback_args, $group ) {
+		if ( empty( $hook ) && empty( $group ) ) {
+			\WP_CLI::error( __( 'Please specify hook and/or group of actions to cancel.', 'action-scheduler' ) );
+		}
+
+		try {
+			$result = as_unschedule_all_actions( $hook, $callback_args, $group );
+		} catch ( \Exception $e ) {
+			$this->print_error( $e, $multiple );
+		}
+
+		/**
+		 * Because as_unschedule_all_actions() does not provide a result,
+		 * neither confirm or deny actions cancelled.
+		 */
+		\WP_CLI::success( __( 'Request to cancel scheduled actions completed.', 'action-scheduler' ) );
+	}
+
+	/**
+	 * Print a success message.
+	 *
+	 * @return void
+	 */
+	protected function print_success() {
+		\WP_CLI::success( __( 'Scheduled action cancelled.', 'action-scheduler' ) );
+	}
+
+	/**
+	 * Convert an exception into a WP CLI error.
+	 *
+	 * @param \Exception $e The error object.
+	 * @param bool       $multiple Boolean if multiple actions.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 * @return void
+	 */
+	protected function print_error( \Exception $e, $multiple ) {
+		\WP_CLI::error(
+			sprintf(
+				/* translators: %1$s: singular or plural %2$s: refers to the exception error message. */
+				__( 'There was an error cancelling the %1$s: %2$s', 'action-scheduler' ),
+				$multiple ? __( 'scheduled actions', 'action-scheduler' ) : __( 'scheduled action', 'action-scheduler' ),
+				$e->getMessage()
+			)
+		);
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Create_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Create_Command.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+/**
+ * WP-CLI command: action-scheduler action create
+ */
+class Create_Command extends \ActionScheduler_WPCLI_Command {
+
+	const ASYNC_OPTS = array( 'async', 0 );
+
+	/**
+	 * Execute command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$hook           = $this->args[0];
+		$schedule_start = $this->args[1];
+		$callback_args  = get_flag_value( $this->assoc_args, 'args', array() );
+		$group          = get_flag_value( $this->assoc_args, 'group', '' );
+		$interval       = absint( get_flag_value( $this->assoc_args, 'interval', 0 ) );
+		$cron           = get_flag_value( $this->assoc_args, 'cron', '' );
+		$unique         = get_flag_value( $this->assoc_args, 'unique', false );
+		$priority       = absint( get_flag_value( $this->assoc_args, 'priority', 10 ) );
+
+		if ( ! empty( $callback_args ) ) {
+			$callback_args = json_decode( $callback_args, true );
+		}
+
+		$function_args = array(
+			'start'         => $schedule_start,
+			'cron'          => $cron,
+			'interval'      => $interval,
+			'hook'          => $hook,
+			'callback_args' => $callback_args,
+			'group'         => $group,
+			'unique'        => $unique,
+			'priority'      => $priority,
+		);
+
+		try {
+			// Generate schedule start if appropriate.
+			if ( ! in_array( $schedule_start, static::ASYNC_OPTS, true ) ) {
+				$schedule_start         = as_get_datetime_object( $schedule_start );
+				$function_args['start'] = $schedule_start->format( 'U' );
+			}
+		} catch ( \Exception $e ) {
+			\WP_CLI::error( $e->getMessage() );
+		}
+
+		// Default to creating single action.
+		$action_type = 'single';
+		$function    = 'as_schedule_single_action';
+
+		if ( ! empty( $interval ) ) { // Creating recurring action.
+			$action_type = 'recurring';
+			$function    = 'as_schedule_recurring_action';
+
+			$function_args = array_filter(
+				$function_args,
+				static function( $key ) {
+					return in_array( $key, array( 'start', 'interval', 'hook', 'callback_args', 'group', 'unique', 'priority' ), true );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+		} elseif ( ! empty( $cron ) ) { // Creating cron action.
+			$action_type = 'cron';
+			$function    = 'as_schedule_cron_action';
+
+			$function_args = array_filter(
+				$function_args,
+				static function( $key ) {
+					return in_array( $key, array( 'start', 'cron', 'hook', 'callback_args', 'group', 'unique', 'priority' ), true );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+		} elseif ( in_array( $function_args['start'], static::ASYNC_OPTS, true ) ) { // Enqueue async action.
+			$action_type = 'async';
+			$function    = 'as_enqueue_async_action';
+
+			$function_args = array_filter(
+				$function_args,
+				static function( $key ) {
+					return in_array( $key, array( 'hook', 'callback_args', 'group', 'unique', 'priority' ), true );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+		} else { // Enqueue single action.
+			$function_args = array_filter(
+				$function_args,
+				static function( $key ) {
+					return in_array( $key, array( 'start', 'hook', 'callback_args', 'group', 'unique', 'priority' ), true );
+				},
+				ARRAY_FILTER_USE_KEY
+			);
+		}
+
+		$function_args = array_values( $function_args );
+
+		try {
+			$action_id = call_user_func_array( $function, $function_args );
+		} catch ( \Exception $e ) {
+			$this->print_error( $e );
+		}
+
+		if ( 0 === $action_id ) {
+			$e = new \Exception( __( 'Unable to create a scheduled action.', 'action-scheduler' ) );
+			$this->print_error( $e );
+		}
+
+		$this->print_success( $action_id, $action_type );
+	}
+
+	/**
+	 * Print a success message with the action ID.
+	 *
+	 * @param int    $action_id   Created action ID.
+	 * @param string $action_type Type of action.
+	 *
+	 * @return void
+	 */
+	protected function print_success( $action_id, $action_type ) {
+		\WP_CLI::success(
+			sprintf(
+				/* translators: %1$s: type of action, %2$d: ID of the created action */
+				__( '%1$s action (%2$d) scheduled.', 'action-scheduler' ),
+				ucfirst( $action_type ),
+				$action_id
+			)
+		);
+	}
+
+	/**
+	 * Convert an exception into a WP CLI error.
+	 *
+	 * @param \Exception $e The error object.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 * @return void
+	 */
+	protected function print_error( \Exception $e ) {
+		\WP_CLI::error(
+			sprintf(
+				/* translators: %s refers to the exception error message. */
+				__( 'There was an error creating the scheduled action: %s', 'action-scheduler' ),
+				$e->getMessage()
+			)
+		);
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Delete_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Delete_Command.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+/**
+ * WP-CLI command: action-scheduler action delete
+ */
+class Delete_Command extends \ActionScheduler_WPCLI_Command {
+
+	/**
+	 * Array of action IDs to delete.
+	 *
+	 * @var int[]
+	 */
+	protected $action_ids = array();
+
+	/**
+	 * Number of deleted, failed, and total actions deleted.
+	 *
+	 * @var array<string, int>
+	 */
+	protected $action_counts = array(
+		'deleted' => 0,
+		'failed'  => 0,
+		'total'   => 0,
+	);
+
+	/**
+	 * Construct.
+	 *
+	 * @param string[]              $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Keyed arguments.
+	 */
+	public function __construct( array $args, array $assoc_args ) {
+		parent::__construct( $args, $assoc_args );
+
+		$this->action_ids             = array_map( 'absint', $args );
+		$this->action_counts['total'] = count( $this->action_ids );
+
+		add_action( 'action_scheduler_deleted_action', array( $this, 'on_action_deleted' ) );
+	}
+
+	/**
+	 * Execute.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$store = \ActionScheduler::store();
+
+		$progress_bar = \WP_CLI\Utils\make_progress_bar(
+			sprintf(
+				/* translators: %d: number of actions to be deleted */
+				_n( 'Deleting %d action', 'Deleting %d actions', $this->action_counts['total'], 'action-scheduler' ),
+				number_format_i18n( $this->action_counts['total'] )
+			),
+			$this->action_counts['total']
+		);
+
+		foreach ( $this->action_ids as $action_id ) {
+			try {
+				$store->delete_action( $action_id );
+			} catch ( \Exception $e ) {
+				$this->action_counts['failed']++;
+				\WP_CLI::warning( $e->getMessage() );
+			}
+
+			$progress_bar->tick();
+		}
+
+		$progress_bar->finish();
+
+		/* translators: %1$d: number of actions deleted */
+		$format = _n( 'Deleted %1$d action', 'Deleted %1$d actions', $this->action_counts['deleted'], 'action-scheduler' ) . ', ';
+		/* translators: %2$d: number of actions deletions failed */
+		$format .= _n( '%2$d failure.', '%2$d failures.', $this->action_counts['failed'], 'action-scheduler' );
+
+		\WP_CLI::success(
+			sprintf(
+				$format,
+				number_format_i18n( $this->action_counts['deleted'] ),
+				number_format_i18n( $this->action_counts['failed'] )
+			)
+		);
+	}
+
+	/**
+	 * Action: action_scheduler_deleted_action
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 */
+	public function on_action_deleted( $action_id ) {
+		if ( 'action_scheduler_deleted_action' !== current_action() ) {
+			return;
+		}
+
+		$action_id = absint( $action_id );
+
+		if ( ! in_array( $action_id, $this->action_ids, true ) ) {
+			return;
+		}
+
+		$this->action_counts['deleted']++;
+		\WP_CLI::debug( sprintf( 'Action %d was deleted.', $action_id ) );
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Generate_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Generate_Command.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+use function \WP_CLI\Utils\get_flag_value;
+
+/**
+ * WP-CLI command: action-scheduler action generate
+ */
+class Generate_Command extends \ActionScheduler_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$hook           = $this->args[0];
+		$schedule_start = $this->args[1];
+		$callback_args  = get_flag_value( $this->assoc_args, 'args', array() );
+		$group          = get_flag_value( $this->assoc_args, 'group', '' );
+		$interval       = (int) get_flag_value( $this->assoc_args, 'interval', 0 ); // avoid absint() to support negative intervals
+		$count          = absint( get_flag_value( $this->assoc_args, 'count', 1 ) );
+
+		if ( ! empty( $callback_args ) ) {
+			$callback_args = json_decode( $callback_args, true );
+		}
+
+		$schedule_start = as_get_datetime_object( $schedule_start );
+
+		$function_args = array(
+			'start'         => absint( $schedule_start->format( 'U' ) ),
+			'interval'      => $interval,
+			'count'         => $count,
+			'hook'          => $hook,
+			'callback_args' => $callback_args,
+			'group'         => $group,
+		);
+
+		$function_args = array_values( $function_args );
+
+		try {
+			$actions_added = $this->generate( ...$function_args );
+		} catch ( \Exception $e ) {
+			$this->print_error( $e );
+		}
+
+		$num_actions_added = count( (array) $actions_added );
+
+		$this->print_success( $num_actions_added, 'single' );
+	}
+
+	/**
+	 * Schedule multiple single actions.
+	 *
+	 * @param int    $schedule_start Starting timestamp of first action.
+	 * @param int    $interval How long to wait between runs.
+	 * @param int    $count Limit number of actions to schedule.
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
+	 * @return int[] IDs of actions added.
+	 */
+	protected function generate( $schedule_start, $interval, $count, $hook, array $args = array(), $group = '' ) {
+		$actions_added = array();
+
+		$progress_bar = \WP_CLI\Utils\make_progress_bar(
+			sprintf(
+				/* translators: %d is number of actions to create */
+				_n( 'Creating %d action', 'Creating %d actions', $count, 'action-scheduler' ),
+				number_format_i18n( $count )
+			),
+			$count
+		);
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$actions_added[] = as_schedule_single_action( $schedule_start + ( $i * $interval ), $hook, $args, $group );
+			$progress_bar->tick();
+		}
+
+		$progress_bar->finish();
+
+		return $actions_added;
+	}
+
+	/**
+	 * Print a success message with the action ID.
+	 *
+	 * @param int    $actions_added Number of actions generated.
+	 * @param string $action_type   Type of actions scheduled.
+	 * @return void
+	 */
+	protected function print_success( $actions_added, $action_type ) {
+		\WP_CLI::success(
+			sprintf(
+				/* translators: %1$d refers to the total number of tasks added, %2$s is the action type */
+				_n( '%1$d %2$s action scheduled.', '%1$d %2$s actions scheduled.', $actions_added, 'action-scheduler' ),
+				number_format_i18n( $actions_added ),
+				$action_type
+			)
+		);
+	}
+
+	/**
+	 * Convert an exception into a WP CLI error.
+	 *
+	 * @param \Exception $e The error object.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 * @return void
+	 */
+	protected function print_error( \Exception $e ) {
+		\WP_CLI::error(
+			sprintf(
+				/* translators: %s refers to the exception error message. */
+				__( 'There was an error creating the scheduled action: %s', 'action-scheduler' ),
+				$e->getMessage()
+			)
+		);
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Get_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Get_Command.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+/**
+ * WP-CLI command: action-scheduler action get
+ */
+class Get_Command extends \ActionScheduler_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$action_id = $this->args[0];
+		$store     = \ActionScheduler::store();
+		$logger    = \ActionScheduler::logger();
+		$action    = $store->fetch_action( $action_id );
+
+		if ( is_a( $action, ActionScheduler_NullAction::class ) ) {
+			/* translators: %d is action ID. */
+			\WP_CLI::error( sprintf( esc_html__( 'Unable to retrieve action %d.', 'action-scheduler' ), $action_id ) );
+		}
+
+		$only_logs   = ! empty( $this->assoc_args['field'] ) && 'log_entries' === $this->assoc_args['field'];
+		$only_logs   = $only_logs || ( ! empty( $this->assoc_args['fields'] && 'log_entries' === $this->assoc_args['fields'] ) );
+		$log_entries = array();
+
+		foreach ( $logger->get_logs( $action_id ) as $log_entry ) {
+			$log_entries[] = array(
+				'date'    => $log_entry->get_date()->format( static::DATE_FORMAT ),
+				'message' => $log_entry->get_message(),
+			);
+		}
+
+		if ( $only_logs ) {
+			$args = array(
+				'format' => \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'format', 'table' ),
+			);
+
+			$formatter = new \WP_CLI\Formatter( $args, array( 'date', 'message' ) );
+			$formatter->display_items( $log_entries );
+
+			return;
+		}
+
+		try {
+			$status = $store->get_status( $action_id );
+		} catch ( \Exception $e ) {
+			\WP_CLI::error( $e->getMessage() );
+		}
+
+		$action_arr = array(
+			'id'             => $this->args[0],
+			'hook'           => $action->get_hook(),
+			'status'         => $status,
+			'args'           => $action->get_args(),
+			'group'          => $action->get_group(),
+			'recurring'      => $action->get_schedule()->is_recurring() ? 'yes' : 'no',
+			'scheduled_date' => $this->get_schedule_display_string( $action->get_schedule() ),
+			'log_entries'    => $log_entries,
+		);
+
+		$fields = array_keys( $action_arr );
+
+		if ( ! empty( $this->assoc_args['fields'] ) ) {
+			$fields = explode( ',', $this->assoc_args['fields'] );
+		}
+
+		$formatter = new \WP_CLI\Formatter( $this->assoc_args, $fields );
+		$formatter->display_item( $action_arr );
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/List_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/List_Command.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping output is not necessary in WP CLI.
+
+/**
+ * WP-CLI command: action-scheduler action list
+ */
+class List_Command extends \ActionScheduler_WPCLI_Command {
+
+	const PARAMETERS = array(
+		'hook',
+		'args',
+		'date',
+		'date_compare',
+		'modified',
+		'modified_compare',
+		'group',
+		'status',
+		'claimed',
+		'per_page',
+		'offset',
+		'orderby',
+		'order',
+	);
+
+	/**
+	 * Execute command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$store  = \ActionScheduler::store();
+		$logger = \ActionScheduler::logger();
+
+		$fields = array(
+			'id',
+			'hook',
+			'status',
+			'group',
+			'recurring',
+			'scheduled_date',
+		);
+
+		$this->process_csv_arguments_to_arrays();
+
+		if ( ! empty( $this->assoc_args['fields'] ) ) {
+			$fields = $this->assoc_args['fields'];
+		}
+
+		$formatter  = new \WP_CLI\Formatter( $this->assoc_args, $fields );
+		$query_args = $this->assoc_args;
+
+		/**
+		 * The `claimed` parameter expects a boolean or integer:
+		 * check for string 'false', and set explicitly to `false` boolean.
+		 */
+		if ( array_key_exists( 'claimed', $query_args ) && 'false' === strtolower( $query_args['claimed'] ) ) {
+			$query_args['claimed'] = false;
+		}
+
+		$return_format = 'OBJECT';
+
+		if ( in_array( $formatter->format, array( 'ids', 'count' ), true ) ) {
+			$return_format = '\'ids\'';
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$params = var_export( $query_args, true );
+
+		if ( empty( $query_args ) ) {
+			$params = 'array()';
+		}
+
+		\WP_CLI::debug(
+			sprintf(
+				'as_get_scheduled_actions( %s, %s )',
+				$params,
+				$return_format
+			)
+		);
+
+		if ( ! empty( $query_args['args'] ) ) {
+			$query_args['args'] = json_decode( $query_args['args'], true );
+		}
+
+		switch ( $formatter->format ) {
+
+			case 'ids':
+				$actions = as_get_scheduled_actions( $query_args, 'ids' );
+				echo implode( ' ', $actions );
+				break;
+
+			case 'count':
+				$actions = as_get_scheduled_actions( $query_args, 'ids' );
+				$formatter->display_items( $actions );
+				break;
+
+			default:
+				$actions = as_get_scheduled_actions( $query_args, OBJECT );
+
+				$actions_arr = array();
+
+				foreach ( $actions as $action_id => $action ) {
+					$action_arr = array(
+						'id'             => $action_id,
+						'hook'           => $action->get_hook(),
+						'status'         => $store->get_status( $action_id ),
+						'args'           => $action->get_args(),
+						'group'          => $action->get_group(),
+						'recurring'      => $action->get_schedule()->is_recurring() ? 'yes' : 'no',
+						'scheduled_date' => $this->get_schedule_display_string( $action->get_schedule() ),
+						'log_entries'    => array(),
+					);
+
+					foreach ( $logger->get_logs( $action_id ) as $log_entry ) {
+						$action_arr['log_entries'][] = array(
+							'date'    => $log_entry->get_date()->format( static::DATE_FORMAT ),
+							'message' => $log_entry->get_message(),
+						);
+					}
+
+					$actions_arr[] = $action_arr;
+				}
+
+				$formatter->display_items( $actions_arr );
+				break;
+
+		}
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Next_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Next_Command.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping output is not necessary in WP CLI.
+
+use function \WP_CLI\Utils\get_flag_value;
+
+/**
+ * WP-CLI command: action-scheduler action next
+ */
+class Next_Command extends \ActionScheduler_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$hook          = $this->args[0];
+		$group         = get_flag_value( $this->assoc_args, 'group', '' );
+		$callback_args = get_flag_value( $this->assoc_args, 'args', null );
+		$raw           = (bool) get_flag_value( $this->assoc_args, 'raw', false );
+
+		if ( ! empty( $callback_args ) ) {
+			$callback_args = json_decode( $callback_args, true );
+		}
+
+		if ( $raw ) {
+			\WP_CLI::line( as_next_scheduled_action( $hook, $callback_args, $group ) );
+			return;
+		}
+
+		$params = array(
+			'hook'    => $hook,
+			'orderby' => 'date',
+			'order'   => 'ASC',
+			'group'   => $group,
+		);
+
+		if ( is_array( $callback_args ) ) {
+			$params['args'] = $callback_args;
+		}
+
+		$params['status'] = \ActionScheduler_Store::STATUS_RUNNING;
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		\WP_CLI::debug( 'ActionScheduler()::store()->query_action( ' . var_export( $params, true ) . ' )' );
+
+		$store     = \ActionScheduler::store();
+		$action_id = $store->query_action( $params );
+
+		if ( $action_id ) {
+			echo $action_id;
+			return;
+		}
+
+		$params['status'] = \ActionScheduler_Store::STATUS_PENDING;
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		\WP_CLI::debug( 'ActionScheduler()::store()->query_action( ' . var_export( $params, true ) . ' )' );
+
+		$action_id = $store->query_action( $params );
+
+		if ( $action_id ) {
+			echo $action_id;
+			return;
+		}
+
+		\WP_CLI::warning( 'No matching next action.' );
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action/Run_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action/Run_Command.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI\Action;
+
+/**
+ * WP-CLI command: action-scheduler action run
+ */
+class Run_Command extends \ActionScheduler_WPCLI_Command {
+
+	/**
+	 * Array of action IDs to execute.
+	 *
+	 * @var int[]
+	 */
+	protected $action_ids = array();
+
+	/**
+	 * Number of executed, failed, ignored, invalid, and total actions.
+	 *
+	 * @var array<string, int>
+	 */
+	protected $action_counts = array(
+		'executed' => 0,
+		'failed'   => 0,
+		'ignored'  => 0,
+		'invalid'  => 0,
+		'total'    => 0,
+	);
+
+	/**
+	 * Construct.
+	 *
+	 * @param string[]              $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Keyed arguments.
+	 */
+	public function __construct( array $args, array $assoc_args ) {
+		parent::__construct( $args, $assoc_args );
+
+		$this->action_ids             = array_map( 'absint', $args );
+		$this->action_counts['total'] = count( $this->action_ids );
+
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'on_action_ignored' ) );
+		add_action( 'action_scheduler_after_execute', array( $this, 'on_action_executed' ) );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'on_action_failed' ), 10, 2 );
+		add_action( 'action_scheduler_failed_validation', array( $this, 'on_action_invalid' ), 10, 2 );
+	}
+
+	/**
+	 * Execute.
+	 *
+	 * @return void
+	 */
+	public function execute() {
+		$runner = \ActionScheduler::runner();
+
+		$progress_bar = \WP_CLI\Utils\make_progress_bar(
+			sprintf(
+				/* translators: %d: number of actions */
+				_n( 'Executing %d action', 'Executing %d actions', $this->action_counts['total'], 'action-scheduler' ),
+				number_format_i18n( $this->action_counts['total'] )
+			),
+			$this->action_counts['total']
+		);
+
+		foreach ( $this->action_ids as $action_id ) {
+			$runner->process_action( $action_id, 'Action Scheduler CLI' );
+			$progress_bar->tick();
+		}
+
+		$progress_bar->finish();
+
+		foreach ( array(
+			'ignored',
+			'invalid',
+			'failed',
+		) as $type ) {
+			$count = $this->action_counts[ $type ];
+
+			if ( empty( $count ) ) {
+				continue;
+			}
+
+			/*
+			 * translators:
+			 * %1$d: count of actions evaluated.
+			 * %2$s: type of action evaluated.
+			 */
+			$format = _n( '%1$d action %2$s.', '%1$d actions %2$s.', $count, 'action-scheduler' );
+
+			\WP_CLI::warning(
+				sprintf(
+					$format,
+					number_format_i18n( $count ),
+					$type
+				)
+			);
+		}
+
+		\WP_CLI::success(
+			sprintf(
+				/* translators: %d: number of executed actions */
+				_n( 'Executed %d action.', 'Executed %d actions.', $this->action_counts['executed'], 'action-scheduler' ),
+				number_format_i18n( $this->action_counts['executed'] )
+			)
+		);
+	}
+
+	/**
+	 * Action: action_scheduler_execution_ignored
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 */
+	public function on_action_ignored( $action_id ) {
+		if ( 'action_scheduler_execution_ignored' !== current_action() ) {
+			return;
+		}
+
+		$action_id = absint( $action_id );
+
+		if ( ! in_array( $action_id, $this->action_ids, true ) ) {
+			return;
+		}
+
+		$this->action_counts['ignored']++;
+		\WP_CLI::debug( sprintf( 'Action %d was ignored.', $action_id ) );
+	}
+
+	/**
+	 * Action: action_scheduler_after_execute
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 */
+	public function on_action_executed( $action_id ) {
+		if ( 'action_scheduler_after_execute' !== current_action() ) {
+			return;
+		}
+
+		$action_id = absint( $action_id );
+
+		if ( ! in_array( $action_id, $this->action_ids, true ) ) {
+			return;
+		}
+
+		$this->action_counts['executed']++;
+		\WP_CLI::debug( sprintf( 'Action %d was executed.', $action_id ) );
+	}
+
+	/**
+	 * Action: action_scheduler_failed_execution
+	 *
+	 * @param int        $action_id Action ID.
+	 * @param \Exception $e         Exception.
+	 * @return void
+	 */
+	public function on_action_failed( $action_id, \Exception $e ) {
+		if ( 'action_scheduler_failed_execution' !== current_action() ) {
+			return;
+		}
+
+		$action_id = absint( $action_id );
+
+		if ( ! in_array( $action_id, $this->action_ids, true ) ) {
+			return;
+		}
+
+		$this->action_counts['failed']++;
+		\WP_CLI::debug( sprintf( 'Action %d failed execution: %s', $action_id, $e->getMessage() ) );
+	}
+
+	/**
+	 * Action: action_scheduler_failed_validation
+	 *
+	 * @param int        $action_id Action ID.
+	 * @param \Exception $e         Exception.
+	 * @return void
+	 */
+	public function on_action_invalid( $action_id, \Exception $e ) {
+		if ( 'action_scheduler_failed_validation' !== current_action() ) {
+			return;
+		}
+
+		$action_id = absint( $action_id );
+
+		if ( ! in_array( $action_id, $this->action_ids, true ) ) {
+			return;
+		}
+
+		$this->action_counts['invalid']++;
+		\WP_CLI::debug( sprintf( 'Action %d failed validation: %s', $action_id, $e->getMessage() ) );
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Commands for Action Scheduler.
+ */
+class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
+	/**
+	 * Run the Action Scheduler Queue Cleaner
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<size>]
+	 * : The maximum number of actions to delete per batch. Defaults to 20.
+	 *
+	 * [--batches=<size>]
+	 * : Limit execution to a number of batches. Defaults to 0, meaning batches will continue all eligible actions are deleted.
+	 *
+	 * [--status=<status>]
+	 * : Only clean actions with the specified status. Defaults to Canceled, Completed. Define multiple statuses as a comma separated string (without spaces), e.g. `--status=complete,failed,canceled`
+	 *
+	 * [--before=<datestring>]
+	 * : Only delete actions with scheduled date older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
+	 *
+	 * [--pause=<seconds>]
+	 * : The number of seconds to pause between batches. Default no pause.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 *
+	 * @subcommand clean
+	 */
+	public function clean( $args, $assoc_args ) {
+		// Handle passed arguments.
+		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 20 ) );
+		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
+		$status  = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'status', '' ) );
+		$status  = array_filter( array_map( 'trim', $status ) );
+		$before  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'before', '' );
+		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
+
+		$batches_completed = 0;
+		$actions_deleted   = 0;
+		$unlimited         = 0 === $batches;
+		try {
+			$lifespan = as_get_datetime_object( $before );
+		} catch ( Exception $e ) {
+			$lifespan = null;
+		}
+
+		try {
+			// Custom queue cleaner instance.
+			$cleaner = new ActionScheduler_QueueCleaner( null, $batch );
+
+			// Clean actions for as long as possible.
+			while ( $unlimited || $batches_completed < $batches ) {
+				if ( $sleep && $batches_completed > 0 ) {
+					sleep( $sleep );
+				}
+
+				$deleted = count( $cleaner->clean_actions( $status, $lifespan, null, 'CLI' ) );
+				if ( $deleted <= 0 ) {
+					break;
+				}
+				$actions_deleted += $deleted;
+				$batches_completed++;
+				$this->print_success( $deleted );
+			}
+		} catch ( Exception $e ) {
+			$this->print_error( $e );
+		}
+
+		$this->print_total_batches( $batches_completed );
+		if ( $batches_completed > 1 ) {
+			$this->print_success( $actions_deleted );
+		}
+	}
+
+	/**
+	 * Print WP CLI message about how many batches of actions were processed.
+	 *
+	 * @param int $batches_processed Number of batches processed.
+	 */
+	protected function print_total_batches( int $batches_processed ) {
+		WP_CLI::log(
+			sprintf(
+				/* translators: %d refers to the total number of batches processed */
+				_n( '%d batch processed.', '%d batches processed.', $batches_processed, 'action-scheduler' ),
+				$batches_processed
+			)
+		);
+	}
+
+	/**
+	 * Convert an exception into a WP CLI error.
+	 *
+	 * @param Exception $e The error object.
+	 */
+	protected function print_error( Exception $e ) {
+		WP_CLI::error(
+			sprintf(
+				/* translators: %s refers to the exception error message */
+				__( 'There was an error deleting an action: %s', 'action-scheduler' ),
+				$e->getMessage()
+			)
+		);
+	}
+
+	/**
+	 * Print a success message with the number of completed actions.
+	 *
+	 * @param int $actions_deleted Number of deleted actions.
+	 */
+	protected function print_success( int $actions_deleted ) {
+		WP_CLI::success(
+			sprintf(
+				/* translators: %d refers to the total number of actions deleted */
+				_n( '%d action deleted.', '%d actions deleted.', $actions_deleted, 'action-scheduler' ),
+				$actions_deleted
+			)
+		);
+	}
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
@@ -1,0 +1,195 @@
+<?php
+
+use Action_Scheduler\WP_CLI\ProgressBar;
+
+/**
+ * WP CLI Queue runner.
+ *
+ * This class can only be called from within a WP CLI instance.
+ */
+class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
+
+	/**
+	 * Claimed actions.
+	 *
+	 * @var array
+	 */
+	protected $actions;
+
+	/**
+	 * ActionScheduler_ActionClaim instance.
+	 *
+	 * @var ActionScheduler_ActionClaim
+	 */
+	protected $claim;
+
+	/**
+	 * Progress bar instance.
+	 *
+	 * @var \cli\progress\Bar
+	 */
+	protected $progress_bar;
+
+	/**
+	 * ActionScheduler_WPCLI_QueueRunner constructor.
+	 *
+	 * @param ActionScheduler_Store|null             $store Store object.
+	 * @param ActionScheduler_FatalErrorMonitor|null $monitor Monitor object.
+	 * @param ActionScheduler_QueueCleaner|null      $cleaner Cleaner object.
+	 *
+	 * @throws Exception When this is not run within WP CLI.
+	 */
+	public function __construct( ?ActionScheduler_Store $store = null, ?ActionScheduler_FatalErrorMonitor $monitor = null, ?ActionScheduler_QueueCleaner $cleaner = null ) {
+		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			/* translators: %s php class name */
+			throw new Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'action-scheduler' ), __CLASS__ ) );
+		}
+
+		parent::__construct( $store, $monitor, $cleaner );
+	}
+
+	/**
+	 * Set up the Queue before processing.
+	 *
+	 * @param int    $batch_size The batch size to process.
+	 * @param array  $hooks      The hooks being used to filter the actions claimed in this batch.
+	 * @param string $group      The group of actions to claim with this batch.
+	 * @param bool   $force      Whether to force running even with too many concurrent processes.
+	 *
+	 * @return int The number of actions that will be run.
+	 * @throws \WP_CLI\ExitException When there are too many concurrent batches.
+	 */
+	public function setup( $batch_size, $hooks = array(), $group = '', $force = false ) {
+		$this->run_cleanup();
+		$this->add_hooks();
+
+		// Check to make sure there aren't too many concurrent processes running.
+		if ( $this->has_maximum_concurrent_batches() ) {
+			if ( $force ) {
+				WP_CLI::warning( __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
+			} else {
+				WP_CLI::error( __( 'There are too many concurrent batches.', 'action-scheduler' ) );
+			}
+		}
+
+		// Stake a claim and store it.
+		$this->claim = $this->store->stake_claim( $batch_size, null, $hooks, $group );
+		$this->monitor->attach( $this->claim );
+		$this->actions = $this->claim->get_actions();
+
+		return count( $this->actions );
+	}
+
+	/**
+	 * Add our hooks to the appropriate actions.
+	 */
+	protected function add_hooks() {
+		add_action( 'action_scheduler_before_execute', array( $this, 'before_execute' ) );
+		add_action( 'action_scheduler_after_execute', array( $this, 'after_execute' ), 10, 2 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'action_failed' ), 10, 2 );
+	}
+
+	/**
+	 * Set up the WP CLI progress bar.
+	 */
+	protected function setup_progress_bar() {
+		$count              = count( $this->actions );
+		$this->progress_bar = new ProgressBar(
+			/* translators: %d: amount of actions */
+			sprintf( _n( 'Running %d action', 'Running %d actions', $count, 'action-scheduler' ), $count ),
+			$count
+		);
+	}
+
+	/**
+	 * Process actions in the queue.
+	 *
+	 * @param string $context Optional runner context. Default 'WP CLI'.
+	 *
+	 * @return int The number of actions processed.
+	 */
+	public function run( $context = 'WP CLI' ) {
+		do_action( 'action_scheduler_before_process_queue' );
+		$this->setup_progress_bar();
+		foreach ( $this->actions as $action_id ) {
+			// Error if we lost the claim.
+			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $this->claim->get_id() ), true ) ) {
+				WP_CLI::warning( __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
+				break;
+			}
+
+			$this->process_action( $action_id, $context );
+			$this->progress_bar->tick();
+		}
+
+		$completed = $this->progress_bar->current();
+		$this->progress_bar->finish();
+		$this->store->release_claim( $this->claim );
+		do_action( 'action_scheduler_after_process_queue' );
+
+		return $completed;
+	}
+
+	/**
+	 * Handle WP CLI message when the action is starting.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function before_execute( $action_id ) {
+		/* translators: %s refers to the action ID */
+		WP_CLI::log( sprintf( __( 'Started processing action %s', 'action-scheduler' ), $action_id ) );
+	}
+
+	/**
+	 * Handle WP CLI message when the action has completed.
+	 *
+	 * @param int                         $action_id ActionID.
+	 * @param null|ActionScheduler_Action $action The instance of the action. Default to null for backward compatibility.
+	 */
+	public function after_execute( $action_id, $action = null ) {
+		// backward compatibility.
+		if ( null === $action ) {
+			$action = $this->store->fetch_action( $action_id );
+		}
+		/* translators: 1: action ID 2: hook name */
+		WP_CLI::log( sprintf( __( 'Completed processing action %1$s with hook: %2$s', 'action-scheduler' ), $action_id, $action->get_hook() ) );
+	}
+
+	/**
+	 * Handle WP CLI message when the action has failed.
+	 *
+	 * @param int       $action_id Action ID.
+	 * @param Exception $exception Exception.
+	 * @throws \WP_CLI\ExitException With failure message.
+	 */
+	public function action_failed( $action_id, $exception ) {
+		WP_CLI::error(
+			/* translators: 1: action ID 2: exception message */
+			sprintf( __( 'Error processing action %1$s: %2$s', 'action-scheduler' ), $action_id, $exception->getMessage() ),
+			false
+		);
+	}
+
+	/**
+	 * Sleep and help avoid hitting memory limit
+	 *
+	 * @param int $sleep_time Amount of seconds to sleep.
+	 * @deprecated 3.0.0
+	 */
+	protected function stop_the_insanity( $sleep_time = 0 ) {
+		_deprecated_function( 'ActionScheduler_WPCLI_QueueRunner::stop_the_insanity', '3.0.0', 'ActionScheduler_DataController::free_memory' );
+
+		ActionScheduler_DataController::free_memory();
+	}
+
+	/**
+	 * Maybe trigger the stop_the_insanity() method to free up memory.
+	 */
+	protected function maybe_stop_the_insanity() {
+		// The value returned by progress_bar->current() might be padded. Remove padding, and convert to int.
+		$current_iteration = intval( trim( $this->progress_bar->current() ) );
+		if ( 0 === $current_iteration % 50 ) {
+			$this->stop_the_insanity();
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Commands for Action Scheduler.
+ */
+class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
+
+	/**
+	 * Force tables schema creation for Action Scheduler
+	 *
+	 * ## OPTIONS
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 *
+	 * @subcommand fix-schema
+	 */
+	public function fix_schema( $args, $assoc_args ) {
+		$schema_classes = array( ActionScheduler_LoggerSchema::class, ActionScheduler_StoreSchema::class );
+
+		foreach ( $schema_classes as $classname ) {
+			if ( is_subclass_of( $classname, ActionScheduler_Abstract_Schema::class ) ) {
+				$obj = new $classname();
+				$obj->init();
+				$obj->register_tables( true );
+
+				WP_CLI::success(
+					sprintf(
+						/* translators: %s refers to the schema name*/
+						__( 'Registered schema for %s', 'action-scheduler' ),
+						$classname
+					)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Run the Action Scheduler
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<size>]
+	 * : The maximum number of actions to run. Defaults to 100.
+	 *
+	 * [--batches=<size>]
+	 * : Limit execution to a number of batches. Defaults to 0, meaning batches will continue being executed until all actions are complete.
+	 *
+	 * [--cleanup-batch-size=<size>]
+	 * : The maximum number of actions to clean up. Defaults to the value of --batch-size.
+	 *
+	 * [--hooks=<hooks>]
+	 * : Only run actions with the specified hook. Omitting this option runs actions with any hook. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=hook_one,hook_two,hook_three`
+	 *
+	 * [--group=<group>]
+	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
+	 *
+	 * [--exclude-groups=<groups>]
+	 * : Run actions from all groups except the specified group(s). Define multiple groups as a comma separated string (without spaces), e.g. '--group_a,group_b'. This option is ignored when `--group` is used.
+	 *
+	 * [--free-memory-on=<count>]
+	 * : The number of actions to process between freeing memory. 0 disables freeing memory. Default 50.
+	 *
+	 * [--pause=<seconds>]
+	 * : The number of seconds to pause when freeing memory. Default no pause.
+	 *
+	 * [--force]
+	 * : Whether to force execution despite the maximum number of concurrent processes being exceeded.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 *
+	 * @subcommand run
+	 */
+	public function run( $args, $assoc_args ) {
+		// Handle passed arguments.
+		$batch          = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
+		$batches        = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
+		$clean          = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
+		$hooks          = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
+		$hooks          = array_filter( array_map( 'trim', $hooks ) );
+		$group          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
+		$exclude_groups = \WP_CLI\Utils\get_flag_value( $assoc_args, 'exclude-groups', '' );
+		$free_on        = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
+		$sleep          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
+		$force          = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+
+		ActionScheduler_DataController::set_free_ticks( $free_on );
+		ActionScheduler_DataController::set_sleep_time( $sleep );
+
+		$batches_completed = 0;
+		$actions_completed = 0;
+		$unlimited         = 0 === $batches;
+		if ( is_callable( array( ActionScheduler::store(), 'set_claim_filter' ) ) ) {
+			$exclude_groups = $this->parse_comma_separated_string( $exclude_groups );
+
+			if ( ! empty( $exclude_groups ) ) {
+				ActionScheduler::store()->set_claim_filter( 'exclude-groups', $exclude_groups );
+			}
+		}
+
+		try {
+			// Custom queue cleaner instance.
+			$cleaner = new ActionScheduler_QueueCleaner( null, $clean );
+
+			// Get the queue runner instance.
+			$runner = new ActionScheduler_WPCLI_QueueRunner( null, null, $cleaner );
+
+			// Determine how many tasks will be run in the first batch.
+			$total = $runner->setup( $batch, $hooks, $group, $force );
+
+			// Run actions for as long as possible.
+			while ( $total > 0 ) {
+				$this->print_total_actions( $total );
+				$actions_completed += $runner->run();
+				$batches_completed++;
+
+				// Maybe set up tasks for the next batch.
+				$total = ( $unlimited || $batches_completed < $batches ) ? $runner->setup( $batch, $hooks, $group, $force ) : 0;
+			}
+		} catch ( Exception $e ) {
+			$this->print_error( $e );
+		}
+
+		$this->print_total_batches( $batches_completed );
+		$this->print_success( $actions_completed );
+	}
+
+	/**
+	 * Converts a string of comma-separated values into an array of those same values.
+	 *
+	 * @param string $string The string of one or more comma separated values.
+	 *
+	 * @return array
+	 */
+	private function parse_comma_separated_string( $string ): array {
+		return array_filter( str_getcsv( $string ) );
+	}
+
+	/**
+	 * Print WP CLI message about how many actions are about to be processed.
+	 *
+	 * @param int $total Number of actions found.
+	 */
+	protected function print_total_actions( $total ) {
+		WP_CLI::log(
+			sprintf(
+				/* translators: %d refers to how many scheduled tasks were found to run */
+				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
+				$total
+			)
+		);
+	}
+
+	/**
+	 * Print WP CLI message about how many batches of actions were processed.
+	 *
+	 * @param int $batches_completed Number of completed batches.
+	 */
+	protected function print_total_batches( $batches_completed ) {
+		WP_CLI::log(
+			sprintf(
+				/* translators: %d refers to the total number of batches executed */
+				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				$batches_completed
+			)
+		);
+	}
+
+	/**
+	 * Convert an exception into a WP CLI error.
+	 *
+	 * @param Exception $e The error object.
+	 *
+	 * @throws \WP_CLI\ExitException Under some conditions WP CLI may throw an exception.
+	 */
+	protected function print_error( Exception $e ) {
+		WP_CLI::error(
+			sprintf(
+				/* translators: %s refers to the exception error message */
+				__( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				$e->getMessage()
+			)
+		);
+	}
+
+	/**
+	 * Print a success message with the number of completed actions.
+	 *
+	 * @param int $actions_completed Number of completed actions.
+	 */
+	protected function print_success( $actions_completed ) {
+		WP_CLI::success(
+			sprintf(
+				/* translators: %d refers to the total number of tasks completed */
+				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				$actions_completed
+			)
+		);
+	}
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Action_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Action_Command.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI;
+
+/**
+ * Action command for Action Scheduler.
+ */
+class Action_Command extends \WP_CLI_Command {
+
+	/**
+	 * Cancel the next occurrence or all occurrences of a scheduled action.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<hook>]
+	 * : Name of the action hook.
+	 *
+	 * [--group=<group>]
+	 * : The group the job is assigned to.
+	 *
+	 * [--args=<args>]
+	 * : JSON object of arguments assigned to the job.
+	 * ---
+	 * default: []
+	 * ---
+	 *
+	 * [--all]
+	 * : Cancel all occurrences of a scheduled action.
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function cancel( array $args, array $assoc_args ) {
+		require_once 'Action/Cancel_Command.php';
+		$command = new Action\Cancel_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Creates a new scheduled action.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <hook>
+	 * : Name of the action hook.
+	 *
+	 * <start>
+	 * : A unix timestamp representing the date you want the action to start. Also 'async' or 'now' to enqueue an async action.
+	 *
+	 * [--args=<args>]
+	 * : JSON object of arguments to pass to callbacks when the hook triggers.
+	 * ---
+	 * default: []
+	 * ---
+	 *
+	 * [--cron=<cron>]
+	 * : A cron-like schedule string (https://crontab.guru/).
+	 * ---
+	 * default: ''
+	 * ---
+	 *
+	 * [--group=<group>]
+	 * : The group to assign this job to.
+	 * ---
+	 * default: ''
+	 * ---
+	 *
+	 * [--interval=<interval>]
+	 * : Number of seconds to wait between runs.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp action-scheduler action create hook_async async
+	 *     wp action-scheduler action create hook_single 1627147598
+	 *     wp action-scheduler action create hook_recurring 1627148188 --interval=5
+	 *     wp action-scheduler action create hook_cron 1627147655 --cron='5 4 * * *'
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function create( array $args, array $assoc_args ) {
+		require_once 'Action/Create_Command.php';
+		$command = new Action\Create_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Delete existing scheduled action(s).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>...
+	 * : One or more IDs of actions to delete.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Delete the action with id 100
+	 *     $ wp action-scheduler action delete 100
+	 *
+	 *     # Delete the actions with ids 100 and 200
+	 *     $ wp action-scheduler action delete 100 200
+	 *
+	 *     # Delete the first five pending actions in 'action-scheduler' group
+	 *     $ wp action-scheduler action delete $( wp action-scheduler action list --status=pending --group=action-scheduler --format=ids )
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function delete( array $args, array $assoc_args ) {
+		require_once 'Action/Delete_Command.php';
+		$command = new Action\Delete_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Generates some scheduled actions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <hook>
+	 * : Name of the action hook.
+	 *
+	 * <start>
+	 * : The Unix timestamp representing the date you want the action to start.
+	 *
+	 * [--count=<count>]
+	 * : Number of actions to create.
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * [--interval=<interval>]
+	 * : Number of seconds to wait between runs.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--args=<args>]
+	 * : JSON object of arguments to pass to callbacks when the hook triggers.
+	 * ---
+	 * default: []
+	 * ---
+	 *
+	 * [--group=<group>]
+	 * : The group to assign this job to.
+	 * ---
+	 * default: ''
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp action-scheduler action generate test_multiple 1627147598 --count=5 --interval=5
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function generate( array $args, array $assoc_args ) {
+		require_once 'Action/Generate_Command.php';
+		$command = new Action\Generate_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Get details about a scheduled action.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The ID of the action to get.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--field=<field>]
+	 * : Instead of returning the whole action, returns the value of a single field.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific fields (comma-separated). Defaults to all fields.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function get( array $args, array $assoc_args ) {
+		require_once 'Action/Get_Command.php';
+		$command = new Action\Get_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Get a list of scheduled actions.
+	 *
+	 * Display actions based on all arguments supported by
+	 * [as_get_scheduled_actions()](https://actionscheduler.org/api/#function-reference--as_get_scheduled_actions).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--<field>=<value>]
+	 * : One or more arguments to pass to as_get_scheduled_actions().
+	 *
+	 * [--field=<field>]
+	 * : Prints the value of a single property for each action.
+	 *
+	 * [--fields=<fields>]
+	 * : Limit the output to specific object properties.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - ids
+	 *   - json
+	 *   - count
+	 *   - yaml
+	 * ---
+	 *
+	 * ## AVAILABLE FIELDS
+	 *
+	 * These fields will be displayed by default for each action:
+	 *
+	 * * id
+	 * * hook
+	 * * status
+	 * * group
+	 * * recurring
+	 * * scheduled_date
+	 *
+	 * These fields are optionally available:
+	 *
+	 * * args
+	 * * log_entries
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 *
+	 * @subcommand list
+	 */
+	public function subcommand_list( array $args, array $assoc_args ) {
+		require_once 'Action/List_Command.php';
+		$command = new Action\List_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Get logs for a scheduled action.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The ID of the action to get.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * @param array $args Positional arguments.
+	 * @return void
+	 */
+	public function logs( array $args ) {
+		$command = sprintf( 'action-scheduler action get %d --field=log_entries', $args[0] );
+		WP_CLI::runcommand( $command );
+	}
+
+	/**
+	 * Get the ID or timestamp of the next scheduled action.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <hook>
+	 * : The hook of the next scheduled action.
+	 *
+	 * [--args=<args>]
+	 * : JSON object of arguments to search for next scheduled action.
+	 * ---
+	 * default: []
+	 * ---
+	 *
+	 * [--group=<group>]
+	 * : The group to which the next scheduled action is assigned.
+	 * ---
+	 * default: ''
+	 * ---
+	 *
+	 * [--raw]
+	 * : Display the raw output of as_next_scheduled_action() (timestamp or boolean).
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function next( array $args, array $assoc_args ) {
+		require_once 'Action/Next_Command.php';
+		$command = new Action\Next_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+	/**
+	 * Run existing scheduled action(s).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>...
+	 * : One or more IDs of actions to run.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Run the action with id 100
+	 *     $ wp action-scheduler action run 100
+	 *
+	 *     # Run the actions with ids 100 and 200
+	 *     $ wp action-scheduler action run 100 200
+	 *
+	 *     # Run the first five pending actions in 'action-scheduler' group
+	 *     $ wp action-scheduler action run $( wp action-scheduler action list --status=pending --group=action-scheduler --format=ids )
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @return void
+	 */
+	public function run( array $args, array $assoc_args ) {
+		require_once 'Action/Run_Command.php';
+		$command = new Action\Run_Command( $args, $assoc_args );
+		$command->execute();
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/Migration_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/Migration_Command.php
@@ -1,0 +1,190 @@
+<?php
+
+
+namespace Action_Scheduler\WP_CLI;
+
+use Action_Scheduler\Migration\Config;
+use Action_Scheduler\Migration\Runner;
+use Action_Scheduler\Migration\Scheduler;
+use Action_Scheduler\Migration\Controller;
+use WP_CLI;
+use WP_CLI_Command;
+
+/**
+ * Class Migration_Command
+ *
+ * @package Action_Scheduler\WP_CLI
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class Migration_Command extends WP_CLI_Command {
+
+	/**
+	 * Number of actions migrated.
+	 *
+	 * @var int
+	 */
+	private $total_processed = 0;
+
+	/**
+	 * Register the command with WP-CLI
+	 */
+	public function register() {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		WP_CLI::add_command(
+			'action-scheduler migrate',
+			array( $this, 'migrate' ),
+			array(
+				'shortdesc' => 'Migrates actions to the DB tables store',
+				'synopsis'  => array(
+					array(
+						'type'        => 'assoc',
+						'name'        => 'batch-size',
+						'optional'    => true,
+						'default'     => 100,
+						'description' => 'The number of actions to process in each batch',
+					),
+					array(
+						'type'        => 'assoc',
+						'name'        => 'free-memory-on',
+						'optional'    => true,
+						'default'     => 50,
+						'description' => 'The number of actions to process between freeing memory. 0 disables freeing memory',
+					),
+					array(
+						'type'        => 'assoc',
+						'name'        => 'pause',
+						'optional'    => true,
+						'default'     => 0,
+						'description' => 'The number of seconds to pause when freeing memory',
+					),
+					array(
+						'type'        => 'flag',
+						'name'        => 'dry-run',
+						'optional'    => true,
+						'description' => 'Reports on the actions that would have been migrated, but does not change any data',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Process the data migration.
+	 *
+	 * @param array $positional_args Required for WP CLI. Not used in migration.
+	 * @param array $assoc_args Optional arguments.
+	 *
+	 * @return void
+	 */
+	public function migrate( $positional_args, $assoc_args ) {
+		$this->init_logging();
+
+		$config = $this->get_migration_config( $assoc_args );
+		$runner = new Runner( $config );
+		$runner->init_destination();
+
+		$batch_size = isset( $assoc_args['batch-size'] ) ? (int) $assoc_args['batch-size'] : 100;
+		$free_on    = isset( $assoc_args['free-memory-on'] ) ? (int) $assoc_args['free-memory-on'] : 50;
+		$sleep      = isset( $assoc_args['pause'] ) ? (int) $assoc_args['pause'] : 0;
+		\ActionScheduler_DataController::set_free_ticks( $free_on );
+		\ActionScheduler_DataController::set_sleep_time( $sleep );
+
+		do {
+			$actions_processed      = $runner->run( $batch_size );
+			$this->total_processed += $actions_processed;
+		} while ( $actions_processed > 0 );
+
+		if ( ! $config->get_dry_run() ) {
+			// let the scheduler know that there's nothing left to do.
+			$scheduler = new Scheduler();
+			$scheduler->mark_complete();
+		}
+
+		WP_CLI::success( sprintf( '%s complete. %d actions processed.', $config->get_dry_run() ? 'Dry run' : 'Migration', $this->total_processed ) );
+	}
+
+	/**
+	 * Build the config object used to create the Runner
+	 *
+	 * @param array $args Optional arguments.
+	 *
+	 * @return ActionScheduler\Migration\Config
+	 */
+	private function get_migration_config( $args ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'dry-run' => false,
+			)
+		);
+
+		$config = Controller::instance()->get_migration_config_object();
+		$config->set_dry_run( ! empty( $args['dry-run'] ) );
+
+		return $config;
+	}
+
+	/**
+	 * Hook command line logging into migration actions.
+	 */
+	private function init_logging() {
+		add_action(
+			'action_scheduler/migrate_action_dry_run',
+			function ( $action_id ) {
+				WP_CLI::debug( sprintf( 'Dry-run: migrated action %d', $action_id ) );
+			}
+		);
+
+		add_action(
+			'action_scheduler/no_action_to_migrate',
+			function ( $action_id ) {
+				WP_CLI::debug( sprintf( 'No action found to migrate for ID %d', $action_id ) );
+			}
+		);
+
+		add_action(
+			'action_scheduler/migrate_action_failed',
+			function ( $action_id ) {
+				WP_CLI::warning( sprintf( 'Failed migrating action with ID %d', $action_id ) );
+			}
+		);
+
+		add_action(
+			'action_scheduler/migrate_action_incomplete',
+			function ( $source_id, $destination_id ) {
+				WP_CLI::warning( sprintf( 'Unable to remove source action with ID %d after migrating to new ID %d', $source_id, $destination_id ) );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'action_scheduler/migrated_action',
+			function ( $source_id, $destination_id ) {
+				WP_CLI::debug( sprintf( 'Migrated source action with ID %d to new store with ID %d', $source_id, $destination_id ) );
+			},
+			10,
+			2
+		);
+
+		add_action(
+			'action_scheduler/migration_batch_starting',
+			function ( $batch ) {
+				WP_CLI::debug( 'Beginning migration of batch: ' . print_r( $batch, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			}
+		);
+
+		add_action(
+			'action_scheduler/migration_batch_complete',
+			function ( $batch ) {
+				WP_CLI::log( sprintf( 'Completed migration of %d actions', count( $batch ) ) );
+			}
+		);
+	}
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/ProgressBar.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/ProgressBar.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI;
+
+/**
+ * WP_CLI progress bar for Action Scheduler.
+ */
+
+/**
+ * Class ProgressBar
+ *
+ * @package Action_Scheduler\WP_CLI
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class ProgressBar {
+
+	/**
+	 * Current number of ticks.
+	 *
+	 * @var integer
+	 */
+	protected $total_ticks;
+
+	/**
+	 * Total number of ticks.
+	 *
+	 * @var integer
+	 */
+	protected $count;
+
+	/**
+	 * Progress bar update interval.
+	 *
+	 * @var integer
+	 */
+	protected $interval;
+
+	/**
+	 * Progress bar message.
+	 *
+	 * @var string
+	 */
+	protected $message;
+
+	/**
+	 * Instance.
+	 *
+	 * @var \cli\progress\Bar
+	 */
+	protected $progress_bar;
+
+	/**
+	 * ProgressBar constructor.
+	 *
+	 * @param string  $message    Text to display before the progress bar.
+	 * @param integer $count      Total number of ticks to be performed.
+	 * @param integer $interval   Optional. The interval in milliseconds between updates. Default 100.
+	 *
+	 * @throws \Exception When this is not run within WP CLI.
+	 */
+	public function __construct( $message, $count, $interval = 100 ) {
+		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			/* translators: %s php class name */
+			throw new \Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'action-scheduler' ), __CLASS__ ) );
+		}
+
+		$this->total_ticks = 0;
+		$this->message     = $message;
+		$this->count       = $count;
+		$this->interval    = $interval;
+	}
+
+	/**
+	 * Increment the progress bar ticks.
+	 */
+	public function tick() {
+		if ( null === $this->progress_bar ) {
+			$this->setup_progress_bar();
+		}
+
+		$this->progress_bar->tick();
+		$this->total_ticks++;
+
+		do_action( 'action_scheduler/progress_tick', $this->total_ticks ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	}
+
+	/**
+	 * Get the progress bar tick count.
+	 *
+	 * @return int
+	 */
+	public function current() {
+		return $this->progress_bar ? $this->progress_bar->current() : 0;
+	}
+
+	/**
+	 * Finish the current progress bar.
+	 */
+	public function finish() {
+		if ( null !== $this->progress_bar ) {
+			$this->progress_bar->finish();
+		}
+
+		$this->progress_bar = null;
+	}
+
+	/**
+	 * Set the message used when creating the progress bar.
+	 *
+	 * @param string $message The message to be used when the next progress bar is created.
+	 */
+	public function set_message( $message ) {
+		$this->message = $message;
+	}
+
+	/**
+	 * Set the count for a new progress bar.
+	 *
+	 * @param integer $count The total number of ticks expected to complete.
+	 */
+	public function set_count( $count ) {
+		$this->count = $count;
+		$this->finish();
+	}
+
+	/**
+	 * Set up the progress bar.
+	 */
+	protected function setup_progress_bar() {
+		$this->progress_bar = \WP_CLI\Utils\make_progress_bar(
+			$this->message,
+			$this->count,
+			$this->interval
+		);
+	}
+}

--- a/includes/lib/action-scheduler/classes/WP_CLI/System_Command.php
+++ b/includes/lib/action-scheduler/classes/WP_CLI/System_Command.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Action_Scheduler\WP_CLI;
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping output is not necessary in WP CLI.
+
+use ActionScheduler_SystemInformation;
+use WP_CLI;
+use function \WP_CLI\Utils\get_flag_value;
+
+/**
+ * System info WP-CLI commands for Action Scheduler.
+ */
+class System_Command {
+
+	/**
+	 * Data store for querying actions
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	protected $store;
+
+	/**
+	 * Construct.
+	 */
+	public function __construct() {
+		$this->store = \ActionScheduler::store();
+	}
+
+	/**
+	 * Print in-use data store class.
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Keyed args.
+	 * @return void
+	 *
+	 * @subcommand data-store
+	 */
+	public function datastore( array $args, array $assoc_args ) {
+		echo $this->get_current_datastore();
+	}
+
+	/**
+	 * Print in-use runner class.
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Keyed args.
+	 * @return void
+	 */
+	public function runner( array $args, array $assoc_args ) {
+		echo $this->get_current_runner();
+	}
+
+	/**
+	 * Get system status.
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Keyed args.
+	 * @return void
+	 */
+	public function status( array $args, array $assoc_args ) {
+		/**
+		 * Get runner status.
+		 *
+		 * @link https://github.com/woocommerce/action-scheduler-disable-default-runner
+		 */
+		$runner_enabled = has_action( 'action_scheduler_run_queue', array( \ActionScheduler::runner(), 'run' ) );
+
+		\WP_CLI::line( sprintf( 'Data store: %s', $this->get_current_datastore() ) );
+		\WP_CLI::line( sprintf( 'Runner: %s%s', $this->get_current_runner(), ( $runner_enabled ? '' : ' (disabled)' ) ) );
+		\WP_CLI::line( sprintf( 'Version: %s', $this->get_latest_version() ) );
+
+		$rows              = array();
+		$action_counts     = $this->store->action_counts();
+		$oldest_and_newest = $this->get_oldest_and_newest( array_keys( $action_counts ) );
+
+		foreach ( $action_counts as $status => $count ) {
+			$rows[] = array(
+				'status' => $status,
+				'count'  => $count,
+				'oldest' => $oldest_and_newest[ $status ]['oldest'],
+				'newest' => $oldest_and_newest[ $status ]['newest'],
+			);
+		}
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'status', 'count', 'oldest', 'newest' ) );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Display the active version, or all registered versions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--all]
+	 * : List all registered versions.
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Keyed args.
+	 * @return void
+	 */
+	public function version( array $args, array $assoc_args ) {
+		$all    = (bool) get_flag_value( $assoc_args, 'all' );
+		$latest = $this->get_latest_version();
+
+		if ( ! $all ) {
+			echo $latest;
+			\WP_CLI::halt( 0 );
+		}
+
+		$instance = \ActionScheduler_Versions::instance();
+		$versions = $instance->get_versions();
+		$rows     = array();
+
+		foreach ( $versions as $version => $callback ) {
+			$active = $version === $latest;
+
+			$rows[ $version ] = array(
+				'version'  => $version,
+				'callback' => $callback,
+				'active'   => $active ? 'yes' : 'no',
+			);
+		}
+
+		uksort( $rows, 'version_compare' );
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'version', 'callback', 'active' ) );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Display the current source, or all registered sources.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--all]
+	 * : List all registered sources.
+	 *
+	 * [--fullpath]
+	 * : List full path of source(s).
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Keyed args.
+	 * @uses ActionScheduler_SystemInformation::active_source_path()
+	 * @uses \WP_CLI\Formatter::display_items()
+	 * @uses $this->get_latest_version()
+	 * @return void
+	 */
+	public function source( array $args, array $assoc_args ) {
+		$all      = (bool) get_flag_value( $assoc_args, 'all' );
+		$fullpath = (bool) get_flag_value( $assoc_args, 'fullpath' );
+		$source   = ActionScheduler_SystemInformation::active_source_path();
+		$path     = $source;
+
+		if ( ! $fullpath ) {
+			$path = str_replace( ABSPATH, '', $path );
+		}
+
+		if ( ! $all ) {
+			echo $path;
+			\WP_CLI::halt( 0 );
+		}
+
+		$sources = ActionScheduler_SystemInformation::get_sources();
+
+		if ( empty( $sources ) ) {
+			WP_CLI::log( __( 'Detailed information about registered sources is not currently available.', 'action-scheduler' ) );
+			return;
+		}
+
+		$rows = array();
+
+		foreach ( $sources as $check_source => $version ) {
+			$active = dirname( $check_source ) === $source;
+			$path   = $check_source;
+
+			if ( ! $fullpath ) {
+				$path = str_replace( ABSPATH, '', $path );
+			}
+
+			$rows[ $check_source ] = array(
+				'source'  => $path,
+				'version' => $version,
+				'active'  => $active ? 'yes' : 'no',
+			);
+		}
+
+		ksort( $rows );
+
+		\WP_CLI::log( PHP_EOL . 'Please note there can only be one unique registered instance of Action Scheduler per ' . PHP_EOL . 'version number, so this list may not include all the currently present copies of ' . PHP_EOL . 'Action Scheduler.' . PHP_EOL );
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'source', 'version', 'active' ) );
+		$formatter->display_items( $rows );
+	}
+
+	/**
+	 * Get current data store.
+	 *
+	 * @return string
+	 */
+	protected function get_current_datastore() {
+		return get_class( $this->store );
+	}
+
+	/**
+	 * Get latest version.
+	 *
+	 * @param null|\ActionScheduler_Versions $instance Versions.
+	 * @return string
+	 */
+	protected function get_latest_version( $instance = null ) {
+		if ( is_null( $instance ) ) {
+			$instance = \ActionScheduler_Versions::instance();
+		}
+
+		return $instance->latest_version();
+	}
+
+	/**
+	 * Get current runner.
+	 *
+	 * @return string
+	 */
+	protected function get_current_runner() {
+		return get_class( \ActionScheduler::runner() );
+	}
+
+	/**
+	 * Get oldest and newest scheduled dates for a given set of statuses.
+	 *
+	 * @param array $status_keys Set of statuses to find oldest & newest action for.
+	 * @return array
+	 */
+	protected function get_oldest_and_newest( $status_keys ) {
+		$oldest_and_newest = array();
+
+		foreach ( $status_keys as $status ) {
+			$oldest_and_newest[ $status ] = array(
+				'oldest' => '&ndash;',
+				'newest' => '&ndash;',
+			);
+
+			if ( 'in-progress' === $status ) {
+				continue;
+			}
+
+			$oldest_and_newest[ $status ]['oldest'] = $this->get_action_status_date( $status, 'oldest' );
+			$oldest_and_newest[ $status ]['newest'] = $this->get_action_status_date( $status, 'newest' );
+		}
+
+		return $oldest_and_newest;
+	}
+
+	/**
+	 * Get oldest or newest scheduled date for a given status.
+	 *
+	 * @param string $status Action status label/name string.
+	 * @param string $date_type Oldest or Newest.
+	 * @return string
+	 */
+	protected function get_action_status_date( $status, $date_type = 'oldest' ) {
+		$order = 'oldest' === $date_type ? 'ASC' : 'DESC';
+
+		$args = array(
+			'claimed'  => false,
+			'status'   => $status,
+			'per_page' => 1,
+			'order'    => $order,
+		);
+
+		$action = $this->store->query_actions( $args );
+
+		if ( ! empty( $action ) ) {
+			$date_object = $this->store->get_date( $action[0] );
+			$action_date = $date_object->format( 'Y-m-d H:i:s O' );
+		} else {
+			$action_date = '&ndash;';
+		}
+
+		return $action_date;
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler.php
@@ -1,0 +1,400 @@
+<?php
+
+use Action_Scheduler\WP_CLI\Migration_Command;
+use Action_Scheduler\Migration\Controller;
+
+/**
+ * Class ActionScheduler
+ *
+ * @codeCoverageIgnore
+ */
+abstract class ActionScheduler {
+
+	/**
+	 * Plugin file path.
+	 *
+	 * @var string
+	 */
+	private static $plugin_file = '';
+
+	/**
+	 * ActionScheduler_ActionFactory instance.
+	 *
+	 * @var ActionScheduler_ActionFactory
+	 */
+	private static $factory = null;
+
+	/**
+	 * Data store is initialized.
+	 *
+	 * @var bool
+	 */
+	private static $data_store_initialized = false;
+
+	/**
+	 * Factory.
+	 */
+	public static function factory() {
+		if ( ! isset( self::$factory ) ) {
+			self::$factory = new ActionScheduler_ActionFactory();
+		}
+		return self::$factory;
+	}
+
+	/**
+	 * Get Store instance.
+	 */
+	public static function store() {
+		return ActionScheduler_Store::instance();
+	}
+
+	/**
+	 * Get Lock instance.
+	 */
+	public static function lock() {
+		return ActionScheduler_Lock::instance();
+	}
+
+	/**
+	 * Get Logger instance.
+	 */
+	public static function logger() {
+		return ActionScheduler_Logger::instance();
+	}
+
+	/**
+	 * Get QueueRunner instance.
+	 */
+	public static function runner() {
+		return ActionScheduler_QueueRunner::instance();
+	}
+
+	/**
+	 * Get AdminView instance.
+	 */
+	public static function admin_view() {
+		return ActionScheduler_AdminView::instance();
+	}
+
+	/**
+	 * Get the absolute system path to the plugin directory, or a file therein
+	 *
+	 * @static
+	 * @param string $path Path relative to plugin directory.
+	 * @return string
+	 */
+	public static function plugin_path( $path ) {
+		$base = dirname( self::$plugin_file );
+		if ( $path ) {
+			return trailingslashit( $base ) . $path;
+		} else {
+			return untrailingslashit( $base );
+		}
+	}
+
+	/**
+	 * Get the absolute URL to the plugin directory, or a file therein
+	 *
+	 * @static
+	 * @param string $path Path relative to plugin directory.
+	 * @return string
+	 */
+	public static function plugin_url( $path ) {
+		return plugins_url( $path, self::$plugin_file );
+	}
+
+	/**
+	 * Autoload.
+	 *
+	 * @param string $class Class name.
+	 */
+	public static function autoload( $class ) {
+		$d           = DIRECTORY_SEPARATOR;
+		$classes_dir = self::plugin_path( 'classes' . $d );
+		$separator   = strrpos( $class, '\\' );
+		if ( false !== $separator ) {
+			if ( 0 !== strpos( $class, 'Action_Scheduler' ) ) {
+				return;
+			}
+			$class = substr( $class, $separator + 1 );
+		}
+
+		if ( 'Deprecated' === substr( $class, -10 ) ) {
+			$dir = self::plugin_path( 'deprecated' . $d );
+		} elseif ( self::is_class_abstract( $class ) ) {
+			$dir = $classes_dir . 'abstracts' . $d;
+		} elseif ( self::is_class_migration( $class ) ) {
+			$dir = $classes_dir . 'migration' . $d;
+		} elseif ( 'Schedule' === substr( $class, -8 ) ) {
+			$dir = $classes_dir . 'schedules' . $d;
+		} elseif ( 'Action' === substr( $class, -6 ) ) {
+			$dir = $classes_dir . 'actions' . $d;
+		} elseif ( 'Schema' === substr( $class, -6 ) ) {
+			$dir = $classes_dir . 'schema' . $d;
+		} elseif ( strpos( $class, 'ActionScheduler' ) === 0 ) {
+			$segments = explode( '_', $class );
+			$type     = isset( $segments[1] ) ? $segments[1] : '';
+
+			switch ( $type ) {
+				case 'WPCLI':
+					$dir = $classes_dir . 'WP_CLI' . $d;
+					break;
+				case 'DBLogger':
+				case 'DBStore':
+				case 'HybridStore':
+				case 'wpPostStore':
+				case 'wpCommentLogger':
+					$dir = $classes_dir . 'data-stores' . $d;
+					break;
+				default:
+					$dir = $classes_dir;
+					break;
+			}
+		} elseif ( self::is_class_cli( $class ) ) {
+			$dir = $classes_dir . 'WP_CLI' . $d;
+		} elseif ( strpos( $class, 'CronExpression' ) === 0 ) {
+			$dir = self::plugin_path( 'lib' . $d . 'cron-expression' . $d );
+		} elseif ( strpos( $class, 'WP_Async_Request' ) === 0 ) {
+			$dir = self::plugin_path( 'lib' . $d );
+		} else {
+			return;
+		}
+
+		if ( file_exists( $dir . "{$class}.php" ) ) {
+			include $dir . "{$class}.php";
+			return;
+		}
+	}
+
+	/**
+	 * Initialize the plugin
+	 *
+	 * @static
+	 * @param string $plugin_file Plugin file path.
+	 */
+	public static function init( $plugin_file ) {
+		self::$plugin_file = $plugin_file;
+		spl_autoload_register( array( __CLASS__, 'autoload' ) );
+
+		/**
+		 * Fires in the early stages of Action Scheduler init hook.
+		 */
+		do_action( 'action_scheduler_pre_init' );
+
+		require_once self::plugin_path( 'functions.php' );
+		ActionScheduler_DataController::init();
+
+		$store      = self::store();
+		$logger     = self::logger();
+		$runner     = self::runner();
+		$admin_view = self::admin_view();
+
+		// Ensure initialization on plugin activation.
+		if ( ! did_action( 'init' ) ) {
+			// phpcs:ignore Squiz.PHP.CommentedOutCode
+			add_action( 'init', array( $admin_view, 'init' ), 0, 0 ); // run before $store::init().
+			add_action( 'init', array( $store, 'init' ), 1, 0 );
+			add_action( 'init', array( $logger, 'init' ), 1, 0 );
+			add_action( 'init', array( $runner, 'init' ), 1, 0 );
+
+			add_action(
+				'init',
+				/**
+				 * Runs after the active store's init() method has been called.
+				 *
+				 * It would probably be preferable to have $store->init() (or it's parent method) set this itself,
+				 * once it has initialized, however that would cause problems in cases where a custom data store is in
+				 * use and it has not yet been updated to follow that same logic.
+				 */
+				function () {
+					self::$data_store_initialized = true;
+
+					/**
+					 * Fires when Action Scheduler is ready: it is safe to use the procedural API after this point.
+					 *
+					 * @since 3.5.5
+					 */
+					do_action( 'action_scheduler_init' );
+				},
+				1
+			);
+		} else {
+			$admin_view->init();
+			$store->init();
+			$logger->init();
+			$runner->init();
+			self::$data_store_initialized = true;
+
+			/**
+			 * Fires when Action Scheduler is ready: it is safe to use the procedural API after this point.
+			 *
+			 * @since 3.5.5
+			 */
+			do_action( 'action_scheduler_init' );
+		}
+
+		if ( apply_filters( 'action_scheduler_load_deprecated_functions', true ) ) {
+			require_once self::plugin_path( 'deprecated/functions.php' );
+		}
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Scheduler_command' );
+			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Clean_Command' );
+			WP_CLI::add_command( 'action-scheduler action', '\Action_Scheduler\WP_CLI\Action_Command' );
+			WP_CLI::add_command( 'action-scheduler', '\Action_Scheduler\WP_CLI\System_Command' );
+			if ( ! ActionScheduler_DataController::is_migration_complete() && Controller::instance()->allow_migration() ) {
+				$command = new Migration_Command();
+				$command->register();
+			}
+		}
+
+		/**
+		 * Handle WP comment cleanup after migration.
+		 */
+		if ( is_a( $logger, 'ActionScheduler_DBLogger' ) && ActionScheduler_DataController::is_migration_complete() && ActionScheduler_WPCommentCleaner::has_logs() ) {
+			ActionScheduler_WPCommentCleaner::init();
+		}
+
+		add_action( 'action_scheduler/migration_complete', 'ActionScheduler_WPCommentCleaner::maybe_schedule_cleanup' );
+	}
+
+	/**
+	 * Check whether the AS data store has been initialized.
+	 *
+	 * @param string $function_name The name of the function being called. Optional. Default `null`.
+	 * @return bool
+	 */
+	public static function is_initialized( $function_name = null ) {
+		if ( ! self::$data_store_initialized && ! empty( $function_name ) ) {
+			$message = sprintf(
+				/* translators: %s function name. */
+				__( '%s() was called before the Action Scheduler data store was initialized', 'action-scheduler' ),
+				esc_attr( $function_name )
+			);
+			_doing_it_wrong( esc_html( $function_name ), esc_html( $message ), '3.1.6' );
+		}
+
+		return self::$data_store_initialized;
+	}
+
+	/**
+	 * Determine if the class is one of our abstract classes.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $class The class name.
+	 *
+	 * @return bool
+	 */
+	protected static function is_class_abstract( $class ) {
+		static $abstracts = array(
+			'ActionScheduler'                            => true,
+			'ActionScheduler_Abstract_ListTable'         => true,
+			'ActionScheduler_Abstract_QueueRunner'       => true,
+			'ActionScheduler_Abstract_Schedule'          => true,
+			'ActionScheduler_Abstract_RecurringSchedule' => true,
+			'ActionScheduler_Lock'                       => true,
+			'ActionScheduler_Logger'                     => true,
+			'ActionScheduler_Abstract_Schema'            => true,
+			'ActionScheduler_Store'                      => true,
+			'ActionScheduler_TimezoneHelper'             => true,
+			'ActionScheduler_WPCLI_Command'              => true,
+		);
+
+		return isset( $abstracts[ $class ] ) && $abstracts[ $class ];
+	}
+
+	/**
+	 * Determine if the class is one of our migration classes.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $class The class name.
+	 *
+	 * @return bool
+	 */
+	protected static function is_class_migration( $class ) {
+		static $migration_segments = array(
+			'ActionMigrator'  => true,
+			'BatchFetcher'    => true,
+			'DBStoreMigrator' => true,
+			'DryRun'          => true,
+			'LogMigrator'     => true,
+			'Config'          => true,
+			'Controller'      => true,
+			'Runner'          => true,
+			'Scheduler'       => true,
+		);
+
+		$segments = explode( '_', $class );
+		$segment  = isset( $segments[1] ) ? $segments[1] : $class;
+
+		return isset( $migration_segments[ $segment ] ) && $migration_segments[ $segment ];
+	}
+
+	/**
+	 * Determine if the class is one of our WP CLI classes.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $class The class name.
+	 *
+	 * @return bool
+	 */
+	protected static function is_class_cli( $class ) {
+		static $cli_segments = array(
+			'QueueRunner'                             => true,
+			'Command'                                 => true,
+			'ProgressBar'                             => true,
+			'\Action_Scheduler\WP_CLI\Action_Command' => true,
+			'\Action_Scheduler\WP_CLI\System_Command' => true,
+		);
+
+		$segments = explode( '_', $class );
+		$segment  = isset( $segments[1] ) ? $segments[1] : $class;
+
+		return isset( $cli_segments[ $segment ] ) && $cli_segments[ $segment ];
+	}
+
+	/**
+	 * Clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Wakeup.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Construct.
+	 */
+	final private function __construct() {}
+
+	/** Deprecated **/
+
+	/**
+	 * Get DateTime object.
+	 *
+	 * @param null|string $when     Date/time string.
+	 * @param string      $timezone Timezone string.
+	 */
+	public static function get_datetime_object( $when = null, $timezone = 'UTC' ) {
+		_deprecated_function( __METHOD__, '2.0', 'wcs_add_months()' );
+		return as_get_datetime_object( $when, $timezone );
+	}
+
+	/**
+	 * Issue deprecated warning if an Action Scheduler function is called in the shutdown hook.
+	 *
+	 * @param string $function_name The name of the function being called.
+	 * @deprecated 3.1.6.
+	 */
+	public static function check_shutdown_hook( $function_name ) {
+		_deprecated_function( __FUNCTION__, '3.1.6' );
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -1,0 +1,797 @@
+<?php
+
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Action Scheduler Abstract List Table class
+ *
+ * This abstract class enhances WP_List_Table making it ready to use.
+ *
+ * By extending this class we can focus on describing how our table looks like,
+ * which columns needs to be shown, filter, ordered by and more and forget about the details.
+ *
+ * This class supports:
+ *  - Bulk actions
+ *  - Search
+ *  - Sortable columns
+ *  - Automatic translations of the columns
+ *
+ * @codeCoverageIgnore
+ * @since  2.0.0
+ */
+abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
+
+	/**
+	 * The table name
+	 *
+	 * @var string
+	 */
+	protected $table_name;
+
+	/**
+	 * Package name, used to get options from WP_List_Table::get_items_per_page.
+	 *
+	 * @var string
+	 */
+	protected $package;
+
+	/**
+	 * How many items do we render per page?
+	 *
+	 * @var int
+	 */
+	protected $items_per_page = 10;
+
+	/**
+	 * Enables search in this table listing. If this array
+	 * is empty it means the listing is not searchable.
+	 *
+	 * @var array
+	 */
+	protected $search_by = array();
+
+	/**
+	 * Columns to show in the table listing. It is a key => value pair. The
+	 * key must much the table column name and the value is the label, which is
+	 * automatically translated.
+	 *
+	 * @var array
+	 */
+	protected $columns = array();
+
+	/**
+	 * Defines the row-actions. It expects an array where the key
+	 * is the column name and the value is an array of actions.
+	 *
+	 * The array of actions are key => value, where key is the method name
+	 * (with the prefix row_action_<key>) and the value is the label
+	 * and title.
+	 *
+	 * @var array
+	 */
+	protected $row_actions = array();
+
+	/**
+	 * The Primary key of our table
+	 *
+	 * @var string
+	 */
+	protected $ID = 'ID';
+
+	/**
+	 * Enables sorting, it expects an array
+	 * of columns (the column names are the values)
+	 *
+	 * @var array
+	 */
+	protected $sort_by = array();
+
+	/**
+	 * The default sort order
+	 *
+	 * @var string
+	 */
+	protected $filter_by = array();
+
+	/**
+	 * The status name => count combinations for this table's items. Used to display status filters.
+	 *
+	 * @var array
+	 */
+	protected $status_counts = array();
+
+	/**
+	 * Notices to display when loading the table. Array of arrays of form array( 'class' => {updated|error}, 'message' => 'This is the notice text display.' ).
+	 *
+	 * @var array
+	 */
+	protected $admin_notices = array();
+
+	/**
+	 * Localised string displayed in the <h1> element above the able.
+	 *
+	 * @var string
+	 */
+	protected $table_header;
+
+	/**
+	 * Enables bulk actions. It must be an array where the key is the action name
+	 * and the value is the label (which is translated automatically). It is important
+	 * to notice that it will check that the method exists (`bulk_$name`) and will throw
+	 * an exception if it does not exists.
+	 *
+	 * This class will automatically check if the current request has a bulk action, will do the
+	 * validations and afterwards will execute the bulk method, with two arguments. The first argument
+	 * is the array with primary keys, the second argument is a string with a list of the primary keys,
+	 * escaped and ready to use (with `IN`).
+	 *
+	 * @var array
+	 */
+	protected $bulk_actions = array();
+
+	/**
+	 * Makes translation easier, it basically just wraps
+	 * `_x` with some default (the package name).
+	 *
+	 * @param string $text The new text to translate.
+	 * @param string $context The context of the text.
+	 * @return string|void The translated text.
+	 *
+	 * @deprecated 3.0.0 Use `_x()` instead.
+	 */
+	protected function translate( $text, $context = '' ) {
+		return $text;
+	}
+
+	/**
+	 * Reads `$this->bulk_actions` and returns an array that WP_List_Table understands. It
+	 * also validates that the bulk method handler exists. It throws an exception because
+	 * this is a library meant for developers and missing a bulk method is a development-time error.
+	 *
+	 * @return array
+	 *
+	 * @throws RuntimeException Throws RuntimeException when the bulk action does not have a callback method.
+	 */
+	protected function get_bulk_actions() {
+		$actions = array();
+
+		foreach ( $this->bulk_actions as $action => $label ) {
+			if ( ! is_callable( array( $this, 'bulk_' . $action ) ) ) {
+				throw new RuntimeException( "The bulk action $action does not have a callback method" );
+			}
+
+			$actions[ $action ] = $label;
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Checks if the current request has a bulk action. If that is the case it will validate and will
+	 * execute the bulk method handler. Regardless if the action is valid or not it will redirect to
+	 * the previous page removing the current arguments that makes this request a bulk action.
+	 */
+	protected function process_bulk_action() {
+		global $wpdb;
+		// Detect when a bulk action is being triggered.
+		$action = $this->current_action();
+		if ( ! $action ) {
+			return;
+		}
+
+		check_admin_referer( 'bulk-' . $this->_args['plural'] );
+
+		$method = 'bulk_' . $action;
+		if ( array_key_exists( $action, $this->bulk_actions ) && is_callable( array( $this, $method ) ) && ! empty( $_GET['ID'] ) && is_array( $_GET['ID'] ) ) {
+			$ids_sql = '(' . implode( ',', array_fill( 0, count( $_GET['ID'] ), '%s' ) ) . ')';
+			$id      = array_map( 'absint', $_GET['ID'] );
+			$this->$method( $id, $wpdb->prepare( $ids_sql, $id ) ); //phpcs:ignore WordPress.DB.PreparedSQL
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			wp_safe_redirect(
+				remove_query_arg(
+					array( '_wp_http_referer', '_wpnonce', 'ID', 'action', 'action2' ),
+					esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+				)
+			);
+			exit;
+		}
+	}
+
+	/**
+	 * Default code for deleting entries.
+	 * validated already by process_bulk_action()
+	 *
+	 * @param array  $ids ids of the items to delete.
+	 * @param string $ids_sql the sql for the ids.
+	 * @return void
+	 */
+	protected function bulk_delete( array $ids, $ids_sql ) {
+		$store = ActionScheduler::store();
+		foreach ( $ids as $action_id ) {
+			$store->delete( $action_id );
+		}
+	}
+
+	/**
+	 * Prepares the _column_headers property which is used by WP_Table_List at rendering.
+	 * It merges the columns and the sortable columns.
+	 */
+	protected function prepare_column_headers() {
+		$this->_column_headers = array(
+			$this->get_columns(),
+			get_hidden_columns( $this->screen ),
+			$this->get_sortable_columns(),
+		);
+	}
+
+	/**
+	 * Reads $this->sort_by and returns the columns name in a format that WP_Table_List
+	 * expects
+	 */
+	public function get_sortable_columns() {
+		$sort_by = array();
+		foreach ( $this->sort_by as $column ) {
+			$sort_by[ $column ] = array( $column, true );
+		}
+		return $sort_by;
+	}
+
+	/**
+	 * Returns the columns names for rendering. It adds a checkbox for selecting everything
+	 * as the first column
+	 */
+	public function get_columns() {
+		$columns = array_merge(
+			array( 'cb' => '<input type="checkbox" />' ),
+			$this->columns
+		);
+
+		return $columns;
+	}
+
+	/**
+	 * Get prepared LIMIT clause for items query
+	 *
+	 * @global wpdb $wpdb
+	 *
+	 * @return string Prepared LIMIT clause for items query.
+	 */
+	protected function get_items_query_limit() {
+		global $wpdb;
+
+		$per_page = $this->get_items_per_page( $this->get_per_page_option_name(), $this->items_per_page );
+		return $wpdb->prepare( 'LIMIT %d', $per_page );
+	}
+
+	/**
+	 * Returns the number of items to offset/skip for this current view.
+	 *
+	 * @return int
+	 */
+	protected function get_items_offset() {
+		$per_page     = $this->get_items_per_page( $this->get_per_page_option_name(), $this->items_per_page );
+		$current_page = $this->get_pagenum();
+		if ( 1 < $current_page ) {
+			$offset = $per_page * ( $current_page - 1 );
+		} else {
+			$offset = 0;
+		}
+
+		return $offset;
+	}
+
+	/**
+	 * Get prepared OFFSET clause for items query
+	 *
+	 * @global wpdb $wpdb
+	 *
+	 * @return string Prepared OFFSET clause for items query.
+	 */
+	protected function get_items_query_offset() {
+		global $wpdb;
+
+		return $wpdb->prepare( 'OFFSET %d', $this->get_items_offset() );
+	}
+
+	/**
+	 * Prepares the ORDER BY sql statement. It uses `$this->sort_by` to know which
+	 * columns are sortable. This requests validates the orderby $_GET parameter is a valid
+	 * column and sortable. It will also use order (ASC|DESC) using DESC by default.
+	 */
+	protected function get_items_query_order() {
+		if ( empty( $this->sort_by ) ) {
+			return '';
+		}
+
+		$orderby = esc_sql( $this->get_request_orderby() );
+		$order   = esc_sql( $this->get_request_order() );
+
+		return "ORDER BY {$orderby} {$order}";
+	}
+
+	/**
+	 * Querystring arguments to persist between form submissions.
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return string[]
+	 */
+	protected function get_request_query_args_to_persist() {
+		return array_merge(
+			$this->sort_by,
+			array(
+				'page',
+				'status',
+				'tab',
+			)
+		);
+	}
+
+	/**
+	 * Return the sortable column specified for this request to order the results by, if any.
+	 *
+	 * @return string
+	 */
+	protected function get_request_orderby() {
+
+		$valid_sortable_columns = array_values( $this->sort_by );
+
+		if ( ! empty( $_GET['orderby'] ) && in_array( $_GET['orderby'], $valid_sortable_columns, true ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$orderby = sanitize_text_field( wp_unslash( $_GET['orderby'] ) ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} else {
+			$orderby = $valid_sortable_columns[0];
+		}
+
+		return $orderby;
+	}
+
+	/**
+	 * Return the sortable column order specified for this request.
+	 *
+	 * @return string
+	 */
+	protected function get_request_order() {
+
+		if ( ! empty( $_GET['order'] ) && 'desc' === strtolower( sanitize_text_field( wp_unslash( $_GET['order'] ) ) ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$order = 'DESC';
+		} else {
+			$order = 'ASC';
+		}
+
+		return $order;
+	}
+
+	/**
+	 * Return the status filter for this request, if any.
+	 *
+	 * @return string
+	 */
+	protected function get_request_status() {
+		$status = ( ! empty( $_GET['status'] ) ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return $status;
+	}
+
+	/**
+	 * Return the search filter for this request, if any.
+	 *
+	 * @return string
+	 */
+	protected function get_request_search_query() {
+		$search_query = ( ! empty( $_GET['s'] ) ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return $search_query;
+	}
+
+	/**
+	 * Process and return the columns name. This is meant for using with SQL, this means it
+	 * always includes the primary key.
+	 *
+	 * @return array
+	 */
+	protected function get_table_columns() {
+		$columns = array_keys( $this->columns );
+		if ( ! in_array( $this->ID, $columns, true ) ) {
+			$columns[] = $this->ID;
+		}
+
+		return $columns;
+	}
+
+	/**
+	 * Check if the current request is doing a "full text" search. If that is the case
+	 * prepares the SQL to search texts using LIKE.
+	 *
+	 * If the current request does not have any search or if this list table does not support
+	 * that feature it will return an empty string.
+	 *
+	 * @return string
+	 */
+	protected function get_items_query_search() {
+		global $wpdb;
+
+		if ( empty( $_GET['s'] ) || empty( $this->search_by ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return '';
+		}
+
+		$search_string = sanitize_text_field( wp_unslash( $_GET['s'] ) ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$filter = array();
+		foreach ( $this->search_by as $column ) {
+			$wild     = '%';
+			$sql_like = $wild . $wpdb->esc_like( $search_string ) . $wild;
+			$filter[] = $wpdb->prepare( '`' . $column . '` LIKE %s', $sql_like ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.DB.PreparedSQL.NotPrepared
+		}
+		return implode( ' OR ', $filter );
+	}
+
+	/**
+	 * Prepares the SQL to filter rows by the options defined at `$this->filter_by`. Before trusting
+	 * any data sent by the user it validates that it is a valid option.
+	 */
+	protected function get_items_query_filters() {
+		global $wpdb;
+
+		if ( ! $this->filter_by || empty( $_GET['filter_by'] ) || ! is_array( $_GET['filter_by'] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return '';
+		}
+
+		$filter = array();
+
+		foreach ( $this->filter_by as $column => $options ) {
+			if ( empty( $_GET['filter_by'][ $column ] ) || empty( $options[ $_GET['filter_by'][ $column ] ] ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				continue;
+			}
+
+			$filter[] = $wpdb->prepare( "`$column` = %s", sanitize_text_field( wp_unslash( $_GET['filter_by'][ $column ] ) ) ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		return implode( ' AND ', $filter );
+
+	}
+
+	/**
+	 * Prepares the data to feed WP_Table_List.
+	 *
+	 * This has the core for selecting, sorting and filtering data. To keep the code simple
+	 * its logic is split among many methods (get_items_query_*).
+	 *
+	 * Beside populating the items this function will also count all the records that matches
+	 * the filtering criteria and will do fill the pagination variables.
+	 */
+	public function prepare_items() {
+		global $wpdb;
+
+		$this->process_bulk_action();
+
+		$this->process_row_actions();
+
+		if ( ! empty( $_REQUEST['_wp_http_referer'] && ! empty( $_SERVER['REQUEST_URI'] ) ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// _wp_http_referer is used only on bulk actions, we remove it to keep the $_GET shorter
+			wp_safe_redirect( remove_query_arg( array( '_wp_http_referer', '_wpnonce' ), esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
+			exit;
+		}
+
+		$this->prepare_column_headers();
+
+		$limit   = $this->get_items_query_limit();
+		$offset  = $this->get_items_query_offset();
+		$order   = $this->get_items_query_order();
+		$where   = array_filter(
+			array(
+				$this->get_items_query_search(),
+				$this->get_items_query_filters(),
+			)
+		);
+		$columns = '`' . implode( '`, `', $this->get_table_columns() ) . '`';
+
+		if ( ! empty( $where ) ) {
+			$where = 'WHERE (' . implode( ') AND (', $where ) . ')';
+		} else {
+			$where = '';
+		}
+
+		$sql = "SELECT $columns FROM {$this->table_name} {$where} {$order} {$limit} {$offset}";
+
+		$this->set_items( $wpdb->get_results( $sql, ARRAY_A ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$query_count = "SELECT COUNT({$this->ID}) FROM {$this->table_name} {$where}";
+		$total_items = $wpdb->get_var( $query_count ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$per_page    = $this->get_items_per_page( $this->get_per_page_option_name(), $this->items_per_page );
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => ceil( $total_items / $per_page ),
+			)
+		);
+	}
+
+	/**
+	 * Display the table.
+	 *
+	 * @param string $which The name of the table.
+	 */
+	public function extra_tablenav( $which ) {
+		if ( ! $this->filter_by || 'top' !== $which ) {
+			return;
+		}
+
+		echo '<div class="alignleft actions">';
+
+		foreach ( $this->filter_by as $id => $options ) {
+			$default = ! empty( $_GET['filter_by'][ $id ] ) ? sanitize_text_field( wp_unslash( $_GET['filter_by'][ $id ] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( empty( $options[ $default ] ) ) {
+				$default = '';
+			}
+
+			echo '<select name="filter_by[' . esc_attr( $id ) . ']" class="first" id="filter-by-' . esc_attr( $id ) . '">';
+
+			foreach ( $options as $value => $label ) {
+				echo '<option value="' . esc_attr( $value ) . '" ' . esc_html( $value === $default ? 'selected' : '' ) . '>'
+					. esc_html( $label )
+				. '</option>';
+			}
+
+			echo '</select>';
+		}
+
+		submit_button( esc_html__( 'Filter', 'action-scheduler' ), '', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+		echo '</div>';
+	}
+
+	/**
+	 * Set the data for displaying. It will attempt to unserialize (There is a chance that some columns
+	 * are serialized). This can be override in child classes for further data transformation.
+	 *
+	 * @param array $items Items array.
+	 */
+	protected function set_items( array $items ) {
+		$this->items = array();
+		foreach ( $items as $item ) {
+			$this->items[ $item[ $this->ID ] ] = array_map( 'maybe_unserialize', $item );
+		}
+	}
+
+	/**
+	 * Renders the checkbox for each row, this is the first column and it is named ID regardless
+	 * of how the primary key is named (to keep the code simpler). The bulk actions will do the proper
+	 * name transformation though using `$this->ID`.
+	 *
+	 * @param array $row The row to render.
+	 */
+	public function column_cb( $row ) {
+		return '<input name="ID[]" type="checkbox" value="' . esc_attr( $row[ $this->ID ] ) . '" />';
+	}
+
+	/**
+	 * Renders the row-actions.
+	 *
+	 * This method renders the action menu, it reads the definition from the $row_actions property,
+	 * and it checks that the row action method exists before rendering it.
+	 *
+	 * @param array  $row Row to be rendered.
+	 * @param string $column_name Column name.
+	 * @return string
+	 */
+	protected function maybe_render_actions( $row, $column_name ) {
+		if ( empty( $this->row_actions[ $column_name ] ) ) {
+			return;
+		}
+
+		$row_id = $row[ $this->ID ];
+
+		$actions      = '<div class="row-actions">';
+		$action_count = 0;
+		foreach ( $this->row_actions[ $column_name ] as $action_key => $action ) {
+
+			$action_count++;
+
+			if ( ! method_exists( $this, 'row_action_' . $action_key ) ) {
+				continue;
+			}
+
+			$action_link = ! empty( $action['link'] ) ? $action['link'] : add_query_arg(
+				array(
+					'row_action' => $action_key,
+					'row_id'     => $row_id,
+					'nonce'      => wp_create_nonce( $action_key . '::' . $row_id ),
+				)
+			);
+			$span_class  = ! empty( $action['class'] ) ? $action['class'] : $action_key;
+			$separator   = ( $action_count < count( $this->row_actions[ $column_name ] ) ) ? ' | ' : '';
+
+			$actions .= sprintf( '<span class="%s">', esc_attr( $span_class ) );
+			$actions .= sprintf( '<a href="%1$s" title="%2$s">%3$s</a>', esc_url( $action_link ), esc_attr( $action['desc'] ), esc_html( $action['name'] ) );
+			$actions .= sprintf( '%s</span>', $separator );
+		}
+		$actions .= '</div>';
+		return $actions;
+	}
+
+	/**
+	 * Process the bulk actions.
+	 *
+	 * @return void
+	 */
+	protected function process_row_actions() {
+		$parameters = array( 'row_action', 'row_id', 'nonce' );
+		foreach ( $parameters as $parameter ) {
+			if ( empty( $_REQUEST[ $parameter ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return;
+			}
+		}
+
+		$action = sanitize_text_field( wp_unslash( $_REQUEST['row_action'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$row_id = sanitize_text_field( wp_unslash( $_REQUEST['row_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$nonce  = sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+		$method = 'row_action_' . $action; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( wp_verify_nonce( $nonce, $action . '::' . $row_id ) && method_exists( $this, $method ) ) {
+			$this->$method( sanitize_text_field( wp_unslash( $row_id ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			wp_safe_redirect(
+				remove_query_arg(
+					array( 'row_id', 'row_action', 'nonce' ),
+					esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+				)
+			);
+			exit;
+		}
+	}
+
+	/**
+	 * Default column formatting, it will escape everything for security.
+	 *
+	 * @param array  $item The item array.
+	 * @param string $column_name Column name to display.
+	 *
+	 * @return string
+	 */
+	public function column_default( $item, $column_name ) {
+		$column_html  = esc_html( $item[ $column_name ] );
+		$column_html .= $this->maybe_render_actions( $item, $column_name );
+		return $column_html;
+	}
+
+	/**
+	 * Display the table heading and search query, if any
+	 */
+	protected function display_header() {
+		echo '<h1 class="wp-heading-inline">' . esc_attr( $this->table_header ) . '</h1>';
+		if ( $this->get_request_search_query() ) {
+			/* translators: %s: search query */
+			echo '<span class="subtitle">' . esc_attr( sprintf( __( 'Search results for "%s"', 'action-scheduler' ), $this->get_request_search_query() ) ) . '</span>';
+		}
+		echo '<hr class="wp-header-end">';
+	}
+
+	/**
+	 * Display the table heading and search query, if any
+	 */
+	protected function display_admin_notices() {
+		foreach ( $this->admin_notices as $notice ) {
+			echo '<div id="message" class="' . esc_attr( $notice['class'] ) . '">';
+			echo '	<p>' . wp_kses_post( $notice['message'] ) . '</p>';
+			echo '</div>';
+		}
+	}
+
+	/**
+	 * Prints the available statuses so the user can click to filter.
+	 */
+	protected function display_filter_by_status() {
+
+		$status_list_items = array();
+		$request_status    = $this->get_request_status();
+
+		// Helper to set 'all' filter when not set on status counts passed in.
+		if ( ! isset( $this->status_counts['all'] ) ) {
+			$all_count = array_sum( $this->status_counts );
+			if ( isset( $this->status_counts['past-due'] ) ) {
+				$all_count -= $this->status_counts['past-due'];
+			}
+			$this->status_counts = array( 'all' => $all_count ) + $this->status_counts;
+		}
+
+		// Translated status labels.
+		$status_labels             = ActionScheduler_Store::instance()->get_status_labels();
+		$status_labels['all']      = esc_html_x( 'All', 'status labels', 'action-scheduler' );
+		$status_labels['past-due'] = esc_html_x( 'Past-due', 'status labels', 'action-scheduler' );
+
+		foreach ( $this->status_counts as $status_slug => $count ) {
+
+			if ( 0 === $count ) {
+				continue;
+			}
+
+			if ( $status_slug === $request_status || ( empty( $request_status ) && 'all' === $status_slug ) ) {
+				$status_list_item = '<li class="%1$s"><a href="%2$s" class="current">%3$s</a> (%4$d)</li>';
+			} else {
+				$status_list_item = '<li class="%1$s"><a href="%2$s">%3$s</a> (%4$d)</li>';
+			}
+
+			$status_name         = isset( $status_labels[ $status_slug ] ) ? $status_labels[ $status_slug ] : ucfirst( $status_slug );
+			$status_filter_url   = ( 'all' === $status_slug ) ? remove_query_arg( 'status' ) : add_query_arg( 'status', $status_slug );
+			$status_filter_url   = remove_query_arg( array( 'paged', 's' ), $status_filter_url );
+			$status_list_items[] = sprintf( $status_list_item, esc_attr( $status_slug ), esc_url( $status_filter_url ), esc_html( $status_name ), absint( $count ) );
+		}
+
+		if ( $status_list_items ) {
+			echo '<ul class="subsubsub">';
+			echo implode( " | \n", $status_list_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo '</ul>';
+		}
+	}
+
+	/**
+	 * Renders the table list, we override the original class to render the table inside a form
+	 * and to render any needed HTML (like the search box). By doing so the callee of a function can simple
+	 * forget about any extra HTML.
+	 */
+	protected function display_table() {
+		echo '<form id="' . esc_attr( $this->_args['plural'] ) . '-filter" method="get">';
+		foreach ( $this->get_request_query_args_to_persist() as $arg ) {
+			$arg_value = isset( $_GET[ $arg ] ) ? sanitize_text_field( wp_unslash( $_GET[ $arg ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! $arg_value ) {
+				continue;
+			}
+
+			echo '<input type="hidden" name="' . esc_attr( $arg ) . '" value="' . esc_attr( $arg_value ) . '" />';
+		}
+
+		if ( ! empty( $this->search_by ) ) {
+			echo $this->search_box( $this->get_search_box_button_text(), 'plugin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+		parent::display();
+		echo '</form>';
+	}
+
+	/**
+	 * Process any pending actions.
+	 */
+	public function process_actions() {
+		$this->process_bulk_action();
+		$this->process_row_actions();
+
+		if ( ! empty( $_REQUEST['_wp_http_referer'] ) && ! empty( $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// _wp_http_referer is used only on bulk actions, we remove it to keep the $_GET shorter
+			wp_safe_redirect( remove_query_arg( array( '_wp_http_referer', '_wpnonce' ), esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Render the list table page, including header, notices, status filters and table.
+	 */
+	public function display_page() {
+		$this->prepare_items();
+
+		echo '<div class="wrap">';
+		$this->display_header();
+		$this->display_admin_notices();
+		$this->display_filter_by_status();
+		$this->display_table();
+		echo '</div>';
+	}
+
+	/**
+	 * Get the text to display in the search box on the list table.
+	 */
+	protected function get_search_box_placeholder() {
+		return esc_html__( 'Search', 'action-scheduler' );
+	}
+
+	/**
+	 * Gets the screen per_page option name.
+	 *
+	 * @return string
+	 */
+	protected function get_per_page_option_name() {
+		return $this->package . '_items_per_page';
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -1,0 +1,383 @@
+<?php
+
+/**
+ * Abstract class with common Queue Cleaner functionality.
+ */
+abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abstract_QueueRunner_Deprecated {
+
+	/**
+	 * ActionScheduler_QueueCleaner instance.
+	 *
+	 * @var ActionScheduler_QueueCleaner
+	 */
+	protected $cleaner;
+
+	/**
+	 * ActionScheduler_FatalErrorMonitor instance.
+	 *
+	 * @var ActionScheduler_FatalErrorMonitor
+	 */
+	protected $monitor;
+
+	/**
+	 * ActionScheduler_Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	protected $store;
+
+	/**
+	 * The created time.
+	 *
+	 * Represents when the queue runner was constructed and used when calculating how long a PHP request has been running.
+	 * For this reason it should be as close as possible to the PHP request start time.
+	 *
+	 * @var int
+	 */
+	private $created_time;
+
+	/**
+	 * ActionScheduler_Abstract_QueueRunner constructor.
+	 *
+	 * @param ActionScheduler_Store|null             $store Store object.
+	 * @param ActionScheduler_FatalErrorMonitor|null $monitor Monitor object.
+	 * @param ActionScheduler_QueueCleaner|null      $cleaner Cleaner object.
+	 */
+	public function __construct( ?ActionScheduler_Store $store = null, ?ActionScheduler_FatalErrorMonitor $monitor = null, ?ActionScheduler_QueueCleaner $cleaner = null ) {
+
+		$this->created_time = microtime( true );
+
+		$this->store   = $store ? $store : ActionScheduler_Store::instance();
+		$this->monitor = $monitor ? $monitor : new ActionScheduler_FatalErrorMonitor( $this->store );
+		$this->cleaner = $cleaner ? $cleaner : new ActionScheduler_QueueCleaner( $this->store );
+	}
+
+	/**
+	 * Process an individual action.
+	 *
+	 * @param int    $action_id The action ID to process.
+	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
+	 *                        Generally, this should be capitalised and not localised as it's a proper noun.
+	 * @throws \Exception When error running action.
+	 */
+	public function process_action( $action_id, $context = '' ) {
+		// Temporarily override the error handler while we process the current action.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
+		set_error_handler(
+			/**
+			 * Temporary error handler which can catch errors and convert them into exceptions. This facilitates more
+			 * robust error handling across all supported PHP versions.
+			 *
+			 * @throws Exception
+			 *
+			 * @param int    $type    Error level expressed as an integer.
+			 * @param string $message Error message.
+			 */
+			function ( $type, $message ) {
+				throw new Exception( $message );
+			},
+			E_USER_ERROR | E_RECOVERABLE_ERROR
+		);
+
+		/*
+		 * The nested try/catch structure is required because we potentially need to convert thrown errors into
+		 * exceptions (and an exception thrown from a catch block cannot be caught by a later catch block in the *same*
+		 * structure).
+		 */
+		try {
+			try {
+				$valid_action = false;
+				do_action( 'action_scheduler_before_execute', $action_id, $context );
+
+				if ( ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
+					do_action( 'action_scheduler_execution_ignored', $action_id, $context );
+					return;
+				}
+
+				$valid_action = true;
+				do_action( 'action_scheduler_begin_execute', $action_id, $context );
+
+				$action = $this->store->fetch_action( $action_id );
+				$this->store->log_execution( $action_id );
+				$action->execute();
+				do_action( 'action_scheduler_after_execute', $action_id, $action, $context );
+				$this->store->mark_complete( $action_id );
+			} catch ( Throwable $e ) {
+				// Throwable is defined when executing under PHP 7.0 and up. We convert it to an exception, for
+				// compatibility with ActionScheduler_Logger.
+				throw new Exception( $e->getMessage(), $e->getCode(), $e );
+			}
+		} catch ( Exception $e ) {
+			// This catch block exists for compatibility with PHP 5.6.
+			$this->handle_action_error( $action_id, $e, $context, $valid_action );
+		} finally {
+			restore_error_handler();
+		}
+
+		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
+			$this->schedule_next_instance( $action, $action_id );
+		}
+	}
+
+	/**
+	 * Marks actions as either having failed execution or failed validation, as appropriate.
+	 *
+	 * @param int       $action_id    Action ID.
+	 * @param Exception $e            Exception instance.
+	 * @param string    $context      Execution context.
+	 * @param bool      $valid_action If the action is valid.
+	 *
+	 * @return void
+	 */
+	private function handle_action_error( $action_id, $e, $context, $valid_action ) {
+		if ( $valid_action ) {
+			$this->store->mark_failure( $action_id );
+			/**
+			 * Runs when action execution fails.
+			 *
+			 * @param int       $action_id Action ID.
+			 * @param Exception $e         Exception instance.
+			 * @param string    $context   Execution context.
+			 */
+			do_action( 'action_scheduler_failed_execution', $action_id, $e, $context );
+		} else {
+			/**
+			 * Runs when action validation fails.
+			 *
+			 * @param int       $action_id Action ID.
+			 * @param Exception $e         Exception instance.
+			 * @param string    $context   Execution context.
+			 */
+			do_action( 'action_scheduler_failed_validation', $action_id, $e, $context );
+		}
+	}
+
+	/**
+	 * Schedule the next instance of the action if necessary.
+	 *
+	 * @param ActionScheduler_Action $action Action.
+	 * @param int                    $action_id Action ID.
+	 */
+	protected function schedule_next_instance( ActionScheduler_Action $action, $action_id ) {
+		// If a recurring action has been consistently failing, we may wish to stop rescheduling it.
+		if (
+			ActionScheduler_Store::STATUS_FAILED === $this->store->get_status( $action_id )
+			&& $this->recurring_action_is_consistently_failing( $action, $action_id )
+		) {
+			ActionScheduler_Logger::instance()->log(
+				$action_id,
+				__( 'This action appears to be consistently failing. A new instance will not be scheduled.', 'action-scheduler' )
+			);
+
+			return;
+		}
+
+		try {
+			ActionScheduler::factory()->repeat( $action );
+		} catch ( Exception $e ) {
+			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, $action );
+		}
+	}
+
+	/**
+	 * Determine if the specified recurring action has been consistently failing.
+	 *
+	 * @param ActionScheduler_Action $action    The recurring action to be rescheduled.
+	 * @param int                    $action_id The ID of the recurring action.
+	 *
+	 * @return bool
+	 */
+	private function recurring_action_is_consistently_failing( ActionScheduler_Action $action, $action_id ) {
+		/**
+		 * Controls the failure threshold for recurring actions.
+		 *
+		 * Before rescheduling a recurring action, we look at its status. If it failed, we then check if all of the most
+		 * recent actions (upto the threshold set by this filter) sharing the same hook have also failed: if they have,
+		 * that is considered consistent failure and a new instance of the action will not be scheduled.
+		 *
+		 * @param int $failure_threshold Number of actions of the same hook to examine for failure. Defaults to 5.
+		 */
+		$consistent_failure_threshold = (int) apply_filters( 'action_scheduler_recurring_action_failure_threshold', 5 );
+
+		// This query should find the earliest *failing* action (for the hook we are interested in) within our threshold.
+		$query_args = array(
+			'hook'         => $action->get_hook(),
+			'status'       => ActionScheduler_Store::STATUS_FAILED,
+			'date'         => date_create( 'now', timezone_open( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
+			'date_compare' => '<',
+			'per_page'     => 1,
+			'offset'       => $consistent_failure_threshold - 1,
+		);
+
+		$first_failing_action_id = $this->store->query_actions( $query_args );
+
+		// If we didn't retrieve an action ID, then there haven't been enough failures for us to worry about.
+		if ( empty( $first_failing_action_id ) ) {
+			return false;
+		}
+
+		// Now let's fetch the first action (having the same hook) of *any status* within the same window.
+		unset( $query_args['status'] );
+		$first_action_id_with_the_same_hook = $this->store->query_actions( $query_args );
+
+		/**
+		 * If a recurring action is assessed as consistently failing, it will not be rescheduled. This hook provides a
+		 * way to observe and optionally override that assessment.
+		 *
+		 * @param bool                   $is_consistently_failing If the action is considered to be consistently failing.
+		 * @param ActionScheduler_Action $action                  The action being assessed.
+		 */
+		return (bool) apply_filters(
+			'action_scheduler_recurring_action_is_consistently_failing',
+			$first_action_id_with_the_same_hook === $first_failing_action_id,
+			$action
+		);
+	}
+
+	/**
+	 * Run the queue cleaner.
+	 */
+	protected function run_cleanup() {
+		$this->cleaner->clean( 10 * $this->get_time_limit() );
+	}
+
+	/**
+	 * Get the number of concurrent batches a runner allows.
+	 *
+	 * @return int
+	 */
+	public function get_allowed_concurrent_batches() {
+		return apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 1 );
+	}
+
+	/**
+	 * Check if the number of allowed concurrent batches is met or exceeded.
+	 *
+	 * @return bool
+	 */
+	public function has_maximum_concurrent_batches() {
+		return $this->store->get_claim_count() >= $this->get_allowed_concurrent_batches();
+	}
+
+	/**
+	 * Get the maximum number of seconds a batch can run for.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_time_limit() {
+
+		$time_limit = 30;
+
+		// Apply deprecated filter from deprecated get_maximum_execution_time() method.
+		if ( has_filter( 'action_scheduler_maximum_execution_time' ) ) {
+			_deprecated_function( 'action_scheduler_maximum_execution_time', '2.1.1', 'action_scheduler_queue_runner_time_limit' );
+			$time_limit = apply_filters( 'action_scheduler_maximum_execution_time', $time_limit );
+		}
+
+		return absint( apply_filters( 'action_scheduler_queue_runner_time_limit', $time_limit ) );
+	}
+
+	/**
+	 * Get the number of seconds the process has been running.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_execution_time() {
+		$execution_time = microtime( true ) - $this->created_time;
+
+		// Get the CPU time if the hosting environment uses it rather than wall-clock time to calculate a process's execution time.
+		if ( function_exists( 'getrusage' ) && apply_filters( 'action_scheduler_use_cpu_execution_time', defined( 'PANTHEON_ENVIRONMENT' ) ) ) {
+			$resource_usages = getrusage();
+
+			if ( isset( $resource_usages['ru_stime.tv_usec'], $resource_usages['ru_stime.tv_usec'] ) ) {
+				$execution_time = $resource_usages['ru_stime.tv_sec'] + ( $resource_usages['ru_stime.tv_usec'] / 1000000 );
+			}
+		}
+
+		return $execution_time;
+	}
+
+	/**
+	 * Check if the host's max execution time is (likely) to be exceeded if processing more actions.
+	 *
+	 * @param int $processed_actions The number of actions processed so far - used to determine the likelihood of exceeding the time limit if processing another action.
+	 * @return bool
+	 */
+	protected function time_likely_to_be_exceeded( $processed_actions ) {
+		$execution_time     = $this->get_execution_time();
+		$max_execution_time = $this->get_time_limit();
+
+		// Safety against division by zero errors.
+		if ( 0 === $processed_actions ) {
+			return $execution_time >= $max_execution_time;
+		}
+
+		$time_per_action       = $execution_time / $processed_actions;
+		$estimated_time        = $execution_time + ( $time_per_action * 3 );
+		$likely_to_be_exceeded = $estimated_time > $max_execution_time;
+
+		return apply_filters( 'action_scheduler_maximum_execution_time_likely_to_be_exceeded', $likely_to_be_exceeded, $this, $processed_actions, $execution_time, $max_execution_time );
+	}
+
+	/**
+	 * Get memory limit
+	 *
+	 * Based on WP_Background_Process::get_memory_limit()
+	 *
+	 * @return int
+	 */
+	protected function get_memory_limit() {
+		if ( function_exists( 'ini_get' ) ) {
+			$memory_limit = ini_get( 'memory_limit' );
+		} else {
+			$memory_limit = '128M'; // Sensible default, and minimum required by WooCommerce.
+		}
+
+		if ( ! $memory_limit || -1 === $memory_limit || '-1' === $memory_limit ) {
+			// Unlimited, set to 32GB.
+			$memory_limit = '32G';
+		}
+
+		return ActionScheduler_Compatibility::convert_hr_to_bytes( $memory_limit );
+	}
+
+	/**
+	 * Memory exceeded
+	 *
+	 * Ensures the batch process never exceeds 90% of the maximum WordPress memory.
+	 *
+	 * Based on WP_Background_Process::memory_exceeded()
+	 *
+	 * @return bool
+	 */
+	protected function memory_exceeded() {
+
+		$memory_limit    = $this->get_memory_limit() * 0.90;
+		$current_memory  = memory_get_usage( true );
+		$memory_exceeded = $current_memory >= $memory_limit;
+
+		return apply_filters( 'action_scheduler_memory_exceeded', $memory_exceeded, $this );
+	}
+
+	/**
+	 * See if the batch limits have been exceeded, which is when memory usage is almost at
+	 * the maximum limit, or the time to process more actions will exceed the max time limit.
+	 *
+	 * Based on WC_Background_Process::batch_limits_exceeded()
+	 *
+	 * @param int $processed_actions The number of actions processed so far - used to determine the likelihood of exceeding the time limit if processing another action.
+	 * @return bool
+	 */
+	protected function batch_limits_exceeded( $processed_actions ) {
+		return $this->memory_exceeded() || $this->time_likely_to_be_exceeded( $processed_actions );
+	}
+
+	/**
+	 * Process actions in the queue.
+	 *
+	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
+	 *        Generally, this should be capitalised and not localised as it's a proper noun.
+	 * @return int The number of actions processed.
+	 */
+	abstract public function run( $context = '' );
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Class ActionScheduler_Abstract_RecurringSchedule
+ */
+abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionScheduler_Abstract_Schedule {
+
+	/**
+	 * The date & time the first instance of this schedule was setup to run (which may not be this instance).
+	 *
+	 * Schedule objects are attached to an action object. Each schedule stores the run date for that
+	 * object as the start date - @see $this->start - and logic to calculate the next run date after
+	 * that - @see $this->calculate_next(). The $first_date property also keeps a record of when the very
+	 * first instance of this chain of schedules ran.
+	 *
+	 * @var DateTime
+	 */
+	private $first_date = null;
+
+	/**
+	 * Timestamp equivalent of @see $this->first_date
+	 *
+	 * @var int
+	 */
+	protected $first_timestamp = null;
+
+	/**
+	 * The recurrence between each time an action is run using this schedule.
+	 * Used to calculate the start date & time. Can be a number of seconds, in the
+	 * case of ActionScheduler_IntervalSchedule, or a cron expression, as in the
+	 * case of ActionScheduler_CronSchedule. Or something else.
+	 *
+	 * @var mixed
+	 */
+	protected $recurrence;
+
+	/**
+	 * Construct.
+	 *
+	 * @param DateTime      $date The date & time to run the action.
+	 * @param mixed         $recurrence The data used to determine the schedule's recurrence.
+	 * @param DateTime|null $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
+	 */
+	public function __construct( DateTime $date, $recurrence, ?DateTime $first = null ) {
+		parent::__construct( $date );
+		$this->first_date = empty( $first ) ? $date : $first;
+		$this->recurrence = $recurrence;
+	}
+
+	/**
+	 * Schedule is recurring.
+	 *
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return true;
+	}
+
+	/**
+	 * Get the date & time of the first schedule in this recurring series.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_first_date() {
+		return clone $this->first_date;
+	}
+
+	/**
+	 * Get the schedule's recurrence.
+	 *
+	 * @return string
+	 */
+	public function get_recurrence() {
+		return $this->recurrence;
+	}
+
+	/**
+	 * For PHP 5.2 compat, since DateTime objects can't be serialized
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+		$sleep_params          = parent::__sleep();
+		$this->first_timestamp = $this->first_date->getTimestamp();
+		return array_merge(
+			$sleep_params,
+			array(
+				'first_timestamp',
+				'recurrence',
+			)
+		);
+	}
+
+	/**
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. This was addressed in
+	 * Action Scheduler 3.0.0, where properties and property names were aligned for better
+	 * inheritance. To maintain backward compatibility with scheduled serialized and stored
+	 * prior to 3.0, we need to correctly map the old property names.
+	 */
+	public function __wakeup() {
+		parent::__wakeup();
+		if ( $this->first_timestamp > 0 ) {
+			$this->first_date = as_get_datetime_object( $this->first_timestamp );
+		} else {
+			$this->first_date = $this->get_date();
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_Schedule.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_Schedule.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Class ActionScheduler_Abstract_Schedule
+ */
+abstract class ActionScheduler_Abstract_Schedule extends ActionScheduler_Schedule_Deprecated {
+
+	/**
+	 * The date & time the schedule is set to run.
+	 *
+	 * @var DateTime
+	 */
+	private $scheduled_date = null;
+
+	/**
+	 * Timestamp equivalent of @see $this->scheduled_date
+	 *
+	 * @var int
+	 */
+	protected $scheduled_timestamp = null;
+
+	/**
+	 * Construct.
+	 *
+	 * @param DateTime $date The date & time to run the action.
+	 */
+	public function __construct( DateTime $date ) {
+		$this->scheduled_date = $date;
+	}
+
+	/**
+	 * Check if a schedule should recur.
+	 *
+	 * @return bool
+	 */
+	abstract public function is_recurring();
+
+	/**
+	 * Calculate when the next instance of this schedule would run based on a given date & time.
+	 *
+	 * @param DateTime $after Start timestamp.
+	 * @return DateTime
+	 */
+	abstract protected function calculate_next( DateTime $after );
+
+	/**
+	 * Get the next date & time when this schedule should run after a given date & time.
+	 *
+	 * @param DateTime $after Start timestamp.
+	 * @return DateTime|null
+	 */
+	public function get_next( DateTime $after ) {
+		$after = clone $after;
+		if ( $after > $this->scheduled_date ) {
+			$after = $this->calculate_next( $after );
+			return $after;
+		}
+		return clone $this->scheduled_date;
+	}
+
+	/**
+	 * Get the date & time the schedule is set to run.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_date() {
+		return $this->scheduled_date;
+	}
+
+	/**
+	 * For PHP 5.2 compat, because DateTime objects can't be serialized
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+		$this->scheduled_timestamp = $this->scheduled_date->getTimestamp();
+		return array(
+			'scheduled_timestamp',
+		);
+	}
+
+	/**
+	 * Wakeup.
+	 */
+	public function __wakeup() {
+		$this->scheduled_date = as_get_datetime_object( $this->scheduled_timestamp );
+		unset( $this->scheduled_timestamp );
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -1,0 +1,187 @@
+<?php
+
+
+/**
+ * Class ActionScheduler_Abstract_Schema
+ *
+ * @package Action_Scheduler
+ *
+ * @codeCoverageIgnore
+ *
+ * Utility class for creating/updating custom tables
+ */
+abstract class ActionScheduler_Abstract_Schema {
+
+	/**
+	 * Increment this value in derived class to trigger a schema update.
+	 *
+	 * @var int
+	 */
+	protected $schema_version = 1;
+
+	/**
+	 * Schema version stored in database.
+	 *
+	 * @var string
+	 */
+	protected $db_version;
+
+	/**
+	 * Names of tables that will be registered by this class.
+	 *
+	 * @var array
+	 */
+	protected $tables = array();
+
+	/**
+	 * Can optionally be used by concrete classes to carry out additional initialization work
+	 * as needed.
+	 */
+	public function init() {}
+
+	/**
+	 * Register tables with WordPress, and create them if needed.
+	 *
+	 * @param bool $force_update Optional. Default false. Use true to always run the schema update.
+	 *
+	 * @return void
+	 */
+	public function register_tables( $force_update = false ) {
+		global $wpdb;
+
+		// make WP aware of our tables.
+		foreach ( $this->tables as $table ) {
+			$wpdb->tables[] = $table;
+			$name           = $this->get_full_table_name( $table );
+			$wpdb->$table   = $name;
+		}
+
+		// create the tables.
+		if ( $this->schema_update_required() || $force_update ) {
+			foreach ( $this->tables as $table ) {
+				/**
+				 * Allow custom processing before updating a table schema.
+				 *
+				 * @param string $table Name of table being updated.
+				 * @param string $db_version Existing version of the table being updated.
+				 */
+				do_action( 'action_scheduler_before_schema_update', $table, $this->db_version );
+				$this->update_table( $table );
+			}
+			$this->mark_schema_update_complete();
+		}
+	}
+
+	/**
+	 * Get table definition.
+	 *
+	 * @param string $table The name of the table.
+	 *
+	 * @return string The CREATE TABLE statement, suitable for passing to dbDelta
+	 */
+	abstract protected function get_table_definition( $table );
+
+	/**
+	 * Determine if the database schema is out of date
+	 * by comparing the integer found in $this->schema_version
+	 * with the option set in the WordPress options table
+	 *
+	 * @return bool
+	 */
+	private function schema_update_required() {
+		$option_name      = 'schema-' . static::class;
+		$this->db_version = get_option( $option_name, 0 );
+
+		// Check for schema option stored by the Action Scheduler Custom Tables plugin in case site has migrated from that plugin with an older schema.
+		if ( 0 === $this->db_version ) {
+
+			$plugin_option_name = 'schema-';
+
+			switch ( static::class ) {
+				case 'ActionScheduler_StoreSchema':
+					$plugin_option_name .= 'Action_Scheduler\Custom_Tables\DB_Store_Table_Maker';
+					break;
+				case 'ActionScheduler_LoggerSchema':
+					$plugin_option_name .= 'Action_Scheduler\Custom_Tables\DB_Logger_Table_Maker';
+					break;
+			}
+
+			$this->db_version = get_option( $plugin_option_name, 0 );
+
+			delete_option( $plugin_option_name );
+		}
+
+		return version_compare( $this->db_version, $this->schema_version, '<' );
+	}
+
+	/**
+	 * Update the option in WordPress to indicate that
+	 * our schema is now up to date
+	 *
+	 * @return void
+	 */
+	private function mark_schema_update_complete() {
+		$option_name = 'schema-' . static::class;
+
+		// work around race conditions and ensure that our option updates.
+		$value_to_save = (string) $this->schema_version . '.0.' . time();
+
+		update_option( $option_name, $value_to_save );
+	}
+
+	/**
+	 * Update the schema for the given table
+	 *
+	 * @param string $table The name of the table to update.
+	 *
+	 * @return void
+	 */
+	private function update_table( $table ) {
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		$definition = $this->get_table_definition( $table );
+		if ( $definition ) {
+			$updated = dbDelta( $definition );
+			foreach ( $updated as $updated_table => $update_description ) {
+				if ( strpos( $update_description, 'Created table' ) === 0 ) {
+					do_action( 'action_scheduler/created_table', $updated_table, $table ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get full table name.
+	 *
+	 * @param string $table Table name.
+	 *
+	 * @return string The full name of the table, including the
+	 *                table prefix for the current blog
+	 */
+	protected function get_full_table_name( $table ) {
+		return $GLOBALS['wpdb']->prefix . $table;
+	}
+
+	/**
+	 * Confirms that all of the tables registered by this schema class have been created.
+	 *
+	 * @return bool
+	 */
+	public function tables_exist() {
+		global $wpdb;
+
+		$tables_exist = true;
+
+		foreach ( $this->tables as $table_name ) {
+			$table_name     = $wpdb->prefix . $table_name;
+			$pattern        = str_replace( '_', '\\_', $table_name );
+			$existing_table = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $pattern ) );
+
+			if ( $existing_table !== $table_name ) {
+				$tables_exist = false;
+				break;
+			}
+		}
+
+		return $tables_exist;
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Lock.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Lock.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Abstract class for setting a basic lock to throttle some action.
+ *
+ * Class ActionScheduler_Lock
+ */
+abstract class ActionScheduler_Lock {
+
+	/**
+	 * Instance.
+	 *
+	 * @var ActionScheduler_Lock
+	 */
+	private static $locker = null;
+
+	/**
+	 * Duration of lock.
+	 *
+	 * @var int
+	 */
+	protected static $lock_duration = MINUTE_IN_SECONDS;
+
+	/**
+	 * Check if a lock is set for a given lock type.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool
+	 */
+	public function is_locked( $lock_type ) {
+		return ( $this->get_expiration( $lock_type ) >= time() );
+	}
+
+	/**
+	 * Set a lock.
+	 *
+	 * To prevent race conditions, implementations should avoid setting the lock if the lock is already held.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool
+	 */
+	abstract public function set( $lock_type );
+
+	/**
+	 * If a lock is set, return the timestamp it was set to expiry.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool|int False if no lock is set, otherwise the timestamp for when the lock is set to expire.
+	 */
+	abstract public function get_expiration( $lock_type );
+
+	/**
+	 * Get the amount of time to set for a given lock. 60 seconds by default.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return int
+	 */
+	protected function get_duration( $lock_type ) {
+		return apply_filters( 'action_scheduler_lock_duration', self::$lock_duration, $lock_type );
+	}
+
+	/**
+	 * Get instance.
+	 *
+	 * @return ActionScheduler_Lock
+	 */
+	public static function instance() {
+		if ( empty( self::$locker ) ) {
+			$class        = apply_filters( 'action_scheduler_lock_class', 'ActionScheduler_OptionLock' );
+			self::$locker = new $class();
+		}
+		return self::$locker;
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Logger.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Logger.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Class ActionScheduler_Logger
+ *
+ * @codeCoverageIgnore
+ */
+abstract class ActionScheduler_Logger {
+
+	/**
+	 * Instance.
+	 *
+	 * @var null|self
+	 */
+	private static $logger = null;
+
+	/**
+	 * Get instance.
+	 *
+	 * @return ActionScheduler_Logger
+	 */
+	public static function instance() {
+		if ( empty( self::$logger ) ) {
+			$class        = apply_filters( 'action_scheduler_logger_class', 'ActionScheduler_wpCommentLogger' );
+			self::$logger = new $class();
+		}
+		return self::$logger;
+	}
+
+	/**
+	 * Create log entry.
+	 *
+	 * @param string        $action_id Action ID.
+	 * @param string        $message   Log message.
+	 * @param DateTime|null $date      Log date.
+	 *
+	 * @return string The log entry ID
+	 */
+	abstract public function log( $action_id, $message, ?DateTime $date = null );
+
+	/**
+	 * Get action's log entry.
+	 *
+	 * @param string $entry_id Entry ID.
+	 *
+	 * @return ActionScheduler_LogEntry
+	 */
+	abstract public function get_entry( $entry_id );
+
+	/**
+	 * Get action's logs.
+	 *
+	 * @param string $action_id Action ID.
+	 *
+	 * @return ActionScheduler_LogEntry[]
+	 */
+	abstract public function get_logs( $action_id );
+
+
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		$this->hook_stored_action();
+		add_action( 'action_scheduler_canceled_action', array( $this, 'log_canceled_action' ), 10, 1 );
+		add_action( 'action_scheduler_begin_execute', array( $this, 'log_started_action' ), 10, 2 );
+		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 3 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 3 );
+		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );
+		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
+		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 2 );
+		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 2 );
+		add_action( 'action_scheduler_failed_to_schedule_next_instance', array( $this, 'log_failed_schedule_next_instance' ), 10, 2 );
+		add_action( 'action_scheduler_bulk_cancel_actions', array( $this, 'bulk_log_cancel_actions' ), 10, 1 );
+	}
+
+	/**
+	 * Register callback for storing action.
+	 */
+	public function hook_stored_action() {
+		add_action( 'action_scheduler_stored_action', array( $this, 'log_stored_action' ) );
+	}
+
+	/**
+	 * Unhook callback for storing action.
+	 */
+	public function unhook_stored_action() {
+		remove_action( 'action_scheduler_stored_action', array( $this, 'log_stored_action' ) );
+	}
+
+	/**
+	 * Log action stored.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function log_stored_action( $action_id ) {
+		$this->log( $action_id, __( 'action created', 'action-scheduler' ) );
+	}
+
+	/**
+	 * Log action cancellation.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function log_canceled_action( $action_id ) {
+		$this->log( $action_id, __( 'action canceled', 'action-scheduler' ) );
+	}
+
+	/**
+	 * Log action start.
+	 *
+	 * @param int    $action_id Action ID.
+	 * @param string $context Action execution context.
+	 */
+	public function log_started_action( $action_id, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			/* translators: %s: context */
+			$message = sprintf( __( 'action started via %s', 'action-scheduler' ), $context );
+		} else {
+			$message = __( 'action started', 'action-scheduler' );
+		}
+		$this->log( $action_id, $message );
+	}
+
+	/**
+	 * Log action completion.
+	 *
+	 * @param int                         $action_id Action ID.
+	 * @param null|ActionScheduler_Action $action Action.
+	 * @param string                      $context Action execution context.
+	 */
+	public function log_completed_action( $action_id, $action = null, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			/* translators: %s: context */
+			$message = sprintf( __( 'action complete via %s', 'action-scheduler' ), $context );
+		} else {
+			$message = __( 'action complete', 'action-scheduler' );
+		}
+		$this->log( $action_id, $message );
+	}
+
+	/**
+	 * Log action failure.
+	 *
+	 * @param int       $action_id Action ID.
+	 * @param Exception $exception Exception.
+	 * @param string    $context Action execution context.
+	 */
+	public function log_failed_action( $action_id, Exception $exception, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			/* translators: 1: context 2: exception message */
+			$message = sprintf( __( 'action failed via %1$s: %2$s', 'action-scheduler' ), $context, $exception->getMessage() );
+		} else {
+			/* translators: %s: exception message */
+			$message = sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() );
+		}
+		$this->log( $action_id, $message );
+	}
+
+	/**
+	 * Log action timeout.
+	 *
+	 * @param int    $action_id  Action ID.
+	 * @param string $timeout Timeout.
+	 */
+	public function log_timed_out_action( $action_id, $timeout ) {
+		/* translators: %s: amount of time */
+		$this->log( $action_id, sprintf( __( 'action marked as failed after %s seconds. Unknown error occurred. Check server, PHP and database error logs to diagnose cause.', 'action-scheduler' ), $timeout ) );
+	}
+
+	/**
+	 * Log unexpected shutdown.
+	 *
+	 * @param int     $action_id Action ID.
+	 * @param mixed[] $error     Error.
+	 */
+	public function log_unexpected_shutdown( $action_id, $error ) {
+		if ( ! empty( $error ) ) {
+			/* translators: 1: error message 2: filename 3: line */
+			$this->log( $action_id, sprintf( __( 'unexpected shutdown: PHP Fatal error %1$s in %2$s on line %3$s', 'action-scheduler' ), $error['message'], $error['file'], $error['line'] ) );
+		}
+	}
+
+	/**
+	 * Log action reset.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function log_reset_action( $action_id ) {
+		$this->log( $action_id, __( 'action reset', 'action-scheduler' ) );
+	}
+
+	/**
+	 * Log ignored action.
+	 *
+	 * @param int    $action_id Action ID.
+	 * @param string $context Action execution context.
+	 */
+	public function log_ignored_action( $action_id, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			/* translators: %s: context */
+			$message = sprintf( __( 'action ignored via %s', 'action-scheduler' ), $context );
+		} else {
+			$message = __( 'action ignored', 'action-scheduler' );
+		}
+		$this->log( $action_id, $message );
+	}
+
+	/**
+	 * Log the failure of fetching the action.
+	 *
+	 * @param string         $action_id Action ID.
+	 * @param null|Exception $exception The exception which occurred when fetching the action. NULL by default for backward compatibility.
+	 */
+	public function log_failed_fetch_action( $action_id, ?Exception $exception = null ) {
+
+		if ( ! is_null( $exception ) ) {
+			/* translators: %s: exception message */
+			$log_message = sprintf( __( 'There was a failure fetching this action: %s', 'action-scheduler' ), $exception->getMessage() );
+		} else {
+			$log_message = __( 'There was a failure fetching this action', 'action-scheduler' );
+		}
+
+		$this->log( $action_id, $log_message );
+	}
+
+	/**
+	 * Log the failure of scheduling the action's next instance.
+	 *
+	 * @param int       $action_id Action ID.
+	 * @param Exception $exception Exception object.
+	 */
+	public function log_failed_schedule_next_instance( $action_id, Exception $exception ) {
+		/* translators: %s: exception message */
+		$this->log( $action_id, sprintf( __( 'There was a failure scheduling the next instance of this action: %s', 'action-scheduler' ), $exception->getMessage() ) );
+	}
+
+	/**
+	 * Bulk add cancel action log entries.
+	 *
+	 * Implemented here for backward compatibility. Should be implemented in parent loggers
+	 * for more performant bulk logging.
+	 *
+	 * @param array $action_ids List of action ID.
+	 */
+	public function bulk_log_cancel_actions( $action_ids ) {
+		if ( empty( $action_ids ) ) {
+			return;
+		}
+
+		foreach ( $action_ids as $action_id ) {
+			$this->log_canceled_action( $action_id );
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Store.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_Store.php
@@ -1,0 +1,506 @@
+<?php
+
+/**
+ * Class ActionScheduler_Store
+ *
+ * @codeCoverageIgnore
+ */
+abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
+	const STATUS_COMPLETE = 'complete';
+	const STATUS_PENDING  = 'pending';
+	const STATUS_RUNNING  = 'in-progress';
+	const STATUS_FAILED   = 'failed';
+	const STATUS_CANCELED = 'canceled';
+	const DEFAULT_CLASS   = 'ActionScheduler_wpPostStore';
+
+	/**
+	 * ActionScheduler_Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private static $store = null;
+
+	/**
+	 * Maximum length of args.
+	 *
+	 * @var int
+	 */
+	protected static $max_args_length = 191;
+
+	/**
+	 * Save action.
+	 *
+	 * @param ActionScheduler_Action $action Action to save.
+	 * @param null|DateTime          $scheduled_date Optional Date of the first instance
+	 *                                               to store. Otherwise uses the first date of the action's
+	 *                                               schedule.
+	 *
+	 * @return int The action ID
+	 */
+	abstract public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null );
+
+	/**
+	 * Get action.
+	 *
+	 * @param string $action_id Action ID.
+	 *
+	 * @return ActionScheduler_Action
+	 */
+	abstract public function fetch_action( $action_id );
+
+	/**
+	 * Find an action.
+	 *
+	 * Note: the query ordering changes based on the passed 'status' value.
+	 *
+	 * @param string $hook Action hook.
+	 * @param array  $params Parameters of the action to find.
+	 *
+	 * @return string|null ID of the next action matching the criteria or NULL if not found.
+	 */
+	public function find_action( $hook, $params = array() ) {
+		$params = wp_parse_args(
+			$params,
+			array(
+				'args'   => null,
+				'status' => self::STATUS_PENDING,
+				'group'  => '',
+			)
+		);
+
+		// These params are fixed for this method.
+		$params['hook']     = $hook;
+		$params['orderby']  = 'date';
+		$params['per_page'] = 1;
+
+		if ( ! empty( $params['status'] ) ) {
+			if ( self::STATUS_PENDING === $params['status'] ) {
+				$params['order'] = 'ASC'; // Find the next action that matches.
+			} else {
+				$params['order'] = 'DESC'; // Find the most recent action that matches.
+			}
+		}
+
+		$results = $this->query_actions( $params );
+
+		return empty( $results ) ? null : $results[0];
+	}
+
+	/**
+	 * Query for action count or list of action IDs.
+	 *
+	 * @since 3.3.0 $query['status'] accepts array of statuses instead of a single status.
+	 *
+	 * @param array  $query {
+	 *      Query filtering options.
+	 *
+	 *      @type string       $hook             The name of the actions. Optional.
+	 *      @type string|array $status           The status or statuses of the actions. Optional.
+	 *      @type array        $args             The args array of the actions. Optional.
+	 *      @type DateTime     $date             The scheduled date of the action. Used in UTC timezone. Optional.
+	 *      @type string       $date_compare     Operator for selecting by $date param. Accepted values are '!=', '>', '>=', '<', '<=', '='. Defaults to '<='.
+	 *      @type DateTime     $modified         The last modified date of the action. Used in UTC timezone. Optional.
+	 *      @type string       $modified_compare Operator for comparing $modified param. Accepted values are '!=', '>', '>=', '<', '<=', '='. Defaults to '<='.
+	 *      @type string       $group            The group the action belongs to. Optional.
+	 *      @type bool|int     $claimed          TRUE to find claimed actions, FALSE to find unclaimed actions, an int to find a specific claim ID. Optional.
+	 *      @type int          $per_page         Number of results to return. Defaults to 5.
+	 *      @type int          $offset           The query pagination offset. Defaults to 0.
+	 *      @type int          $orderby          Accepted values are 'hook', 'group', 'modified', 'date' or 'none'. Defaults to 'date'.
+	 *      @type string       $order            Accepted values are 'ASC' or 'DESC'. Defaults to 'ASC'.
+	 * }
+	 * @param string $query_type Whether to select or count the results. Default, select.
+	 *
+	 * @return string|array|null The IDs of actions matching the query. Null on failure.
+	 */
+	abstract public function query_actions( $query = array(), $query_type = 'select' );
+
+	/**
+	 * Run query to get a single action ID.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @see ActionScheduler_Store::query_actions for $query arg usage but 'per_page' and 'offset' can't be used.
+	 *
+	 * @param array $query Query parameters.
+	 *
+	 * @return int|null
+	 */
+	public function query_action( $query ) {
+		$query['per_page'] = 1;
+		$query['offset']   = 0;
+		$results           = $this->query_actions( $query );
+
+		if ( empty( $results ) ) {
+			return null;
+		} else {
+			return (int) $results[0];
+		}
+	}
+
+	/**
+	 * Get a count of all actions in the store, grouped by status
+	 *
+	 * @return array
+	 */
+	abstract public function action_counts();
+
+	/**
+	 * Get additional action counts.
+	 *
+	 * - add past-due actions
+	 *
+	 * @return array
+	 */
+	public function extra_action_counts() {
+		$extra_actions = array();
+
+		$pastdue_action_counts = (int) $this->query_actions(
+			array(
+				'status' => self::STATUS_PENDING,
+				'date'   => as_get_datetime_object(),
+			),
+			'count'
+		);
+
+		if ( $pastdue_action_counts ) {
+			$extra_actions['past-due'] = $pastdue_action_counts;
+		}
+
+		/**
+		 * Allows 3rd party code to add extra action counts (used in filters in the list table).
+		 *
+		 * @since 3.5.0
+		 * @param $extra_actions array Array with format action_count_identifier => action count.
+		 */
+		return apply_filters( 'action_scheduler_extra_action_counts', $extra_actions );
+	}
+
+	/**
+	 * Cancel action.
+	 *
+	 * @param string $action_id Action ID.
+	 */
+	abstract public function cancel_action( $action_id );
+
+	/**
+	 * Delete action.
+	 *
+	 * @param string $action_id Action ID.
+	 */
+	abstract public function delete_action( $action_id );
+
+	/**
+	 * Get action's schedule or run timestamp.
+	 *
+	 * @param string $action_id Action ID.
+	 *
+	 * @return DateTime The date the action is schedule to run, or the date that it ran.
+	 */
+	abstract public function get_date( $action_id );
+
+
+	/**
+	 * Make a claim.
+	 *
+	 * @param int           $max_actions Maximum number of actions to claim.
+	 * @param DateTime|null $before_date Claim only actions schedule before the given date. Defaults to now.
+	 * @param array         $hooks       Claim only actions with a hook or hooks.
+	 * @param string        $group       Claim only actions in the given group.
+	 *
+	 * @return ActionScheduler_ActionClaim
+	 */
+	abstract public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' );
+
+	/**
+	 * Get claim count.
+	 *
+	 * @return int
+	 */
+	abstract public function get_claim_count();
+
+	/**
+	 * Release the claim.
+	 *
+	 * @param ActionScheduler_ActionClaim $claim Claim object.
+	 */
+	abstract public function release_claim( ActionScheduler_ActionClaim $claim );
+
+	/**
+	 * Un-claim the action.
+	 *
+	 * @param string $action_id Action ID.
+	 */
+	abstract public function unclaim_action( $action_id );
+
+	/**
+	 * Mark action as failed.
+	 *
+	 * @param string $action_id Action ID.
+	 */
+	abstract public function mark_failure( $action_id );
+
+	/**
+	 * Log action's execution.
+	 *
+	 * @param string $action_id Actoin ID.
+	 */
+	abstract public function log_execution( $action_id );
+
+	/**
+	 * Mark action as complete.
+	 *
+	 * @param string $action_id Action ID.
+	 */
+	abstract public function mark_complete( $action_id );
+
+	/**
+	 * Get action's status.
+	 *
+	 * @param string $action_id Action ID.
+	 * @return string
+	 */
+	abstract public function get_status( $action_id );
+
+	/**
+	 * Get action's claim ID.
+	 *
+	 * @param string $action_id Action ID.
+	 * @return mixed
+	 */
+	abstract public function get_claim_id( $action_id );
+
+	/**
+	 * Find actions by claim ID.
+	 *
+	 * @param string $claim_id Claim ID.
+	 * @return array
+	 */
+	abstract public function find_actions_by_claim_id( $claim_id );
+
+	/**
+	 * Validate SQL operator.
+	 *
+	 * @param string $comparison_operator Operator.
+	 * @return string
+	 */
+	protected function validate_sql_comparator( $comparison_operator ) {
+		if ( in_array( $comparison_operator, array( '!=', '>', '>=', '<', '<=', '=' ), true ) ) {
+			return $comparison_operator;
+		}
+
+		return '=';
+	}
+
+	/**
+	 * Get the time MySQL formatted date/time string for an action's (next) scheduled date.
+	 *
+	 * @param ActionScheduler_Action $action Action.
+	 * @param null|DateTime          $scheduled_date Action's schedule date (optional).
+	 * @return string
+	 */
+	protected function get_scheduled_date_string( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
+		$next = is_null( $scheduled_date ) ? $action->get_schedule()->get_date() : $scheduled_date;
+
+		if ( ! $next ) {
+			$next = date_create();
+		}
+
+		$next->setTimezone( new DateTimeZone( 'UTC' ) );
+
+		return $next->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Get the time MySQL formatted date/time string for an action's (next) scheduled date.
+	 *
+	 * @param ActionScheduler_Action|null $action Action.
+	 * @param null|DateTime               $scheduled_date Action's scheduled date (optional).
+	 * @return string
+	 */
+	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
+		$next = is_null( $scheduled_date ) ? $action->get_schedule()->get_date() : $scheduled_date;
+
+		if ( ! $next ) {
+			$next = date_create();
+		}
+
+		ActionScheduler_TimezoneHelper::set_local_timezone( $next );
+		return $next->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Validate that we could decode action arguments.
+	 *
+	 * @param mixed $args      The decoded arguments.
+	 * @param int   $action_id The action ID.
+	 *
+	 * @throws ActionScheduler_InvalidActionException When the decoded arguments are invalid.
+	 */
+	protected function validate_args( $args, $action_id ) {
+		// Ensure we have an array of args.
+		if ( ! is_array( $args ) ) {
+			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id );
+		}
+
+		// Validate JSON decoding if possible.
+		if ( function_exists( 'json_last_error' ) && JSON_ERROR_NONE !== json_last_error() ) {
+			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id, $args );
+		}
+	}
+
+	/**
+	 * Validate a ActionScheduler_Schedule object.
+	 *
+	 * @param mixed $schedule  The unserialized ActionScheduler_Schedule object.
+	 * @param int   $action_id The action ID.
+	 *
+	 * @throws ActionScheduler_InvalidActionException When the schedule is invalid.
+	 */
+	protected function validate_schedule( $schedule, $action_id ) {
+		if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
+			throw ActionScheduler_InvalidActionException::from_schedule( $action_id, $schedule );
+		}
+	}
+
+	/**
+	 * InnoDB indexes have a maximum size of 767 bytes by default, which is only 191 characters with utf8mb4.
+	 *
+	 * Previously, AS wasn't concerned about args length, as we used the (unindex) post_content column. However,
+	 * with custom tables, we use an indexed VARCHAR column instead.
+	 *
+	 * @param  ActionScheduler_Action $action Action to be validated.
+	 * @throws InvalidArgumentException When json encoded args is too long.
+	 */
+	protected function validate_action( ActionScheduler_Action $action ) {
+		if ( strlen( wp_json_encode( $action->get_args() ) ) > static::$max_args_length ) {
+			// translators: %d is a number (maximum length of action arguments).
+			throw new InvalidArgumentException( sprintf( __( 'ActionScheduler_Action::$args too long. To ensure the args column can be indexed, action args should not be more than %d characters when encoded as JSON.', 'action-scheduler' ), static::$max_args_length ) );
+		}
+	}
+
+	/**
+	 * Cancel pending actions by hook.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $hook Hook name.
+	 *
+	 * @return void
+	 */
+	public function cancel_actions_by_hook( $hook ) {
+		$action_ids = true;
+		while ( ! empty( $action_ids ) ) {
+			$action_ids = $this->query_actions(
+				array(
+					'hook'     => $hook,
+					'status'   => self::STATUS_PENDING,
+					'per_page' => 1000,
+					'orderby'  => 'none',
+				)
+			);
+
+			$this->bulk_cancel_actions( $action_ids );
+		}
+	}
+
+	/**
+	 * Cancel pending actions by group.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $group Group slug.
+	 *
+	 * @return void
+	 */
+	public function cancel_actions_by_group( $group ) {
+		$action_ids = true;
+		while ( ! empty( $action_ids ) ) {
+			$action_ids = $this->query_actions(
+				array(
+					'group'    => $group,
+					'status'   => self::STATUS_PENDING,
+					'per_page' => 1000,
+					'orderby'  => 'none',
+				)
+			);
+
+			$this->bulk_cancel_actions( $action_ids );
+		}
+	}
+
+	/**
+	 * Cancel a set of action IDs.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param int[] $action_ids List of action IDs.
+	 *
+	 * @return void
+	 */
+	private function bulk_cancel_actions( $action_ids ) {
+		foreach ( $action_ids as $action_id ) {
+			$this->cancel_action( $action_id );
+		}
+
+		do_action( 'action_scheduler_bulk_cancel_actions', $action_ids );
+	}
+
+	/**
+	 * Get status labels.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_status_labels() {
+		return array(
+			self::STATUS_COMPLETE => __( 'Complete', 'action-scheduler' ),
+			self::STATUS_PENDING  => __( 'Pending', 'action-scheduler' ),
+			self::STATUS_RUNNING  => __( 'In-progress', 'action-scheduler' ),
+			self::STATUS_FAILED   => __( 'Failed', 'action-scheduler' ),
+			self::STATUS_CANCELED => __( 'Canceled', 'action-scheduler' ),
+		);
+	}
+
+	/**
+	 * Check if there are any pending scheduled actions due to run.
+	 *
+	 * @return string
+	 */
+	public function has_pending_actions_due() {
+		$pending_actions = $this->query_actions(
+			array(
+				'per_page' => 1,
+				'date'     => as_get_datetime_object(),
+				'status'   => self::STATUS_PENDING,
+				'orderby'  => 'none',
+			),
+			'count'
+		);
+
+		return ! empty( $pending_actions );
+	}
+
+	/**
+	 * Callable initialization function optionally overridden in derived classes.
+	 */
+	public function init() {}
+
+	/**
+	 * Callable function to mark an action as migrated optionally overridden in derived classes.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function mark_migrated( $action_id ) {}
+
+	/**
+	 * Get instance.
+	 *
+	 * @return ActionScheduler_Store
+	 */
+	public static function instance() {
+		if ( empty( self::$store ) ) {
+			$class       = apply_filters( 'action_scheduler_store_class', self::DEFAULT_CLASS );
+			self::$store = new $class();
+		}
+		return self::$store;
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * Class ActionScheduler_TimezoneHelper
+ */
+abstract class ActionScheduler_TimezoneHelper {
+
+	/**
+	 * DateTimeZone object.
+	 *
+	 * @var null|DateTimeZone
+	 */
+	private static $local_timezone = null;
+
+	/**
+	 * Set a DateTime's timezone to the WordPress site's timezone, or a UTC offset
+	 * if no timezone string is available.
+	 *
+	 * @since  2.1.0
+	 *
+	 * @param DateTime $date Timestamp.
+	 * @return ActionScheduler_DateTime
+	 */
+	public static function set_local_timezone( DateTime $date ) {
+
+		// Accept a DateTime for easier backward compatibility, even though we require methods on ActionScheduler_DateTime.
+		if ( ! is_a( $date, 'ActionScheduler_DateTime' ) ) {
+			$date = as_get_datetime_object( $date->format( 'U' ) );
+		}
+
+		if ( get_option( 'timezone_string' ) ) {
+			$date->setTimezone( new DateTimeZone( self::get_local_timezone_string() ) );
+		} else {
+			$date->setUtcOffset( self::get_local_timezone_offset() );
+		}
+
+		return $date;
+	}
+
+	/**
+	 * Helper to retrieve the timezone string for a site until a WP core method exists
+	 * (see https://core.trac.wordpress.org/ticket/24730).
+	 *
+	 * Adapted from wc_timezone_string() and https://secure.php.net/manual/en/function.timezone-name-from-abbr.php#89155.
+	 *
+	 * If no timezone string is set, and its not possible to match the UTC offset set for the site to a timezone
+	 * string, then an empty string will be returned, and the UTC offset should be used to set a DateTime's
+	 * timezone.
+	 *
+	 * @since 2.1.0
+	 * @param bool $reset Unused.
+	 * @return string PHP timezone string for the site or empty if no timezone string is available.
+	 */
+	protected static function get_local_timezone_string( $reset = false ) {
+		// If site timezone string exists, return it.
+		$timezone = get_option( 'timezone_string' );
+		if ( $timezone ) {
+			return $timezone;
+		}
+
+		// Get UTC offset, if it isn't set then return UTC.
+		$utc_offset = intval( get_option( 'gmt_offset', 0 ) );
+		if ( 0 === $utc_offset ) {
+			return 'UTC';
+		}
+
+		// Adjust UTC offset from hours to seconds.
+		$utc_offset *= 3600;
+
+		// Attempt to guess the timezone string from the UTC offset.
+		$timezone = timezone_name_from_abbr( '', $utc_offset );
+		if ( $timezone ) {
+			return $timezone;
+		}
+
+		// Last try, guess timezone string manually.
+		foreach ( timezone_abbreviations_list() as $abbr ) {
+			foreach ( $abbr as $city ) {
+				if ( (bool) date( 'I' ) === (bool) $city['dst'] && $city['timezone_id'] && intval( $city['offset'] ) === $utc_offset ) { // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date	 -- we are actually interested in the runtime timezone.
+					return $city['timezone_id'];
+				}
+			}
+		}
+
+		// No timezone string.
+		return '';
+	}
+
+	/**
+	 * Get timezone offset in seconds.
+	 *
+	 * @since  2.1.0
+	 * @return float
+	 */
+	protected static function get_local_timezone_offset() {
+		$timezone = get_option( 'timezone_string' );
+
+		if ( $timezone ) {
+			$timezone_object = new DateTimeZone( $timezone );
+			return $timezone_object->getOffset( new DateTime( 'now' ) );
+		} else {
+			return floatval( get_option( 'gmt_offset', 0 ) ) * HOUR_IN_SECONDS;
+		}
+	}
+
+	/**
+	 * Get local timezone.
+	 *
+	 * @param bool $reset Toggle to discard stored value.
+	 * @deprecated 2.1.0
+	 */
+	public static function get_local_timezone( $reset = false ) {
+		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
+		if ( $reset ) {
+			self::$local_timezone = null;
+		}
+		if ( ! isset( self::$local_timezone ) ) {
+			$tzstring = get_option( 'timezone_string' );
+
+			if ( empty( $tzstring ) ) {
+				$gmt_offset = absint( get_option( 'gmt_offset' ) );
+				if ( 0 === $gmt_offset ) {
+					$tzstring = 'UTC';
+				} else {
+					$gmt_offset *= HOUR_IN_SECONDS;
+					$tzstring    = timezone_name_from_abbr( '', $gmt_offset, 1 );
+
+					// If there's no timezone string, try again with no DST.
+					if ( false === $tzstring ) {
+						$tzstring = timezone_name_from_abbr( '', $gmt_offset, 0 );
+					}
+
+					// Try mapping to the first abbreviation we can find.
+					if ( false === $tzstring ) {
+						$is_dst = date( 'I' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date	 -- we are actually interested in the runtime timezone.
+						foreach ( timezone_abbreviations_list() as $abbr ) {
+							foreach ( $abbr as $city ) {
+								if ( $city['dst'] === $is_dst && $city['offset'] === $gmt_offset ) {
+									// If there's no valid timezone ID, keep looking.
+									if ( is_null( $city['timezone_id'] ) ) {
+										continue;
+									}
+
+									$tzstring = $city['timezone_id'];
+									break 2;
+								}
+							}
+						}
+					}
+
+					// If we still have no valid string, then fall back to UTC.
+					if ( false === $tzstring ) {
+						$tzstring = 'UTC';
+					}
+				}
+			}
+
+			self::$local_timezone = new DateTimeZone( $tzstring );
+		}
+		return self::$local_timezone;
+	}
+}

--- a/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_WPCLI_Command.php
+++ b/includes/lib/action-scheduler/classes/abstracts/ActionScheduler_WPCLI_Command.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Abstract for WP-CLI commands.
+ */
+abstract class ActionScheduler_WPCLI_Command extends \WP_CLI_Command {
+
+	const DATE_FORMAT = 'Y-m-d H:i:s O';
+
+	/**
+	 * Keyed arguments.
+	 *
+	 * @var string[]
+	 */
+	protected $args;
+
+	/**
+	 * Positional arguments.
+	 *
+	 * @var array<string, string>
+	 */
+	protected $assoc_args;
+
+	/**
+	 * Construct.
+	 *
+	 * @param string[]              $args       Positional arguments.
+	 * @param array<string, string> $assoc_args Keyed arguments.
+	 * @throws \Exception When loading a CLI command file outside of WP CLI context.
+	 */
+	public function __construct( array $args, array $assoc_args ) {
+		if ( ! defined( 'WP_CLI' ) || ! constant( 'WP_CLI' ) ) {
+			/* translators: %s php class name */
+			throw new \Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'action-scheduler' ), get_class( $this ) ) );
+		}
+
+		$this->args       = $args;
+		$this->assoc_args = $assoc_args;
+	}
+
+	/**
+	 * Execute command.
+	 */
+	abstract public function execute();
+
+	/**
+	 * Get the scheduled date in a human friendly format.
+	 *
+	 * @see ActionScheduler_ListTable::get_schedule_display_string()
+	 * @param ActionScheduler_Schedule $schedule Schedule.
+	 * @return string
+	 */
+	protected function get_schedule_display_string( ActionScheduler_Schedule $schedule ) {
+
+		$schedule_display_string = '';
+
+		if ( ! $schedule->get_date() ) {
+			return '0000-00-00 00:00:00';
+		}
+
+		$next_timestamp = $schedule->get_date()->getTimestamp();
+
+		$schedule_display_string .= $schedule->get_date()->format( static::DATE_FORMAT );
+
+		return $schedule_display_string;
+	}
+
+	/**
+	 * Transforms arguments with '__' from CSV into expected arrays.
+	 *
+	 * @see \WP_CLI\CommandWithDBObject::process_csv_arguments_to_arrays()
+	 * @link https://github.com/wp-cli/entity-command/blob/c270cc9a2367cb8f5845f26a6b5e203397c91392/src/WP_CLI/CommandWithDBObject.php#L99
+	 * @return void
+	 */
+	protected function process_csv_arguments_to_arrays() {
+		foreach ( $this->assoc_args as $k => $v ) {
+			if ( false !== strpos( $k, '__' ) ) {
+				$this->assoc_args[ $k ] = explode( ',', $v );
+			}
+		}
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/actions/ActionScheduler_Action.php
+++ b/includes/lib/action-scheduler/classes/actions/ActionScheduler_Action.php
@@ -1,0 +1,191 @@
+<?php
+
+/**
+ * Class ActionScheduler_Action
+ */
+class ActionScheduler_Action {
+	/**
+	 * Action's hook.
+	 *
+	 * @var string
+	 */
+	protected $hook = '';
+
+	/**
+	 * Action's args.
+	 *
+	 * @var array<string, mixed>
+	 */
+	protected $args = array();
+
+	/**
+	 * Action's schedule.
+	 *
+	 * @var ActionScheduler_Schedule
+	 */
+	protected $schedule = null;
+
+	/**
+	 * Action's group.
+	 *
+	 * @var string
+	 */
+	protected $group = '';
+
+	/**
+	 * Priorities are conceptually similar to those used for regular WordPress actions.
+	 * Like those, a lower priority takes precedence over a higher priority and the default
+	 * is 10.
+	 *
+	 * Unlike regular WordPress actions, the priority of a scheduled action is strictly an
+	 * integer and should be kept within the bounds 0-255 (anything outside the bounds will
+	 * be brought back into the acceptable range).
+	 *
+	 * @var int
+	 */
+	protected $priority = 10;
+
+	/**
+	 * Construct.
+	 *
+	 * @param string                        $hook Action's hook.
+	 * @param mixed[]                       $args Action's arguments.
+	 * @param null|ActionScheduler_Schedule $schedule Action's schedule.
+	 * @param string                        $group Action's group.
+	 */
+	public function __construct( $hook, array $args = array(), ?ActionScheduler_Schedule $schedule = null, $group = '' ) {
+		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
+		$this->set_hook( $hook );
+		$this->set_schedule( $schedule );
+		$this->set_args( $args );
+		$this->set_group( $group );
+	}
+
+	/**
+	 * Executes the action.
+	 *
+	 * If no callbacks are registered, an exception will be thrown and the action will not be
+	 * fired. This is useful to help detect cases where the code responsible for setting up
+	 * a scheduled action no longer exists.
+	 *
+	 * @throws Exception If no callbacks are registered for this action.
+	 */
+	public function execute() {
+		$hook = $this->get_hook();
+
+		if ( ! has_action( $hook ) ) {
+			throw new Exception(
+				sprintf(
+					/* translators: 1: action hook. */
+					__( 'Scheduled action for %1$s will not be executed as no callbacks are registered.', 'action-scheduler' ),
+					$hook
+				)
+			);
+		}
+
+		do_action_ref_array( $hook, array_values( $this->get_args() ) );
+	}
+
+	/**
+	 * Set action's hook.
+	 *
+	 * @param string $hook Action's hook.
+	 */
+	protected function set_hook( $hook ) {
+		$this->hook = $hook;
+	}
+
+	/**
+	 * Get action's hook.
+	 */
+	public function get_hook() {
+		return $this->hook;
+	}
+
+	/**
+	 * Set action's schedule.
+	 *
+	 * @param ActionScheduler_Schedule $schedule Action's schedule.
+	 */
+	protected function set_schedule( ActionScheduler_Schedule $schedule ) {
+		$this->schedule = $schedule;
+	}
+
+	/**
+	 * Action's schedule.
+	 *
+	 * @return ActionScheduler_Schedule
+	 */
+	public function get_schedule() {
+		return $this->schedule;
+	}
+
+	/**
+	 * Set action's args.
+	 *
+	 * @param mixed[] $args Action's arguments.
+	 */
+	protected function set_args( array $args ) {
+		$this->args = $args;
+	}
+
+	/**
+	 * Get action's args.
+	 */
+	public function get_args() {
+		return $this->args;
+	}
+
+	/**
+	 * Section action's group.
+	 *
+	 * @param string $group Action's group.
+	 */
+	protected function set_group( $group ) {
+		$this->group = $group;
+	}
+
+	/**
+	 * Action's group.
+	 *
+	 * @return string
+	 */
+	public function get_group() {
+		return $this->group;
+	}
+
+	/**
+	 * Action has not finished.
+	 *
+	 * @return bool
+	 */
+	public function is_finished() {
+		return false;
+	}
+
+	/**
+	 * Sets the priority of the action.
+	 *
+	 * @param int $priority Priority level (lower is higher priority). Should be in the range 0-255.
+	 *
+	 * @return void
+	 */
+	public function set_priority( $priority ) {
+		if ( $priority < 0 ) {
+			$priority = 0;
+		} elseif ( $priority > 255 ) {
+			$priority = 255;
+		}
+
+		$this->priority = (int) $priority;
+	}
+
+	/**
+	 * Gets the action priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority() {
+		return $this->priority;
+	}
+}

--- a/includes/lib/action-scheduler/classes/actions/ActionScheduler_CanceledAction.php
+++ b/includes/lib/action-scheduler/classes/actions/ActionScheduler_CanceledAction.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class ActionScheduler_CanceledAction
+ *
+ * Stored action which was canceled and therefore acts like a finished action but should always return a null schedule,
+ * regardless of schedule passed to its constructor.
+ */
+class ActionScheduler_CanceledAction extends ActionScheduler_FinishedAction {
+
+	/**
+	 * Construct.
+	 *
+	 * @param string                        $hook Action's hook.
+	 * @param array                         $args Action's arguments.
+	 * @param null|ActionScheduler_Schedule $schedule Action's schedule.
+	 * @param string                        $group Action's group.
+	 */
+	public function __construct( $hook, array $args = array(), ?ActionScheduler_Schedule $schedule = null, $group = '' ) {
+		parent::__construct( $hook, $args, $schedule, $group );
+		if ( is_null( $schedule ) ) {
+			$this->set_schedule( new ActionScheduler_NullSchedule() );
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/actions/ActionScheduler_FinishedAction.php
+++ b/includes/lib/action-scheduler/classes/actions/ActionScheduler_FinishedAction.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Class ActionScheduler_FinishedAction
+ */
+class ActionScheduler_FinishedAction extends ActionScheduler_Action {
+
+	/**
+	 * Execute action.
+	 */
+	public function execute() {
+		// don't execute.
+	}
+
+	/**
+	 * Get finished state.
+	 */
+	public function is_finished() {
+		return true;
+	}
+}

--- a/includes/lib/action-scheduler/classes/actions/ActionScheduler_NullAction.php
+++ b/includes/lib/action-scheduler/classes/actions/ActionScheduler_NullAction.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Class ActionScheduler_NullAction
+ */
+class ActionScheduler_NullAction extends ActionScheduler_Action {
+
+	/**
+	 * Construct.
+	 *
+	 * @param string                        $hook Action hook.
+	 * @param mixed[]                       $args Action arguments.
+	 * @param null|ActionScheduler_Schedule $schedule Action schedule.
+	 */
+	public function __construct( $hook = '', array $args = array(), ?ActionScheduler_Schedule $schedule = null ) {
+		$this->set_schedule( new ActionScheduler_NullSchedule() );
+	}
+
+	/**
+	 * Execute action.
+	 */
+	public function execute() {
+		// don't execute.
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_DBLogger.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Class ActionScheduler_DBLogger
+ *
+ * Action logs data table data store.
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_DBLogger extends ActionScheduler_Logger {
+
+	/**
+	 * Add a record to an action log.
+	 *
+	 * @param int           $action_id Action ID.
+	 * @param string        $message Message to be saved in the log entry.
+	 * @param DateTime|null $date Timestamp of the log entry.
+	 *
+	 * @return int     The log entry ID.
+	 */
+	public function log( $action_id, $message, ?DateTime $date = null ) {
+		if ( empty( $date ) ) {
+			$date = as_get_datetime_object();
+		} else {
+			$date = clone $date;
+		}
+
+		$date_gmt = $date->format( 'Y-m-d H:i:s' );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		$date_local = $date->format( 'Y-m-d H:i:s' );
+
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		global $wpdb;
+		$wpdb->insert(
+			$wpdb->actionscheduler_logs,
+			array(
+				'action_id'      => $action_id,
+				'message'        => $message,
+				'log_date_gmt'   => $date_gmt,
+				'log_date_local' => $date_local,
+			),
+			array( '%d', '%s', '%s', '%s' )
+		);
+
+		return $wpdb->insert_id;
+	}
+
+	/**
+	 * Retrieve an action log entry.
+	 *
+	 * @param int $entry_id Log entry ID.
+	 *
+	 * @return ActionScheduler_LogEntry
+	 */
+	public function get_entry( $entry_id ) {
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		global $wpdb;
+		$entry = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_logs} WHERE log_id=%d", $entry_id ) );
+
+		return $this->create_entry_from_db_record( $entry );
+	}
+
+	/**
+	 * Create an action log entry from a database record.
+	 *
+	 * @param object $record Log entry database record object.
+	 *
+	 * @return ActionScheduler_LogEntry
+	 */
+	private function create_entry_from_db_record( $record ) {
+		if ( empty( $record ) ) {
+			return new ActionScheduler_NullLogEntry();
+		}
+
+		if ( is_null( $record->log_date_gmt ) ) {
+			$date = as_get_datetime_object( ActionScheduler_StoreSchema::DEFAULT_DATE );
+		} else {
+			$date = as_get_datetime_object( $record->log_date_gmt );
+		}
+
+		return new ActionScheduler_LogEntry( $record->action_id, $record->message, $date );
+	}
+
+	/**
+	 * Retrieve an action's log entries from the database.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return ActionScheduler_LogEntry[]
+	 */
+	public function get_logs( $action_id ) {
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		global $wpdb;
+
+		$records = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_logs} WHERE action_id=%d", $action_id ) );
+
+		return array_map( array( $this, 'create_entry_from_db_record' ), $records );
+	}
+
+	/**
+	 * Initialize the data store.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		$table_maker = new ActionScheduler_LoggerSchema();
+		$table_maker->init();
+		$table_maker->register_tables();
+
+		parent::init();
+
+		add_action( 'action_scheduler_deleted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
+	}
+
+	/**
+	 * Delete the action logs for an action.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function clear_deleted_action_logs( $action_id ) {
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		global $wpdb;
+		$wpdb->delete( $wpdb->actionscheduler_logs, array( 'action_id' => $action_id ), array( '%d' ) );
+	}
+
+	/**
+	 * Bulk add cancel action log entries.
+	 *
+	 * @param array $action_ids List of action ID.
+	 */
+	public function bulk_log_cancel_actions( $action_ids ) {
+		if ( empty( $action_ids ) ) {
+			return;
+		}
+
+		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
+		global $wpdb;
+		$date     = as_get_datetime_object();
+		$date_gmt = $date->format( 'Y-m-d H:i:s' );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		$date_local = $date->format( 'Y-m-d H:i:s' );
+		$message    = __( 'action canceled', 'action-scheduler' );
+		$format     = '(%d, ' . $wpdb->prepare( '%s, %s, %s', $message, $date_gmt, $date_local ) . ')';
+		$sql_query  = "INSERT {$wpdb->actionscheduler_logs} (action_id, message, log_date_gmt, log_date_local) VALUES ";
+		$value_rows = array();
+
+		foreach ( $action_ids as $action_id ) {
+			$value_rows[] = $wpdb->prepare( $format, $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		$sql_query .= implode( ',', $value_rows );
+
+		$wpdb->query( $sql_query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php
@@ -1,0 +1,1295 @@
+<?php
+
+/**
+ * Class ActionScheduler_DBStore
+ *
+ * Action data table data store.
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_DBStore extends ActionScheduler_Store {
+
+	/**
+	 * Used to share information about the before_date property of claims internally.
+	 *
+	 * This is used in preference to passing the same information as a method param
+	 * for backwards-compatibility reasons.
+	 *
+	 * @var DateTime|null
+	 */
+	private $claim_before_date = null;
+
+	/**
+	 * Maximum length of args.
+	 *
+	 * @var int
+	 */
+	protected static $max_args_length = 8000;
+
+	/**
+	 * Maximum length of index.
+	 *
+	 * @var int
+	 */
+	protected static $max_index_length = 191;
+
+	/**
+	 * List of claim filters.
+	 *
+	 * @var array
+	 */
+	protected $claim_filters = array(
+		'group'          => '',
+		'hooks'          => '',
+		'exclude-groups' => '',
+	);
+
+	/**
+	 * Initialize the data store
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		$table_maker = new ActionScheduler_StoreSchema();
+		$table_maker->init();
+		$table_maker->register_tables();
+	}
+
+	/**
+	 * Save an action, checks if this is a unique action before actually saving.
+	 *
+	 * @param ActionScheduler_Action $action         Action object.
+	 * @param DateTime|null          $scheduled_date Optional schedule date. Default null.
+	 *
+	 * @return int                  Action ID.
+	 * @throws RuntimeException     Throws exception when saving the action fails.
+	 */
+	public function save_unique_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
+		return $this->save_action_to_db( $action, $scheduled_date, true );
+	}
+
+	/**
+	 * Save an action. Can save duplicate action as well, prefer using `save_unique_action` instead.
+	 *
+	 * @param ActionScheduler_Action $action Action object.
+	 * @param DateTime|null          $scheduled_date Optional schedule date. Default null.
+	 *
+	 * @return int Action ID.
+	 * @throws RuntimeException     Throws exception when saving the action fails.
+	 */
+	public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
+		return $this->save_action_to_db( $action, $scheduled_date, false );
+	}
+
+	/**
+	 * Save an action.
+	 *
+	 * @param ActionScheduler_Action $action Action object.
+	 * @param ?DateTime              $date Optional schedule date. Default null.
+	 * @param bool                   $unique Whether the action should be unique.
+	 *
+	 * @return int Action ID.
+	 * @throws \RuntimeException     Throws exception when saving the action fails.
+	 */
+	private function save_action_to_db( ActionScheduler_Action $action, ?DateTime $date = null, $unique = false ) {
+		global $wpdb;
+
+		try {
+			$this->validate_action( $action );
+
+			$data = array(
+				'hook'                 => $action->get_hook(),
+				'status'               => ( $action->is_finished() ? self::STATUS_COMPLETE : self::STATUS_PENDING ),
+				'scheduled_date_gmt'   => $this->get_scheduled_date_string( $action, $date ),
+				'scheduled_date_local' => $this->get_scheduled_date_string_local( $action, $date ),
+				'schedule'             => serialize( $action->get_schedule() ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				'group_id'             => current( $this->get_group_ids( $action->get_group() ) ),
+				'priority'             => $action->get_priority(),
+			);
+
+			$args = wp_json_encode( $action->get_args() );
+			if ( strlen( $args ) <= static::$max_index_length ) {
+				$data['args'] = $args;
+			} else {
+				$data['args']          = $this->hash_args( $args );
+				$data['extended_args'] = $args;
+			}
+
+			$insert_sql = $this->build_insert_sql( $data, $unique );
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $insert_sql should be already prepared.
+			$wpdb->query( $insert_sql );
+			$action_id = $wpdb->insert_id;
+
+			if ( is_wp_error( $action_id ) ) {
+				throw new \RuntimeException( $action_id->get_error_message() );
+			} elseif ( empty( $action_id ) ) {
+				if ( $unique ) {
+					return 0;
+				}
+				throw new \RuntimeException( $wpdb->last_error ? $wpdb->last_error : __( 'Database error.', 'action-scheduler' ) );
+			}
+
+			do_action( 'action_scheduler_stored_action', $action_id );
+
+			return $action_id;
+		} catch ( \Exception $e ) {
+			/* translators: %s: error message */
+			throw new \RuntimeException( sprintf( __( 'Error saving action: %s', 'action-scheduler' ), $e->getMessage() ), 0 );
+		}
+	}
+
+	/**
+	 * Helper function to build insert query.
+	 *
+	 * @param array $data Row data for action.
+	 * @param bool  $unique Whether the action should be unique.
+	 *
+	 * @return string Insert query.
+	 */
+	private function build_insert_sql( array $data, $unique ) {
+		global $wpdb;
+
+		$columns      = array_keys( $data );
+		$values       = array_values( $data );
+		$placeholders = array_map( array( $this, 'get_placeholder_for_column' ), $columns );
+
+		$table_name = ! empty( $wpdb->actionscheduler_actions ) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';
+
+		$column_sql      = '`' . implode( '`, `', $columns ) . '`';
+		$placeholder_sql = implode( ', ', $placeholders );
+		$where_clause    = $this->build_where_clause_for_insert( $data, $table_name, $unique );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare	 -- $column_sql and $where_clause are already prepared. $placeholder_sql is hardcoded.
+		$insert_query = $wpdb->prepare(
+			"
+INSERT INTO $table_name ( $column_sql )
+SELECT $placeholder_sql FROM DUAL
+WHERE ( $where_clause ) IS NULL",
+			$values
+		);
+		// phpcs:enable
+
+		return $insert_query;
+	}
+
+	/**
+	 * Helper method to build where clause for action insert statement.
+	 *
+	 * @param array  $data Row data for action.
+	 * @param string $table_name Action table name.
+	 * @param bool   $unique Where action should be unique.
+	 *
+	 * @return string Where clause to be used with insert.
+	 */
+	private function build_where_clause_for_insert( $data, $table_name, $unique ) {
+		global $wpdb;
+
+		if ( ! $unique ) {
+			return 'SELECT NULL FROM DUAL';
+		}
+
+		$pending_statuses            = array(
+			ActionScheduler_Store::STATUS_PENDING,
+			ActionScheduler_Store::STATUS_RUNNING,
+		);
+		$pending_status_placeholders = implode( ', ', array_fill( 0, count( $pending_statuses ), '%s' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $pending_status_placeholders is hardcoded.
+		$where_clause = $wpdb->prepare(
+			"
+SELECT action_id FROM $table_name
+WHERE status IN ( $pending_status_placeholders )
+AND hook = %s
+AND `group_id` = %d
+",
+			array_merge(
+				$pending_statuses,
+				array(
+					$data['hook'],
+					$data['group_id'],
+				)
+			)
+		);
+		// phpcs:enable
+
+		return "$where_clause" . ' LIMIT 1';
+	}
+
+	/**
+	 * Helper method to get $wpdb->prepare placeholder for a given column name.
+	 *
+	 * @param string $column_name Name of column in actions table.
+	 *
+	 * @return string Placeholder to use for given column.
+	 */
+	private function get_placeholder_for_column( $column_name ) {
+		$string_columns = array(
+			'hook',
+			'status',
+			'scheduled_date_gmt',
+			'scheduled_date_local',
+			'args',
+			'schedule',
+			'last_attempt_gmt',
+			'last_attempt_local',
+			'extended_args',
+		);
+
+		return in_array( $column_name, $string_columns, true ) ? '%s' : '%d';
+	}
+
+	/**
+	 * Generate a hash from json_encoded $args using MD5 as this isn't for security.
+	 *
+	 * @param string $args JSON encoded action args.
+	 * @return string
+	 */
+	protected function hash_args( $args ) {
+		return md5( $args );
+	}
+
+	/**
+	 * Get action args query param value from action args.
+	 *
+	 * @param array $args Action args.
+	 * @return string
+	 */
+	protected function get_args_for_query( $args ) {
+		$encoded = wp_json_encode( $args );
+		if ( strlen( $encoded ) <= static::$max_index_length ) {
+			return $encoded;
+		}
+		return $this->hash_args( $encoded );
+	}
+	/**
+	 * Get a group's ID based on its name/slug.
+	 *
+	 * @param string|array $slugs                The string name of a group, or names for several groups.
+	 * @param bool         $create_if_not_exists Whether to create the group if it does not already exist. Default, true - create the group.
+	 *
+	 * @return array The group IDs, if they exist or were successfully created. May be empty.
+	 */
+	protected function get_group_ids( $slugs, $create_if_not_exists = true ) {
+		$slugs     = (array) $slugs;
+		$group_ids = array();
+
+		if ( empty( $slugs ) ) {
+			return array();
+		}
+
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		foreach ( $slugs as $slug ) {
+			$group_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT group_id FROM {$wpdb->actionscheduler_groups} WHERE slug=%s", $slug ) );
+
+			if ( empty( $group_id ) && $create_if_not_exists ) {
+				$group_id = $this->create_group( $slug );
+			}
+
+			if ( $group_id ) {
+				$group_ids[] = $group_id;
+			}
+		}
+
+		return $group_ids;
+	}
+
+	/**
+	 * Create an action group.
+	 *
+	 * @param string $slug Group slug.
+	 *
+	 * @return int Group ID.
+	 */
+	protected function create_group( $slug ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) );
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Retrieve an action.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return ActionScheduler_Action
+	 */
+	public function fetch_action( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$data = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT a.*, g.slug AS `group` FROM {$wpdb->actionscheduler_actions} a LEFT JOIN {$wpdb->actionscheduler_groups} g ON a.group_id=g.group_id WHERE a.action_id=%d",
+				$action_id
+			)
+		);
+
+		if ( empty( $data ) ) {
+			return $this->get_null_action();
+		}
+
+		if ( ! empty( $data->extended_args ) ) {
+			$data->args = $data->extended_args;
+			unset( $data->extended_args );
+		}
+
+		// Convert NULL dates to zero dates.
+		$date_fields = array(
+			'scheduled_date_gmt',
+			'scheduled_date_local',
+			'last_attempt_gmt',
+			'last_attempt_gmt',
+		);
+		foreach ( $date_fields as $date_field ) {
+			if ( is_null( $data->$date_field ) ) {
+				$data->$date_field = ActionScheduler_StoreSchema::DEFAULT_DATE;
+			}
+		}
+
+		try {
+			$action = $this->make_action_from_db_record( $data );
+		} catch ( ActionScheduler_InvalidActionException $exception ) {
+			do_action( 'action_scheduler_failed_fetch_action', $action_id, $exception );
+			return $this->get_null_action();
+		}
+
+		return $action;
+	}
+
+	/**
+	 * Create a null action.
+	 *
+	 * @return ActionScheduler_NullAction
+	 */
+	protected function get_null_action() {
+		return new ActionScheduler_NullAction();
+	}
+
+	/**
+	 * Create an action from a database record.
+	 *
+	 * @param object $data Action database record.
+	 *
+	 * @return ActionScheduler_Action|ActionScheduler_CanceledAction|ActionScheduler_FinishedAction
+	 */
+	protected function make_action_from_db_record( $data ) {
+
+		$hook     = $data->hook;
+		$args     = json_decode( $data->args, true );
+		$schedule = unserialize( $data->schedule ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+
+		$this->validate_args( $args, $data->action_id );
+		$this->validate_schedule( $schedule, $data->action_id );
+
+		if ( empty( $schedule ) ) {
+			$schedule = new ActionScheduler_NullSchedule();
+		}
+		$group = $data->group ? $data->group : '';
+
+		return ActionScheduler::factory()->get_stored_action( $data->status, $data->hook, $args, $schedule, $group, $data->priority );
+	}
+
+	/**
+	 * Returns the SQL statement to query (or count) actions.
+	 *
+	 * @since 3.3.0 $query['status'] accepts array of statuses instead of a single status.
+	 *
+	 * @param array  $query Filtering options.
+	 * @param string $select_or_count  Whether the SQL should select and return the IDs or just the row count.
+	 *
+	 * @return string SQL statement already properly escaped.
+	 * @throws \InvalidArgumentException If the query is invalid.
+	 * @throws \RuntimeException When "unknown partial args matching value".
+	 */
+	protected function get_query_actions_sql( array $query, $select_or_count = 'select' ) {
+
+		if ( ! in_array( $select_or_count, array( 'select', 'count' ), true ) ) {
+			throw new InvalidArgumentException( __( 'Invalid value for select or count parameter. Cannot query actions.', 'action-scheduler' ) );
+		}
+
+		$query = wp_parse_args(
+			$query,
+			array(
+				'hook'                  => '',
+				'args'                  => null,
+				'partial_args_matching' => 'off', // can be 'like' or 'json'.
+				'date'                  => null,
+				'date_compare'          => '<=',
+				'modified'              => null,
+				'modified_compare'      => '<=',
+				'group'                 => '',
+				'status'                => '',
+				'claimed'               => null,
+				'per_page'              => 5,
+				'offset'                => 0,
+				'orderby'               => 'date',
+				'order'                 => 'ASC',
+			)
+		);
+
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$db_server_info = is_callable( array( $wpdb, 'db_server_info' ) ) ? $wpdb->db_server_info() : $wpdb->db_version();
+		if ( false !== strpos( $db_server_info, 'MariaDB' ) ) {
+			$supports_json = version_compare(
+				PHP_VERSION_ID >= 80016 ? $wpdb->db_version() : preg_replace( '/[^0-9.].*/', '', str_replace( '5.5.5-', '', $db_server_info ) ),
+				'10.2',
+				'>='
+			);
+		} else {
+			$supports_json = version_compare( $wpdb->db_version(), '5.7', '>=' );
+		}
+
+		$sql        = ( 'count' === $select_or_count ) ? 'SELECT count(a.action_id)' : 'SELECT a.action_id';
+		$sql       .= " FROM {$wpdb->actionscheduler_actions} a";
+		$sql_params = array();
+
+		if ( ! empty( $query['group'] ) || 'group' === $query['orderby'] ) {
+			$sql .= " LEFT JOIN {$wpdb->actionscheduler_groups} g ON g.group_id=a.group_id";
+		}
+
+		$sql .= ' WHERE 1=1';
+
+		if ( ! empty( $query['group'] ) ) {
+			$sql         .= ' AND g.slug=%s';
+			$sql_params[] = $query['group'];
+		}
+
+		if ( ! empty( $query['hook'] ) ) {
+			$sql         .= ' AND a.hook=%s';
+			$sql_params[] = $query['hook'];
+		}
+
+		if ( ! is_null( $query['args'] ) ) {
+			switch ( $query['partial_args_matching'] ) {
+				case 'json':
+					if ( ! $supports_json ) {
+						throw new \RuntimeException( __( 'JSON partial matching not supported in your environment. Please check your MySQL/MariaDB version.', 'action-scheduler' ) );
+					}
+					$supported_types = array(
+						'integer' => '%d',
+						'boolean' => '%s',
+						'double'  => '%f',
+						'string'  => '%s',
+					);
+					foreach ( $query['args'] as $key => $value ) {
+						$value_type = gettype( $value );
+						if ( 'boolean' === $value_type ) {
+							$value = $value ? 'true' : 'false';
+						}
+						$placeholder = isset( $supported_types[ $value_type ] ) ? $supported_types[ $value_type ] : false;
+						if ( ! $placeholder ) {
+							throw new \RuntimeException(
+								sprintf(
+									/* translators: %s: provided value type */
+									__( 'The value type for the JSON partial matching is not supported. Must be either integer, boolean, double or string. %s type provided.', 'action-scheduler' ),
+									$value_type
+								)
+							);
+						}
+						$sql         .= ' AND JSON_EXTRACT(a.args, %s)=' . $placeholder;
+						$sql_params[] = '$.' . $key;
+						$sql_params[] = $value;
+					}
+					break;
+				case 'like':
+					foreach ( $query['args'] as $key => $value ) {
+						$sql         .= ' AND a.args LIKE %s';
+						$json_partial = $wpdb->esc_like( trim( wp_json_encode( array( $key => $value ) ), '{}' ) );
+						$sql_params[] = "%{$json_partial}%";
+					}
+					break;
+				case 'off':
+					$sql         .= ' AND a.args=%s';
+					$sql_params[] = $this->get_args_for_query( $query['args'] );
+					break;
+				default:
+					throw new \RuntimeException( __( 'Unknown partial args matching value.', 'action-scheduler' ) );
+			}
+		}
+
+		if ( $query['status'] ) {
+			$statuses     = (array) $query['status'];
+			$placeholders = array_fill( 0, count( $statuses ), '%s' );
+			$sql         .= ' AND a.status IN (' . join( ', ', $placeholders ) . ')';
+			$sql_params   = array_merge( $sql_params, array_values( $statuses ) );
+		}
+
+		if ( $query['date'] instanceof \DateTime ) {
+			$date = clone $query['date'];
+			$date->setTimezone( new \DateTimeZone( 'UTC' ) );
+			$date_string  = $date->format( 'Y-m-d H:i:s' );
+			$comparator   = $this->validate_sql_comparator( $query['date_compare'] );
+			$sql         .= " AND a.scheduled_date_gmt $comparator %s";
+			$sql_params[] = $date_string;
+		}
+
+		if ( $query['modified'] instanceof \DateTime ) {
+			$modified = clone $query['modified'];
+			$modified->setTimezone( new \DateTimeZone( 'UTC' ) );
+			$date_string  = $modified->format( 'Y-m-d H:i:s' );
+			$comparator   = $this->validate_sql_comparator( $query['modified_compare'] );
+			$sql         .= " AND a.last_attempt_gmt $comparator %s";
+			$sql_params[] = $date_string;
+		}
+
+		if ( true === $query['claimed'] ) {
+			$sql .= ' AND a.claim_id != 0';
+		} elseif ( false === $query['claimed'] ) {
+			$sql .= ' AND a.claim_id = 0';
+		} elseif ( ! is_null( $query['claimed'] ) ) {
+			$sql         .= ' AND a.claim_id = %d';
+			$sql_params[] = $query['claimed'];
+		}
+
+		if ( ! empty( $query['search'] ) ) {
+			$sql .= ' AND (a.hook LIKE %s OR (a.extended_args IS NULL AND a.args LIKE %s) OR a.extended_args LIKE %s';
+			for ( $i = 0; $i < 3; $i++ ) {
+				$sql_params[] = sprintf( '%%%s%%', $query['search'] );
+			}
+
+			$search_claim_id = (int) $query['search'];
+			if ( $search_claim_id ) {
+				$sql         .= ' OR a.claim_id = %d';
+				$sql_params[] = $search_claim_id;
+			}
+
+			$sql .= ')';
+		}
+
+		if ( 'select' === $select_or_count ) {
+			if ( 'ASC' === strtoupper( $query['order'] ) ) {
+				$order = 'ASC';
+			} else {
+				$order = 'DESC';
+			}
+			switch ( $query['orderby'] ) {
+				case 'hook':
+					$sql .= " ORDER BY a.hook $order";
+					break;
+				case 'group':
+					$sql .= " ORDER BY g.slug $order";
+					break;
+				case 'modified':
+					$sql .= " ORDER BY a.last_attempt_gmt $order";
+					break;
+				case 'none':
+					break;
+				case 'action_id':
+					$sql .= " ORDER BY a.action_id $order";
+					break;
+				case 'date':
+				default:
+					$sql .= " ORDER BY a.scheduled_date_gmt $order";
+					break;
+			}
+
+			if ( $query['per_page'] > 0 ) {
+				$sql         .= ' LIMIT %d, %d';
+				$sql_params[] = $query['offset'];
+				$sql_params[] = $query['per_page'];
+			}
+		}
+
+		if ( ! empty( $sql_params ) ) {
+			$sql = $wpdb->prepare( $sql, $sql_params ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		return $sql;
+	}
+
+	/**
+	 * Query for action count or list of action IDs.
+	 *
+	 * @since 3.3.0 $query['status'] accepts array of statuses instead of a single status.
+	 *
+	 * @see ActionScheduler_Store::query_actions for $query arg usage.
+	 *
+	 * @param array  $query      Query filtering options.
+	 * @param string $query_type Whether to select or count the results. Defaults to select.
+	 *
+	 * @return string|array|null The IDs of actions matching the query. Null on failure.
+	 */
+	public function query_actions( $query = array(), $query_type = 'select' ) {
+		/**
+		 * Global.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$sql = $this->get_query_actions_sql( $query, $query_type );
+
+		return ( 'count' === $query_type ) ? $wpdb->get_var( $sql ) : $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoSql, WordPress.DB.DirectDatabaseQuery.NoCaching
+	}
+
+	/**
+	 * Get a count of all actions in the store, grouped by status.
+	 *
+	 * @return array Set of 'status' => int $count pairs for statuses with 1 or more actions of that status.
+	 */
+	public function action_counts() {
+		global $wpdb;
+
+		$sql  = "SELECT a.status, count(a.status) as 'count'";
+		$sql .= " FROM {$wpdb->actionscheduler_actions} a";
+		$sql .= ' GROUP BY a.status';
+
+		$actions_count_by_status = array();
+		$action_stati_and_labels = $this->get_status_labels();
+
+		foreach ( $wpdb->get_results( $sql ) as $action_data ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			// Ignore any actions with invalid status.
+			if ( array_key_exists( $action_data->status, $action_stati_and_labels ) ) {
+				$actions_count_by_status[ $action_data->status ] = $action_data->count;
+			}
+		}
+
+		return $actions_count_by_status;
+	}
+
+	/**
+	 * Cancel an action.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException If the action update failed.
+	 */
+	public function cancel_action( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$updated = $wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'status' => self::STATUS_CANCELED ),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		if ( false === $updated ) {
+			/* translators: %s: action ID */
+			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to cancel this action. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		do_action( 'action_scheduler_canceled_action', $action_id );
+	}
+
+	/**
+	 * Cancel pending actions by hook.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $hook Hook name.
+	 *
+	 * @return void
+	 */
+	public function cancel_actions_by_hook( $hook ) {
+		$this->bulk_cancel_actions( array( 'hook' => $hook ) );
+	}
+
+	/**
+	 * Cancel pending actions by group.
+	 *
+	 * @param string $group Group slug.
+	 *
+	 * @return void
+	 */
+	public function cancel_actions_by_group( $group ) {
+		$this->bulk_cancel_actions( array( 'group' => $group ) );
+	}
+
+	/**
+	 * Bulk cancel actions.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param array $query_args Query parameters.
+	 */
+	protected function bulk_cancel_actions( $query_args ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		if ( ! is_array( $query_args ) ) {
+			return;
+		}
+
+		// Don't cancel actions that are already canceled.
+		if ( isset( $query_args['status'] ) && self::STATUS_CANCELED === $query_args['status'] ) {
+			return;
+		}
+
+		$action_ids = true;
+		$query_args = wp_parse_args(
+			$query_args,
+			array(
+				'per_page' => 1000,
+				'status'   => self::STATUS_PENDING,
+				'orderby'  => 'none',
+			)
+		);
+
+		while ( $action_ids ) {
+			$action_ids = $this->query_actions( $query_args );
+			if ( empty( $action_ids ) ) {
+				break;
+			}
+
+			$format     = array_fill( 0, count( $action_ids ), '%d' );
+			$query_in   = '(' . implode( ',', $format ) . ')';
+			$parameters = $action_ids;
+			array_unshift( $parameters, self::STATUS_CANCELED );
+
+			$wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->actionscheduler_actions} SET status = %s WHERE action_id IN {$query_in}", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$parameters
+				)
+			);
+
+			do_action( 'action_scheduler_bulk_cancel_actions', $action_ids );
+		}
+	}
+
+	/**
+	 * Delete an action.
+	 *
+	 * @param int $action_id Action ID.
+	 * @throws \InvalidArgumentException If the action deletion failed.
+	 */
+	public function delete_action( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$deleted = $wpdb->delete( $wpdb->actionscheduler_actions, array( 'action_id' => $action_id ), array( '%d' ) );
+		if ( empty( $deleted ) ) {
+			/* translators: %s is the action ID */
+			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to delete this action. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		do_action( 'action_scheduler_deleted_action', $action_id );
+	}
+
+	/**
+	 * Get the schedule date for an action.
+	 *
+	 * @param string $action_id Action ID.
+	 *
+	 * @return \DateTime The local date the action is scheduled to run, or the date that it ran.
+	 */
+	public function get_date( $action_id ) {
+		$date = $this->get_date_gmt( $action_id );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		return $date;
+	}
+
+	/**
+	 * Get the GMT schedule date for an action.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @throws \InvalidArgumentException If action cannot be identified.
+	 * @return \DateTime The GMT date the action is scheduled to run, or the date that it ran.
+	 */
+	protected function get_date_gmt( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$record = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d", $action_id ) );
+		if ( empty( $record ) ) {
+			/* translators: %s is the action ID */
+			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to determine the date of this action. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		if ( self::STATUS_PENDING === $record->status ) {
+			return as_get_datetime_object( $record->scheduled_date_gmt );
+		} else {
+			return as_get_datetime_object( $record->last_attempt_gmt );
+		}
+	}
+
+	/**
+	 * Stake a claim on actions.
+	 *
+	 * @param int           $max_actions Maximum number of action to include in claim.
+	 * @param DateTime|null $before_date Jobs must be schedule before this date. Defaults to now.
+	 * @param array         $hooks Hooks to filter for.
+	 * @param string        $group Group to filter for.
+	 *
+	 * @return ActionScheduler_ActionClaim
+	 */
+	public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
+		$claim_id = $this->generate_claim_id();
+
+		$this->claim_before_date = $before_date;
+		$this->claim_actions( $claim_id, $max_actions, $before_date, $hooks, $group );
+		$action_ids              = $this->find_actions_by_claim_id( $claim_id );
+		$this->claim_before_date = null;
+
+		return new ActionScheduler_ActionClaim( $claim_id, $action_ids );
+	}
+
+	/**
+	 * Generate a new action claim.
+	 *
+	 * @return int Claim ID.
+	 */
+	protected function generate_claim_id() {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$now = as_get_datetime_object();
+		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => $now->format( 'Y-m-d H:i:s' ) ) );
+
+		return $wpdb->insert_id;
+	}
+
+	/**
+	 * Set a claim filter.
+	 *
+	 * @param string $filter_name Claim filter name.
+	 * @param mixed  $filter_values Values to filter.
+	 * @return void
+	 */
+	public function set_claim_filter( $filter_name, $filter_values ) {
+		if ( isset( $this->claim_filters[ $filter_name ] ) ) {
+			$this->claim_filters[ $filter_name ] = $filter_values;
+		}
+	}
+
+	/**
+	 * Get the claim filter value.
+	 *
+	 * @param string $filter_name Claim filter name.
+	 * @return mixed
+	 */
+	public function get_claim_filter( $filter_name ) {
+		if ( isset( $this->claim_filters[ $filter_name ] ) ) {
+			return $this->claim_filters[ $filter_name ];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Mark actions claimed.
+	 *
+	 * @param string        $claim_id Claim Id.
+	 * @param int           $limit Number of action to include in claim.
+	 * @param DateTime|null $before_date Should use UTC timezone.
+	 * @param array         $hooks Hooks to filter for.
+	 * @param string        $group Group to filter for.
+	 *
+	 * @return int The number of actions that were claimed.
+	 * @throws \InvalidArgumentException Throws InvalidArgumentException if group doesn't exist.
+	 * @throws \RuntimeException Throws RuntimeException if unable to claim action.
+	 */
+	protected function claim_actions( $claim_id, $limit, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$now  = as_get_datetime_object();
+		$date = is_null( $before_date ) ? $now : clone $before_date;
+		// can't use $wpdb->update() because of the <= condition.
+		$update = "UPDATE {$wpdb->actionscheduler_actions} SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
+		$params = array(
+			$claim_id,
+			$now->format( 'Y-m-d H:i:s' ),
+			current_time( 'mysql' ),
+		);
+
+		// Set claim filters.
+		if ( ! empty( $hooks ) ) {
+			$this->set_claim_filter( 'hooks', $hooks );
+		} else {
+			$hooks = $this->get_claim_filter( 'hooks' );
+		}
+		if ( ! empty( $group ) ) {
+			$this->set_claim_filter( 'group', $group );
+		} else {
+			$group = $this->get_claim_filter( 'group' );
+		}
+
+		$where    = 'WHERE claim_id = 0 AND scheduled_date_gmt <= %s AND status=%s';
+		$params[] = $date->format( 'Y-m-d H:i:s' );
+		$params[] = self::STATUS_PENDING;
+
+		if ( ! empty( $hooks ) ) {
+			$placeholders = array_fill( 0, count( $hooks ), '%s' );
+			$where       .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
+			$params       = array_merge( $params, array_values( $hooks ) );
+		}
+
+		$group_operator = 'IN';
+		if ( empty( $group ) ) {
+			$group          = $this->get_claim_filter( 'exclude-groups' );
+			$group_operator = 'NOT IN';
+		}
+
+		if ( ! empty( $group ) ) {
+			$group_ids = $this->get_group_ids( $group, false );
+
+			// throw exception if no matching group(s) found, this matches ActionScheduler_wpPostStore's behaviour.
+			if ( empty( $group_ids ) ) {
+				throw new InvalidArgumentException(
+					sprintf(
+						/* translators: %s: group name(s) */
+						_n(
+							'The group "%s" does not exist.',
+							'The groups "%s" do not exist.',
+							is_array( $group ) ? count( $group ) : 1,
+							'action-scheduler'
+						),
+						$group
+					)
+				);
+			}
+
+			$id_list = implode( ',', array_map( 'intval', $group_ids ) );
+			$where  .= " AND group_id {$group_operator} ( $id_list )";
+		}
+
+		/**
+		 * Sets the order-by clause used in the action claim query.
+		 *
+		 * @since 3.4.0
+		 * @since 3.8.3 Made $claim_id and $hooks available.
+		 *
+		 * @param string $order_by_sql
+		 * @param string $claim_id Claim Id.
+		 * @param array  $hooks Hooks to filter for.
+		 */
+		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
+		$params[] = $limit;
+
+		$sql           = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
+		$rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		if ( false === $rows_affected ) {
+			$error = empty( $wpdb->last_error )
+				? _x( 'unknown', 'database error', 'action-scheduler' )
+				: $wpdb->last_error;
+
+			throw new \RuntimeException(
+				sprintf(
+					/* translators: %s database error. */
+					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+					$error
+				)
+			);
+		}
+
+		return (int) $rows_affected;
+	}
+
+	/**
+	 * Get the number of active claims.
+	 *
+	 * @return int
+	 */
+	public function get_claim_count() {
+		global $wpdb;
+
+		$sql = "SELECT COUNT(DISTINCT claim_id) FROM {$wpdb->actionscheduler_actions} WHERE claim_id != 0 AND status IN ( %s, %s)";
+		$sql = $wpdb->prepare( $sql, array( self::STATUS_PENDING, self::STATUS_RUNNING ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Return an action's claim ID, as stored in the claim_id column.
+	 *
+	 * @param string $action_id Action ID.
+	 * @return mixed
+	 */
+	public function get_claim_id( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$sql = "SELECT claim_id FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d";
+		$sql = $wpdb->prepare( $sql, $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return (int) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Retrieve the action IDs of action in a claim.
+	 *
+	 * @param  int $claim_id Claim ID.
+	 * @return int[]
+	 */
+	public function find_actions_by_claim_id( $claim_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$action_ids  = array();
+		$before_date = isset( $this->claim_before_date ) ? $this->claim_before_date : as_get_datetime_object();
+		$cut_off     = $before_date->format( 'Y-m-d H:i:s' );
+
+		$sql = $wpdb->prepare(
+			"SELECT action_id, scheduled_date_gmt FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC",
+			$claim_id
+		);
+
+		// Verify that the scheduled date for each action is within the expected bounds (in some unusual
+		// cases, we cannot depend on MySQL to honor all of the WHERE conditions we specify).
+		foreach ( $wpdb->get_results( $sql ) as $claimed_action ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			if ( $claimed_action->scheduled_date_gmt <= $cut_off ) {
+				$action_ids[] = absint( $claimed_action->action_id );
+			}
+		}
+
+		return $action_ids;
+	}
+
+	/**
+	 * Release actions from a claim and delete the claim.
+	 *
+	 * @param ActionScheduler_ActionClaim $claim Claim object.
+	 * @throws \RuntimeException When unable to release actions from claim.
+	 */
+	public function release_claim( ActionScheduler_ActionClaim $claim ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		/**
+		 * Deadlock warning: This function modifies actions to release them from claims that have been processed. Earlier, we used to it in a atomic query, i.e. we would update all actions belonging to a particular claim_id with claim_id = 0.
+		 * While this was functionally correct, it would cause deadlock, since this update query will hold a lock on the claim_id_.. index on the action table.
+		 * This allowed the possibility of a race condition, where the claimer query is also running at the same time, then the claimer query will also try to acquire a lock on the claim_id_.. index, and in this case if claim release query has already progressed to the point of acquiring the lock, but have not updated yet, it would cause a deadlock.
+		 *
+		 * We resolve this by getting all the actions_id that we want to release claim from in a separate query, and then releasing the claim on each of them. This way, our lock is acquired on the action_id index instead of the claim_id index. Note that the lock on claim_id will still be acquired, but it will only when we actually make the update, rather than when we select the actions.
+		 */
+		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d", $claim->get_id() ) );
+
+		$row_updates = 0;
+		if ( count( $action_ids ) > 0 ) {
+			$action_id_string = implode( ',', array_map( 'absint', $action_ids ) );
+			$row_updates      = $wpdb->query( "UPDATE {$wpdb->actionscheduler_actions} SET claim_id = 0 WHERE action_id IN ({$action_id_string})" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
+
+		if ( $row_updates < count( $action_ids ) ) {
+			throw new RuntimeException(
+				sprintf(
+					// translators: %d is an id.
+					__( 'Unable to release actions from claim id %d.', 'action-scheduler' ),
+					$claim->get_id()
+				)
+			);
+		}
+	}
+
+	/**
+	 * Remove the claim from an action.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
+	 */
+	public function unclaim_action( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'claim_id' => 0 ),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+	}
+
+	/**
+	 * Mark an action as failed.
+	 *
+	 * @param int $action_id Action ID.
+	 * @throws \InvalidArgumentException Throw an exception if action was not updated.
+	 */
+	public function mark_failure( $action_id ) {
+		/**
+		 * Global.
+
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$updated = $wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'status' => self::STATUS_FAILED ),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		if ( empty( $updated ) ) {
+			/* translators: %s is the action ID */
+			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to mark this action as having failed. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+	}
+
+	/**
+	 * Add execution message to action log.
+	 *
+	 * @throws Exception If the action status cannot be updated to self::STATUS_RUNNING ('in-progress').
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
+	 */
+	public function log_execution( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$sql = "UPDATE {$wpdb->actionscheduler_actions} SET attempts = attempts+1, status=%s, last_attempt_gmt = %s, last_attempt_local = %s WHERE action_id = %d";
+		$sql = $wpdb->prepare( $sql, self::STATUS_RUNNING, current_time( 'mysql', true ), current_time( 'mysql' ), $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$status_updated = $wpdb->query( $sql );
+
+		if ( ! $status_updated ) {
+			throw new Exception(
+				sprintf(
+					/* translators: 1: action ID. 2: status slug. */
+					__( 'Unable to update the status of action %1$d to %2$s.', 'action-scheduler' ),
+					$action_id,
+					self::STATUS_RUNNING
+				)
+			);
+		}
+	}
+
+	/**
+	 * Mark an action as complete.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
+	 * @throws \InvalidArgumentException Throw an exception if action was not updated.
+	 */
+	public function mark_complete( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$updated = $wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array(
+				'status'             => self::STATUS_COMPLETE,
+				'last_attempt_gmt'   => current_time( 'mysql', true ),
+				'last_attempt_local' => current_time( 'mysql' ),
+			),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		if ( empty( $updated ) ) {
+			/* translators: %s is the action ID */
+			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to mark this action as having completed. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+
+		/**
+		 * Fires after a scheduled action has been completed.
+		 *
+		 * @since 3.4.2
+		 *
+		 * @param int $action_id Action ID.
+		 */
+		do_action( 'action_scheduler_completed_action', $action_id );
+	}
+
+	/**
+	 * Get an action's status.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return string
+	 * @throws \InvalidArgumentException Throw an exception if not status was found for action_id.
+	 * @throws \RuntimeException Throw an exception if action status could not be retrieved.
+	 */
+	public function get_status( $action_id ) {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$sql    = "SELECT status FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d";
+		$sql    = $wpdb->prepare( $sql, $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$status = $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( is_null( $status ) ) {
+			throw new \InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
+		} elseif ( empty( $status ) ) {
+			throw new \RuntimeException( __( 'Unknown status found for action.', 'action-scheduler' ) );
+		} else {
+			return $status;
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_HybridStore.php
@@ -1,0 +1,460 @@
+<?php
+
+use ActionScheduler_Store as Store;
+use Action_Scheduler\Migration\Runner;
+use Action_Scheduler\Migration\Config;
+use Action_Scheduler\Migration\Controller;
+
+/**
+ * Class ActionScheduler_HybridStore
+ *
+ * A wrapper around multiple stores that fetches data from both.
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_HybridStore extends Store {
+	const DEMARKATION_OPTION = 'action_scheduler_hybrid_store_demarkation';
+
+	/**
+	 * Primary store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $primary_store;
+
+	/**
+	 * Secondary store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $secondary_store;
+
+	/**
+	 * Runner instance.
+	 *
+	 * @var Action_Scheduler\Migration\Runner
+	 */
+	private $migration_runner;
+
+	/**
+	 * The dividing line between IDs of actions created
+	 * by the primary and secondary stores.
+	 *
+	 * @var int
+	 *
+	 * Methods that accept an action ID will compare the ID against
+	 * this to determine which store will contain that ID. In almost
+	 * all cases, the ID should come from the primary store, but if
+	 * client code is bypassing the API functions and fetching IDs
+	 * from elsewhere, then there is a chance that an unmigrated ID
+	 * might be requested.
+	 */
+	private $demarkation_id = 0;
+
+	/**
+	 * ActionScheduler_HybridStore constructor.
+	 *
+	 * @param Config|null $config Migration config object.
+	 */
+	public function __construct( ?Config $config = null ) {
+		$this->demarkation_id = (int) get_option( self::DEMARKATION_OPTION, 0 );
+		if ( empty( $config ) ) {
+			$config = Controller::instance()->get_migration_config_object();
+		}
+		$this->primary_store    = $config->get_destination_store();
+		$this->secondary_store  = $config->get_source_store();
+		$this->migration_runner = new Runner( $config );
+	}
+
+	/**
+	 * Initialize the table data store tables.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		add_action( 'action_scheduler/created_table', array( $this, 'set_autoincrement' ), 10, 2 );
+		$this->primary_store->init();
+		$this->secondary_store->init();
+		remove_action( 'action_scheduler/created_table', array( $this, 'set_autoincrement' ), 10 );
+	}
+
+	/**
+	 * When the actions table is created, set its autoincrement
+	 * value to be one higher than the posts table to ensure that
+	 * there are no ID collisions.
+	 *
+	 * @param string $table_name Table name.
+	 * @param string $table_suffix Suffix of table name.
+	 *
+	 * @return void
+	 * @codeCoverageIgnore
+	 */
+	public function set_autoincrement( $table_name, $table_suffix ) {
+		if ( ActionScheduler_StoreSchema::ACTIONS_TABLE === $table_suffix ) {
+			if ( empty( $this->demarkation_id ) ) {
+				$this->demarkation_id = $this->set_demarkation_id();
+			}
+
+			/**
+			 * Global.
+			 *
+			 * @var \wpdb $wpdb
+			 */
+			global $wpdb;
+
+			/**
+			 * A default date of '0000-00-00 00:00:00' is invalid in MySQL 5.7 when configured with
+			 * sql_mode including both STRICT_TRANS_TABLES and NO_ZERO_DATE.
+			 */
+			$default_date = new DateTime( 'tomorrow' );
+			$null_action  = new ActionScheduler_NullAction();
+			$date_gmt     = $this->get_scheduled_date_string( $null_action, $default_date );
+			$date_local   = $this->get_scheduled_date_string_local( $null_action, $default_date );
+
+			$row_count = $wpdb->insert(
+				$wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE},
+				array(
+					'action_id'            => $this->demarkation_id,
+					'hook'                 => '',
+					'status'               => '',
+					'scheduled_date_gmt'   => $date_gmt,
+					'scheduled_date_local' => $date_local,
+					'last_attempt_gmt'     => $date_gmt,
+					'last_attempt_local'   => $date_local,
+				)
+			);
+			if ( $row_count > 0 ) {
+				$wpdb->delete(
+					$wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE},
+					array( 'action_id' => $this->demarkation_id )
+				);
+			}
+		}
+	}
+
+	/**
+	 * Store the demarkation id in WP options.
+	 *
+	 * @param int $id The ID to set as the demarkation point between the two stores
+	 *                Leave null to use the next ID from the WP posts table.
+	 *
+	 * @return int The new ID.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	private function set_demarkation_id( $id = null ) {
+		if ( empty( $id ) ) {
+			/**
+			 * Global.
+			 *
+			 * @var \wpdb $wpdb
+			 */
+			global $wpdb;
+
+			$id = (int) $wpdb->get_var( "SELECT MAX(ID) FROM $wpdb->posts" );
+			$id++;
+		}
+		update_option( self::DEMARKATION_OPTION, $id );
+
+		return $id;
+	}
+
+	/**
+	 * Find the first matching action from the secondary store.
+	 * If it exists, migrate it to the primary store immediately.
+	 * After it migrates, the secondary store will logically contain
+	 * the next matching action, so return the result thence.
+	 *
+	 * @param string $hook Action's hook.
+	 * @param array  $params Action's arguments.
+	 *
+	 * @return string
+	 */
+	public function find_action( $hook, $params = array() ) {
+		$found_unmigrated_action = $this->secondary_store->find_action( $hook, $params );
+		if ( ! empty( $found_unmigrated_action ) ) {
+			$this->migrate( array( $found_unmigrated_action ) );
+		}
+
+		return $this->primary_store->find_action( $hook, $params );
+	}
+
+	/**
+	 * Find actions matching the query in the secondary source first.
+	 * If any are found, migrate them immediately. Then the secondary
+	 * store will contain the canonical results.
+	 *
+	 * @param array  $query Query arguments.
+	 * @param string $query_type Whether to select or count the results. Default, select.
+	 *
+	 * @return int[]
+	 */
+	public function query_actions( $query = array(), $query_type = 'select' ) {
+		$found_unmigrated_actions = $this->secondary_store->query_actions( $query, 'select' );
+		if ( ! empty( $found_unmigrated_actions ) ) {
+			$this->migrate( $found_unmigrated_actions );
+		}
+
+		return $this->primary_store->query_actions( $query, $query_type );
+	}
+
+	/**
+	 * Get a count of all actions in the store, grouped by status
+	 *
+	 * @return array Set of 'status' => int $count pairs for statuses with 1 or more actions of that status.
+	 */
+	public function action_counts() {
+		$unmigrated_actions_count = $this->secondary_store->action_counts();
+		$migrated_actions_count   = $this->primary_store->action_counts();
+		$actions_count_by_status  = array();
+
+		foreach ( $this->get_status_labels() as $status_key => $status_label ) {
+
+			$count = 0;
+
+			if ( isset( $unmigrated_actions_count[ $status_key ] ) ) {
+				$count += $unmigrated_actions_count[ $status_key ];
+			}
+
+			if ( isset( $migrated_actions_count[ $status_key ] ) ) {
+				$count += $migrated_actions_count[ $status_key ];
+			}
+
+			$actions_count_by_status[ $status_key ] = $count;
+		}
+
+		$actions_count_by_status = array_filter( $actions_count_by_status );
+
+		return $actions_count_by_status;
+	}
+
+	/**
+	 * If any actions would have been claimed by the secondary store,
+	 * migrate them immediately, then ask the primary store for the
+	 * canonical claim.
+	 *
+	 * @param int           $max_actions Maximum number of actions to claim.
+	 * @param null|DateTime $before_date Latest timestamp of actions to claim.
+	 * @param string[]      $hooks Hook of actions to claim.
+	 * @param string        $group Group of actions to claim.
+	 *
+	 * @return ActionScheduler_ActionClaim
+	 */
+	public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
+		$claim = $this->secondary_store->stake_claim( $max_actions, $before_date, $hooks, $group );
+
+		$claimed_actions = $claim->get_actions();
+		if ( ! empty( $claimed_actions ) ) {
+			$this->migrate( $claimed_actions );
+		}
+
+		$this->secondary_store->release_claim( $claim );
+
+		return $this->primary_store->stake_claim( $max_actions, $before_date, $hooks, $group );
+	}
+
+	/**
+	 * Migrate a list of actions to the table data store.
+	 *
+	 * @param array $action_ids List of action IDs.
+	 */
+	private function migrate( $action_ids ) {
+		$this->migration_runner->migrate_actions( $action_ids );
+	}
+
+	/**
+	 * Save an action to the primary store.
+	 *
+	 * @param ActionScheduler_Action $action Action object to be saved.
+	 * @param DateTime|null          $date Optional. Schedule date. Default null.
+	 *
+	 * @return int The action ID
+	 */
+	public function save_action( ActionScheduler_Action $action, ?DateTime $date = null ) {
+		return $this->primary_store->save_action( $action, $date );
+	}
+
+	/**
+	 * Retrieve an existing action whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function fetch_action( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id, true );
+		if ( $store ) {
+			return $store->fetch_action( $action_id );
+		} else {
+			return new ActionScheduler_NullAction();
+		}
+	}
+
+	/**
+	 * Cancel an existing action whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function cancel_action( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			$store->cancel_action( $action_id );
+		}
+	}
+
+	/**
+	 * Delete an existing action whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function delete_action( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			$store->delete_action( $action_id );
+		}
+	}
+
+	/**
+	 * Get the schedule date an existing action whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function get_date( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			return $store->get_date( $action_id );
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Mark an existing action as failed whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function mark_failure( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			$store->mark_failure( $action_id );
+		}
+	}
+
+	/**
+	 * Log the execution of an existing action whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function log_execution( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			$store->log_execution( $action_id );
+		}
+	}
+
+	/**
+	 * Mark an existing action complete whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function mark_complete( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			$store->mark_complete( $action_id );
+		}
+	}
+
+	/**
+	 * Get an existing action status whether migrated or not.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function get_status( $action_id ) {
+		$store = $this->get_store_from_action_id( $action_id );
+		if ( $store ) {
+			return $store->get_status( $action_id );
+		}
+		return null;
+	}
+
+	/**
+	 * Return which store an action is stored in.
+	 *
+	 * @param int  $action_id ID of the action.
+	 * @param bool $primary_first Optional flag indicating search the primary store first.
+	 * @return ActionScheduler_Store
+	 */
+	protected function get_store_from_action_id( $action_id, $primary_first = false ) {
+		if ( $primary_first ) {
+			$stores = array(
+				$this->primary_store,
+				$this->secondary_store,
+			);
+		} elseif ( $action_id < $this->demarkation_id ) {
+			$stores = array(
+				$this->secondary_store,
+				$this->primary_store,
+			);
+		} else {
+			$stores = array(
+				$this->primary_store,
+			);
+		}
+
+		foreach ( $stores as $store ) {
+			$action = $store->fetch_action( $action_id );
+			if ( ! is_a( $action, 'ActionScheduler_NullAction' ) ) {
+				return $store;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 * All claim-related functions should operate solely
+	 * on the primary store.
+	 * * * * * * * * * * * * * * * * * * * * * * * * * * *
+	 */
+
+	/**
+	 * Get the claim count from the table data store.
+	 */
+	public function get_claim_count() {
+		return $this->primary_store->get_claim_count();
+	}
+
+	/**
+	 * Retrieve the claim ID for an action from the table data store.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function get_claim_id( $action_id ) {
+		return $this->primary_store->get_claim_id( $action_id );
+	}
+
+	/**
+	 * Release a claim in the table data store.
+	 *
+	 * @param ActionScheduler_ActionClaim $claim Claim object.
+	 */
+	public function release_claim( ActionScheduler_ActionClaim $claim ) {
+		$this->primary_store->release_claim( $claim );
+	}
+
+	/**
+	 * Release claims on an action in the table data store.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function unclaim_action( $action_id ) {
+		$this->primary_store->unclaim_action( $action_id );
+	}
+
+	/**
+	 * Retrieve a list of action IDs by claim.
+	 *
+	 * @param int $claim_id Claim ID.
+	 */
+	public function find_actions_by_claim_id( $claim_id ) {
+		return $this->primary_store->find_actions_by_claim_id( $claim_id );
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpCommentLogger.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpCommentLogger.php
@@ -1,0 +1,282 @@
+<?php
+
+/**
+ * Class ActionScheduler_wpCommentLogger
+ */
+class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
+	const AGENT = 'ActionScheduler';
+	const TYPE  = 'action_log';
+
+	/**
+	 * Create log entry.
+	 *
+	 * @param string        $action_id Action ID.
+	 * @param string        $message   Action log's message.
+	 * @param DateTime|null $date      Action log's timestamp.
+	 *
+	 * @return string The log entry ID
+	 */
+	public function log( $action_id, $message, ?DateTime $date = null ) {
+		if ( empty( $date ) ) {
+			$date = as_get_datetime_object();
+		} else {
+			$date = as_get_datetime_object( clone $date );
+		}
+		$comment_id = $this->create_wp_comment( $action_id, $message, $date );
+		return $comment_id;
+	}
+
+	/**
+	 * Create comment.
+	 *
+	 * @param int      $action_id Action ID.
+	 * @param string   $message Action log's message.
+	 * @param DateTime $date Action log entry's timestamp.
+	 */
+	protected function create_wp_comment( $action_id, $message, DateTime $date ) {
+
+		$comment_date_gmt = $date->format( 'Y-m-d H:i:s' );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		$comment_data = array(
+			'comment_post_ID'  => $action_id,
+			'comment_date'     => $date->format( 'Y-m-d H:i:s' ),
+			'comment_date_gmt' => $comment_date_gmt,
+			'comment_author'   => self::AGENT,
+			'comment_content'  => $message,
+			'comment_agent'    => self::AGENT,
+			'comment_type'     => self::TYPE,
+		);
+
+		return wp_insert_comment( $comment_data );
+	}
+
+	/**
+	 * Get single log entry for action.
+	 *
+	 * @param string $entry_id Entry ID.
+	 *
+	 * @return ActionScheduler_LogEntry
+	 */
+	public function get_entry( $entry_id ) {
+		$comment = $this->get_comment( $entry_id );
+
+		if ( empty( $comment ) || self::TYPE !== $comment->comment_type ) {
+			return new ActionScheduler_NullLogEntry();
+		}
+
+		$date = as_get_datetime_object( $comment->comment_date_gmt );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		return new ActionScheduler_LogEntry( $comment->comment_post_ID, $comment->comment_content, $date );
+	}
+
+	/**
+	 * Get action's logs.
+	 *
+	 * @param string $action_id Action ID.
+	 *
+	 * @return ActionScheduler_LogEntry[]
+	 */
+	public function get_logs( $action_id ) {
+		$status = 'all';
+		$logs   = array();
+
+		if ( get_post_status( $action_id ) === 'trash' ) {
+			$status = 'post-trashed';
+		}
+
+		$comments = get_comments(
+			array(
+				'post_id' => $action_id,
+				'orderby' => 'comment_date_gmt',
+				'order'   => 'ASC',
+				'type'    => self::TYPE,
+				'status'  => $status,
+			)
+		);
+
+		foreach ( $comments as $c ) {
+			$entry = $this->get_entry( $c );
+
+			if ( ! empty( $entry ) ) {
+				$logs[] = $entry;
+			}
+		}
+
+		return $logs;
+	}
+
+	/**
+	 * Get comment.
+	 *
+	 * @param int $comment_id Comment ID.
+	 */
+	protected function get_comment( $comment_id ) {
+		return get_comment( $comment_id );
+	}
+
+	/**
+	 * Filter comment queries.
+	 *
+	 * @param WP_Comment_Query $query Comment query object.
+	 */
+	public function filter_comment_queries( $query ) {
+		foreach ( array( 'ID', 'parent', 'post_author', 'post_name', 'post_parent', 'type', 'post_type', 'post_id', 'post_ID' ) as $key ) {
+			if ( ! empty( $query->query_vars[ $key ] ) ) {
+				return; // don't slow down queries that wouldn't include action_log comments anyway.
+			}
+		}
+		$query->query_vars['action_log_filter'] = true;
+		add_filter( 'comments_clauses', array( $this, 'filter_comment_query_clauses' ), 10, 2 );
+	}
+
+	/**
+	 * Filter comment queries.
+	 *
+	 * @param array            $clauses Query's clauses.
+	 * @param WP_Comment_Query $query Query object.
+	 *
+	 * @return array
+	 */
+	public function filter_comment_query_clauses( $clauses, $query ) {
+		if ( ! empty( $query->query_vars['action_log_filter'] ) ) {
+			$clauses['where'] .= $this->get_where_clause();
+		}
+		return $clauses;
+	}
+
+	/**
+	 * Make sure Action Scheduler logs are excluded from comment feeds, which use WP_Query, not
+	 * the WP_Comment_Query class handled by @see self::filter_comment_queries().
+	 *
+	 * @param string   $where Query's `where` clause.
+	 * @param WP_Query $query Query object.
+	 *
+	 * @return string
+	 */
+	public function filter_comment_feed( $where, $query ) {
+		if ( is_comment_feed() ) {
+			$where .= $this->get_where_clause();
+		}
+		return $where;
+	}
+
+	/**
+	 * Return a SQL clause to exclude Action Scheduler comments.
+	 *
+	 * @return string
+	 */
+	protected function get_where_clause() {
+		global $wpdb;
+		return sprintf( " AND {$wpdb->comments}.comment_type != '%s'", self::TYPE );
+	}
+
+	/**
+	 * Remove action log entries from wp_count_comments()
+	 *
+	 * @param array $stats   Comment count.
+	 * @param int   $post_id Post ID.
+	 *
+	 * @return object
+	 */
+	public function filter_comment_count( $stats, $post_id ) {
+		global $wpdb;
+
+		if ( 0 === $post_id ) {
+			$stats = $this->get_comment_count();
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Retrieve the comment counts from our cache, or the database if the cached version isn't set.
+	 *
+	 * @return object
+	 */
+	protected function get_comment_count() {
+		global $wpdb;
+
+		$stats = get_transient( 'as_comment_count' );
+
+		if ( ! $stats ) {
+			$stats    = array();
+			$count    = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type NOT IN('order_note','action_log') GROUP BY comment_approved", ARRAY_A );
+			$total    = 0;
+			$stats    = array();
+			$approved = array(
+				'0'            => 'moderated',
+				'1'            => 'approved',
+				'spam'         => 'spam',
+				'trash'        => 'trash',
+				'post-trashed' => 'post-trashed',
+			);
+
+			foreach ( (array) $count as $row ) {
+				// Don't count post-trashed toward totals.
+				if ( 'post-trashed' !== $row['comment_approved'] && 'trash' !== $row['comment_approved'] ) {
+					$total += $row['num_comments'];
+				}
+				if ( isset( $approved[ $row['comment_approved'] ] ) ) {
+					$stats[ $approved[ $row['comment_approved'] ] ] = $row['num_comments'];
+				}
+			}
+
+			$stats['total_comments'] = $total;
+			$stats['all']            = $total;
+
+			foreach ( $approved as $key ) {
+				if ( empty( $stats[ $key ] ) ) {
+					$stats[ $key ] = 0;
+				}
+			}
+
+			$stats = (object) $stats;
+			set_transient( 'as_comment_count', $stats );
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Delete comment count cache whenever there is new comment or the status of a comment changes. Cache
+	 * will be regenerated next time ActionScheduler_wpCommentLogger::filter_comment_count() is called.
+	 */
+	public function delete_comment_count_cache() {
+		delete_transient( 'as_comment_count' );
+	}
+
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		add_action( 'action_scheduler_before_process_queue', array( $this, 'disable_comment_counting' ), 10, 0 );
+		add_action( 'action_scheduler_after_process_queue', array( $this, 'enable_comment_counting' ), 10, 0 );
+
+		parent::init();
+
+		add_action( 'pre_get_comments', array( $this, 'filter_comment_queries' ), 10, 1 );
+		add_action( 'wp_count_comments', array( $this, 'filter_comment_count' ), 20, 2 ); // run after WC_Comments::wp_count_comments() to make sure we exclude order notes and action logs.
+		add_action( 'comment_feed_where', array( $this, 'filter_comment_feed' ), 10, 2 );
+
+		// Delete comments count cache whenever there is a new comment or a comment status changes.
+		add_action( 'wp_insert_comment', array( $this, 'delete_comment_count_cache' ) );
+		add_action( 'wp_set_comment_status', array( $this, 'delete_comment_count_cache' ) );
+	}
+
+	/**
+	 * Defer comment counting.
+	 */
+	public function disable_comment_counting() {
+		wp_defer_comment_counting( true );
+	}
+
+	/**
+	 * Enable comment counting.
+	 */
+	public function enable_comment_counting() {
+		wp_defer_comment_counting( false );
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -1,0 +1,1088 @@
+<?php
+
+/**
+ * Class ActionScheduler_wpPostStore
+ */
+class ActionScheduler_wpPostStore extends ActionScheduler_Store {
+	const POST_TYPE         = 'scheduled-action';
+	const GROUP_TAXONOMY    = 'action-group';
+	const SCHEDULE_META_KEY = '_action_manager_schedule';
+	const DEPENDENCIES_MET  = 'as-post-store-dependencies-met';
+
+	/**
+	 * Used to share information about the before_date property of claims internally.
+	 *
+	 * This is used in preference to passing the same information as a method param
+	 * for backwards-compatibility reasons.
+	 *
+	 * @var DateTime|null
+	 */
+	private $claim_before_date = null;
+
+	/**
+	 * Local Timezone.
+	 *
+	 * @var DateTimeZone
+	 */
+	protected $local_timezone = null;
+
+	/**
+	 * Save action.
+	 *
+	 * @param ActionScheduler_Action $action Scheduled Action.
+	 * @param DateTime|null          $scheduled_date Scheduled Date.
+	 *
+	 * @throws RuntimeException Throws an exception if the action could not be saved.
+	 * @return int
+	 */
+	public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
+		try {
+			$this->validate_action( $action );
+			$post_array = $this->create_post_array( $action, $scheduled_date );
+			$post_id    = $this->save_post_array( $post_array );
+			$this->save_post_schedule( $post_id, $action->get_schedule() );
+			$this->save_action_group( $post_id, $action->get_group() );
+			do_action( 'action_scheduler_stored_action', $post_id );
+			return $post_id;
+		} catch ( Exception $e ) {
+			/* translators: %s: action error message */
+			throw new RuntimeException( sprintf( __( 'Error saving action: %s', 'action-scheduler' ), $e->getMessage() ), 0 );
+		}
+	}
+
+	/**
+	 * Create post array.
+	 *
+	 * @param ActionScheduler_Action $action Scheduled Action.
+	 * @param DateTime|null          $scheduled_date Scheduled Date.
+	 *
+	 * @return array Returns an array of post data.
+	 */
+	protected function create_post_array( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
+		$post = array(
+			'post_type'     => self::POST_TYPE,
+			'post_title'    => $action->get_hook(),
+			'post_content'  => wp_json_encode( $action->get_args() ),
+			'post_status'   => ( $action->is_finished() ? 'publish' : 'pending' ),
+			'post_date_gmt' => $this->get_scheduled_date_string( $action, $scheduled_date ),
+			'post_date'     => $this->get_scheduled_date_string_local( $action, $scheduled_date ),
+		);
+		return $post;
+	}
+
+	/**
+	 * Save post array.
+	 *
+	 * @param array $post_array Post array.
+	 * @return int Returns the post ID.
+	 * @throws RuntimeException Throws an exception if the action could not be saved.
+	 */
+	protected function save_post_array( $post_array ) {
+		add_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10, 1 );
+		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
+
+		$has_kses = false !== has_filter( 'content_save_pre', 'wp_filter_post_kses' );
+
+		if ( $has_kses ) {
+			// Prevent KSES from corrupting JSON in post_content.
+			kses_remove_filters();
+		}
+
+		$post_id = wp_insert_post( $post_array );
+
+		if ( $has_kses ) {
+			kses_init_filters();
+		}
+
+		remove_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10 );
+		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
+
+		if ( is_wp_error( $post_id ) || empty( $post_id ) ) {
+			throw new RuntimeException( __( 'Unable to save action.', 'action-scheduler' ) );
+		}
+		return $post_id;
+	}
+
+	/**
+	 * Filter insert post data.
+	 *
+	 * @param array $postdata Post data to filter.
+	 *
+	 * @return array
+	 */
+	public function filter_insert_post_data( $postdata ) {
+		if ( self::POST_TYPE === $postdata['post_type'] ) {
+			$postdata['post_author'] = 0;
+			if ( 'future' === $postdata['post_status'] ) {
+				$postdata['post_status'] = 'publish';
+			}
+		}
+		return $postdata;
+	}
+
+	/**
+	 * Create a (probably unique) post name for scheduled actions in a more performant manner than wp_unique_post_slug().
+	 *
+	 * When an action's post status is transitioned to something other than 'draft', 'pending' or 'auto-draft, like 'publish'
+	 * or 'failed' or 'trash', WordPress will find a unique slug (stored in post_name column) using the wp_unique_post_slug()
+	 * function. This is done to ensure URL uniqueness. The approach taken by wp_unique_post_slug() is to iterate over existing
+	 * post_name values that match, and append a number 1 greater than the largest. This makes sense when manually creating a
+	 * post from the Edit Post screen. It becomes a bottleneck when automatically processing thousands of actions, with a
+	 * database containing thousands of related post_name values.
+	 *
+	 * WordPress 5.1 introduces the 'pre_wp_unique_post_slug' filter for plugins to address this issue.
+	 *
+	 * We can short-circuit WordPress's wp_unique_post_slug() approach using the 'pre_wp_unique_post_slug' filter. This
+	 * method is available to be used as a callback on that filter. It provides a more scalable approach to generating a
+	 * post_name/slug that is probably unique. Because Action Scheduler never actually uses the post_name field, or an
+	 * action's slug, being probably unique is good enough.
+	 *
+	 * For more backstory on this issue, see:
+	 * - https://github.com/woocommerce/action-scheduler/issues/44 and
+	 * - https://core.trac.wordpress.org/ticket/21112
+	 *
+	 * @param string $override_slug Short-circuit return value.
+	 * @param string $slug          The desired slug (post_name).
+	 * @param int    $post_ID       Post ID.
+	 * @param string $post_status   The post status.
+	 * @param string $post_type     Post type.
+	 * @return string
+	 */
+	public function set_unique_post_slug( $override_slug, $slug, $post_ID, $post_status, $post_type ) {
+		if ( self::POST_TYPE === $post_type ) {
+			$override_slug = uniqid( self::POST_TYPE . '-', true ) . '-' . wp_generate_password( 32, false );
+		}
+		return $override_slug;
+	}
+
+	/**
+	 * Save post schedule.
+	 *
+	 * @param int    $post_id  Post ID of the scheduled action.
+	 * @param string $schedule Schedule to save.
+	 *
+	 * @return void
+	 */
+	protected function save_post_schedule( $post_id, $schedule ) {
+		update_post_meta( $post_id, self::SCHEDULE_META_KEY, $schedule );
+	}
+
+	/**
+	 * Save action group.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $group   Group to save.
+	 * @return void
+	 */
+	protected function save_action_group( $post_id, $group ) {
+		if ( empty( $group ) ) {
+			wp_set_object_terms( $post_id, array(), self::GROUP_TAXONOMY, false );
+		} else {
+			wp_set_object_terms( $post_id, array( $group ), self::GROUP_TAXONOMY, false );
+		}
+	}
+
+	/**
+	 * Fetch actions.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return object
+	 */
+	public function fetch_action( $action_id ) {
+		$post = $this->get_post( $action_id );
+		if ( empty( $post ) || self::POST_TYPE !== $post->post_type ) {
+			return $this->get_null_action();
+		}
+
+		try {
+			$action = $this->make_action_from_post( $post );
+		} catch ( ActionScheduler_InvalidActionException $exception ) {
+			do_action( 'action_scheduler_failed_fetch_action', $post->ID, $exception );
+			return $this->get_null_action();
+		}
+
+		return $action;
+	}
+
+	/**
+	 * Get post.
+	 *
+	 * @param string $action_id - Action ID.
+	 * @return WP_Post|null
+	 */
+	protected function get_post( $action_id ) {
+		if ( empty( $action_id ) ) {
+			return null;
+		}
+		return get_post( $action_id );
+	}
+
+	/**
+	 * Get NULL action.
+	 *
+	 * @return ActionScheduler_NullAction
+	 */
+	protected function get_null_action() {
+		return new ActionScheduler_NullAction();
+	}
+
+	/**
+	 * Make action from post.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return WP_Post
+	 */
+	protected function make_action_from_post( $post ) {
+		$hook = $post->post_title;
+
+		$args = json_decode( $post->post_content, true );
+		$this->validate_args( $args, $post->ID );
+
+		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
+		$this->validate_schedule( $schedule, $post->ID );
+
+		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array( 'fields' => 'names' ) );
+		$group = empty( $group ) ? '' : reset( $group );
+
+		return ActionScheduler::factory()->get_stored_action( $this->get_action_status_by_post_status( $post->post_status ), $hook, $args, $schedule, $group );
+	}
+
+	/**
+	 * Get action status by post status.
+	 *
+	 * @param string $post_status Post status.
+	 *
+	 * @throws InvalidArgumentException Throw InvalidArgumentException if $post_status not in known status fields returned by $this->get_status_labels().
+	 * @return string
+	 */
+	protected function get_action_status_by_post_status( $post_status ) {
+
+		switch ( $post_status ) {
+			case 'publish':
+				$action_status = self::STATUS_COMPLETE;
+				break;
+			case 'trash':
+				$action_status = self::STATUS_CANCELED;
+				break;
+			default:
+				if ( ! array_key_exists( $post_status, $this->get_status_labels() ) ) {
+					throw new InvalidArgumentException( sprintf( 'Invalid post status: "%s". No matching action status available.', $post_status ) );
+				}
+				$action_status = $post_status;
+				break;
+		}
+
+		return $action_status;
+	}
+
+	/**
+	 * Get post status by action status.
+	 *
+	 * @param string $action_status Action status.
+	 *
+	 * @throws InvalidArgumentException Throws InvalidArgumentException if $post_status not in known status fields returned by $this->get_status_labels().
+	 * @return string
+	 */
+	protected function get_post_status_by_action_status( $action_status ) {
+
+		switch ( $action_status ) {
+			case self::STATUS_COMPLETE:
+				$post_status = 'publish';
+				break;
+			case self::STATUS_CANCELED:
+				$post_status = 'trash';
+				break;
+			default:
+				if ( ! array_key_exists( $action_status, $this->get_status_labels() ) ) {
+					throw new InvalidArgumentException( sprintf( 'Invalid action status: "%s".', $action_status ) );
+				}
+				$post_status = $action_status;
+				break;
+		}
+
+		return $post_status;
+	}
+
+	/**
+	 * Returns the SQL statement to query (or count) actions.
+	 *
+	 * @param array  $query            - Filtering options.
+	 * @param string $select_or_count  - Whether the SQL should select and return the IDs or just the row count.
+	 *
+	 * @throws InvalidArgumentException - Throw InvalidArgumentException if $select_or_count not count or select.
+	 * @return string SQL statement. The returned SQL is already properly escaped.
+	 */
+	protected function get_query_actions_sql( array $query, $select_or_count = 'select' ) {
+
+		if ( ! in_array( $select_or_count, array( 'select', 'count' ), true ) ) {
+			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+		}
+
+		$query = wp_parse_args(
+			$query,
+			array(
+				'hook'             => '',
+				'args'             => null,
+				'date'             => null,
+				'date_compare'     => '<=',
+				'modified'         => null,
+				'modified_compare' => '<=',
+				'group'            => '',
+				'status'           => '',
+				'claimed'          => null,
+				'per_page'         => 5,
+				'offset'           => 0,
+				'orderby'          => 'date',
+				'order'            => 'ASC',
+				'search'           => '',
+			)
+		);
+
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+		$sql        = ( 'count' === $select_or_count ) ? 'SELECT count(p.ID)' : 'SELECT p.ID ';
+		$sql       .= "FROM {$wpdb->posts} p";
+		$sql_params = array();
+		if ( empty( $query['group'] ) && 'group' === $query['orderby'] ) {
+			$sql .= " LEFT JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
+			$sql .= " LEFT JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
+			$sql .= " LEFT JOIN {$wpdb->terms} t ON tt.term_id=t.term_id";
+		} elseif ( ! empty( $query['group'] ) ) {
+			$sql         .= " INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
+			$sql         .= " INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
+			$sql         .= " INNER JOIN {$wpdb->terms} t ON tt.term_id=t.term_id";
+			$sql         .= ' AND t.slug=%s';
+			$sql_params[] = $query['group'];
+		}
+		$sql         .= ' WHERE post_type=%s';
+		$sql_params[] = self::POST_TYPE;
+		if ( $query['hook'] ) {
+			$sql         .= ' AND p.post_title=%s';
+			$sql_params[] = $query['hook'];
+		}
+		if ( ! is_null( $query['args'] ) ) {
+			$sql         .= ' AND p.post_content=%s';
+			$sql_params[] = wp_json_encode( $query['args'] );
+		}
+
+		if ( $query['status'] ) {
+			$post_statuses = array_map( array( $this, 'get_post_status_by_action_status' ), (array) $query['status'] );
+			$placeholders  = array_fill( 0, count( $post_statuses ), '%s' );
+			$sql          .= ' AND p.post_status IN (' . join( ', ', $placeholders ) . ')';
+			$sql_params    = array_merge( $sql_params, array_values( $post_statuses ) );
+		}
+
+		if ( $query['date'] instanceof DateTime ) {
+			$date = clone $query['date'];
+			$date->setTimezone( new DateTimeZone( 'UTC' ) );
+			$date_string  = $date->format( 'Y-m-d H:i:s' );
+			$comparator   = $this->validate_sql_comparator( $query['date_compare'] );
+			$sql         .= " AND p.post_date_gmt $comparator %s";
+			$sql_params[] = $date_string;
+		}
+
+		if ( $query['modified'] instanceof DateTime ) {
+			$modified = clone $query['modified'];
+			$modified->setTimezone( new DateTimeZone( 'UTC' ) );
+			$date_string  = $modified->format( 'Y-m-d H:i:s' );
+			$comparator   = $this->validate_sql_comparator( $query['modified_compare'] );
+			$sql         .= " AND p.post_modified_gmt $comparator %s";
+			$sql_params[] = $date_string;
+		}
+
+		if ( true === $query['claimed'] ) {
+			$sql .= " AND p.post_password != ''";
+		} elseif ( false === $query['claimed'] ) {
+			$sql .= " AND p.post_password = ''";
+		} elseif ( ! is_null( $query['claimed'] ) ) {
+			$sql         .= ' AND p.post_password = %s';
+			$sql_params[] = $query['claimed'];
+		}
+
+		if ( ! empty( $query['search'] ) ) {
+			$sql .= ' AND (p.post_title LIKE %s OR p.post_content LIKE %s OR p.post_password LIKE %s)';
+			for ( $i = 0; $i < 3; $i++ ) {
+				$sql_params[] = sprintf( '%%%s%%', $query['search'] );
+			}
+		}
+
+		if ( 'select' === $select_or_count ) {
+			switch ( $query['orderby'] ) {
+				case 'hook':
+					$orderby = 'p.post_title';
+					break;
+				case 'group':
+					$orderby = 't.name';
+					break;
+				case 'status':
+					$orderby = 'p.post_status';
+					break;
+				case 'modified':
+					$orderby = 'p.post_modified';
+					break;
+				case 'claim_id':
+					$orderby = 'p.post_password';
+					break;
+				case 'schedule':
+				case 'date':
+				default:
+					$orderby = 'p.post_date_gmt';
+					break;
+			}
+			if ( 'ASC' === strtoupper( $query['order'] ) ) {
+				$order = 'ASC';
+			} else {
+				$order = 'DESC';
+			}
+			$sql .= " ORDER BY $orderby $order";
+			if ( $query['per_page'] > 0 ) {
+				$sql         .= ' LIMIT %d, %d';
+				$sql_params[] = $query['offset'];
+				$sql_params[] = $query['per_page'];
+			}
+		}
+
+		return $wpdb->prepare( $sql, $sql_params ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Query for action count or list of action IDs.
+	 *
+	 * @since 3.3.0 $query['status'] accepts array of statuses instead of a single status.
+	 *
+	 * @see ActionScheduler_Store::query_actions for $query arg usage.
+	 *
+	 * @param array  $query      Query filtering options.
+	 * @param string $query_type Whether to select or count the results. Defaults to select.
+	 *
+	 * @return string|array|null The IDs of actions matching the query. Null on failure.
+	 */
+	public function query_actions( $query = array(), $query_type = 'select' ) {
+		/**
+		 * Global $wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$sql = $this->get_query_actions_sql( $query, $query_type );
+
+		return ( 'count' === $query_type ) ? $wpdb->get_var( $sql ) : $wpdb->get_col( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Get a count of all actions in the store, grouped by status
+	 *
+	 * @return array
+	 */
+	public function action_counts() {
+
+		$action_counts_by_status = array();
+		$action_stati_and_labels = $this->get_status_labels();
+		$posts_count_by_status   = (array) wp_count_posts( self::POST_TYPE, 'readable' );
+
+		foreach ( $posts_count_by_status as $post_status_name => $count ) {
+
+			try {
+				$action_status_name = $this->get_action_status_by_post_status( $post_status_name );
+			} catch ( Exception $e ) {
+				// Ignore any post statuses that aren't for actions.
+				continue;
+			}
+			if ( array_key_exists( $action_status_name, $action_stati_and_labels ) ) {
+				$action_counts_by_status[ $action_status_name ] = $count;
+			}
+		}
+
+		return $action_counts_by_status;
+	}
+
+	/**
+	 * Cancel action.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @throws InvalidArgumentException If $action_id is not identified.
+	 */
+	public function cancel_action( $action_id ) {
+		$post = get_post( $action_id );
+		if ( empty( $post ) || ( self::POST_TYPE !== $post->post_type ) ) {
+			/* translators: %s is the action ID */
+			throw new InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to cancel this action. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		do_action( 'action_scheduler_canceled_action', $action_id );
+		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
+		wp_trash_post( $action_id );
+		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
+	}
+
+	/**
+	 * Delete action.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 * @throws InvalidArgumentException If action is not identified.
+	 */
+	public function delete_action( $action_id ) {
+		$post = get_post( $action_id );
+		if ( empty( $post ) || ( self::POST_TYPE !== $post->post_type ) ) {
+			/* translators: %s is the action ID */
+			throw new InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to delete this action. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		do_action( 'action_scheduler_deleted_action', $action_id );
+
+		wp_delete_post( $action_id, true );
+	}
+
+	/**
+	 * Get date for claim id.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return ActionScheduler_DateTime The date the action is schedule to run, or the date that it ran.
+	 */
+	public function get_date( $action_id ) {
+		$next = $this->get_date_gmt( $action_id );
+		return ActionScheduler_TimezoneHelper::set_local_timezone( $next );
+	}
+
+	/**
+	 * Get Date GMT.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @throws InvalidArgumentException If $action_id is not identified.
+	 * @return ActionScheduler_DateTime The date the action is schedule to run, or the date that it ran.
+	 */
+	public function get_date_gmt( $action_id ) {
+		$post = get_post( $action_id );
+		if ( empty( $post ) || ( self::POST_TYPE !== $post->post_type ) ) {
+			/* translators: %s is the action ID */
+			throw new InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to determine the date of this action. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		if ( 'publish' === $post->post_status ) {
+			return as_get_datetime_object( $post->post_modified_gmt );
+		} else {
+			return as_get_datetime_object( $post->post_date_gmt );
+		}
+	}
+
+	/**
+	 * Stake claim.
+	 *
+	 * @param int           $max_actions Maximum number of actions.
+	 * @param DateTime|null $before_date Jobs must be schedule before this date. Defaults to now.
+	 * @param array         $hooks       Claim only actions with a hook or hooks.
+	 * @param string        $group       Claim only actions in the given group.
+	 *
+	 * @return ActionScheduler_ActionClaim
+	 * @throws RuntimeException When there is an error staking a claim.
+	 * @throws InvalidArgumentException When the given group is not valid.
+	 */
+	public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
+		$this->claim_before_date = $before_date;
+		$claim_id                = $this->generate_claim_id();
+		$this->claim_actions( $claim_id, $max_actions, $before_date, $hooks, $group );
+		$action_ids              = $this->find_actions_by_claim_id( $claim_id );
+		$this->claim_before_date = null;
+
+		return new ActionScheduler_ActionClaim( $claim_id, $action_ids );
+	}
+
+	/**
+	 * Get claim count.
+	 *
+	 * @return int
+	 */
+	public function get_claim_count() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT post_password) FROM {$wpdb->posts} WHERE post_password != '' AND post_type = %s AND post_status IN ('in-progress','pending')",
+				array( self::POST_TYPE )
+			)
+		);
+	}
+
+	/**
+	 * Generate claim id.
+	 *
+	 * @return string
+	 */
+	protected function generate_claim_id() {
+		$claim_id = md5( microtime( true ) . wp_rand( 0, 1000 ) );
+		return substr( $claim_id, 0, 20 ); // to fit in db field with 20 char limit.
+	}
+
+	/**
+	 * Claim actions.
+	 *
+	 * @param string        $claim_id    Claim ID.
+	 * @param int           $limit       Limit.
+	 * @param DateTime|null $before_date Should use UTC timezone.
+	 * @param array         $hooks       Claim only actions with a hook or hooks.
+	 * @param string        $group       Claim only actions in the given group.
+	 *
+	 * @return int The number of actions that were claimed.
+	 * @throws RuntimeException  When there is a database error.
+	 */
+	protected function claim_actions( $claim_id, $limit, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
+		// Set up initial variables.
+		$date      = null === $before_date ? as_get_datetime_object() : clone $before_date;
+		$limit_ids = ! empty( $group );
+		$ids       = $limit_ids ? $this->get_actions_by_group( $group, $limit, $date ) : array();
+
+		// If limiting by IDs and no posts found, then return early since we have nothing to update.
+		if ( $limit_ids && 0 === count( $ids ) ) {
+			return 0;
+		}
+
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		/*
+		 * Build up custom query to update the affected posts. Parameters are built as a separate array
+		 * to make it easier to identify where they are in the query.
+		 *
+		 * We can't use $wpdb->update() here because of the "ID IN ..." clause.
+		 */
+		$update = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s";
+		$params = array(
+			$claim_id,
+			current_time( 'mysql', true ),
+			current_time( 'mysql' ),
+		);
+
+		// Build initial WHERE clause.
+		$where    = "WHERE post_type = %s AND post_status = %s AND post_password = ''";
+		$params[] = self::POST_TYPE;
+		$params[] = ActionScheduler_Store::STATUS_PENDING;
+
+		if ( ! empty( $hooks ) ) {
+			$placeholders = array_fill( 0, count( $hooks ), '%s' );
+			$where       .= ' AND post_title IN (' . join( ', ', $placeholders ) . ')';
+			$params       = array_merge( $params, array_values( $hooks ) );
+		}
+
+		/*
+		 * Add the IDs to the WHERE clause. IDs not escaped because they came directly from a prior DB query.
+		 *
+		 * If we're not limiting by IDs, then include the post_date_gmt clause.
+		 */
+		if ( $limit_ids ) {
+			$where .= ' AND ID IN (' . join( ',', $ids ) . ')';
+		} else {
+			$where   .= ' AND post_date_gmt <= %s';
+			$params[] = $date->format( 'Y-m-d H:i:s' );
+		}
+
+		// Add the ORDER BY clause and,ms limit.
+		$order    = 'ORDER BY menu_order ASC, post_date_gmt ASC, ID ASC LIMIT %d';
+		$params[] = $limit;
+
+		// Run the query and gather results.
+		$rows_affected = $wpdb->query( $wpdb->prepare( "{$update} {$where} {$order}", $params ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+
+		if ( false === $rows_affected ) {
+			throw new RuntimeException( __( 'Unable to claim actions. Database error.', 'action-scheduler' ) );
+		}
+
+		return (int) $rows_affected;
+	}
+
+	/**
+	 * Get IDs of actions within a certain group and up to a certain date/time.
+	 *
+	 * @param string   $group The group to use in finding actions.
+	 * @param int      $limit The number of actions to retrieve.
+	 * @param DateTime $date  DateTime object representing cutoff time for actions. Actions retrieved will be
+	 *                        up to and including this DateTime.
+	 *
+	 * @return array IDs of actions in the appropriate group and before the appropriate time.
+	 * @throws InvalidArgumentException When the group does not exist.
+	 */
+	protected function get_actions_by_group( $group, $limit, DateTime $date ) {
+		// Ensure the group exists before continuing.
+		if ( ! term_exists( $group, self::GROUP_TAXONOMY ) ) {
+			/* translators: %s is the group name */
+			throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
+		}
+
+		// Set up a query for post IDs to use later.
+		$query      = new WP_Query();
+		$query_args = array(
+			'fields'           => 'ids',
+			'post_type'        => self::POST_TYPE,
+			'post_status'      => ActionScheduler_Store::STATUS_PENDING,
+			'has_password'     => false,
+			'posts_per_page'   => $limit * 3,
+			'suppress_filters' => true, // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters
+			'no_found_rows'    => true,
+			'orderby'          => array(
+				'menu_order' => 'ASC',
+				'date'       => 'ASC',
+				'ID'         => 'ASC',
+			),
+			'date_query'       => array(
+				'column'    => 'post_date_gmt',
+				'before'    => $date->format( 'Y-m-d H:i' ),
+				'inclusive' => true,
+			),
+			'tax_query'        => array( // phpcs:ignore WordPress.DB.SlowDBQuery
+				array(
+					'taxonomy'         => self::GROUP_TAXONOMY,
+					'field'            => 'slug',
+					'terms'            => $group,
+					'include_children' => false,
+				),
+			),
+		);
+
+		return $query->query( $query_args );
+	}
+
+	/**
+	 * Find actions by claim ID.
+	 *
+	 * @param string $claim_id Claim ID.
+	 * @return array
+	 */
+	public function find_actions_by_claim_id( $claim_id ) {
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$action_ids  = array();
+		$before_date = isset( $this->claim_before_date ) ? $this->claim_before_date : as_get_datetime_object();
+		$cut_off     = $before_date->format( 'Y-m-d H:i:s' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ID, post_date_gmt FROM {$wpdb->posts} WHERE post_type = %s AND post_password = %s",
+				array(
+					self::POST_TYPE,
+					$claim_id,
+				)
+			)
+		);
+
+		// Verify that the scheduled date for each action is within the expected bounds (in some unusual
+		// cases, we cannot depend on MySQL to honor all of the WHERE conditions we specify).
+		foreach ( $results as $claimed_action ) {
+			if ( $claimed_action->post_date_gmt <= $cut_off ) {
+				$action_ids[] = absint( $claimed_action->ID );
+			}
+		}
+
+		return $action_ids;
+	}
+
+	/**
+	 * Release claim.
+	 *
+	 * @param ActionScheduler_ActionClaim $claim Claim object to release.
+	 * @return void
+	 * @throws RuntimeException When the claim is not unlocked.
+	 */
+	public function release_claim( ActionScheduler_ActionClaim $claim ) {
+		$action_ids = $this->find_actions_by_claim_id( $claim->get_id() );
+		if ( empty( $action_ids ) ) {
+			return; // nothing to do.
+		}
+		$action_id_string = implode( ',', array_map( 'intval', $action_ids ) );
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->posts} SET post_password = '' WHERE ID IN ($action_id_string) AND post_password = %s", //phpcs:ignore
+				array(
+					$claim->get_id(),
+				)
+			)
+		);
+		if ( false === $result ) {
+			/* translators: %s: claim ID */
+			throw new RuntimeException( sprintf( __( 'Unable to unlock claim %s. Database error.', 'action-scheduler' ), $claim->get_id() ) );
+		}
+	}
+
+	/**
+	 * Unclaim action.
+	 *
+	 * @param string $action_id Action ID.
+	 * @throws RuntimeException When unable to unlock claim on action ID.
+	 */
+	public function unclaim_action( $action_id ) {
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		//phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->posts} SET post_password = '' WHERE ID = %d AND post_type = %s",
+				$action_id,
+				self::POST_TYPE
+			)
+		);
+		if ( false === $result ) {
+			/* translators: %s: action ID */
+			throw new RuntimeException( sprintf( __( 'Unable to unlock claim on action %s. Database error.', 'action-scheduler' ), $action_id ) );
+		}
+	}
+
+	/**
+	 * Mark failure on action.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
+	 * @throws RuntimeException When unable to mark failure on action ID.
+	 */
+	public function mark_failure( $action_id ) {
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->query(
+			$wpdb->prepare( "UPDATE {$wpdb->posts} SET post_status = %s WHERE ID = %d AND post_type = %s", self::STATUS_FAILED, $action_id, self::POST_TYPE )
+		);
+		if ( false === $result ) {
+			/* translators: %s: action ID */
+			throw new RuntimeException( sprintf( __( 'Unable to mark failure on action %s. Database error.', 'action-scheduler' ), $action_id ) );
+		}
+	}
+
+	/**
+	 * Return an action's claim ID, as stored in the post password column
+	 *
+	 * @param int $action_id Action ID.
+	 * @return mixed
+	 */
+	public function get_claim_id( $action_id ) {
+		return $this->get_post_column( $action_id, 'post_password' );
+	}
+
+	/**
+	 * Return an action's status, as stored in the post status column
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return mixed
+	 * @throws InvalidArgumentException When the action ID is invalid.
+	 */
+	public function get_status( $action_id ) {
+		$status = $this->get_post_column( $action_id, 'post_status' );
+
+		if ( null === $status ) {
+			throw new InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
+		}
+
+		return $this->get_action_status_by_post_status( $status );
+	}
+
+	/**
+	 * Get post column
+	 *
+	 * @param string $action_id Action ID.
+	 * @param string $column_name Column Name.
+	 *
+	 * @return string|null
+	 */
+	private function get_post_column( $action_id, $column_name ) {
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT {$column_name} FROM {$wpdb->posts} WHERE ID=%d AND post_type=%s", // phpcs:ignore
+				$action_id,
+				self::POST_TYPE
+			)
+		);
+	}
+
+	/**
+	 * Log Execution.
+	 *
+	 * @throws Exception If the action status cannot be updated to self::STATUS_RUNNING ('in-progress').
+	 *
+	 * @param string $action_id Action ID.
+	 */
+	public function log_execution( $action_id ) {
+		/**
+		 * Global wpdb object.
+		 *
+		 * @var wpdb $wpdb
+		 */
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$status_updated = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->posts} SET menu_order = menu_order+1, post_status=%s, post_modified_gmt = %s, post_modified = %s WHERE ID = %d AND post_type = %s",
+				self::STATUS_RUNNING,
+				current_time( 'mysql', true ),
+				current_time( 'mysql' ),
+				$action_id,
+				self::POST_TYPE
+			)
+		);
+
+		if ( ! $status_updated ) {
+			throw new Exception(
+				sprintf(
+					/* translators: 1: action ID. 2: status slug. */
+					__( 'Unable to update the status of action %1$d to %2$s.', 'action-scheduler' ),
+					$action_id,
+					self::STATUS_RUNNING
+				)
+			);
+		}
+	}
+
+	/**
+	 * Record that an action was completed.
+	 *
+	 * @param string $action_id ID of the completed action.
+	 *
+	 * @throws InvalidArgumentException When the action ID is invalid.
+	 * @throws RuntimeException         When there was an error executing the action.
+	 */
+	public function mark_complete( $action_id ) {
+		$post = get_post( $action_id );
+		if ( empty( $post ) || ( self::POST_TYPE !== $post->post_type ) ) {
+			/* translators: %s is the action ID */
+			throw new InvalidArgumentException( sprintf( __( 'Unidentified action %s: we were unable to mark this action as having completed. It may may have been deleted by another process.', 'action-scheduler' ), $action_id ) );
+		}
+		add_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10, 1 );
+		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
+		$result = wp_update_post(
+			array(
+				'ID'          => $action_id,
+				'post_status' => 'publish',
+			),
+			true
+		);
+		remove_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10 );
+		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( $result->get_error_message() );
+		}
+
+		/**
+		 * Fires after a scheduled action has been completed.
+		 *
+		 * @since 3.4.2
+		 *
+		 * @param int $action_id Action ID.
+		 */
+		do_action( 'action_scheduler_completed_action', $action_id );
+	}
+
+	/**
+	 * Mark action as migrated when there is an error deleting the action.
+	 *
+	 * @param int $action_id Action ID.
+	 */
+	public function mark_migrated( $action_id ) {
+		wp_update_post(
+			array(
+				'ID'          => $action_id,
+				'post_status' => 'migrated',
+			)
+		);
+	}
+
+	/**
+	 * Determine whether the post store can be migrated.
+	 *
+	 * @param [type] $setting - Setting value.
+	 * @return bool
+	 */
+	public function migration_dependencies_met( $setting ) {
+		global $wpdb;
+
+		$dependencies_met = get_transient( self::DEPENDENCIES_MET );
+		if ( empty( $dependencies_met ) ) {
+			$maximum_args_length = apply_filters( 'action_scheduler_maximum_args_length', 191 );
+			$found_action        = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s AND CHAR_LENGTH(post_content) > %d LIMIT 1",
+					$maximum_args_length,
+					self::POST_TYPE
+				)
+			);
+			$dependencies_met    = $found_action ? 'no' : 'yes';
+			set_transient( self::DEPENDENCIES_MET, $dependencies_met, DAY_IN_SECONDS );
+		}
+
+		return 'yes' === $dependencies_met ? $setting : false;
+	}
+
+	/**
+	 * InnoDB indexes have a maximum size of 767 bytes by default, which is only 191 characters with utf8mb4.
+	 *
+	 * Previously, AS wasn't concerned about args length, as we used the (unindex) post_content column. However,
+	 * as we prepare to move to custom tables, and can use an indexed VARCHAR column instead, we want to warn
+	 * developers of this impending requirement.
+	 *
+	 * @param ActionScheduler_Action $action Action object.
+	 */
+	protected function validate_action( ActionScheduler_Action $action ) {
+		try {
+			parent::validate_action( $action );
+		} catch ( Exception $e ) {
+			/* translators: %s is the error message */
+			$message = sprintf( __( '%s Support for strings longer than this will be removed in a future version.', 'action-scheduler' ), $e->getMessage() );
+			_doing_it_wrong( 'ActionScheduler_Action::$args', esc_html( $message ), '2.1.0' );
+		}
+	}
+
+	/**
+	 * (@codeCoverageIgnore)
+	 */
+	public function init() {
+		add_filter( 'action_scheduler_migration_dependencies_met', array( $this, 'migration_dependencies_met' ) );
+
+		$post_type_registrar = new ActionScheduler_wpPostStore_PostTypeRegistrar();
+		$post_type_registrar->register();
+
+		$post_status_registrar = new ActionScheduler_wpPostStore_PostStatusRegistrar();
+		$post_status_registrar->register();
+
+		$taxonomy_registrar = new ActionScheduler_wpPostStore_TaxonomyRegistrar();
+		$taxonomy_registrar->register();
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore_PostStatusRegistrar.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore_PostStatusRegistrar.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Class ActionScheduler_wpPostStore_PostStatusRegistrar
+ *
+ * @codeCoverageIgnore
+ */
+class ActionScheduler_wpPostStore_PostStatusRegistrar {
+
+	/**
+	 * Registrar.
+	 */
+	public function register() {
+		register_post_status( ActionScheduler_Store::STATUS_RUNNING, array_merge( $this->post_status_args(), $this->post_status_running_labels() ) );
+		register_post_status( ActionScheduler_Store::STATUS_FAILED, array_merge( $this->post_status_args(), $this->post_status_failed_labels() ) );
+	}
+
+	/**
+	 * Build the args array for the post type definition
+	 *
+	 * @return array
+	 */
+	protected function post_status_args() {
+		$args = array(
+			'public'                    => false,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => true,
+			'show_in_admin_status_list' => true,
+		);
+
+		return apply_filters( 'action_scheduler_post_status_args', $args );
+	}
+
+	/**
+	 * Build the args array for the post type definition
+	 *
+	 * @return array
+	 */
+	protected function post_status_failed_labels() {
+		$labels = array(
+			'label'       => _x( 'Failed', 'post', 'action-scheduler' ),
+			/* translators: %s: count */
+			'label_count' => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'action-scheduler' ),
+		);
+
+		return apply_filters( 'action_scheduler_post_status_failed_labels', $labels );
+	}
+
+	/**
+	 * Build the args array for the post type definition
+	 *
+	 * @return array
+	 */
+	protected function post_status_running_labels() {
+		$labels = array(
+			'label'       => _x( 'In-Progress', 'post', 'action-scheduler' ),
+			/* translators: %s: count */
+			'label_count' => _n_noop( 'In-Progress <span class="count">(%s)</span>', 'In-Progress <span class="count">(%s)</span>', 'action-scheduler' ),
+		);
+
+		return apply_filters( 'action_scheduler_post_status_running_labels', $labels );
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Class ActionScheduler_wpPostStore_PostTypeRegistrar
+ *
+ * @codeCoverageIgnore
+ */
+class ActionScheduler_wpPostStore_PostTypeRegistrar {
+	/**
+	 * Registrar.
+	 */
+	public function register() {
+		register_post_type( ActionScheduler_wpPostStore::POST_TYPE, $this->post_type_args() );
+	}
+
+	/**
+	 * Build the args array for the post type definition
+	 *
+	 * @return array
+	 */
+	protected function post_type_args() {
+		$args = array(
+			'label'        => __( 'Scheduled Actions', 'action-scheduler' ),
+			'description'  => __( 'Scheduled actions are hooks triggered on a certain date and time.', 'action-scheduler' ),
+			'public'       => false,
+			'map_meta_cap' => true,
+			'hierarchical' => false,
+			'supports'     => array( 'title', 'editor', 'comments' ),
+			'rewrite'      => false,
+			'query_var'    => false,
+			'can_export'   => true,
+			'ep_mask'      => EP_NONE,
+			'labels'       => array(
+				'name'               => __( 'Scheduled Actions', 'action-scheduler' ),
+				'singular_name'      => __( 'Scheduled Action', 'action-scheduler' ),
+				'menu_name'          => _x( 'Scheduled Actions', 'Admin menu name', 'action-scheduler' ),
+				'add_new'            => __( 'Add', 'action-scheduler' ),
+				'add_new_item'       => __( 'Add New Scheduled Action', 'action-scheduler' ),
+				'edit'               => __( 'Edit', 'action-scheduler' ),
+				'edit_item'          => __( 'Edit Scheduled Action', 'action-scheduler' ),
+				'new_item'           => __( 'New Scheduled Action', 'action-scheduler' ),
+				'view'               => __( 'View Action', 'action-scheduler' ),
+				'view_item'          => __( 'View Action', 'action-scheduler' ),
+				'search_items'       => __( 'Search Scheduled Actions', 'action-scheduler' ),
+				'not_found'          => __( 'No actions found', 'action-scheduler' ),
+				'not_found_in_trash' => __( 'No actions found in trash', 'action-scheduler' ),
+			),
+		);
+
+		$args = apply_filters( 'action_scheduler_post_type_args', $args );
+		return $args;
+	}
+}

--- a/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore_TaxonomyRegistrar.php
+++ b/includes/lib/action-scheduler/classes/data-stores/ActionScheduler_wpPostStore_TaxonomyRegistrar.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Class ActionScheduler_wpPostStore_TaxonomyRegistrar
+ *
+ * @codeCoverageIgnore
+ */
+class ActionScheduler_wpPostStore_TaxonomyRegistrar {
+
+	/**
+	 * Registrar.
+	 */
+	public function register() {
+		register_taxonomy( ActionScheduler_wpPostStore::GROUP_TAXONOMY, ActionScheduler_wpPostStore::POST_TYPE, $this->taxonomy_args() );
+	}
+
+	/**
+	 * Get taxonomy arguments.
+	 */
+	protected function taxonomy_args() {
+		$args = array(
+			'label'             => __( 'Action Group', 'action-scheduler' ),
+			'public'            => false,
+			'hierarchical'      => false,
+			'show_admin_column' => true,
+			'query_var'         => false,
+			'rewrite'           => false,
+		);
+
+		$args = apply_filters( 'action_scheduler_taxonomy_args', $args );
+		return $args;
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/ActionMigrator.php
+++ b/includes/lib/action-scheduler/classes/migration/ActionMigrator.php
@@ -1,0 +1,126 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+/**
+ * Class ActionMigrator
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class ActionMigrator {
+	/**
+	 * Source store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $source;
+
+	/**
+	 * Destination store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $destination;
+
+	/**
+	 * LogMigrator instance.
+	 *
+	 * @var LogMigrator
+	 */
+	private $log_migrator;
+
+	/**
+	 * ActionMigrator constructor.
+	 *
+	 * @param \ActionScheduler_Store $source_store Source store object.
+	 * @param \ActionScheduler_Store $destination_store Destination store object.
+	 * @param LogMigrator            $log_migrator Log migrator object.
+	 */
+	public function __construct( \ActionScheduler_Store $source_store, \ActionScheduler_Store $destination_store, LogMigrator $log_migrator ) {
+		$this->source       = $source_store;
+		$this->destination  = $destination_store;
+		$this->log_migrator = $log_migrator;
+	}
+
+	/**
+	 * Migrate an action.
+	 *
+	 * @param int $source_action_id Action ID.
+	 *
+	 * @return int 0|new action ID
+	 * @throws \RuntimeException When unable to delete action from the source store.
+	 */
+	public function migrate( $source_action_id ) {
+		try {
+			$action = $this->source->fetch_action( $source_action_id );
+			$status = $this->source->get_status( $source_action_id );
+		} catch ( \Exception $e ) {
+			$action = null;
+			$status = '';
+		}
+
+		if ( is_null( $action ) || empty( $status ) || ! $action->get_schedule()->get_date() ) {
+			// null action or empty status means the fetch operation failed or the action didn't exist.
+			// null schedule means it's missing vital data.
+			// delete it and move on.
+			try {
+				$this->source->delete_action( $source_action_id );
+			} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+				// nothing to do, it didn't exist in the first place.
+			}
+			do_action( 'action_scheduler/no_action_to_migrate', $source_action_id, $this->source, $this->destination ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+			return 0;
+		}
+
+		try {
+
+			// Make sure the last attempt date is set correctly for completed and failed actions.
+			$last_attempt_date = ( \ActionScheduler_Store::STATUS_PENDING !== $status ) ? $this->source->get_date( $source_action_id ) : null;
+
+			$destination_action_id = $this->destination->save_action( $action, null, $last_attempt_date );
+		} catch ( \Exception $e ) {
+			do_action( 'action_scheduler/migrate_action_failed', $source_action_id, $this->source, $this->destination ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+			return 0; // could not save the action in the new store.
+		}
+
+		try {
+			switch ( $status ) {
+				case \ActionScheduler_Store::STATUS_FAILED:
+					$this->destination->mark_failure( $destination_action_id );
+					break;
+				case \ActionScheduler_Store::STATUS_CANCELED:
+					$this->destination->cancel_action( $destination_action_id );
+					break;
+			}
+
+			$this->log_migrator->migrate( $source_action_id, $destination_action_id );
+			$this->source->delete_action( $source_action_id );
+
+			$test_action = $this->source->fetch_action( $source_action_id );
+			if ( ! is_a( $test_action, 'ActionScheduler_NullAction' ) ) {
+				// translators: %s is an action ID.
+				throw new \RuntimeException( sprintf( __( 'Unable to remove source migrated action %s', 'action-scheduler' ), $source_action_id ) );
+			}
+			do_action( 'action_scheduler/migrated_action', $source_action_id, $destination_action_id, $this->source, $this->destination ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+			return $destination_action_id;
+		} catch ( \Exception $e ) {
+			// could not delete from the old store.
+			$this->source->mark_migrated( $source_action_id );
+
+			// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
+			do_action( 'action_scheduler/migrate_action_incomplete', $source_action_id, $destination_action_id, $this->source, $this->destination );
+			do_action( 'action_scheduler/migrated_action', $source_action_id, $destination_action_id, $this->source, $this->destination );
+			// phpcs:enable
+
+			return $destination_action_id;
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/ActionScheduler_DBStoreMigrator.php
+++ b/includes/lib/action-scheduler/classes/migration/ActionScheduler_DBStoreMigrator.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class ActionScheduler_DBStoreMigrator
+ *
+ * A class for direct saving of actions to the table data store during migration.
+ *
+ * @since 3.0.0
+ */
+class ActionScheduler_DBStoreMigrator extends ActionScheduler_DBStore {
+
+	/**
+	 * Save an action with optional last attempt date.
+	 *
+	 * Normally, saving an action sets its attempted date to 0000-00-00 00:00:00 because when an action is first saved,
+	 * it can't have been attempted yet, but migrated completed actions will have an attempted date, so we need to save
+	 * that when first saving the action.
+	 *
+	 * @param ActionScheduler_Action $action Action to migrate.
+	 * @param null|DateTime          $scheduled_date Optional date of the first instance to store.
+	 * @param null|DateTime          $last_attempt_date Optional date the action was last attempted.
+	 *
+	 * @return string The action ID
+	 * @throws \RuntimeException When the action is not saved.
+	 */
+	public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null, ?DateTime $last_attempt_date = null ) {
+		try {
+			/**
+			 * Global.
+			 *
+			 * @var \wpdb $wpdb
+			 */
+			global $wpdb;
+
+			$action_id = parent::save_action( $action, $scheduled_date );
+
+			if ( null !== $last_attempt_date ) {
+				$data = array(
+					'last_attempt_gmt'   => $this->get_scheduled_date_string( $action, $last_attempt_date ),
+					'last_attempt_local' => $this->get_scheduled_date_string_local( $action, $last_attempt_date ),
+				);
+
+				$wpdb->update( $wpdb->actionscheduler_actions, $data, array( 'action_id' => $action_id ), array( '%s', '%s' ), array( '%d' ) );
+			}
+
+			return $action_id;
+		} catch ( \Exception $e ) {
+			// translators: %s is an error message.
+			throw new \RuntimeException( sprintf( __( 'Error saving action: %s', 'action-scheduler' ), $e->getMessage() ), 0 );
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/BatchFetcher.php
+++ b/includes/lib/action-scheduler/classes/migration/BatchFetcher.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Action_Scheduler\Migration;
+
+use ActionScheduler_Store as Store;
+
+/**
+ * Class BatchFetcher
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class BatchFetcher {
+	/**
+	 * Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $store;
+
+	/**
+	 * BatchFetcher constructor.
+	 *
+	 * @param ActionScheduler_Store $source_store Source store object.
+	 */
+	public function __construct( Store $source_store ) {
+		$this->store = $source_store;
+	}
+
+	/**
+	 * Retrieve a list of actions.
+	 *
+	 * @param int $count The number of actions to retrieve.
+	 *
+	 * @return int[] A list of action IDs
+	 */
+	public function fetch( $count = 10 ) {
+		foreach ( $this->get_query_strategies( $count ) as $query ) {
+			$action_ids = $this->store->query_actions( $query );
+			if ( ! empty( $action_ids ) ) {
+				return $action_ids;
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * Generate a list of prioritized of action search parameters.
+	 *
+	 * @param int $count Number of actions to find.
+	 *
+	 * @return array
+	 */
+	private function get_query_strategies( $count ) {
+		$now  = as_get_datetime_object();
+		$args = array(
+			'date'     => $now,
+			'per_page' => $count,
+			'offset'   => 0,
+			'orderby'  => 'date',
+			'order'    => 'ASC',
+		);
+
+		$priorities = array(
+			Store::STATUS_PENDING,
+			Store::STATUS_FAILED,
+			Store::STATUS_CANCELED,
+			Store::STATUS_COMPLETE,
+			Store::STATUS_RUNNING,
+			'', // any other unanticipated status.
+		);
+
+		foreach ( $priorities as $status ) {
+			yield wp_parse_args(
+				array(
+					'status'       => $status,
+					'date_compare' => '<=',
+				),
+				$args
+			);
+
+			yield wp_parse_args(
+				array(
+					'status'       => $status,
+					'date_compare' => '>=',
+				),
+				$args
+			);
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/Config.php
+++ b/includes/lib/action-scheduler/classes/migration/Config.php
@@ -1,0 +1,196 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+use Action_Scheduler\WP_CLI\ProgressBar;
+use ActionScheduler_Logger as Logger;
+use ActionScheduler_Store as Store;
+
+/**
+ * Class Config
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * A config builder for the ActionScheduler\Migration\Runner class
+ */
+class Config {
+	/**
+	 * Source store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $source_store;
+
+	/**
+	 * Source logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	private $source_logger;
+
+	/**
+	 * Destination store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $destination_store;
+
+	/**
+	 * Destination logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	private $destination_logger;
+
+	/**
+	 * Progress bar object.
+	 *
+	 * @var Action_Scheduler\WP_CLI\ProgressBar
+	 */
+	private $progress_bar;
+
+	/**
+	 * Flag indicating a dryrun.
+	 *
+	 * @var bool
+	 */
+	private $dry_run = false;
+
+	/**
+	 * Config constructor.
+	 */
+	public function __construct() {
+
+	}
+
+	/**
+	 * Get the configured source store.
+	 *
+	 * @return ActionScheduler_Store
+	 * @throws \RuntimeException When source store is not configured.
+	 */
+	public function get_source_store() {
+		if ( empty( $this->source_store ) ) {
+			throw new \RuntimeException( __( 'Source store must be configured before running a migration', 'action-scheduler' ) );
+		}
+
+		return $this->source_store;
+	}
+
+	/**
+	 * Set the configured source store.
+	 *
+	 * @param ActionScheduler_Store $store Source store object.
+	 */
+	public function set_source_store( Store $store ) {
+		$this->source_store = $store;
+	}
+
+	/**
+	 * Get the configured source logger.
+	 *
+	 * @return ActionScheduler_Logger
+	 * @throws \RuntimeException When source logger is not configured.
+	 */
+	public function get_source_logger() {
+		if ( empty( $this->source_logger ) ) {
+			throw new \RuntimeException( __( 'Source logger must be configured before running a migration', 'action-scheduler' ) );
+		}
+
+		return $this->source_logger;
+	}
+
+	/**
+	 * Set the configured source logger.
+	 *
+	 * @param ActionScheduler_Logger $logger Logger object.
+	 */
+	public function set_source_logger( Logger $logger ) {
+		$this->source_logger = $logger;
+	}
+
+	/**
+	 * Get the configured destination store.
+	 *
+	 * @return ActionScheduler_Store
+	 * @throws \RuntimeException When destination store is not configured.
+	 */
+	public function get_destination_store() {
+		if ( empty( $this->destination_store ) ) {
+			throw new \RuntimeException( __( 'Destination store must be configured before running a migration', 'action-scheduler' ) );
+		}
+
+		return $this->destination_store;
+	}
+
+	/**
+	 * Set the configured destination store.
+	 *
+	 * @param ActionScheduler_Store $store Action store object.
+	 */
+	public function set_destination_store( Store $store ) {
+		$this->destination_store = $store;
+	}
+
+	/**
+	 * Get the configured destination logger.
+	 *
+	 * @return ActionScheduler_Logger
+	 * @throws \RuntimeException When destination logger is not configured.
+	 */
+	public function get_destination_logger() {
+		if ( empty( $this->destination_logger ) ) {
+			throw new \RuntimeException( __( 'Destination logger must be configured before running a migration', 'action-scheduler' ) );
+		}
+
+		return $this->destination_logger;
+	}
+
+	/**
+	 * Set the configured destination logger.
+	 *
+	 * @param ActionScheduler_Logger $logger Logger object.
+	 */
+	public function set_destination_logger( Logger $logger ) {
+		$this->destination_logger = $logger;
+	}
+
+	/**
+	 * Get flag indicating whether it's a dry run.
+	 *
+	 * @return bool
+	 */
+	public function get_dry_run() {
+		return $this->dry_run;
+	}
+
+	/**
+	 * Set flag indicating whether it's a dry run.
+	 *
+	 * @param bool $dry_run Dry run toggle.
+	 */
+	public function set_dry_run( $dry_run ) {
+		$this->dry_run = (bool) $dry_run;
+	}
+
+	/**
+	 * Get progress bar object.
+	 *
+	 * @return ActionScheduler\WPCLI\ProgressBar
+	 */
+	public function get_progress_bar() {
+		return $this->progress_bar;
+	}
+
+	/**
+	 * Set progress bar object.
+	 *
+	 * @param ActionScheduler\WPCLI\ProgressBar $progress_bar Progress bar object.
+	 */
+	public function set_progress_bar( ProgressBar $progress_bar ) {
+		$this->progress_bar = $progress_bar;
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/Controller.php
+++ b/includes/lib/action-scheduler/classes/migration/Controller.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Action_Scheduler\Migration;
+
+use ActionScheduler_DataController;
+use ActionScheduler_LoggerSchema;
+use ActionScheduler_StoreSchema;
+use Action_Scheduler\WP_CLI\ProgressBar;
+
+/**
+ * Class Controller
+ *
+ * The main plugin/initialization class for migration to custom tables.
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class Controller {
+	/**
+	 * Instance.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Scheduler instance.
+	 *
+	 * @var Action_Scheduler\Migration\Scheduler
+	 */
+	private $migration_scheduler;
+
+	/**
+	 * Class name of the store object.
+	 *
+	 * @var string
+	 */
+	private $store_classname;
+
+	/**
+	 * Class name of the logger object.
+	 *
+	 * @var string
+	 */
+	private $logger_classname;
+
+	/**
+	 * Flag to indicate migrating custom store.
+	 *
+	 * @var bool
+	 */
+	private $migrate_custom_store;
+
+	/**
+	 * Controller constructor.
+	 *
+	 * @param Scheduler $migration_scheduler Migration scheduler object.
+	 */
+	protected function __construct( Scheduler $migration_scheduler ) {
+		$this->migration_scheduler = $migration_scheduler;
+		$this->store_classname     = '';
+	}
+
+	/**
+	 * Set the action store class name.
+	 *
+	 * @param string $class Classname of the store class.
+	 *
+	 * @return string
+	 */
+	public function get_store_class( $class ) {
+		if ( \ActionScheduler_DataController::is_migration_complete() ) {
+			return \ActionScheduler_DataController::DATASTORE_CLASS;
+		} elseif ( \ActionScheduler_Store::DEFAULT_CLASS !== $class ) {
+			$this->store_classname = $class;
+			return $class;
+		} else {
+			return 'ActionScheduler_HybridStore';
+		}
+	}
+
+	/**
+	 * Set the action logger class name.
+	 *
+	 * @param string $class Classname of the logger class.
+	 *
+	 * @return string
+	 */
+	public function get_logger_class( $class ) {
+		\ActionScheduler_Store::instance();
+
+		if ( $this->has_custom_datastore() ) {
+			$this->logger_classname = $class;
+			return $class;
+		} else {
+			return \ActionScheduler_DataController::LOGGER_CLASS;
+		}
+	}
+
+	/**
+	 * Get flag indicating whether a custom datastore is in use.
+	 *
+	 * @return bool
+	 */
+	public function has_custom_datastore() {
+		return (bool) $this->store_classname;
+	}
+
+	/**
+	 * Set up the background migration process.
+	 *
+	 * @return void
+	 */
+	public function schedule_migration() {
+		$logging_tables = new ActionScheduler_LoggerSchema();
+		$store_tables   = new ActionScheduler_StoreSchema();
+
+		/*
+		 * In some unusual cases, the expected tables may not have been created. In such cases
+		 * we do not schedule a migration as doing so will lead to fatal error conditions.
+		 *
+		 * In such cases the user will likely visit the Tools > Scheduled Actions screen to
+		 * investigate, and will see appropriate messaging (this step also triggers an attempt
+		 * to rebuild any missing tables).
+		 *
+		 * @see https://github.com/woocommerce/action-scheduler/issues/653
+		 */
+		if (
+			ActionScheduler_DataController::is_migration_complete()
+			|| $this->migration_scheduler->is_migration_scheduled()
+			|| ! $store_tables->tables_exist()
+			|| ! $logging_tables->tables_exist()
+		) {
+			return;
+		}
+
+		$this->migration_scheduler->schedule_migration();
+	}
+
+	/**
+	 * Get the default migration config object
+	 *
+	 * @return ActionScheduler\Migration\Config
+	 */
+	public function get_migration_config_object() {
+		static $config = null;
+
+		if ( ! $config ) {
+			$source_store  = $this->store_classname ? new $this->store_classname() : new \ActionScheduler_wpPostStore();
+			$source_logger = $this->logger_classname ? new $this->logger_classname() : new \ActionScheduler_wpCommentLogger();
+
+			$config = new Config();
+			$config->set_source_store( $source_store );
+			$config->set_source_logger( $source_logger );
+			$config->set_destination_store( new \ActionScheduler_DBStoreMigrator() );
+			$config->set_destination_logger( new \ActionScheduler_DBLogger() );
+
+			if ( defined( 'WP_CLI' ) && WP_CLI ) {
+				$config->set_progress_bar( new ProgressBar( '', 0 ) );
+			}
+		}
+
+		return apply_filters( 'action_scheduler/migration_config', $config ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	}
+
+	/**
+	 * Hook dashboard migration notice.
+	 */
+	public function hook_admin_notices() {
+		if ( ! $this->allow_migration() || \ActionScheduler_DataController::is_migration_complete() ) {
+			return;
+		}
+		add_action( 'admin_notices', array( $this, 'display_migration_notice' ), 10, 0 );
+	}
+
+	/**
+	 * Show a dashboard notice that migration is in progress.
+	 */
+	public function display_migration_notice() {
+		printf( '<div class="notice notice-warning"><p>%s</p></div>', esc_html__( 'Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ) );
+	}
+
+	/**
+	 * Add store classes. Hook migration.
+	 */
+	private function hook() {
+		add_filter( 'action_scheduler_store_class', array( $this, 'get_store_class' ), 100, 1 );
+		add_filter( 'action_scheduler_logger_class', array( $this, 'get_logger_class' ), 100, 1 );
+		add_action( 'init', array( $this, 'maybe_hook_migration' ) );
+		add_action( 'wp_loaded', array( $this, 'schedule_migration' ) );
+
+		// Action Scheduler may be displayed as a Tools screen or WooCommerce > Status administration screen.
+		add_action( 'load-tools_page_action-scheduler', array( $this, 'hook_admin_notices' ), 10, 0 );
+		add_action( 'load-woocommerce_page_wc-status', array( $this, 'hook_admin_notices' ), 10, 0 );
+	}
+
+	/**
+	 * Possibly hook the migration scheduler action.
+	 */
+	public function maybe_hook_migration() {
+		if ( ! $this->allow_migration() || \ActionScheduler_DataController::is_migration_complete() ) {
+			return;
+		}
+
+		$this->migration_scheduler->hook();
+	}
+
+	/**
+	 * Allow datastores to enable migration to AS tables.
+	 */
+	public function allow_migration() {
+		if ( ! \ActionScheduler_DataController::dependencies_met() ) {
+			return false;
+		}
+
+		if ( null === $this->migrate_custom_store ) {
+			$this->migrate_custom_store = apply_filters( 'action_scheduler_migrate_data_store', false );
+		}
+
+		return ( ! $this->has_custom_datastore() ) || $this->migrate_custom_store;
+	}
+
+	/**
+	 * Proceed with the migration if the dependencies have been met.
+	 */
+	public static function init() {
+		if ( \ActionScheduler_DataController::dependencies_met() ) {
+			self::instance()->hook();
+		}
+	}
+
+	/**
+	 * Singleton factory.
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new static( new Scheduler() );
+		}
+
+		return self::$instance;
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/DryRun_ActionMigrator.php
+++ b/includes/lib/action-scheduler/classes/migration/DryRun_ActionMigrator.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+/**
+ * Class DryRun_ActionMigrator
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class DryRun_ActionMigrator extends ActionMigrator {
+	/**
+	 * Simulate migrating an action.
+	 *
+	 * @param int $source_action_id Action ID.
+	 *
+	 * @return int
+	 */
+	public function migrate( $source_action_id ) {
+		do_action( 'action_scheduler/migrate_action_dry_run', $source_action_id ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		return 0;
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/DryRun_LogMigrator.php
+++ b/includes/lib/action-scheduler/classes/migration/DryRun_LogMigrator.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+/**
+ * Class DryRun_LogMigrator
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @codeCoverageIgnore
+ */
+class DryRun_LogMigrator extends LogMigrator {
+	/**
+	 * Simulate migrating an action log.
+	 *
+	 * @param int $source_action_id Source logger object.
+	 * @param int $destination_action_id Destination logger object.
+	 */
+	public function migrate( $source_action_id, $destination_action_id ) {
+		// no-op.
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/LogMigrator.php
+++ b/includes/lib/action-scheduler/classes/migration/LogMigrator.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+use ActionScheduler_Logger;
+
+/**
+ * Class LogMigrator
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class LogMigrator {
+	/**
+	 * Source logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	private $source;
+
+	/**
+	 * Destination logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	private $destination;
+
+	/**
+	 * ActionMigrator constructor.
+	 *
+	 * @param ActionScheduler_Logger $source_logger Source logger object.
+	 * @param ActionScheduler_Logger $destination_logger Destination logger object.
+	 */
+	public function __construct( ActionScheduler_Logger $source_logger, ActionScheduler_Logger $destination_logger ) {
+		$this->source      = $source_logger;
+		$this->destination = $destination_logger;
+	}
+
+	/**
+	 * Migrate an action log.
+	 *
+	 * @param int $source_action_id Source logger object.
+	 * @param int $destination_action_id Destination logger object.
+	 */
+	public function migrate( $source_action_id, $destination_action_id ) {
+		$logs = $this->source->get_logs( $source_action_id );
+
+		foreach ( $logs as $log ) {
+			if ( absint( $log->get_action_id() ) === absint( $source_action_id ) ) {
+				$this->destination->log( $destination_action_id, $log->get_message(), $log->get_date() );
+			}
+		}
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/Runner.php
+++ b/includes/lib/action-scheduler/classes/migration/Runner.php
@@ -1,0 +1,171 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+/**
+ * Class Runner
+ *
+ * @package Action_Scheduler\Migration
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class Runner {
+	/**
+	 * Source store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $source_store;
+
+	/**
+	 * Destination store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private $destination_store;
+
+	/**
+	 * Source logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	private $source_logger;
+
+	/**
+	 * Destination logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
+	private $destination_logger;
+
+	/**
+	 * Batch fetcher instance.
+	 *
+	 * @var BatchFetcher
+	 */
+	private $batch_fetcher;
+
+	/**
+	 * Action migrator instance.
+	 *
+	 * @var ActionMigrator
+	 */
+	private $action_migrator;
+
+	/**
+	 * Log migrator instance.
+	 *
+	 * @var LogMigrator
+	 */
+	private $log_migrator;
+
+	/**
+	 * Progress bar instance.
+	 *
+	 * @var ProgressBar
+	 */
+	private $progress_bar;
+
+	/**
+	 * Runner constructor.
+	 *
+	 * @param Config $config Migration configuration object.
+	 */
+	public function __construct( Config $config ) {
+		$this->source_store       = $config->get_source_store();
+		$this->destination_store  = $config->get_destination_store();
+		$this->source_logger      = $config->get_source_logger();
+		$this->destination_logger = $config->get_destination_logger();
+
+		$this->batch_fetcher = new BatchFetcher( $this->source_store );
+		if ( $config->get_dry_run() ) {
+			$this->log_migrator    = new DryRun_LogMigrator( $this->source_logger, $this->destination_logger );
+			$this->action_migrator = new DryRun_ActionMigrator( $this->source_store, $this->destination_store, $this->log_migrator );
+		} else {
+			$this->log_migrator    = new LogMigrator( $this->source_logger, $this->destination_logger );
+			$this->action_migrator = new ActionMigrator( $this->source_store, $this->destination_store, $this->log_migrator );
+		}
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$this->progress_bar = $config->get_progress_bar();
+		}
+	}
+
+	/**
+	 * Run migration batch.
+	 *
+	 * @param int $batch_size Optional batch size. Default 10.
+	 *
+	 * @return int Size of batch processed.
+	 */
+	public function run( $batch_size = 10 ) {
+		$batch      = $this->batch_fetcher->fetch( $batch_size );
+		$batch_size = count( $batch );
+
+		if ( ! $batch_size ) {
+			return 0;
+		}
+
+		if ( $this->progress_bar ) {
+			/* translators: %d: amount of actions */
+			$this->progress_bar->set_message( sprintf( _n( 'Migrating %d action', 'Migrating %d actions', $batch_size, 'action-scheduler' ), $batch_size ) );
+			$this->progress_bar->set_count( $batch_size );
+		}
+
+		$this->migrate_actions( $batch );
+
+		return $batch_size;
+	}
+
+	/**
+	 * Migration a batch of actions.
+	 *
+	 * @param array $action_ids List of action IDs to migrate.
+	 */
+	public function migrate_actions( array $action_ids ) {
+		do_action( 'action_scheduler/migration_batch_starting', $action_ids ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		\ActionScheduler::logger()->unhook_stored_action();
+		$this->destination_logger->unhook_stored_action();
+
+		foreach ( $action_ids as $source_action_id ) {
+			$destination_action_id = $this->action_migrator->migrate( $source_action_id );
+			if ( $destination_action_id ) {
+				$this->destination_logger->log(
+					$destination_action_id,
+					sprintf(
+						/* translators: 1: source action ID 2: source store class 3: destination action ID 4: destination store class */
+						__( 'Migrated action with ID %1$d in %2$s to ID %3$d in %4$s', 'action-scheduler' ),
+						$source_action_id,
+						get_class( $this->source_store ),
+						$destination_action_id,
+						get_class( $this->destination_store )
+					)
+				);
+			}
+
+			if ( $this->progress_bar ) {
+				$this->progress_bar->tick();
+			}
+		}
+
+		if ( $this->progress_bar ) {
+			$this->progress_bar->finish();
+		}
+
+		\ActionScheduler::logger()->hook_stored_action();
+
+		do_action( 'action_scheduler/migration_batch_complete', $action_ids ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	}
+
+	/**
+	 * Initialize destination store and logger.
+	 */
+	public function init_destination() {
+		$this->destination_store->init();
+		$this->destination_logger->init();
+	}
+}

--- a/includes/lib/action-scheduler/classes/migration/Scheduler.php
+++ b/includes/lib/action-scheduler/classes/migration/Scheduler.php
@@ -1,0 +1,128 @@
+<?php
+
+
+namespace Action_Scheduler\Migration;
+
+/**
+ * Class Scheduler
+ *
+ * @package Action_Scheduler\WP_CLI
+ *
+ * @since 3.0.0
+ *
+ * @codeCoverageIgnore
+ */
+class Scheduler {
+	/** Migration action hook. */
+	const HOOK = 'action_scheduler/migration_hook';
+
+	/** Migration action group. */
+	const GROUP = 'action-scheduler-migration';
+
+	/**
+	 * Set up the callback for the scheduled job.
+	 */
+	public function hook() {
+		add_action( self::HOOK, array( $this, 'run_migration' ), 10, 0 );
+	}
+
+	/**
+	 * Remove the callback for the scheduled job.
+	 */
+	public function unhook() {
+		remove_action( self::HOOK, array( $this, 'run_migration' ), 10 );
+	}
+
+	/**
+	 * The migration callback.
+	 */
+	public function run_migration() {
+		$migration_runner = $this->get_migration_runner();
+		$count            = $migration_runner->run( $this->get_batch_size() );
+
+		if ( 0 === $count ) {
+			$this->mark_complete();
+		} else {
+			$this->schedule_migration( time() + $this->get_schedule_interval() );
+		}
+	}
+
+	/**
+	 * Mark the migration complete.
+	 */
+	public function mark_complete() {
+		$this->unschedule_migration();
+
+		\ActionScheduler_DataController::mark_migration_complete();
+		do_action( 'action_scheduler/migration_complete' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	}
+
+	/**
+	 * Get a flag indicating whether the migration is scheduled.
+	 *
+	 * @return bool Whether there is a pending action in the store to handle the migration
+	 */
+	public function is_migration_scheduled() {
+		$next = as_next_scheduled_action( self::HOOK );
+
+		return ! empty( $next );
+	}
+
+	/**
+	 * Schedule the migration.
+	 *
+	 * @param int $when Optional timestamp to run the next migration batch. Defaults to now.
+	 *
+	 * @return string The action ID
+	 */
+	public function schedule_migration( $when = 0 ) {
+		$next = as_next_scheduled_action( self::HOOK );
+
+		if ( ! empty( $next ) ) {
+			return $next;
+		}
+
+		if ( empty( $when ) ) {
+			$when = time() + MINUTE_IN_SECONDS;
+		}
+
+		return as_schedule_single_action( $when, self::HOOK, array(), self::GROUP );
+	}
+
+	/**
+	 * Remove the scheduled migration action.
+	 */
+	public function unschedule_migration() {
+		as_unschedule_action( self::HOOK, null, self::GROUP );
+	}
+
+	/**
+	 * Get migration batch schedule interval.
+	 *
+	 * @return int Seconds between migration runs. Defaults to 0 seconds to allow chaining migration via Async Runners.
+	 */
+	private function get_schedule_interval() {
+		return (int) apply_filters( 'action_scheduler/migration_interval', 0 ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	}
+
+	/**
+	 * Get migration batch size.
+	 *
+	 * @return int Number of actions to migrate in each batch. Defaults to 250.
+	 */
+	private function get_batch_size() {
+		return (int) apply_filters( 'action_scheduler/migration_batch_size', 250 ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	}
+
+	/**
+	 * Get migration runner object.
+	 *
+	 * @return Runner
+	 */
+	private function get_migration_runner() {
+		$config = Controller::instance()->get_migration_config_object();
+
+		return new Runner( $config );
+	}
+
+}

--- a/includes/lib/action-scheduler/classes/schedules/ActionScheduler_CanceledSchedule.php
+++ b/includes/lib/action-scheduler/classes/schedules/ActionScheduler_CanceledSchedule.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Class ActionScheduler_SimpleSchedule
+ */
+class ActionScheduler_CanceledSchedule extends ActionScheduler_SimpleSchedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 *
+	 * @var null
+	 */
+	private $timestamp = null;
+
+	/**
+	 * Calculate when the next instance of this schedule would run based on a given date & time.
+	 *
+	 * @param DateTime $after Timestamp.
+	 *
+	 * @return DateTime|null
+	 */
+	public function calculate_next( DateTime $after ) {
+		return null;
+	}
+
+	/**
+	 * Cancelled actions should never have a next schedule, even if get_next()
+	 * is called with $after < $this->scheduled_date.
+	 *
+	 * @param DateTime $after Timestamp.
+	 * @return DateTime|null
+	 */
+	public function get_next( DateTime $after ) {
+		return null;
+	}
+
+	/**
+	 * Action is not recurring.
+	 *
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return false;
+	}
+
+	/**
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To maintain backward
+	 * compatibility with schedules serialized and stored prior to 3.0, we need to correctly
+	 * map the old property names with matching visibility.
+	 */
+	public function __wakeup() {
+		if ( ! is_null( $this->timestamp ) ) {
+			$this->scheduled_timestamp = $this->timestamp;
+			unset( $this->timestamp );
+		}
+		parent::__wakeup();
+	}
+}

--- a/includes/lib/action-scheduler/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/includes/lib/action-scheduler/classes/schedules/ActionScheduler_CronSchedule.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * Class ActionScheduler_CronSchedule
+ */
+class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSchedule implements ActionScheduler_Schedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 *
+	 * @var null
+	 */
+	private $start_timestamp = null;
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 *
+	 * @var null
+	 */
+	private $cron = null;
+
+	/**
+	 * Wrapper for parent constructor to accept a cron expression string and map it to a CronExpression for this
+	 * objects $recurrence property.
+	 *
+	 * @param DateTime              $start The date & time to run the action at or after. If $start aligns with the CronSchedule passed via $recurrence, it will be used. If it does not align, the first matching date after it will be used.
+	 * @param CronExpression|string $recurrence The CronExpression used to calculate the schedule's next instance.
+	 * @param DateTime|null         $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
+	 */
+	public function __construct( DateTime $start, $recurrence, ?DateTime $first = null ) {
+		if ( ! is_a( $recurrence, 'CronExpression' ) ) {
+			$recurrence = CronExpression::factory( $recurrence );
+		}
+
+		// For backward compatibility, we need to make sure the date is set to the first matching cron date, not whatever date is passed in. Importantly, by passing true as the 3rd param, if $start matches the cron expression, then it will be used. This was previously handled in the now deprecated next() method.
+		$date = $recurrence->getNextRunDate( $start, 0, true );
+
+		// parent::__construct() will set this to $date by default, but that may be different to $start now.
+		$first = empty( $first ) ? $start : $first;
+
+		parent::__construct( $date, $recurrence, $first );
+	}
+
+	/**
+	 * Calculate when an instance of this schedule would start based on a given
+	 * date & time using its the CronExpression.
+	 *
+	 * @param DateTime $after Timestamp.
+	 * @return DateTime
+	 */
+	protected function calculate_next( DateTime $after ) {
+		return $this->recurrence->getNextRunDate( $after, 0, false );
+	}
+
+	/**
+	 * Get the schedule's recurrence.
+	 *
+	 * @return string
+	 */
+	public function get_recurrence() {
+		return strval( $this->recurrence );
+	}
+
+	/**
+	 * Serialize cron schedules with data required prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, recurring schedules used different property names to
+	 * refer to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To guard against the
+	 * possibility of infinite loops if downgrading to Action Scheduler < 3.0.0, we need to
+	 * also store the data with the old property names so if it's unserialized in AS < 3.0,
+	 * the schedule doesn't end up with a null recurrence.
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+
+		$sleep_params = parent::__sleep();
+
+		$this->start_timestamp = $this->scheduled_timestamp;
+		$this->cron            = $this->recurrence;
+
+		return array_merge(
+			$sleep_params,
+			array(
+				'start_timestamp',
+				'cron',
+			)
+		);
+	}
+
+	/**
+	 * Unserialize cron schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * For more background, @see ActionScheduler_Abstract_RecurringSchedule::__wakeup().
+	 */
+	public function __wakeup() {
+		if ( is_null( $this->scheduled_timestamp ) && ! is_null( $this->start_timestamp ) ) {
+			$this->scheduled_timestamp = $this->start_timestamp;
+			unset( $this->start_timestamp );
+		}
+
+		if ( is_null( $this->recurrence ) && ! is_null( $this->cron ) ) {
+			$this->recurrence = $this->cron;
+			unset( $this->cron );
+		}
+		parent::__wakeup();
+	}
+}
+

--- a/includes/lib/action-scheduler/classes/schedules/ActionScheduler_IntervalSchedule.php
+++ b/includes/lib/action-scheduler/classes/schedules/ActionScheduler_IntervalSchedule.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Class ActionScheduler_IntervalSchedule
+ */
+class ActionScheduler_IntervalSchedule extends ActionScheduler_Abstract_RecurringSchedule implements ActionScheduler_Schedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 *
+	 * @var null
+	 */
+	private $start_timestamp = null;
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 *
+	 * @var null
+	 */
+	private $interval_in_seconds = null;
+
+	/**
+	 * Calculate when this schedule should start after a given date & time using
+	 * the number of seconds between recurrences.
+	 *
+	 * @param DateTime $after Timestamp.
+	 * @return DateTime
+	 */
+	protected function calculate_next( DateTime $after ) {
+		$after->modify( '+' . (int) $this->get_recurrence() . ' seconds' );
+		return $after;
+	}
+
+	/**
+	 * Schedule interval in seconds.
+	 *
+	 * @return int
+	 */
+	public function interval_in_seconds() {
+		_deprecated_function( __METHOD__, '3.0.0', '(int)ActionScheduler_Abstract_RecurringSchedule::get_recurrence()' );
+		return (int) $this->get_recurrence();
+	}
+
+	/**
+	 * Serialize interval schedules with data required prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, recurring schedules used different property names to
+	 * refer to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To guard against the
+	 * possibility of infinite loops if downgrading to Action Scheduler < 3.0.0, we need to
+	 * also store the data with the old property names so if it's unserialized in AS < 3.0,
+	 * the schedule doesn't end up with a null/false/0 recurrence.
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+
+		$sleep_params = parent::__sleep();
+
+		$this->start_timestamp     = $this->scheduled_timestamp;
+		$this->interval_in_seconds = $this->recurrence;
+
+		return array_merge(
+			$sleep_params,
+			array(
+				'start_timestamp',
+				'interval_in_seconds',
+			)
+		);
+	}
+
+	/**
+	 * Unserialize interval schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * For more background, @see ActionScheduler_Abstract_RecurringSchedule::__wakeup().
+	 */
+	public function __wakeup() {
+		if ( is_null( $this->scheduled_timestamp ) && ! is_null( $this->start_timestamp ) ) {
+			$this->scheduled_timestamp = $this->start_timestamp;
+			unset( $this->start_timestamp );
+		}
+
+		if ( is_null( $this->recurrence ) && ! is_null( $this->interval_in_seconds ) ) {
+			$this->recurrence = $this->interval_in_seconds;
+			unset( $this->interval_in_seconds );
+		}
+		parent::__wakeup();
+	}
+}

--- a/includes/lib/action-scheduler/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/includes/lib/action-scheduler/classes/schedules/ActionScheduler_NullSchedule.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Class ActionScheduler_NullSchedule
+ */
+class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
+
+	/**
+	 * DateTime instance.
+	 *
+	 * @var DateTime|null
+	 */
+	protected $scheduled_date;
+
+	/**
+	 * Make the $date param optional and default to null.
+	 *
+	 * @param null|DateTime $date The date & time to run the action.
+	 */
+	public function __construct( ?DateTime $date = null ) {
+		$this->scheduled_date = null;
+	}
+
+	/**
+	 * This schedule has no scheduled DateTime, so we need to override the parent __sleep().
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+		return array();
+	}
+
+	/**
+	 * Wakeup.
+	 */
+	public function __wakeup() {
+		$this->scheduled_date = null;
+	}
+}

--- a/includes/lib/action-scheduler/classes/schedules/ActionScheduler_Schedule.php
+++ b/includes/lib/action-scheduler/classes/schedules/ActionScheduler_Schedule.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Class ActionScheduler_Schedule
+ */
+interface ActionScheduler_Schedule {
+	/**
+	 * Get the date & time this schedule was created to run, or calculate when it should be run
+	 * after a given date & time.
+	 *
+	 * @param null|DateTime $after Timestamp.
+	 * @return DateTime|null
+	 */
+	public function next( ?DateTime $after = null );
+
+	/**
+	 * Identify the schedule as (not) recurring.
+	 *
+	 * @return bool
+	 */
+	public function is_recurring();
+}

--- a/includes/lib/action-scheduler/classes/schedules/ActionScheduler_SimpleSchedule.php
+++ b/includes/lib/action-scheduler/classes/schedules/ActionScheduler_SimpleSchedule.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Class ActionScheduler_SimpleSchedule
+ */
+class ActionScheduler_SimpleSchedule extends ActionScheduler_Abstract_Schedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 *
+	 * @var null|DateTime
+	 */
+	private $timestamp = null;
+
+	/**
+	 * Calculate when this schedule should start after a given date & time using
+	 * the number of seconds between recurrences.
+	 *
+	 * @param DateTime $after Timestamp.
+	 *
+	 * @return DateTime|null
+	 */
+	public function calculate_next( DateTime $after ) {
+		return null;
+	}
+
+	/**
+	 * Schedule is not recurring.
+	 *
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return false;
+	}
+
+	/**
+	 * Serialize schedule with data required prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To guard against the
+	 * scheduled date for single actions always being seen as "now" if downgrading to
+	 * Action Scheduler < 3.0.0, we need to also store the data with the old property names
+	 * so if it's unserialized in AS < 3.0, the schedule doesn't end up with a null recurrence.
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+
+		$sleep_params = parent::__sleep();
+
+		$this->timestamp = $this->scheduled_timestamp;
+
+		return array_merge(
+			$sleep_params,
+			array(
+				'timestamp',
+			)
+		);
+	}
+
+	/**
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To maintain backward
+	 * compatibility with schedules serialized and stored prior to 3.0, we need to correctly
+	 * map the old property names with matching visibility.
+	 */
+	public function __wakeup() {
+
+		if ( is_null( $this->scheduled_timestamp ) && ! is_null( $this->timestamp ) ) {
+			$this->scheduled_timestamp = $this->timestamp;
+			unset( $this->timestamp );
+		}
+		parent::__wakeup();
+	}
+}

--- a/includes/lib/action-scheduler/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/includes/lib/action-scheduler/classes/schema/ActionScheduler_LoggerSchema.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Class ActionScheduler_LoggerSchema
+ *
+ * @codeCoverageIgnore
+ *
+ * Creates a custom table for storing action logs
+ */
+class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
+	const LOG_TABLE = 'actionscheduler_logs';
+
+	/**
+	 * Schema version.
+	 *
+	 * Increment this value to trigger a schema update.
+	 *
+	 * @var int
+	 */
+	protected $schema_version = 3;
+
+	/**
+	 * Construct.
+	 */
+	public function __construct() {
+		$this->tables = array(
+			self::LOG_TABLE,
+		);
+	}
+
+	/**
+	 * Performs additional setup work required to support this schema.
+	 */
+	public function init() {
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_schema_3_0' ), 10, 2 );
+	}
+
+	/**
+	 * Get table definition.
+	 *
+	 * @param string $table Table name.
+	 */
+	protected function get_table_definition( $table ) {
+		global $wpdb;
+		$table_name      = $wpdb->$table;
+		$charset_collate = $wpdb->get_charset_collate();
+		switch ( $table ) {
+
+			case self::LOG_TABLE:
+				$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
+				return "CREATE TABLE $table_name (
+				        log_id bigint(20) unsigned NOT NULL auto_increment,
+				        action_id bigint(20) unsigned NOT NULL,
+				        message text NOT NULL,
+				        log_date_gmt datetime NULL default '{$default_date}',
+				        log_date_local datetime NULL default '{$default_date}',
+				        PRIMARY KEY  (log_id),
+				        KEY action_id (action_id),
+				        KEY log_date_gmt (log_date_gmt)
+				        ) $charset_collate";
+
+			default:
+				return '';
+		}
+	}
+
+	/**
+	 * Update the logs table schema, allowing datetime fields to be NULL.
+	 *
+	 * This is needed because the NOT NULL constraint causes a conflict with some versions of MySQL
+	 * configured with sql_mode=NO_ZERO_DATE, which can for instance lead to tables not being created.
+	 *
+	 * Most other schema updates happen via ActionScheduler_Abstract_Schema::update_table(), however
+	 * that method relies on dbDelta() and this change is not possible when using that function.
+	 *
+	 * @param string $table Name of table being updated.
+	 * @param string $db_version The existing schema version of the table.
+	 */
+	public function update_schema_3_0( $table, $db_version ) {
+		global $wpdb;
+
+		if ( 'actionscheduler_logs' !== $table || version_compare( $db_version, '3', '>=' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$table_name   = $wpdb->prefix . 'actionscheduler_logs';
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '{$table_name}'" );
+		$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
+
+		if ( ! empty( $table_list ) ) {
+			$query = "
+				ALTER TABLE {$table_name}
+				MODIFY COLUMN log_date_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN log_date_local datetime NULL default '{$default_date}'
+			";
+			$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+}

--- a/includes/lib/action-scheduler/classes/schema/ActionScheduler_StoreSchema.php
+++ b/includes/lib/action-scheduler/classes/schema/ActionScheduler_StoreSchema.php
@@ -1,0 +1,143 @@
+<?php
+
+/**
+ * Class ActionScheduler_StoreSchema
+ *
+ * @codeCoverageIgnore
+ *
+ * Creates custom tables for storing scheduled actions
+ */
+class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
+	const ACTIONS_TABLE = 'actionscheduler_actions';
+	const CLAIMS_TABLE  = 'actionscheduler_claims';
+	const GROUPS_TABLE  = 'actionscheduler_groups';
+	const DEFAULT_DATE  = '0000-00-00 00:00:00';
+
+	/**
+	 * Schema version.
+	 *
+	 * Increment this value to trigger a schema update.
+	 *
+	 * @var int
+	 */
+	protected $schema_version = 7;
+
+	/**
+	 * Construct.
+	 */
+	public function __construct() {
+		$this->tables = array(
+			self::ACTIONS_TABLE,
+			self::CLAIMS_TABLE,
+			self::GROUPS_TABLE,
+		);
+	}
+
+	/**
+	 * Performs additional setup work required to support this schema.
+	 */
+	public function init() {
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_schema_5_0' ), 10, 2 );
+	}
+
+	/**
+	 * Get table definition.
+	 *
+	 * @param string $table Table name.
+	 */
+	protected function get_table_definition( $table ) {
+		global $wpdb;
+		$table_name      = $wpdb->$table;
+		$charset_collate = $wpdb->get_charset_collate();
+		$default_date    = self::DEFAULT_DATE;
+		// phpcs:ignore Squiz.PHP.CommentedOutCode
+		$max_index_length = 191; // @see wp_get_db_schema()
+
+		$hook_status_scheduled_date_gmt_max_index_length = $max_index_length - 20 - 8; // - status, - scheduled_date_gmt
+
+		switch ( $table ) {
+
+			case self::ACTIONS_TABLE:
+				return "CREATE TABLE {$table_name} (
+				        action_id bigint(20) unsigned NOT NULL auto_increment,
+				        hook varchar(191) NOT NULL,
+				        status varchar(20) NOT NULL,
+				        scheduled_date_gmt datetime NULL default '{$default_date}',
+				        scheduled_date_local datetime NULL default '{$default_date}',
+				        priority tinyint unsigned NOT NULL default '10',
+				        args varchar($max_index_length),
+				        schedule longtext,
+				        group_id bigint(20) unsigned NOT NULL default '0',
+				        attempts int(11) NOT NULL default '0',
+				        last_attempt_gmt datetime NULL default '{$default_date}',
+				        last_attempt_local datetime NULL default '{$default_date}',
+				        claim_id bigint(20) unsigned NOT NULL default '0',
+				        extended_args varchar(8000) DEFAULT NULL,
+				        PRIMARY KEY  (action_id),
+				        KEY hook_status_scheduled_date_gmt (hook($hook_status_scheduled_date_gmt_max_index_length), status, scheduled_date_gmt),
+				        KEY status_scheduled_date_gmt (status, scheduled_date_gmt),
+				        KEY scheduled_date_gmt (scheduled_date_gmt),
+				        KEY args (args($max_index_length)),
+				        KEY group_id (group_id),
+				        KEY last_attempt_gmt (last_attempt_gmt),
+				        KEY `claim_id_status_scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
+				        ) $charset_collate";
+
+			case self::CLAIMS_TABLE:
+				return "CREATE TABLE {$table_name} (
+				        claim_id bigint(20) unsigned NOT NULL auto_increment,
+				        date_created_gmt datetime NULL default '{$default_date}',
+				        PRIMARY KEY  (claim_id),
+				        KEY date_created_gmt (date_created_gmt)
+				        ) $charset_collate";
+
+			case self::GROUPS_TABLE:
+				return "CREATE TABLE {$table_name} (
+				        group_id bigint(20) unsigned NOT NULL auto_increment,
+				        slug varchar(255) NOT NULL,
+				        PRIMARY KEY  (group_id),
+				        KEY slug (slug($max_index_length))
+				        ) $charset_collate";
+
+			default:
+				return '';
+		}
+	}
+
+	/**
+	 * Update the actions table schema, allowing datetime fields to be NULL.
+	 *
+	 * This is needed because the NOT NULL constraint causes a conflict with some versions of MySQL
+	 * configured with sql_mode=NO_ZERO_DATE, which can for instance lead to tables not being created.
+	 *
+	 * Most other schema updates happen via ActionScheduler_Abstract_Schema::update_table(), however
+	 * that method relies on dbDelta() and this change is not possible when using that function.
+	 *
+	 * @param string $table Name of table being updated.
+	 * @param string $db_version The existing schema version of the table.
+	 */
+	public function update_schema_5_0( $table, $db_version ) {
+		global $wpdb;
+
+		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '5', '>=' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '{$table_name}'" );
+		$default_date = self::DEFAULT_DATE;
+
+		if ( ! empty( $table_list ) ) {
+			$query = "
+				ALTER TABLE {$table_name}
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '{$default_date}',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN last_attempt_local datetime NULL default '{$default_date}'
+		";
+			$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+}

--- a/includes/lib/action-scheduler/deprecated/ActionScheduler_Abstract_QueueRunner_Deprecated.php
+++ b/includes/lib/action-scheduler/deprecated/ActionScheduler_Abstract_QueueRunner_Deprecated.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Abstract class with common Queue Cleaner functionality.
+ */
+abstract class ActionScheduler_Abstract_QueueRunner_Deprecated {
+
+	/**
+	 * Get the maximum number of seconds a batch can run for.
+	 *
+	 * @deprecated 2.1.1
+	 * @return int The number of seconds.
+	 */
+	protected function get_maximum_execution_time() {
+		_deprecated_function( __METHOD__, '2.1.1', 'ActionScheduler_Abstract_QueueRunner::get_time_limit()' );
+
+		$maximum_execution_time = 30;
+
+		// Apply deprecated filter.
+		if ( has_filter( 'action_scheduler_maximum_execution_time' ) ) {
+			_deprecated_function( 'action_scheduler_maximum_execution_time', '2.1.1', 'action_scheduler_queue_runner_time_limit' );
+			$maximum_execution_time = apply_filters( 'action_scheduler_maximum_execution_time', $maximum_execution_time );
+		}
+
+		return absint( $maximum_execution_time );
+	}
+}

--- a/includes/lib/action-scheduler/deprecated/ActionScheduler_AdminView_Deprecated.php
+++ b/includes/lib/action-scheduler/deprecated/ActionScheduler_AdminView_Deprecated.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Class ActionScheduler_AdminView_Deprecated
+ *
+ * Store deprecated public functions previously found in the ActionScheduler_AdminView class.
+ * Keeps them out of the way of the main class.
+ *
+ * @codeCoverageIgnore
+ */
+class ActionScheduler_AdminView_Deprecated {
+
+	/**
+	 * Adjust parameters for custom post type.
+	 *
+	 * @param array $args Args.
+	 */
+	public function action_scheduler_post_type_args( $args ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $args;
+	}
+
+	/**
+	 * Customise the post status related views displayed on the Scheduled Actions administration screen.
+	 *
+	 * @param array $views An associative array of views and view labels which can be used to filter the 'scheduled-action' posts displayed on the Scheduled Actions administration screen.
+	 * @return array $views An associative array of views and view labels which can be used to filter the 'scheduled-action' posts displayed on the Scheduled Actions administration screen.
+	 */
+	public function list_table_views( $views ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $views;
+	}
+
+	/**
+	 * Do not include the "Edit" action for the Scheduled Actions administration screen.
+	 *
+	 * Hooked to the 'bulk_actions-edit-action-scheduler' filter.
+	 *
+	 * @param array $actions An associative array of actions which can be performed on the 'scheduled-action' post type.
+	 * @return array $actions An associative array of actions which can be performed on the 'scheduled-action' post type.
+	 */
+	public function bulk_actions( $actions ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $actions;
+	}
+
+	/**
+	 * Completely customer the columns displayed on the Scheduled Actions administration screen.
+	 *
+	 * Because we can't filter the content of the default title and date columns, we need to recreate our own
+	 * custom columns for displaying those post fields. For the column content, @see self::list_table_column_content().
+	 *
+	 * @param array $columns An associative array of columns that are use for the table on the Scheduled Actions administration screen.
+	 * @return array $columns An associative array of columns that are use for the table on the Scheduled Actions administration screen.
+	 */
+	public function list_table_columns( $columns ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $columns;
+	}
+
+	/**
+	 * Make our custom title & date columns use defaulting title & date sorting.
+	 *
+	 * @param array $columns An associative array of columns that can be used to sort the table on the Scheduled Actions administration screen.
+	 * @return array $columns An associative array of columns that can be used to sort the table on the Scheduled Actions administration screen.
+	 */
+	public static function list_table_sortable_columns( $columns ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $columns;
+	}
+
+	/**
+	 * Print the content for our custom columns.
+	 *
+	 * @param string $column_name The key for the column for which we should output our content.
+	 * @param int    $post_id The ID of the 'scheduled-action' post for which this row relates.
+	 */
+	public static function list_table_column_content( $column_name, $post_id ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+	}
+
+	/**
+	 * Hide the inline "Edit" action for all 'scheduled-action' posts.
+	 *
+	 * Hooked to the 'post_row_actions' filter.
+	 *
+	 * @param array   $actions An associative array of actions which can be performed on the 'scheduled-action' post type.
+	 * @param WP_Post $post The 'scheduled-action' post object.
+	 * @return array $actions An associative array of actions which can be performed on the 'scheduled-action' post type.
+	 */
+	public static function row_actions( $actions, $post ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $actions;
+	}
+
+	/**
+	 * Run an action when triggered from the Action Scheduler administration screen.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function maybe_execute_action() {
+		_deprecated_function( __METHOD__, '2.0.0' );
+	}
+
+	/**
+	 * Convert an interval of seconds into a two part human friendly string.
+	 *
+	 * The WordPress human_time_diff() function only calculates the time difference to one degree, meaning
+	 * even if an action is 1 day and 11 hours away, it will display "1 day". This function goes one step
+	 * further to display two degrees of accuracy.
+	 *
+	 * Based on Crontrol::interval() function by Edward Dale: https://wordpress.org/plugins/wp-crontrol/
+	 *
+	 * @return void
+	 */
+	public static function admin_notices() {
+		_deprecated_function( __METHOD__, '2.0.0' );
+	}
+
+	/**
+	 * Filter search queries to allow searching by Claim ID (i.e. post_password).
+	 *
+	 * @param string   $orderby MySQL orderby string.
+	 * @param WP_Query $query Instance of a WP_Query object.
+	 * @return void
+	 */
+	public function custom_orderby( $orderby, $query ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+	}
+
+	/**
+	 * Filter search queries to allow searching by Claim ID (i.e. post_password).
+	 *
+	 * @param string   $search MySQL search string.
+	 * @param WP_Query $query Instance of a WP_Query object.
+	 * @return void
+	 */
+	public function search_post_password( $search, $query ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+	}
+
+	/**
+	 * Change messages when a scheduled action is updated.
+	 *
+	 * @param  array $messages Messages.
+	 * @return array
+	 */
+	public function post_updated_messages( $messages ) {
+		_deprecated_function( __METHOD__, '2.0.0' );
+		return $messages;
+	}
+
+}

--- a/includes/lib/action-scheduler/deprecated/ActionScheduler_Schedule_Deprecated.php
+++ b/includes/lib/action-scheduler/deprecated/ActionScheduler_Schedule_Deprecated.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class ActionScheduler_Abstract_Schedule
+ */
+abstract class ActionScheduler_Schedule_Deprecated implements ActionScheduler_Schedule {
+
+	/**
+	 * Get the date & time this schedule was created to run, or calculate when it should be run
+	 * after a given date & time.
+	 *
+	 * @param DateTime $after DateTime to calculate against.
+	 *
+	 * @return DateTime|null
+	 */
+	public function next( ?DateTime $after = null ) {
+		if ( empty( $after ) ) {
+			$return_value       = $this->get_date();
+			$replacement_method = 'get_date()';
+		} else {
+			$return_value       = $this->get_next( $after );
+			$replacement_method = 'get_next( $after )';
+		}
+
+		_deprecated_function( __METHOD__, '3.0.0', __CLASS__ . '::' . $replacement_method ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+		return $return_value;
+	}
+}

--- a/includes/lib/action-scheduler/deprecated/ActionScheduler_Store_Deprecated.php
+++ b/includes/lib/action-scheduler/deprecated/ActionScheduler_Store_Deprecated.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Class ActionScheduler_Store_Deprecated
+ *
+ * @codeCoverageIgnore
+ */
+abstract class ActionScheduler_Store_Deprecated {
+
+	/**
+	 * Mark an action that failed to fetch correctly as failed.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param int $action_id The ID of the action.
+	 */
+	public function mark_failed_fetch_action( $action_id ) {
+		_deprecated_function( __METHOD__, '3.0.0', 'ActionScheduler_Store::mark_failure()' );
+		self::$store->mark_failure( $action_id );
+	}
+
+	/**
+	 * Add base hooks
+	 *
+	 * @since 2.2.6
+	 */
+	protected static function hook() {
+		_deprecated_function( __METHOD__, '3.0.0' );
+	}
+
+	/**
+	 * Remove base hooks
+	 *
+	 * @since 2.2.6
+	 */
+	protected static function unhook() {
+		_deprecated_function( __METHOD__, '3.0.0' );
+	}
+
+	/**
+	 * Get the site's local time.
+	 *
+	 * @deprecated 2.1.0
+	 * @return DateTimeZone
+	 */
+	protected function get_local_timezone() {
+		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
+		return ActionScheduler_TimezoneHelper::get_local_timezone();
+	}
+}

--- a/includes/lib/action-scheduler/deprecated/functions.php
+++ b/includes/lib/action-scheduler/deprecated/functions.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Deprecated API functions for scheduling actions
+ *
+ * Functions with the wc prefix were deprecated to avoid confusion with
+ * Action Scheduler being included in WooCommerce core, and it providing
+ * a different set of APIs for working with the action queue.
+ *
+ * @package ActionScheduler
+ */
+
+/**
+ * Schedule an action to run one time.
+ *
+ * @param int    $timestamp When the job will run.
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ *
+ * @return string The job ID
+ */
+function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_single_action()' );
+	return as_schedule_single_action( $timestamp, $hook, $args, $group );
+}
+
+/**
+ * Schedule a recurring action.
+ *
+ * @param int    $timestamp When the first instance of the job will run.
+ * @param int    $interval_in_seconds How long to wait between runs.
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ *
+ * @deprecated 2.1.0
+ *
+ * @return string The job ID
+ */
+function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_recurring_action()' );
+	return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
+}
+
+/**
+ * Schedule an action that recurs on a cron-like schedule.
+ *
+ * @param int    $timestamp The schedule will start on or after this time.
+ * @param string $schedule A cron-link schedule string.
+ * @see http://en.wikipedia.org/wiki/Cron
+ *   *    *    *    *    *    *
+ *   ┬    ┬    ┬    ┬    ┬    ┬
+ *   |    |    |    |    |    |
+ *   |    |    |    |    |    + year [optional]
+ *   |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
+ *   |    |    |    +---------- month (1 - 12)
+ *   |    |    +--------------- day of month (1 - 31)
+ *   |    +-------------------- hour (0 - 23)
+ *   +------------------------- min (0 - 59)
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ *
+ * @deprecated 2.1.0
+ *
+ * @return string The job ID
+ */
+function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_cron_action()' );
+	return as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
+}
+
+/**
+ * Cancel the next occurrence of a job.
+ *
+ * @param string $hook The hook that the job will trigger.
+ * @param array  $args Args that would have been passed to the job.
+ * @param string $group Action's group.
+ *
+ * @deprecated 2.1.0
+ */
+function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_unschedule_action()' );
+	as_unschedule_action( $hook, $args, $group );
+}
+
+/**
+ * Get next scheduled action.
+ *
+ * @param string $hook Action's hook.
+ * @param array  $args Action's args.
+ * @param string $group Action's group.
+ *
+ * @deprecated 2.1.0
+ *
+ * @return int|bool The timestamp for the next occurrence, or false if nothing was found
+ */
+function wc_next_scheduled_action( $hook, $args = null, $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_next_scheduled_action()' );
+	return as_next_scheduled_action( $hook, $args, $group );
+}
+
+/**
+ * Find scheduled actions
+ *
+ * @param array  $args Possible arguments, with their default values:
+ *        'hook' => '' - the name of the action that will be triggered
+ *        'args' => NULL - the args array that will be passed with the action
+ *        'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='
+ *        'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='
+ *        'group' => '' - the group the action belongs to
+ *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING
+ *        'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID
+ *        'per_page' => 5 - Number of results to return
+ *        'offset' => 0
+ *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'
+ *        'order' => 'ASC'.
+ * @param string $return_format OBJECT, ARRAY_A, or ids.
+ *
+ * @deprecated 2.1.0
+ *
+ * @return array
+ */
+function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_get_scheduled_actions()' );
+	return as_get_scheduled_actions( $args, $return_format );
+}

--- a/includes/lib/action-scheduler/functions.php
+++ b/includes/lib/action-scheduler/functions.php
@@ -1,0 +1,495 @@
+<?php
+/**
+ * General API functions for scheduling actions
+ *
+ * @package ActionScheduler.
+ */
+
+/**
+ * Enqueue an action to run one time, as soon as possible
+ *
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ * @param bool   $unique Whether the action should be unique. It will not be scheduled if another pending or running action has the same hook and group parameters.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
+ *
+ * @return int The action ID. Zero if there was an error scheduling the action.
+ */
+function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing async
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the enqueued action ID (enqueued using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 * @param int      $priority   Action priority.
+	 * @param bool     $unique     Unique action.
+	 */
+	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group, $priority, $unique );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'async',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
+}
+
+/**
+ * Schedule an action to run one time
+ *
+ * @param int    $timestamp When the job will run.
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ * @param bool   $unique Whether the action should be unique. It will not be scheduled if another pending or running action has the same hook and group parameters.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
+ *
+ * @return int The action ID. Zero if there was an error scheduling the action.
+ */
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing single
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param int      $timestamp  When the action will run.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 * @param int      $priorities Action priority.
+	 */
+	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group, $priority );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'single',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
+}
+
+/**
+ * Schedule a recurring action
+ *
+ * @param int    $timestamp When the first instance of the job will run.
+ * @param int    $interval_in_seconds How long to wait between runs.
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ * @param bool   $unique Whether the action should be unique. It will not be scheduled if another pending or running action has the same hook and group parameters.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
+ *
+ * @return int The action ID. Zero if there was an error scheduling the action.
+ */
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
+
+	$interval = (int) $interval_in_seconds;
+
+	// We expect an integer and allow it to be passed using float and string types, but otherwise
+	// should reject unexpected values.
+	// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+	if ( ! is_numeric( $interval_in_seconds ) || $interval_in_seconds != $interval ) {
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf(
+				/* translators: 1: provided value 2: provided type. */
+				esc_html__( 'An integer was expected but "%1$s" (%2$s) was received.', 'action-scheduler' ),
+				esc_html( $interval_in_seconds ),
+				esc_html( gettype( $interval_in_seconds ) )
+			),
+			'3.6.0'
+		);
+
+		return 0;
+	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing recurring
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option          The value to return instead of the option value.
+	 * @param int      $timestamp           When the action will run.
+	 * @param int      $interval_in_seconds How long to wait between runs.
+	 * @param string   $hook                Action hook.
+	 * @param array    $args                Action arguments.
+	 * @param string   $group               Action group.
+	 * @param int      $priority            Action priority.
+	 */
+	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group, $priority );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'recurring',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'pattern'   => $interval_in_seconds,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
+}
+
+/**
+ * Schedule an action that recurs on a cron-like schedule.
+ *
+ * @param int    $timestamp The first instance of the action will be scheduled
+ *           to run at a time calculated after this timestamp matching the cron
+ *           expression. This can be used to delay the first instance of the action.
+ * @param string $schedule A cron-link schedule string.
+ * @see http://en.wikipedia.org/wiki/Cron
+ *   *    *    *    *    *    *
+ *   ┬    ┬    ┬    ┬    ┬    ┬
+ *   |    |    |    |    |    |
+ *   |    |    |    |    |    + year [optional]
+ *   |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
+ *   |    |    |    +---------- month (1 - 12)
+ *   |    |    +--------------- day of month (1 - 31)
+ *   |    +-------------------- hour (0 - 23)
+ *   +------------------------- min (0 - 59)
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ * @param bool   $unique Whether the action should be unique. It will not be scheduled if another pending or running action has the same hook and group parameters.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
+ *
+ * @return int The action ID. Zero if there was an error scheduling the action.
+ */
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
+
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing cron
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param int      $timestamp  When the action will run.
+	 * @param string   $schedule   Cron-like schedule string.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 * @param int      $priority   Action priority.
+	 */
+	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group, $priority );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'cron',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'pattern'   => $schedule,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
+}
+
+/**
+ * Cancel the next occurrence of a scheduled action.
+ *
+ * While only the next instance of a recurring or cron action is unscheduled by this method, that will also prevent
+ * all future instances of that recurring or cron action from being run. Recurring and cron actions are scheduled in
+ * a sequence instead of all being scheduled at once. Each successive occurrence of a recurring action is scheduled
+ * only after the former action is run. If the next instance is never run, because it's unscheduled by this function,
+ * then the following instance will never be scheduled (or exist), which is effectively the same as being unscheduled
+ * by this method also.
+ *
+ * @param string $hook The hook that the job will trigger.
+ * @param array  $args Args that would have been passed to the job.
+ * @param string $group The group the job is assigned to.
+ *
+ * @return int|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
+ */
+function as_unschedule_action( $hook, $args = array(), $group = '' ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return 0;
+	}
+	$params = array(
+		'hook'    => $hook,
+		'status'  => ActionScheduler_Store::STATUS_PENDING,
+		'orderby' => 'date',
+		'order'   => 'ASC',
+		'group'   => $group,
+	);
+	if ( is_array( $args ) ) {
+		$params['args'] = $args;
+	}
+
+	$action_id = ActionScheduler::store()->query_action( $params );
+
+	if ( $action_id ) {
+		try {
+			ActionScheduler::store()->cancel_action( $action_id );
+		} catch ( Exception $exception ) {
+			ActionScheduler::logger()->log(
+				$action_id,
+				sprintf(
+					/* translators: %1$s is the name of the hook to be cancelled, %2$s is the exception message. */
+					__( 'Caught exception while cancelling action "%1$s": %2$s', 'action-scheduler' ),
+					$hook,
+					$exception->getMessage()
+				)
+			);
+
+			$action_id = null;
+		}
+	}
+
+	return $action_id;
+}
+
+/**
+ * Cancel all occurrences of a scheduled action.
+ *
+ * @param string $hook The hook that the job will trigger.
+ * @param array  $args Args that would have been passed to the job.
+ * @param string $group The group the job is assigned to.
+ */
+function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return;
+	}
+	if ( empty( $args ) ) {
+		if ( ! empty( $hook ) && empty( $group ) ) {
+			ActionScheduler_Store::instance()->cancel_actions_by_hook( $hook );
+			return;
+		}
+		if ( ! empty( $group ) && empty( $hook ) ) {
+			ActionScheduler_Store::instance()->cancel_actions_by_group( $group );
+			return;
+		}
+	}
+	do {
+		$unscheduled_action = as_unschedule_action( $hook, $args, $group );
+	} while ( ! empty( $unscheduled_action ) );
+}
+
+/**
+ * Check if there is an existing action in the queue with a given hook, args and group combination.
+ *
+ * An action in the queue could be pending, in-progress or async. If the is pending for a time in
+ * future, its scheduled date will be returned as a timestamp. If it is currently being run, or an
+ * async action sitting in the queue waiting to be processed, in which case boolean true will be
+ * returned. Or there may be no async, in-progress or pending action for this hook, in which case,
+ * boolean false will be the return value.
+ *
+ * @param string $hook Name of the hook to search for.
+ * @param array  $args Arguments of the action to be searched.
+ * @param string $group Group of the action to be searched.
+ *
+ * @return int|bool The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
+ */
+function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return false;
+	}
+
+	$params = array(
+		'hook'    => $hook,
+		'orderby' => 'date',
+		'order'   => 'ASC',
+		'group'   => $group,
+	);
+
+	if ( is_array( $args ) ) {
+		$params['args'] = $args;
+	}
+
+	$params['status'] = ActionScheduler_Store::STATUS_RUNNING;
+	$action_id        = ActionScheduler::store()->query_action( $params );
+	if ( $action_id ) {
+		return true;
+	}
+
+	$params['status'] = ActionScheduler_Store::STATUS_PENDING;
+	$action_id        = ActionScheduler::store()->query_action( $params );
+	if ( null === $action_id ) {
+		return false;
+	}
+
+	$action         = ActionScheduler::store()->fetch_action( $action_id );
+	$scheduled_date = $action->get_schedule()->get_date();
+	if ( $scheduled_date ) {
+		return (int) $scheduled_date->format( 'U' );
+	} elseif ( null === $scheduled_date ) { // pending async action with NullSchedule.
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Check if there is a scheduled action in the queue but more efficiently than as_next_scheduled_action().
+ *
+ * It's recommended to use this function when you need to know whether a specific action is currently scheduled
+ * (pending or in-progress).
+ *
+ * @since 3.3.0
+ *
+ * @param string $hook  The hook of the action.
+ * @param array  $args  Args that have been passed to the action. Null will matches any args.
+ * @param string $group The group the job is assigned to.
+ *
+ * @return bool True if a matching action is pending or in-progress, false otherwise.
+ */
+function as_has_scheduled_action( $hook, $args = null, $group = '' ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return false;
+	}
+
+	$query_args = array(
+		'hook'    => $hook,
+		'status'  => array( ActionScheduler_Store::STATUS_RUNNING, ActionScheduler_Store::STATUS_PENDING ),
+		'group'   => $group,
+		'orderby' => 'none',
+	);
+
+	if ( null !== $args ) {
+		$query_args['args'] = $args;
+	}
+
+	$action_id = ActionScheduler::store()->query_action( $query_args );
+
+	return null !== $action_id;
+}
+
+/**
+ * Find scheduled actions
+ *
+ * @param array  $args Possible arguments, with their default values.
+ *         'hook' => '' - the name of the action that will be triggered.
+ *         'args' => NULL - the args array that will be passed with the action.
+ *         'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *         'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='.
+ *         'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *         'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='.
+ *         'group' => '' - the group the action belongs to.
+ *         'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING.
+ *         'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID.
+ *         'per_page' => 5 - Number of results to return.
+ *         'offset' => 0.
+ *         'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', 'date' or 'none'.
+ *         'order' => 'ASC'.
+ *
+ * @param string $return_format OBJECT, ARRAY_A, or ids.
+ *
+ * @return array
+ */
+function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
+		return array();
+	}
+	$store = ActionScheduler::store();
+	foreach ( array( 'date', 'modified' ) as $key ) {
+		if ( isset( $args[ $key ] ) ) {
+			$args[ $key ] = as_get_datetime_object( $args[ $key ] );
+		}
+	}
+	$ids = $store->query_actions( $args );
+
+	if ( 'ids' === $return_format || 'int' === $return_format ) {
+		return $ids;
+	}
+
+	$actions = array();
+	foreach ( $ids as $action_id ) {
+		$actions[ $action_id ] = $store->fetch_action( $action_id );
+	}
+
+	if ( ARRAY_A === $return_format ) {
+		foreach ( $actions as $action_id => $action_object ) {
+			$actions[ $action_id ] = get_object_vars( $action_object );
+		}
+	}
+
+	return $actions;
+}
+
+/**
+ * Helper function to create an instance of DateTime based on a given
+ * string and timezone. By default, will return the current date/time
+ * in the UTC timezone.
+ *
+ * Needed because new DateTime() called without an explicit timezone
+ * will create a date/time in PHP's timezone, but we need to have
+ * assurance that a date/time uses the right timezone (which we almost
+ * always want to be UTC), which means we need to always include the
+ * timezone when instantiating datetimes rather than leaving it up to
+ * the PHP default.
+ *
+ * @param mixed  $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php.
+ * @param string $timezone A timezone identifier, like UTC or Europe/Lisbon. The list of valid identifiers is available http://php.net/manual/en/timezones.php.
+ *
+ * @return ActionScheduler_DateTime
+ */
+function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
+	if ( is_object( $date_string ) && $date_string instanceof DateTime ) {
+		$date = new ActionScheduler_DateTime( $date_string->format( 'Y-m-d H:i:s' ), new DateTimeZone( $timezone ) );
+	} elseif ( is_numeric( $date_string ) ) {
+		$date = new ActionScheduler_DateTime( '@' . $date_string, new DateTimeZone( $timezone ) );
+	} else {
+		$date = new ActionScheduler_DateTime( null === $date_string ? 'now' : $date_string, new DateTimeZone( $timezone ) );
+	}
+	return $date;
+}

--- a/includes/lib/action-scheduler/lib/WP_Async_Request.php
+++ b/includes/lib/action-scheduler/lib/WP_Async_Request.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * WP Async Request
+ *
+ * @package WP-Background-Processing
+ */
+
+/*
+Library URI: https://github.com/deliciousbrains/wp-background-processing/blob/fbbc56f2480910d7959972ec9ec0819a13c6150a/classes/wp-async-request.php
+Author: Delicious Brains Inc.
+Author URI: https://deliciousbrains.com/
+License: GNU General Public License v2.0
+License URI: https://github.com/deliciousbrains/wp-background-processing/commit/126d7945dd3d39f39cb6488ca08fe1fb66cb351a
+*/
+
+if ( ! class_exists( 'WP_Async_Request' ) ) {
+
+	/**
+	 * Abstract WP_Async_Request class.
+	 *
+	 * @abstract
+	 */
+	abstract class WP_Async_Request {
+
+		/**
+		 * Prefix
+		 *
+		 * (default value: 'wp')
+		 *
+		 * @var string
+		 */
+		protected $prefix = 'wp';
+
+		/**
+		 * Action
+		 *
+		 * (default value: 'async_request')
+		 *
+		 * @var string
+		 */
+		protected $action = 'async_request';
+
+		/**
+		 * Identifier
+		 *
+		 * @var mixed
+		 */
+		protected $identifier;
+
+		/**
+		 * Data
+		 *
+		 * (default value: array())
+		 *
+		 * @var array
+		 */
+		protected $data = array();
+
+		/**
+		 * Initiate new async request
+		 */
+		public function __construct() {
+			$this->identifier = $this->prefix . '_' . $this->action;
+
+			add_action( 'wp_ajax_' . $this->identifier, array( $this, 'maybe_handle' ) );
+			add_action( 'wp_ajax_nopriv_' . $this->identifier, array( $this, 'maybe_handle' ) );
+		}
+
+		/**
+		 * Set data used during the request
+		 *
+		 * @param array $data Data.
+		 *
+		 * @return $this
+		 */
+		public function data( $data ) {
+			$this->data = $data;
+
+			return $this;
+		}
+
+		/**
+		 * Dispatch the async request
+		 *
+		 * @return array|WP_Error
+		 */
+		public function dispatch() {
+			$url  = add_query_arg( $this->get_query_args(), $this->get_query_url() );
+			$args = $this->get_post_args();
+
+			return wp_remote_post( esc_url_raw( $url ), $args );
+		}
+
+		/**
+		 * Get query args
+		 *
+		 * @return array
+		 */
+		protected function get_query_args() {
+			if ( property_exists( $this, 'query_args' ) ) {
+				return $this->query_args;
+			}
+
+			$args = array(
+				'action' => $this->identifier,
+				'nonce'  => wp_create_nonce( $this->identifier ),
+			);
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param array $url
+			 */
+			return apply_filters( $this->identifier . '_query_args', $args );
+		}
+
+		/**
+		 * Get query URL
+		 *
+		 * @return string
+		 */
+		protected function get_query_url() {
+			if ( property_exists( $this, 'query_url' ) ) {
+				return $this->query_url;
+			}
+
+			$url = admin_url( 'admin-ajax.php' );
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param string $url
+			 */
+			return apply_filters( $this->identifier . '_query_url', $url );
+		}
+
+		/**
+		 * Get post args
+		 *
+		 * @return array
+		 */
+		protected function get_post_args() {
+			if ( property_exists( $this, 'post_args' ) ) {
+				return $this->post_args;
+			}
+
+			$args = array(
+				'timeout'   => 0.01,
+				'blocking'  => false,
+				'body'      => $this->data,
+				'cookies'   => $_COOKIE,
+				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+			);
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param array $args
+			 */
+			return apply_filters( $this->identifier . '_post_args', $args );
+		}
+
+		/**
+		 * Maybe handle
+		 *
+		 * Check for correct nonce and pass to handler.
+		 */
+		public function maybe_handle() {
+			// Don't lock up other requests while processing.
+			session_write_close();
+
+			check_ajax_referer( $this->identifier, 'nonce' );
+
+			$this->handle();
+
+			wp_die();
+		}
+
+		/**
+		 * Handle
+		 *
+		 * Override this method to perform any actions required
+		 * during the async request.
+		 */
+		abstract protected function handle();
+
+	}
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * CRON expression parser that can determine whether or not a CRON expression is
+ * due to run, the next run date and previous run date of a CRON expression.
+ * The determinations made by this class are accurate if checked run once per
+ * minute (seconds are dropped from date time comparisons).
+ *
+ * Schedule parts must map to:
+ * minute [0-59], hour [0-23], day of month, month [1-12|JAN-DEC], day of week
+ * [1-7|MON-SUN], and an optional year.
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ * @link http://en.wikipedia.org/wiki/Cron
+ */
+class CronExpression
+{
+    const MINUTE = 0;
+    const HOUR = 1;
+    const DAY = 2;
+    const MONTH = 3;
+    const WEEKDAY = 4;
+    const YEAR = 5;
+
+    /**
+     * @var array CRON expression parts
+     */
+    private $cronParts;
+
+    /**
+     * @var CronExpression_FieldFactory CRON field factory
+     */
+    private $fieldFactory;
+
+    /**
+     * @var array Order in which to test of cron parts
+     */
+    private static $order = array(self::YEAR, self::MONTH, self::DAY, self::WEEKDAY, self::HOUR, self::MINUTE);
+
+    /**
+     * Factory method to create a new CronExpression.
+     *
+     * @param string $expression The CRON expression to create.  There are
+     *      several special predefined values which can be used to substitute the
+     *      CRON expression:
+     *
+     *      @yearly, @annually) - Run once a year, midnight, Jan. 1 - 0 0 1 1 *
+     *      @monthly - Run once a month, midnight, first of month - 0 0 1 * *
+     *      @weekly - Run once a week, midnight on Sun - 0 0 * * 0
+     *      @daily - Run once a day, midnight - 0 0 * * *
+     *      @hourly - Run once an hour, first minute - 0 * * * *
+     *
+*@param CronExpression_FieldFactory $fieldFactory (optional) Field factory to use
+     *
+     * @return CronExpression
+     */
+    public static function factory($expression, ?CronExpression_FieldFactory $fieldFactory = null)
+    {
+        $mappings = array(
+            '@yearly' => '0 0 1 1 *',
+            '@annually' => '0 0 1 1 *',
+            '@monthly' => '0 0 1 * *',
+            '@weekly' => '0 0 * * 0',
+            '@daily' => '0 0 * * *',
+            '@hourly' => '0 * * * *'
+        );
+
+        if (isset($mappings[$expression])) {
+            $expression = $mappings[$expression];
+        }
+
+        return new self($expression, $fieldFactory ? $fieldFactory : new CronExpression_FieldFactory());
+    }
+
+    /**
+     * Parse a CRON expression
+     *
+     * @param string       $expression   CRON expression (e.g. '8 * * * *')
+     * @param CronExpression_FieldFactory $fieldFactory Factory to create cron fields
+     */
+    public function __construct($expression, CronExpression_FieldFactory $fieldFactory)
+    {
+        $this->fieldFactory = $fieldFactory;
+        $this->setExpression($expression);
+    }
+
+    /**
+     * Set or change the CRON expression
+     *
+     * @param string $value CRON expression (e.g. 8 * * * *)
+     *
+     * @return CronExpression
+     * @throws InvalidArgumentException if not a valid CRON expression
+     */
+    public function setExpression($value)
+    {
+        $this->cronParts = preg_split('/\s/', $value, -1, PREG_SPLIT_NO_EMPTY);
+        if (count($this->cronParts) < 5) {
+            throw new InvalidArgumentException(
+                $value . ' is not a valid CRON expression'
+            );
+        }
+
+        foreach ($this->cronParts as $position => $part) {
+            $this->setPart($position, $part);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set part of the CRON expression
+     *
+     * @param int    $position The position of the CRON expression to set
+     * @param string $value    The value to set
+     *
+     * @return CronExpression
+     * @throws InvalidArgumentException if the value is not valid for the part
+     */
+    public function setPart($position, $value)
+    {
+        if (!$this->fieldFactory->getField($position)->validate($value)) {
+            throw new InvalidArgumentException(
+                'Invalid CRON field value ' . $value . ' as position ' . $position
+            );
+        }
+
+        $this->cronParts[$position] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get a next run date relative to the current date or a specific date
+     *
+     * @param string|DateTime $currentTime (optional) Relative calculation date
+     * @param int             $nth         (optional) Number of matches to skip before returning a
+     *     matching next run date.  0, the default, will return the current
+     *     date and time if the next run date falls on the current date and
+     *     time.  Setting this value to 1 will skip the first match and go to
+     *     the second match.  Setting this value to 2 will skip the first 2
+     *     matches and so on.
+     * @param bool $allowCurrentDate (optional) Set to TRUE to return the
+     *     current date if it matches the cron expression
+     *
+     * @return DateTime
+     * @throws RuntimeException on too many iterations
+     */
+    public function getNextRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false)
+    {
+        return $this->getRunDate($currentTime, $nth, false, $allowCurrentDate);
+    }
+
+    /**
+     * Get a previous run date relative to the current date or a specific date
+     *
+     * @param string|DateTime $currentTime      (optional) Relative calculation date
+     * @param int             $nth              (optional) Number of matches to skip before returning
+     * @param bool            $allowCurrentDate (optional) Set to TRUE to return the
+     *     current date if it matches the cron expression
+     *
+     * @return DateTime
+     * @throws RuntimeException on too many iterations
+     * @see CronExpression::getNextRunDate
+     */
+    public function getPreviousRunDate($currentTime = 'now', $nth = 0, $allowCurrentDate = false)
+    {
+        return $this->getRunDate($currentTime, $nth, true, $allowCurrentDate);
+    }
+
+    /**
+     * Get multiple run dates starting at the current date or a specific date
+     *
+     * @param int             $total            Set the total number of dates to calculate
+     * @param string|DateTime $currentTime      (optional) Relative calculation date
+     * @param bool            $invert           (optional) Set to TRUE to retrieve previous dates
+     * @param bool            $allowCurrentDate (optional) Set to TRUE to return the
+     *     current date if it matches the cron expression
+     *
+     * @return array Returns an array of run dates
+     */
+    public function getMultipleRunDates($total, $currentTime = 'now', $invert = false, $allowCurrentDate = false)
+    {
+        $matches = array();
+        for ($i = 0; $i < max(0, $total); $i++) {
+            $matches[] = $this->getRunDate($currentTime, $i, $invert, $allowCurrentDate);
+        }
+
+        return $matches;
+    }
+
+    /**
+     * Get all or part of the CRON expression
+     *
+     * @param string $part (optional) Specify the part to retrieve or NULL to
+     *      get the full cron schedule string.
+     *
+     * @return string|null Returns the CRON expression, a part of the
+     *      CRON expression, or NULL if the part was specified but not found
+     */
+    public function getExpression($part = null)
+    {
+        if (null === $part) {
+            return implode(' ', $this->cronParts);
+        } elseif (array_key_exists($part, $this->cronParts)) {
+            return $this->cronParts[$part];
+        }
+
+        return null;
+    }
+
+    /**
+     * Helper method to output the full expression.
+     *
+     * @return string Full CRON expression
+     */
+    public function __toString()
+    {
+        return $this->getExpression();
+    }
+
+    /**
+     * Determine if the cron is due to run based on the current date or a
+     * specific date.  This method assumes that the current number of
+     * seconds are irrelevant, and should be called once per minute.
+     *
+     * @param string|DateTime $currentTime (optional) Relative calculation date
+     *
+     * @return bool Returns TRUE if the cron is due to run or FALSE if not
+     */
+    public function isDue($currentTime = 'now')
+    {
+        if ('now' === $currentTime) {
+            $currentDate = date('Y-m-d H:i');
+            $currentTime = strtotime($currentDate);
+        } elseif ($currentTime instanceof DateTime) {
+            $currentDate = $currentTime->format('Y-m-d H:i');
+            $currentTime = strtotime($currentDate);
+        } else {
+            $currentTime = new DateTime($currentTime);
+            $currentTime->setTime($currentTime->format('H'), $currentTime->format('i'), 0);
+            $currentDate = $currentTime->format('Y-m-d H:i');
+            $currentTime = (int)($currentTime->getTimestamp());
+        }
+
+        return $this->getNextRunDate($currentDate, 0, true)->getTimestamp() == $currentTime;
+    }
+
+    /**
+     * Get the next or previous run date of the expression relative to a date
+     *
+     * @param string|DateTime $currentTime      (optional) Relative calculation date
+     * @param int             $nth              (optional) Number of matches to skip before returning
+     * @param bool            $invert           (optional) Set to TRUE to go backwards in time
+     * @param bool            $allowCurrentDate (optional) Set to TRUE to return the
+     *     current date if it matches the cron expression
+     *
+     * @return DateTime
+     * @throws RuntimeException on too many iterations
+     */
+    protected function getRunDate($currentTime = null, $nth = 0, $invert = false, $allowCurrentDate = false)
+    {
+        if ($currentTime instanceof DateTime) {
+            $currentDate = $currentTime;
+        } else {
+            $currentDate = new DateTime($currentTime ? $currentTime : 'now');
+            $currentDate->setTimezone(new DateTimeZone(date_default_timezone_get()));
+        }
+
+        $currentDate->setTime($currentDate->format('H'), $currentDate->format('i'), 0);
+        $nextRun = clone $currentDate;
+        $nth = (int) $nth;
+
+        // Set a hard limit to bail on an impossible date
+        for ($i = 0; $i < 1000; $i++) {
+
+            foreach (self::$order as $position) {
+                $part = $this->getExpression($position);
+                if (null === $part) {
+                    continue;
+                }
+
+                $satisfied = false;
+                // Get the field object used to validate this part
+                $field = $this->fieldFactory->getField($position);
+                // Check if this is singular or a list
+                if (strpos($part, ',') === false) {
+                    $satisfied = $field->isSatisfiedBy($nextRun, $part);
+                } else {
+                    foreach (array_map('trim', explode(',', $part)) as $listPart) {
+                        if ($field->isSatisfiedBy($nextRun, $listPart)) {
+                            $satisfied = true;
+                            break;
+                        }
+                    }
+                }
+
+                // If the field is not satisfied, then start over
+                if (!$satisfied) {
+                    $field->increment($nextRun, $invert);
+                    continue 2;
+                }
+            }
+
+            // Skip this match if needed
+            if ((!$allowCurrentDate && $nextRun == $currentDate) || --$nth > -1) {
+                $this->fieldFactory->getField(0)->increment($nextRun, $invert);
+                continue;
+            }
+
+            return $nextRun;
+        }
+
+        // @codeCoverageIgnoreStart
+        throw new RuntimeException('Impossible CRON expression');
+        // @codeCoverageIgnoreEnd
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_AbstractField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_AbstractField.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Abstract CRON expression field
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+abstract class CronExpression_AbstractField implements CronExpression_FieldInterface
+{
+    /**
+     * Check to see if a field is satisfied by a value
+     *
+     * @param string $dateValue Date value to check
+     * @param string $value     Value to test
+     *
+     * @return bool
+     */
+    public function isSatisfied($dateValue, $value)
+    {
+        if ($this->isIncrementsOfRanges($value)) {
+            return $this->isInIncrementsOfRanges($dateValue, $value);
+        } elseif ($this->isRange($value)) {
+            return $this->isInRange($dateValue, $value);
+        }
+
+        return $value == '*' || $dateValue == $value;
+    }
+
+    /**
+     * Check if a value is a range
+     *
+     * @param string $value Value to test
+     *
+     * @return bool
+     */
+    public function isRange($value)
+    {
+        return strpos($value, '-') !== false;
+    }
+
+    /**
+     * Check if a value is an increments of ranges
+     *
+     * @param string $value Value to test
+     *
+     * @return bool
+     */
+    public function isIncrementsOfRanges($value)
+    {
+        return strpos($value, '/') !== false;
+    }
+
+    /**
+     * Test if a value is within a range
+     *
+     * @param string $dateValue Set date value
+     * @param string $value     Value to test
+     *
+     * @return bool
+     */
+    public function isInRange($dateValue, $value)
+    {
+        $parts = array_map('trim', explode('-', $value, 2));
+
+        return $dateValue >= $parts[0] && $dateValue <= $parts[1];
+    }
+
+    /**
+     * Test if a value is within an increments of ranges (offset[-to]/step size)
+     *
+     * @param string $dateValue Set date value
+     * @param string $value     Value to test
+     *
+     * @return bool
+     */
+    public function isInIncrementsOfRanges($dateValue, $value)
+    {
+        $parts = array_map('trim', explode('/', $value, 2));
+        $stepSize = isset($parts[1]) ? $parts[1] : 0;
+        if ($parts[0] == '*' || $parts[0] === '0') {
+            return (int) $dateValue % $stepSize == 0;
+        }
+
+        $range = explode('-', $parts[0], 2);
+        $offset = $range[0];
+        $to = isset($range[1]) ? $range[1] : $dateValue;
+        // Ensure that the date value is within the range
+        if ($dateValue < $offset || $dateValue > $to) {
+            return false;
+        }
+
+        for ($i = $offset; $i <= $to; $i+= $stepSize) {
+            if ($i == $dateValue) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_DayOfMonthField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_DayOfMonthField.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Day of month field.  Allows: * , / - ? L W
+ *
+ * 'L' stands for "last" and specifies the last day of the month.
+ *
+ * The 'W' character is used to specify the weekday (Monday-Friday) nearest the
+ * given day. As an example, if you were to specify "15W" as the value for the
+ * day-of-month field, the meaning is: "the nearest weekday to the 15th of the
+ * month". So if the 15th is a Saturday, the trigger will fire on Friday the
+ * 14th. If the 15th is a Sunday, the trigger will fire on Monday the 16th. If
+ * the 15th is a Tuesday, then it will fire on Tuesday the 15th. However if you
+ * specify "1W" as the value for day-of-month, and the 1st is a Saturday, the
+ * trigger will fire on Monday the 3rd, as it will not 'jump' over the boundary
+ * of a month's days. The 'W' character can only be specified when the
+ * day-of-month is a single day, not a range or list of days.
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+class CronExpression_DayOfMonthField extends CronExpression_AbstractField
+{
+    /**
+     * Get the nearest day of the week for a given day in a month
+     *
+     * @param int $currentYear  Current year
+     * @param int $currentMonth Current month
+     * @param int $targetDay    Target day of the month
+     *
+     * @return DateTime Returns the nearest date
+     */
+    private static function getNearestWeekday($currentYear, $currentMonth, $targetDay)
+    {
+        $tday = str_pad($targetDay, 2, '0', STR_PAD_LEFT);
+        $target = new DateTime("$currentYear-$currentMonth-$tday");
+        $currentWeekday = (int) $target->format('N');
+
+        if ($currentWeekday < 6) {
+            return $target;
+        }
+
+        $lastDayOfMonth = $target->format('t');
+
+        foreach (array(-1, 1, -2, 2) as $i) {
+            $adjusted = $targetDay + $i;
+            if ($adjusted > 0 && $adjusted <= $lastDayOfMonth) {
+                $target->setDate($currentYear, $currentMonth, $adjusted);
+                if ($target->format('N') < 6 && $target->format('m') == $currentMonth) {
+                    return $target;
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSatisfiedBy(DateTime $date, $value)
+    {
+        // ? states that the field value is to be skipped
+        if ($value == '?') {
+            return true;
+        }
+
+        $fieldValue = $date->format('d');
+
+        // Check to see if this is the last day of the month
+        if ($value == 'L') {
+            return $fieldValue == $date->format('t');
+        }
+
+        // Check to see if this is the nearest weekday to a particular value
+        if (strpos($value, 'W')) {
+            // Parse the target day
+            $targetDay = substr($value, 0, strpos($value, 'W'));
+            // Find out if the current day is the nearest day of the week
+            return $date->format('j') == self::getNearestWeekday(
+                $date->format('Y'),
+                $date->format('m'),
+                $targetDay
+            )->format('j');
+        }
+
+        return $this->isSatisfied($date->format('d'), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(DateTime $date, $invert = false)
+    {
+        if ($invert) {
+            $date->modify('previous day');
+            $date->setTime(23, 59);
+        } else {
+            $date->modify('next day');
+            $date->setTime(0, 0);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value)
+    {
+        return (bool) preg_match('/[\*,\/\-\?LW0-9A-Za-z]+/', $value);
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_DayOfWeekField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_DayOfWeekField.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Day of week field.  Allows: * / , - ? L #
+ *
+ * Days of the week can be represented as a number 0-7 (0|7 = Sunday)
+ * or as a three letter string: SUN, MON, TUE, WED, THU, FRI, SAT.
+ *
+ * 'L' stands for "last". It allows you to specify constructs such as
+ * "the last Friday" of a given month.
+ *
+ * '#' is allowed for the day-of-week field, and must be followed by a
+ * number between one and five. It allows you to specify constructs such as
+ * "the second Friday" of a given month.
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+class CronExpression_DayOfWeekField extends CronExpression_AbstractField
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isSatisfiedBy(DateTime $date, $value)
+    {
+        if ($value == '?') {
+            return true;
+        }
+
+        // Convert text day of the week values to integers
+        $value = str_ireplace(
+            array('SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'),
+            range(0, 6),
+            $value
+        );
+
+        $currentYear = $date->format('Y');
+        $currentMonth = $date->format('m');
+        $lastDayOfMonth = $date->format('t');
+
+        // Find out if this is the last specific weekday of the month
+        if (strpos($value, 'L')) {
+            $weekday = str_replace('7', '0', substr($value, 0, strpos($value, 'L')));
+            $tdate = clone $date;
+            $tdate->setDate($currentYear, $currentMonth, $lastDayOfMonth);
+            while ($tdate->format('w') != $weekday) {
+                $tdate->setDate($currentYear, $currentMonth, --$lastDayOfMonth);
+            }
+
+            return $date->format('j') == $lastDayOfMonth;
+        }
+
+        // Handle # hash tokens
+        if (strpos($value, '#')) {
+            list($weekday, $nth) = explode('#', $value);
+            // Validate the hash fields
+            if ($weekday < 1 || $weekday > 5) {
+                throw new InvalidArgumentException("Weekday must be a value between 1 and 5. {$weekday} given");
+            }
+            if ($nth > 5) {
+                throw new InvalidArgumentException('There are never more than 5 of a given weekday in a month');
+            }
+            // The current weekday must match the targeted weekday to proceed
+            if ($date->format('N') != $weekday) {
+                return false;
+            }
+
+            $tdate = clone $date;
+            $tdate->setDate($currentYear, $currentMonth, 1);
+            $dayCount = 0;
+            $currentDay = 1;
+            while ($currentDay < $lastDayOfMonth + 1) {
+                if ($tdate->format('N') == $weekday) {
+                    if (++$dayCount >= $nth) {
+                        break;
+                    }
+                }
+                $tdate->setDate($currentYear, $currentMonth, ++$currentDay);
+            }
+
+            return $date->format('j') == $currentDay;
+        }
+
+        // Handle day of the week values
+        if (strpos($value, '-')) {
+            $parts = explode('-', $value);
+            if ($parts[0] == '7') {
+                $parts[0] = '0';
+            } elseif ($parts[1] == '0') {
+                $parts[1] = '7';
+            }
+            $value = implode('-', $parts);
+        }
+
+        // Test to see which Sunday to use -- 0 == 7 == Sunday
+        $format = in_array(7, str_split($value)) ? 'N' : 'w';
+        $fieldValue = $date->format($format);
+
+        return $this->isSatisfied($fieldValue, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(DateTime $date, $invert = false)
+    {
+        if ($invert) {
+            $date->modify('-1 day');
+            $date->setTime(23, 59, 0);
+        } else {
+            $date->modify('+1 day');
+            $date->setTime(0, 0, 0);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value)
+    {
+        return (bool) preg_match('/[\*,\/\-0-9A-Z]+/', $value);
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_FieldFactory.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_FieldFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * CRON field factory implementing a flyweight factory
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ * @link http://en.wikipedia.org/wiki/Cron
+ */
+class CronExpression_FieldFactory
+{
+    /**
+     * @var array Cache of instantiated fields
+     */
+    private $fields = array();
+
+    /**
+     * Get an instance of a field object for a cron expression position
+     *
+     * @param int $position CRON expression position value to retrieve
+     *
+     * @return CronExpression_FieldInterface
+     * @throws InvalidArgumentException if a position is not valid
+     */
+    public function getField($position)
+    {
+        if (!isset($this->fields[$position])) {
+            switch ($position) {
+                case 0:
+                    $this->fields[$position] = new CronExpression_MinutesField();
+                    break;
+                case 1:
+                    $this->fields[$position] = new CronExpression_HoursField();
+                    break;
+                case 2:
+                    $this->fields[$position] = new CronExpression_DayOfMonthField();
+                    break;
+                case 3:
+                    $this->fields[$position] = new CronExpression_MonthField();
+                    break;
+                case 4:
+                    $this->fields[$position] = new CronExpression_DayOfWeekField();
+                    break;
+                case 5:
+                    $this->fields[$position] = new CronExpression_YearField();
+                    break;
+                default:
+                    throw new InvalidArgumentException(
+                        $position . ' is not a valid position'
+                    );
+            }
+        }
+
+        return $this->fields[$position];
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_FieldInterface.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_FieldInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * CRON field interface
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+interface CronExpression_FieldInterface
+{
+    /**
+     * Check if the respective value of a DateTime field satisfies a CRON exp
+     *
+     * @param DateTime $date  DateTime object to check
+     * @param string   $value CRON expression to test against
+     *
+     * @return bool Returns TRUE if satisfied, FALSE otherwise
+     */
+    public function isSatisfiedBy(DateTime $date, $value);
+
+    /**
+     * When a CRON expression is not satisfied, this method is used to increment
+     * or decrement a DateTime object by the unit of the cron field
+     *
+     * @param DateTime $date   DateTime object to change
+     * @param bool     $invert (optional) Set to TRUE to decrement
+     *
+     * @return CronExpression_FieldInterface
+     */
+    public function increment(DateTime $date, $invert = false);
+
+    /**
+     * Validates a CRON expression for a given field
+     *
+     * @param string $value CRON expression value to validate
+     *
+     * @return bool Returns TRUE if valid, FALSE otherwise
+     */
+    public function validate($value);
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_HoursField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_HoursField.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Hours field.  Allows: * , / -
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+class CronExpression_HoursField extends CronExpression_AbstractField
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isSatisfiedBy(DateTime $date, $value)
+    {
+        return $this->isSatisfied($date->format('H'), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(DateTime $date, $invert = false)
+    {
+        // Change timezone to UTC temporarily. This will
+        // allow us to go back or forwards and hour even
+        // if DST will be changed between the hours.
+        $timezone = $date->getTimezone();
+        $date->setTimezone(new DateTimeZone('UTC'));
+        if ($invert) {
+            $date->modify('-1 hour');
+            $date->setTime($date->format('H'), 59);
+        } else {
+            $date->modify('+1 hour');
+            $date->setTime($date->format('H'), 0);
+        }
+        $date->setTimezone($timezone);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value)
+    {
+        return (bool) preg_match('/[\*,\/\-0-9]+/', $value);
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_MinutesField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_MinutesField.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Minutes field.  Allows: * , / -
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+class CronExpression_MinutesField extends CronExpression_AbstractField
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isSatisfiedBy(DateTime $date, $value)
+    {
+        return $this->isSatisfied($date->format('i'), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(DateTime $date, $invert = false)
+    {
+        if ($invert) {
+            $date->modify('-1 minute');
+        } else {
+            $date->modify('+1 minute');
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value)
+    {
+        return (bool) preg_match('/[\*,\/\-0-9]+/', $value);
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_MonthField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_MonthField.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Month field.  Allows: * , / -
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+class CronExpression_MonthField extends CronExpression_AbstractField
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isSatisfiedBy(DateTime $date, $value)
+    {
+        // Convert text month values to integers
+        $value = str_ireplace(
+            array(
+                'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
+                'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'
+            ),
+            range(1, 12),
+            $value
+        );
+
+        return $this->isSatisfied($date->format('m'), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(DateTime $date, $invert = false)
+    {
+        if ($invert) {
+            // $date->modify('last day of previous month'); // remove for php 5.2 compat
+            $date->modify('previous month');
+            $date->modify($date->format('Y-m-t'));
+            $date->setTime(23, 59);
+        } else {
+            //$date->modify('first day of next month'); // remove for php 5.2 compat
+            $date->modify('next month');
+            $date->modify($date->format('Y-m-01'));
+            $date->setTime(0, 0);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value)
+    {
+        return (bool) preg_match('/[\*,\/\-0-9A-Z]+/', $value);
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/CronExpression_YearField.php
+++ b/includes/lib/action-scheduler/lib/cron-expression/CronExpression_YearField.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Year field.  Allows: * , / -
+ *
+ * @author Michael Dowling <mtdowling@gmail.com>
+ */
+class CronExpression_YearField extends CronExpression_AbstractField
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isSatisfiedBy(DateTime $date, $value)
+    {
+        return $this->isSatisfied($date->format('Y'), $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(DateTime $date, $invert = false)
+    {
+        if ($invert) {
+            $date->modify('-1 year');
+            $date->setDate($date->format('Y'), 12, 31);
+            $date->setTime(23, 59, 0);
+        } else {
+            $date->modify('+1 year');
+            $date->setDate($date->format('Y'), 1, 1);
+            $date->setTime(0, 0, 0);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value)
+    {
+        return (bool) preg_match('/[\*,\/\-0-9]+/', $value);
+    }
+}

--- a/includes/lib/action-scheduler/lib/cron-expression/LICENSE
+++ b/includes/lib/action-scheduler/lib/cron-expression/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2011 Michael Dowling <mtdowling@gmail.com> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/includes/lib/action-scheduler/lib/cron-expression/README.md
+++ b/includes/lib/action-scheduler/lib/cron-expression/README.md
@@ -1,0 +1,92 @@
+PHP Cron Expression Parser
+==========================
+
+[![Latest Stable Version](https://poser.pugx.org/mtdowling/cron-expression/v/stable.png)](https://packagist.org/packages/mtdowling/cron-expression) [![Total Downloads](https://poser.pugx.org/mtdowling/cron-expression/downloads.png)](https://packagist.org/packages/mtdowling/cron-expression) [![Build Status](https://secure.travis-ci.org/mtdowling/cron-expression.png)](http://travis-ci.org/mtdowling/cron-expression)
+
+The PHP cron expression parser can parse a CRON expression, determine if it is
+due to run, calculate the next run date of the expression, and calculate the previous
+run date of the expression.  You can calculate dates far into the future or past by
+skipping n number of matching dates.
+
+The parser can handle increments of ranges (e.g. */12, 2-59/3), intervals (e.g. 0-9),
+lists (e.g. 1,2,3), W to find the nearest weekday for a given day of the month, L to
+find the last day of the month, L to find the last given weekday of a month, and hash
+(#) to find the nth weekday of a given month.
+
+Credits
+==========
+
+Created by Micheal Dowling. Ported to PHP 5.2 by Flightless, Inc.
+Based on version 1.0.3: https://github.com/mtdowling/cron-expression/tree/v1.0.3
+
+Installing
+==========
+
+Add the following to your project's composer.json:
+
+```javascript
+{
+    "require": {
+        "mtdowling/cron-expression": "1.0.*"
+    }
+}
+```
+
+Usage
+=====
+```php
+<?php
+
+require_once '/vendor/autoload.php';
+
+// Works with predefined scheduling definitions
+$cron = Cron\CronExpression::factory('@daily');
+$cron->isDue();
+echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
+echo $cron->getPreviousRunDate()->format('Y-m-d H:i:s');
+
+// Works with complex expressions
+$cron = Cron\CronExpression::factory('3-59/15 2,6-12 */15 1 2-5');
+echo $cron->getNextRunDate()->format('Y-m-d H:i:s');
+
+// Calculate a run date two iterations into the future
+$cron = Cron\CronExpression::factory('@daily');
+echo $cron->getNextRunDate(null, 2)->format('Y-m-d H:i:s');
+
+// Calculate a run date relative to a specific time
+$cron = Cron\CronExpression::factory('@monthly');
+echo $cron->getNextRunDate('2010-01-12 00:00:00')->format('Y-m-d H:i:s');
+```
+
+CRON Expressions
+================
+
+A CRON expression is a string representing the schedule for a particular command to execute.  The parts of a CRON schedule are as follows:
+
+    *    *    *    *    *    *
+    -    -    -    -    -    -
+    |    |    |    |    |    |
+    |    |    |    |    |    + year [optional]
+    |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
+    |    |    |    +---------- month (1 - 12)
+    |    |    +--------------- day of month (1 - 31)
+    |    +-------------------- hour (0 - 23)
+    +------------------------- min (0 - 59)
+
+Requirements
+============
+
+- PHP 5.3+
+- PHPUnit is required to run the unit tests
+- Composer is required to run the unit tests
+
+CHANGELOG
+=========
+
+1.0.3 (2013-11-23)
+------------------
+
+* Only set default timezone if the given $currentTime is not a DateTime instance (#34)
+* Fixes issue #28 where PHP increments of ranges were failing due to PHP casting hyphens to 0
+* Now supports expressions with any number of extra spaces, tabs, or newlines
+* Using static instead of self in `CronExpression::factory`

--- a/includes/lib/action-scheduler/license.txt
+++ b/includes/lib/action-scheduler/license.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/includes/lib/action-scheduler/readme.txt
+++ b/includes/lib/action-scheduler/readme.txt
@@ -1,0 +1,231 @@
+=== Action Scheduler ===
+Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, royho, barryhughes-1
+Tags: scheduler, cron
+Stable tag: 3.9.2
+License: GPLv3
+Requires at least: 6.5
+Tested up to: 6.7
+Requires PHP: 7.1
+
+Action Scheduler - Job Queue for WordPress
+
+== Description ==
+
+Action Scheduler is a scalable, traceable job queue for background processing large sets of actions in WordPress. It's specially designed to be distributed in WordPress plugins.
+
+Action Scheduler works by triggering an action hook to run at some time in the future. Each hook can be scheduled with unique data, to allow callbacks to perform operations on that data. The hook can also be scheduled to run on one or more occasions.
+
+Think of it like an extension to `do_action()` which adds the ability to delay and repeat a hook.
+
+## Battle-Tested Background Processing
+
+Every month, Action Scheduler processes millions of payments for [Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/), webhooks for [WooCommerce](https://wordpress.org/plugins/woocommerce/), as well as emails and other events for a range of other plugins.
+
+It's been seen on live sites processing queues in excess of 50,000 jobs and doing resource intensive operations, like processing payments and creating orders, at a sustained rate of over 10,000 / hour without negatively impacting normal site operations.
+
+This is all on infrastructure and WordPress sites outside the control of the plugin author.
+
+If your plugin needs background processing, especially of large sets of tasks, Action Scheduler can help.
+
+## Learn More
+
+To learn more about how to Action Scheduler works, and how to use it in your plugin, check out the docs on [ActionScheduler.org](https://actionscheduler.org).
+
+There you will find:
+
+* [Usage guide](https://actionscheduler.org/usage/): instructions on installing and using Action Scheduler
+* [WP CLI guide](https://actionscheduler.org/wp-cli/): instructions on running Action Scheduler at scale via WP CLI
+* [API Reference](https://actionscheduler.org/api/): complete reference guide for all API functions
+* [Administration Guide](https://actionscheduler.org/admin/): guide to managing scheduled actions via the administration screen
+* [Guide to Background Processing at Scale](https://actionscheduler.org/perf/): instructions for running Action Scheduler at scale via the default WP Cron queue runner
+
+## Credits
+
+Action Scheduler is developed and maintained by [Automattic](http://automattic.com/) with significant early development completed by [Flightless](https://flightless.us/).
+
+Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.
+
+== Changelog ==
+
+= 3.9.2 - 2025-02-03 =
+* Fixed fatal errors by moving version info methods to a new class and deprecating conflicting ones in ActionScheduler_Versions
+
+= 3.9.1 - 2025-01-21 =
+* A number of new WP CLI commands have been added, making it easier to manage actions in the terminal and from scripts.
+* New wp action-scheduler source command to help determine how Action Scheduler is being loaded.
+* Additional information about the active instance of Action Scheduler is now available in the Help pull-down drawer.
+* Make some other nullable parameters explicitly nullable.
+* Set option value to `no` rather than deleting.
+
+= 3.9.0 - 2024-11-14 =  
+* Minimum required version of PHP is now 7.1.  
+* Performance improvements for the `as_pending_actions_due()` function.  
+* Existing filter hook `action_scheduler_claim_actions_order_by` enhanced to provide callbacks with additional information.  
+* Improved compatibility with PHP 8.4, specifically by making implicitly nullable parameters explicitly nullable.  
+* A large number of coding standards-enhancements, to help reduce friction when submitting plugins to marketplaces and plugin directories. Special props @crstauf for this effort.  
+* Minor documentation tweaks and improvements.
+
+= 3.8.2 - 2024-09-12 =
+* Add missing parameter to the `pre_as_enqueue_async_action` hook.
+* Bump minimum PHP version to 7.0.
+* Bump minimum WordPress version to 6.4.
+* Make the batch size adjustable during processing.
+
+= 3.8.1 - 2024-06-20 =
+* Fix typos.
+* Improve the messaging in our unidentified action exceptions.
+
+= 3.8.0 - 2024-05-22 =
+* Documentation - Fixed typos in perf.md.
+* Update - We now require WordPress 6.3 or higher.
+* Update - We now require PHP 7.0 or higher.
+
+= 3.7.4 - 2024-04-05 =
+* Give a clear description of how the $unique parameter works.
+* Preserve the tab field if set.
+* Tweak - WP 6.5 compatibility.
+
+= 3.7.3 - 2024-03-20 =
+* Do not iterate over all of GET when building form in list table.
+* Fix a few issues reported by PCP (Plugin Check Plugin).
+* Try to save actions as unique even when the store doesn't support it.
+* Tweak - WP 6.4 compatibility.
+* Update "Tested up to" tag to WordPress 6.5.
+* update version in package-lock.json.
+
+= 3.7.2 - 2024-02-14 =
+* No longer user variables in `_n()` translation function.
+
+= 3.7.1 - 2023-12-13 =
+* update semver to 5.7.2 because of a security vulnerability in 5.7.1.
+
+= 3.7.0 - 2023-11-20 =
+* Important: starting with this release, Action Scheduler follows an L-2 version policy (WordPress, and consequently PHP).
+* Add extended indexes for hook_status_scheduled_date_gmt and status_scheduled_date_gmt.
+* Catch and log exceptions thrown when actions can't be created, e.g. under a corrupt database schema.
+* Tweak - WP 6.4 compatibility.
+* Update unit tests for upcoming dependency version policy.
+* make sure hook action_scheduler_failed_execution can access original exception object.
+* mention dependency version policy in usage.md.
+
+= 3.6.4 - 2023-10-11 =
+* Performance improvements when bulk cancelling actions.
+* Dev-related fixes.
+
+= 3.6.3 - 2023-09-13 =
+* Use `_doing_it_wrong` in initialization check.
+
+= 3.6.2 - 2023-08-09 =
+* Add guidance about passing arguments.
+* Atomic option locking.
+* Improve bulk delete handling.
+* Include database error in the exception message.
+* Tweak - WP 6.3 compatibility.
+
+= 3.6.1 - 2023-06-14 =
+* Document new optional `$priority` arg for various API functions.
+* Document the new `--exclude-groups` WP CLI option.
+* Document the new `action_scheduler_init` hook.
+* Ensure actions within each claim are executed in the expected order.
+* Fix incorrect text domain.
+* Remove SHOW TABLES usage when checking if tables exist.
+
+= 3.6.0 - 2023-05-10 =
+* Add $unique parameter to function signatures.
+* Add a cast-to-int for extra safety before forming new DateTime object.
+* Add a hook allowing exceptions for consistently failing recurring actions.
+* Add action priorities.
+* Add init hook.
+* Always raise the time limit.
+* Bump minimatch from 3.0.4 to 3.0.8.
+* Bump yaml from 2.2.1 to 2.2.2.
+* Defensive coding relating to gaps in declared schedule types.
+* Do not process an action if it cannot be set to `in-progress`.
+* Filter view labels (status names) should be translatable | #919.
+* Fix WPCLI progress messages.
+* Improve data-store initialization flow.
+* Improve error handling across all supported PHP versions.
+* Improve logic for flushing the runtime cache.
+* Support exclusion of multiple groups.
+* Update lint-staged and Node/NPM requirements.
+* add CLI clean command.
+* add CLI exclude-group filter.
+* exclude past-due from list table all filter count.
+* throwing an exception if as_schedule_recurring_action interval param is not of type integer.
+
+= 3.5.4 - 2023-01-17 =
+* Add pre filters during action registration.
+* Async scheduling.
+* Calculate timeouts based on total actions.
+* Correctly order the parameters for `ActionScheduler_ActionFactory`'s calls to `single_unique`.
+* Fetch action in memory first before releasing claim to avoid deadlock.
+* PHP 8.2: declare property to fix creation of dynamic property warning.
+* PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead".
+* Prevent `undefined variable` warning for `$num_pastdue_actions`.
+
+= 3.5.3 - 2022-11-09 =
+* Query actions with partial match.
+
+= 3.5.2 - 2022-09-16 =
+* Fix - erroneous 3.5.1 release.
+
+= 3.5.1 - 2022-09-13 =
+* Maintenance on A/S docs.
+* fix: PHP 8.2 deprecated notice.
+
+= 3.5.0 - 2022-08-25 =
+* Add - The active view link within the "Tools > Scheduled Actions" screen is now clickable.
+* Add - A warning when there are past-due actions.
+* Enhancement - Added the ability to schedule unique actions via an atomic operation.
+* Enhancement - Improvements to cache invalidation when processing batches (when running on WordPress 6.0+).
+* Enhancement - If a recurring action is found to be consistently failing, it will stop being rescheduled.
+* Enhancement - Adds a new "Past Due" view to the scheduled actions list table.
+
+= 3.4.2 - 2022-06-08 =
+* Fix - Change the include for better linting.
+* Fix - update: Added Action scheduler completed action hook.
+
+= 3.4.1 - 2022-05-24 =
+* Fix - Change the include for better linting.
+* Fix - Fix the documented return type.
+
+= 3.4.0 - 2021-10-29 =
+* Enhancement - Number of items per page can now be set for the Scheduled Actions view (props @ovidiul). #771
+* Fix - Do not lower the max_execution_time if it is already set to 0 (unlimited) (props @barryhughes). #755
+* Fix - Avoid triggering autoloaders during the version resolution process (props @olegabr). #731 & #776
+* Dev - ActionScheduler_wcSystemStatus PHPCS fixes (props @ovidiul). #761
+* Dev - ActionScheduler_DBLogger.php PHPCS fixes (props @ovidiul). #768
+* Dev - Fixed phpcs for ActionScheduler_Schedule_Deprecated (props @ovidiul). #762
+* Dev - Improve actions table indices (props @glagonikas). #774 & #777
+* Dev - PHPCS fixes for ActionScheduler_DBStore.php (props @ovidiul). #769 & #778
+* Dev - PHPCS Fixes for ActionScheduler_Abstract_ListTable (props @ovidiul). #763 & #779
+* Dev - Adds new filter action_scheduler_claim_actions_order_by to allow tuning of the claim query (props @glagonikas). #773
+* Dev - PHPCS fixes for ActionScheduler_WpPostStore class (props @ovidiul). #780
+
+= 3.3.0 - 2021-09-15 =
+* Enhancement - Adds as_has_scheduled_action() to provide a performant way to test for existing actions. #645
+* Fix - Improves compatibility with environments where NO_ZERO_DATE is enabled. #519
+* Fix - Adds safety checks to guard against errors when our database tables cannot be created. #645
+* Dev - Now supports queries that use multiple statuses. #649
+* Dev - Minimum requirements for WordPress and PHP bumped (to 5.2 and 5.6 respectively). #723
+
+= 3.2.1 - 2021-06-21 =
+* Fix - Add extra safety/account for different versions of AS and different loading patterns. #714
+* Fix - Handle hidden columns (Tools → Scheduled Actions) | #600.
+
+= 3.2.0 - 2021-06-03 =
+* Fix - Add "no ordering" option to as_next_scheduled_action().
+* Fix - Add secondary scheduled date checks when claiming actions (DBStore) | #634.
+* Fix - Add secondary scheduled date checks when claiming actions (wpPostStore) | #634.
+* Fix - Adds a new index to the action table, reducing the potential for deadlocks (props: @glagonikas).
+* Fix - Fix unit tests infrastructure and adapt tests to PHP 8.
+* Fix - Identify in-use data store.
+* Fix - Improve test_migration_is_scheduled.
+* Fix - PHP notice on list table.
+* Fix - Speed up clean up and batch selects.
+* Fix - Update pending dependencies.
+* Fix - [PHP 8.0] Only pass action arg values through to do_action_ref_array().
+* Fix - [PHP 8] Set the PHP version to 7.1 in composer.json for PHP 8 compatibility.
+* Fix - add is_initialized() to docs.
+* Fix - fix file permissions.
+* Fix - fixes #664 by replacing __ with esc_html__.

--- a/includes/license.php
+++ b/includes/license.php
@@ -90,7 +90,7 @@ function pmpro_license_isValid($key = NULL, $type = NULL, $force = false) {
 */
 //activation
 function pmpro_license_activation() {
-	pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'monthly', 'pmpro_license_check_key' );
+	function_exists( 'pmpro_maybe_schedule_event' ) && pmpro_maybe_schedule_event( current_time( 'timestamp' ), 'monthly', 'pmpro_license_check_key' );
 }
 add_action( 'activate_paid-memberships-pro', 'pmpro_license_activation' );
 

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -436,6 +436,16 @@ function pmpro_checkForUpgrades() {
 
 		update_option( 'pmpro_db_version', '3.402' );
 	}
+
+	/**
+	 * Version 3.5
+	 * Moving from WP Cron to WP Scheduled Actions via Action Scheduler.
+	 */
+	if ( $pmpro_db_version < 3.5 ) {
+		// Remove Crons Previously Registered by PMPro.
+		pmpro_clear_crons();
+		update_option( 'pmpro_db_version', '3.5' );
+	}
 }
 
 function pmpro_db_delta() {

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -26,6 +26,10 @@ define( 'PMPRO_MIN_PHP_VERSION', '5.6' );
 define( 'PMPRO_BASE_FILE', __FILE__ );
 define( 'PMPRO_DIR', dirname( __FILE__ ) );
 
+if ( ! class_exists( \ActionScheduler::class ) ) {
+	require_once PMPRO_DIR . '/includes/lib/action-scheduler/action-scheduler.php'; // Load Action Scheduler if it is not already loaded.
+}
+
 require_once( PMPRO_DIR . '/classes/class-deny-network-activation.php' );   // stop PMPro from being network activated
 require_once( PMPRO_DIR . '/includes/sessions.php' );               // start/close PHP session vars
 

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -26,9 +26,6 @@ define( 'PMPRO_MIN_PHP_VERSION', '5.6' );
 define( 'PMPRO_BASE_FILE', __FILE__ );
 define( 'PMPRO_DIR', dirname( __FILE__ ) );
 
-if ( ! class_exists( \ActionScheduler::class ) ) {
-	require_once PMPRO_DIR . '/includes/lib/action-scheduler/action-scheduler.php'; // Load Action Scheduler if it is not already loaded.
-}
 
 require_once( PMPRO_DIR . '/classes/class-deny-network-activation.php' );   // stop PMPro from being network activated
 require_once( PMPRO_DIR . '/includes/sessions.php' );               // start/close PHP session vars
@@ -49,6 +46,7 @@ if ( ! defined( 'PMPRO_LICENSE_SERVER' ) ) {
 if ( ! class_exists( \ActionScheduler::class ) ) {
 	require_once( PMPRO_DIR . '/includes/lib/action-scheduler/action-scheduler.php' ); // Load our copy of Action Scheduler if needed.
 }
+
 require_once( PMPRO_DIR . '/classes/class-pmpro-action-scheduler.php' );   			// Our Action Scheduler Manager for PMPro
 require_once( PMPRO_DIR . '/scheduled/recurring-actions.php' ); 						// Load our recurring scheduled actions.
 

--- a/scheduled/recurring-actions.php
+++ b/scheduled/recurring-actions.php
@@ -1,0 +1,551 @@
+<?php
+
+// This is a new class which registers all the scheduled actions (formerly crons) for PMPro.
+// It is a replacement for the old crons.php file.
+// The class is instantiated in the pmpro_init function.
+
+/**
+ * Class PMPro_Scheduled_Actions
+ *
+ * @since 2.8
+ */
+class PMPro_Scheduled_Actions {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var PMPro_Scheduled_Actions|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * The batch limit for the scheduled actions.
+	 */
+	private $query_batch_limit;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+
+		// Inherit the batch limit from the former PMPro cron settings or default to 50.
+		$this->query_batch_limit = defined( 'PMPRO_CRON_LIMIT' ) ? PMPRO_CRON_LIMIT : 50;
+
+		// Schedule cleanup actions previously handled by pmpro_cleanup_memberships_users_table()
+		add_action( 'pmpro_schedule_weekly', array( $this, 'pmpro_check_inactive_memberships' ) );
+		add_action( 'pmpro_schedule_weekly', array( $this, 'resolve_duplicate_active_rows' ) );
+
+		// Membership expiration reminders (Daily)
+		add_action( 'pmpro_schedule_daily', array( $this, 'membership_expiration_reminders' ) );
+		add_action( 'pmpro_expiration_reminder_email', array( $this, 'pmpro_send_expiration_reminder' ), 10, 2 );
+
+		// Expired Membership Routines (Daily)
+		add_action( 'pmpro_schedule_daily', array( $this, 'pmpro_expire_memberships' ) );
+		add_action( 'pmpro_membership_expired_email', array( $this, 'pmpro_send_membership_expired_email' ), 10, 2 );
+
+		// Admin activity emails (Conditionally Hooked)
+		$this->conditionally_hook_admin_activity_email();
+
+		// Schedule recurring payment reminder tasks.
+		add_action( 'pmpro_schedule_daily', array( $this, 'schedule_recurring_payment_reminder_tasks' ) );
+
+		// Register admin activity email hook.
+		add_action( 'pmpro_admin_activity_email', array( $this, 'pmpro_admin_activity_email' ) );
+
+		// Register recurring payment reminder email hook.
+		add_action( 'pmpro_recurring_payment_reminder_email', array( $this, 'send_recurring_payment_reminder_email' ), 10, 3 );
+
+		// Temporary file cleanup (Daily)
+		add_action( 'pmpro_schedule_daily', array( $this, 'pmpro_delete_tmp' ) );
+
+		// Backwards compatibility for the old cron hooks.
+		add_action( 'pmpro_cron_expire_memberships', array( $this, 'pmpro_expire_memberships' ) );
+		add_action( 'pmpro_cron_expiration_reminder_email', array( $this, 'pmpro_send_membership_expired_email' ), 10, 2 );
+		add_action( 'pmpro_cron_expiration_warnings', array( $this, 'membership_expiration_reminders' ) );
+		add_action( 'pmpro_cron_send_expiration_reminder', array( $this, 'pmpro_send_expiration_reminder' ), 10, 2 );
+		add_action( 'pmpro_cron_admin_activity_email', array( $this, 'pmpro_admin_activity_email' ) );
+		add_action( 'pmpro_cron_recurring_payment_reminders', array( $this, 'schedule_recurring_payment_reminder_tasks' ) );
+	}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return PMPro_Scheduled_Actions
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/** Check if we need to fix inactive memberships.
+	 *
+	 * This function is called weekly to fix any inactive memberships.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	public function pmpro_check_inactive_memberships() {
+		if ( pmpro_is_paused() ) {
+			return;
+		}
+		PMPro_Membership_Level::fix_inactive_memberships();
+	}
+
+	/**
+	 * Check for duplicate active rows in the memberships_users table.
+	 *
+	 * This function is called weekly to resolve any duplicate active rows
+	 * in the memberships_users table.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	public function resolve_duplicate_active_rows() {
+		// Don't let anything run if PMPro is paused
+		if ( pmpro_is_paused() ) {
+			return;
+		}
+
+		PMPro_Membership_Level::resolve_duplicate_active_rows();
+	}
+
+	/**
+	 * Schedule the membership expiration reminder emails.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	public function membership_expiration_reminders() {
+
+		global $wpdb;
+
+		$today = date( 'Y-m-d 00:00:00', current_time( 'timestamp' ) );
+
+		// Get the number of days before expiration to send the email. Filterable.
+		// Default is 7 days.
+		$pmpro_email_days_before_expiration = apply_filters( 'pmpro_email_days_before_expiration', 7 );
+
+		// Configure the interval to select records from
+		$interval_start = $today;
+		$interval_end   = date( 'Y-m-d 00:00:00', strtotime( "+{$pmpro_email_days_before_expiration} days", current_time( 'timestamp' ) ) );
+
+		// look for memberships that are going to expire within one week (but we haven't emailed them within a week)
+		$sqlQuery = $wpdb->prepare(
+			"SELECT DISTINCT
+						mu.user_id,
+						mu.membership_id,
+						mu.startdate,
+						mu.enddate,
+						um.meta_value AS notice
+					FROM {$wpdb->pmpro_memberships_users} AS mu
+					LEFT JOIN {$wpdb->usermeta} AS um ON um.user_id = mu.user_id
+					AND um.meta_key = CONCAT( 'pmpro_expiration_notice_', mu.membership_id )
+				WHERE ( um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d DAY) < %s )
+					AND mu.status = 'active'
+					AND mu.enddate IS NOT NULL
+					AND mu.enddate > '1000-01-01 00:00:00'
+					AND mu.enddate BETWEEN %s AND %s
+					AND mu.membership_id IS NOT NULL
+					AND mu.membership_id <> 0
+				ORDER BY mu.enddate
+				",
+			$pmpro_email_days_before_expiration,
+			$today,
+			$interval_start,
+			$interval_end
+		);
+
+		$query_offset = 0;
+		$query_limit  = $this->query_batch_limit;
+
+		do {
+			$batched_query = $sqlQuery . $wpdb->prepare( ' LIMIT %d OFFSET %d', $query_limit, $query_offset );
+			$expiring_soon = $wpdb->get_results( $batched_query );
+
+			if ( empty( $expiring_soon ) ) {
+				break;
+			}
+
+			// If Action Scheduler is not paused, pause it to prevent other tasks if there are a lot of expiring memberships.
+			$is_paused = PMPro_Action_Scheduler::instance()->is_paused();
+			if ( !$is_paused && count( $expiring_soon ) > 250 ) {
+				PMPro_Action_Scheduler::instance()->pause();
+			}
+
+			foreach ( $expiring_soon as $e ) {
+				PMPro_Action_Scheduler::instance()->maybe_add_task(
+					'pmpro_expiration_reminder_email',
+					array(
+						'user_id'       => $e->user_id,
+						'membership_id' => $e->membership_id,
+					),
+					'pmpro_expiration_tasks'
+				);
+			}
+
+			$query_offset += $query_limit;
+		} while ( count( $expiring_soon ) === $query_limit );
+
+		// If we paused the Action Scheduler, unpause it now.
+		if ( $is_paused ) {
+			PMPro_Action_Scheduler::instance()->unpause();
+		}
+	}
+
+	/**
+	 * Send the membership expiration reminder email.
+	 *
+	 * @param int $user_id The user ID.
+	 * @param int $membership_id The membership ID.
+	 *
+	 * @return void
+	 */
+	function pmpro_send_expiration_reminder( $user_id = null, $membership_id = null ) {
+
+		if ( WP_DEBUG ) {
+			error_log( '[PMPro Notice Args] ' . print_r( compact( 'user_id', 'membership_id' ), true ) );
+		}
+
+		if ( empty( $user_id ) || empty( $membership_id ) ) {
+			return;
+		}
+
+		$send_email = apply_filters( 'pmpro_send_expiration_warning_email', true, $user_id );
+
+		if ( $send_email ) {
+			// send an email
+			$pmpro_email = new PMProEmail();
+			$user        = get_userdata( $user_id );
+			if ( ! empty( $user ) ) {
+				$pmpro_email->sendMembershipExpiringEmail( $user, $membership_id );
+
+				if ( WP_DEBUG ) {
+					error_log( sprintf( esc_html__( 'Membership expiring email sent to %s. ', 'paid-memberships-pro' ), $user->user_email ) );
+				}
+			}
+		}
+
+		// delete all user meta for this key to prevent duplicate user meta rows
+		delete_user_meta( $user_id, 'pmpro_expiration_notice' );
+
+		// update user meta so we don't email them again
+		update_user_meta( $user_id, 'pmpro_expiration_notice_' . $membership_id, current_time( 'Y-m-d H:i:s' ) );
+	}
+
+	/**
+	 * Check for expired memberships and send emails.
+	 *
+	 * This function is called daily.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	public function pmpro_expire_memberships() {
+		global $wpdb;
+
+		$today = date( 'Y-m-d H:i:00', current_time( 'timestamp' ) );
+
+		$sqlQuery = $wpdb->prepare(
+			"SELECT mu.user_id, mu.membership_id
+	         FROM {$wpdb->pmpro_memberships_users} mu
+	         WHERE mu.status = 'active'
+	           AND mu.enddate IS NOT NULL
+	           AND mu.enddate > '1000-01-01 00:00:00'
+	           AND mu.enddate <= %s
+	         ORDER BY mu.enddate",
+			$today
+		);
+
+		$query_offset = 0;
+		$query_limit  = $this->query_batch_limit;
+
+		do {
+			$batched_query = $sqlQuery . $wpdb->prepare( ' LIMIT %d OFFSET %d', $query_limit, $query_offset );
+			$expired       = $wpdb->get_results( $batched_query );
+
+			if ( empty( $expired ) ) {
+				break;
+			}
+
+			// If Action Scheduler is not paused, pause it to prevent other tasks from running 
+			// if there are a lot of expired memberships.
+			$is_paused = PMPro_Action_Scheduler::instance()->is_paused();
+			if ( !$is_paused && count( $expired ) > 250 ) {
+				PMPro_Action_Scheduler::instance()->pause();
+			}
+
+			foreach ( $expired as $e ) {
+				PMPro_Action_Scheduler::instance()->maybe_add_task(
+					'pmpro_membership_expired_email',
+					array(
+						'user_id'       => $e->user_id,
+						'membership_id' => $e->membership_id,
+					),
+					'pmpro_expiration_tasks'
+				);
+			}
+
+			$query_offset += $query_limit;
+		} while ( count( $expired ) === $query_limit );
+
+		// If we paused the Action Scheduler, unpause it now.
+		if ( $is_paused ) {
+			PMPro_Action_Scheduler::instance()->unpause();
+		}
+	}
+
+	/**
+	 * Send the membership expired email.
+	 *
+	 * @access public
+	 * @since 3.5
+	 *
+	 * @param int $user_id The user ID.
+	 * @param int $membership_id The membership ID.
+	 *
+	 * @return void
+	 */
+	public function pmpro_send_membership_expired_email( $user_id, $membership_id ) {
+
+		do_action( 'pmpro_membership_pre_membership_expiry', $user_id, $membership_id );
+
+		// remove their membership
+		pmpro_cancelMembershipLevel( $membership_id, $user_id, 'expired' );
+
+		do_action( 'pmpro_membership_post_membership_expiry', $user_id, $membership_id );
+
+		if ( get_user_meta( $user_id, 'pmpro_disable_notifications', true ) ) {
+			$send_email = false;
+		}
+
+		$send_email = apply_filters( 'pmpro_send_expiration_email', true, $user_id );
+
+		if ( $send_email ) {
+			// send an email
+			$pmproemail = new PMProEmail();
+			$euser      = get_userdata( $user_id );
+			if ( ! empty( $euser ) ) {
+				$pmproemail->sendMembershipExpiredEmail( $euser, $membership_id );
+
+				if ( WP_DEBUG ) {
+					error_log( sprintf( __( 'Membership expired email sent to %s. ', 'paid-memberships-pro' ), $euser->user_email ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Send the admin activity email.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	public function pmpro_admin_activity_email() {
+
+		// Check if the admin activity email is enabled.
+		if ( ! get_option( 'pmpro_activity_email_enabled' ) ) {
+			return;
+		}
+
+		$pmproemail = new PMPro_Admin_Activity_Email();
+		$pmproemail->sendAdminActivity();
+
+		if ( WP_DEBUG ) {
+			error_log( sprintf( __( 'Admin activity email sent to %s. ', 'paid-memberships-pro' ), $user->user_email ) );
+		}
+	}
+
+	/**
+	 * Conditionally hook pmpro_admin_activity_email to scheduled tasks.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	private function conditionally_hook_admin_activity_email() {
+		add_action(
+			'pmpro_schedule_daily',
+			function () {
+				if ( get_option( 'pmpro_activity_email_frequency' ) === 'day' ) {
+					$this->pmpro_admin_activity_email();
+				}
+			}
+		);
+
+		add_action(
+			'pmpro_schedule_weekly',
+			function () {
+				if ( get_option( 'pmpro_activity_email_frequency' ) === 'week' ) {
+					$this->pmpro_admin_activity_email();
+				}
+			}
+		);
+
+		add_action(
+			'pmpro_schedule_monthly',
+			function () {
+				if ( get_option( 'pmpro_activity_email_frequency' ) === 'month' ) {
+					$this->pmpro_admin_activity_email();
+				}
+			}
+		);
+	}
+
+	/**
+	 * Schedule recurring payment reminder tasks.
+	 *
+	 * @return void
+	 */
+	public function schedule_recurring_payment_reminder_tasks() {
+		global $wpdb;
+
+		$emails = apply_filters(
+			'pmpro_upcoming_recurring_payment_reminder',
+			array( 7 => 'membership_recurring' )
+		);
+		ksort( $emails, SORT_NUMERIC );
+
+		$previous_days = 0;
+		foreach ( $emails as $days => $template ) {
+			$sqlQuery = $wpdb->prepare(
+				"SELECT subscription.*
+				FROM {$wpdb->pmpro_subscriptions} subscription
+				LEFT JOIN {$wpdb->pmpro_subscriptionmeta} last_next_payment_date 
+					ON subscription.id = last_next_payment_date.pmpro_subscription_id
+					AND last_next_payment_date.meta_key = 'pmprorm_last_next_payment_date'
+				LEFT JOIN {$wpdb->pmpro_subscriptionmeta} last_days
+					ON subscription.id = last_days.pmpro_subscription_id
+					AND last_days.meta_key = 'pmprorm_last_days'
+				WHERE subscription.status = 'active'
+				AND subscription.next_payment_date >= %s
+				AND subscription.next_payment_date < %s
+				AND ( last_next_payment_date.meta_value IS NULL
+					OR last_next_payment_date.meta_value != subscription.next_payment_date
+					OR last_days.meta_value > %d
+				)",
+				date_i18n( 'Y-m-d', strtotime( "+{$previous_days} days", current_time( 'timestamp' ) ) ),
+				date_i18n( 'Y-m-d', strtotime( "+{$days} days", current_time( 'timestamp' ) ) ),
+				$days
+			);
+
+			$subscriptions_to_notify = $wpdb->get_results( $sqlQuery );
+			if ( is_wp_error( $subscriptions_to_notify ) ) {
+				continue;
+			}
+
+			// If Action Scheduler is not paused, pause it to prevent other tasks from running
+			// if there are a lot of subscriptions to notify.
+			$is_paused = PMPro_Action_Scheduler::instance()->is_paused();
+			if ( !$is_paused && count( $subscriptions_to_notify ) > 250 ) {
+				PMPro_Action_Scheduler::instance()->pause();
+			}
+
+			foreach ( $subscriptions_to_notify as $subscription_to_notify ) {
+				PMPro_Action_Scheduler::instance()->maybe_add_task(
+					'pmpro_recurring_payment_reminder_email',
+					array(
+						'subscription_id' => $subscription_to_notify->id,
+						'template'        => $template,
+						'days'            => $days,
+					),
+					'pmpro_async_tasks'
+				);
+			}
+			$previous_days = $days;
+
+			// If we paused the Action Scheduler, unpause it now.
+			if ( $is_paused ) {
+				PMPro_Action_Scheduler::instance()->unpause();
+			}
+		}
+	}
+
+	/**
+	 * Send recurring payment reminder email.
+	 *
+	 * @param int    $subscription_id The subscription ID.
+	 * @param string $template The template name.
+	 * @param int    $days The number of days before payment.
+	 * @return void
+	 */
+	public function send_recurring_payment_reminder_email( $subscription_id, $template, $days ) {
+		$subscription_obj = new PMPro_Subscription( $subscription_id );
+		$user             = get_userdata( $subscription_obj->get_user_id() );
+
+		if ( empty( $user ) ) {
+			update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date() );
+			update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_days', $days );
+			return;
+		}
+
+		$send_email  = apply_filters( 'pmpro_send_recurring_payment_reminder_email', true, $subscription_obj, $days );
+		$send_emails = apply_filters_deprecated( 'pmprorm_send_reminder_to_user', array( $send_email, $user, null ), '3.2' );
+
+		if ( $send_emails && 'membership_recurring' == $template ) {
+			$pmproemail = new PMPro_Email_Template_Membership_Recurring( $subscription_obj );
+			$pmproemail->send();
+		} elseif ( $send_emails ) {
+			$membership_level     = pmpro_getLevel( $subscription_obj->get_membership_level_id() );
+			$pmproemail           = new PMProEmail();
+			$pmproemail->email    = $user->user_email;
+			$pmproemail->template = $template;
+			$pmproemail->data     = array(
+				'subject'               => $pmproemail->subject,
+				'name'                  => $user->display_name,
+				'user_login'            => $user->user_login,
+				'sitename'              => get_option( 'blogname' ),
+				'membership_id'         => $subscription_obj->get_membership_level_id(),
+				'membership_level_name' => empty( $membership_level ) ? sprintf( esc_html__( '[Deleted level #%d]', 'pmpro-recurring-emails' ), $subscription_obj->get_membership_level_id() ) : $membership_level->name,
+				'membership_cost'       => $subscription_obj->get_cost_text(),
+				'billing_amount'        => pmpro_formatPrice( $subscription_obj->get_billing_amount() ),
+				'renewaldate'           => date_i18n( get_option( 'date_format' ), $subscription_obj->get_next_payment_date() ),
+				'siteemail'             => get_option( 'pmpro_from_email' ),
+				'login_link'            => wp_login_url(),
+				'display_name'          => $user->display_name,
+				'user_email'            => $user->user_email,
+				'cancel_link'           => wp_login_url( pmpro_url( 'cancel' ) ),
+			);
+			$pmproemail->sendEmail();
+		}
+
+		update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date() );
+		update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_days', $days );
+	}
+
+	/**
+	 * Delete old files in wp-content/uploads/pmpro-register-helper/tmp.
+	 *
+	 * @since 3.5
+	 * @return void
+	 */
+	public function pmpro_delete_tmp() {
+		$upload_dir  = wp_upload_dir();
+		$pmprorh_dir = trailingslashit( $upload_dir['basedir'] ) . 'paid-memberships-pro/tmp/';
+
+		if ( ! file_exists( $pmprorh_dir ) || ! is_dir( $pmprorh_dir ) ) {
+			return;
+		}
+
+		if ( $handle = opendir( $pmprorh_dir ) ) {
+			while ( false !== ( $file = readdir( $handle ) ) ) {
+				$filepath = $pmprorh_dir . $file;
+
+				// Skip special directories.
+				if ( in_array( $file, array( '.', '..' ), true ) ) {
+					continue;
+				}
+
+				// Only delete real files older than an hour.
+				if ( is_file( $filepath ) && ! is_link( $filepath ) && ( time() - filemtime( $filepath ) ) > HOUR_IN_SECONDS ) {
+					unlink( $filepath );
+
+					if ( WP_DEBUG ) {
+						error_log( '[PMPro] Deleted temp file: ' . $filepath );
+					}
+				}
+			}
+			closedir( $handle );
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Depends on #3390 (which should be merged first before reviewing this PR).

Introducing Action Scheduler Support in Paid Memberships Pro!

Moving to Action Scheduler has many benefits over using wp-cron and longer running scripts

This PR:

- Adds a new management class `PMPro_Action_Scheduler()` for adding scheduled & async queue tasks for Action Scheduler to handle.


### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
