### PR TITLE
Simplify logic for handling suspended PayPal subscriptions, fix users not receiving emails

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -918,15 +918,6 @@
 			// Always cancel the order locally even if PayPal might fail
 			$order->updateStatus("cancelled");
 
-			// If we're processing an IPN request for this subscription, it's already cancelled at PayPal.
-			if ( ( ! empty( $_POST['subscr_id'] ) && $_POST['subscr_id'] == $order->subscription_transaction_id ) ||
-				 ( ! empty( $_POST['recurring_payment_id'] ) && $_POST['recurring_payment_id'] == $order->subscription_transaction_id ) ) {
-				// recurring_payment_failed transaction still need to be cancelled
-				if ( $_POST['txn_type'] !== 'recurring_payment_failed' ) {
-					return true;
-				}
-			}
-
 			// Cancel at gateway
 			return $this->cancelSubscriptionAtGateway($order);
 		}

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -263,7 +263,12 @@ if ( in_array( $txn_type, $failed_payment_txn_types ) ) {
 
 // Recurring Payment Profile Cancelled (PayPal Express)
 if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_payment_failed' || $txn_type == 'recurring_payment_suspended_due_to_max_failed_payment' ) {
-	// Find subscription.
+	// If the subscription was cancelled due to failed payments, make sure that we don't "cancel on next payment date".
+	if ( $txn_type == 'recurring_payment_failed' || $txn_type == 'recurring_payment_suspended_due_to_max_failed_payment' ) {
+		add_filter( 'pmpro_cancel_on_next_payment_date', '__return_false' );
+	}
+
+	// Handle the cancellation.
 	ipnlog( pmpro_handle_subscription_cancellation_at_gateway( $recurring_payment_id, 'paypalexpress', $gateway_environment ) );
 	pmpro_ipnExit();
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Replaces the solution implemented in #2901 to fix an issue with subscription not always being marked as `cancelled` in PayPal after failed payment retries are exhausted. The fix in #2901 worked, but meant that we couldn't use the abstracted `pmpro_handle_subscription_cancellation_at_gateway()` function to process the gateway.

Instead, this PR removes legacy optimization code from the PayPal Express `cancel()` method that was causing subscription cancellations to not be sent to PayPal. With this legacy behavior corrected, we can now use the abstracted `pmpro_handle_subscription_cancellation_at_gateway()` function again which fixes a bug where users were not receiving membership cancellation emails when failed payment retries are exhausted. Thanks to @dalemugford for this solution.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
