### PR TITLE
Action Scheduler "Pause Mode" refactor

### DIFF
--- a/classes/class-pmpro-action-scheduler.php
+++ b/classes/class-pmpro-action-scheduler.php
@@ -653,4 +653,28 @@ class PMPro_Action_Scheduler {
 		$modified = $datetime->modify( $time_string );
 		return $modified->getTimestamp();
 	}
+
+	/**
+	 * Halt Action Scheduler.
+	 *
+	 * Sets the 'pmpro_paused' option to true and fires the 'pmpro_pause_status_changed' action.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return void
+	 */
+	public static function halt() {
+		update_option( 'pmpro_as_halted', true );
+	}
+
+	/**
+	 * Resumes the Action Scheduler.
+	 *
+	 * @access public
+	 * @since 3.5
+	 * @return void
+	 */
+	public static function resume() {
+		update_option( 'pmpro_as_paused', false );
+	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4711,8 +4711,6 @@ function pmpro_compare_siteurl() {
 function pmpro_is_paused() {
 	// If the current site URL is different than the last known URL, then we are in pause mode.
 	if ( ! pmpro_compare_siteurl() ) {
-		// Tell Action Scheduler that the pause status has changed.
-		do_action('pmpro_as_pause_status_changed', true);
 		return true;
 	}
 

--- a/scheduled/recurring-actions.php
+++ b/scheduled/recurring-actions.php
@@ -162,9 +162,8 @@ class PMPro_Scheduled_Actions {
 		$query_limit  = $this->query_batch_limit;
 
 		// If Action Scheduler is not paused, pause it to prevent running tasks while loading the queue.
-		$is_paused = PMPro_Action_Scheduler::instance()->is_paused();
-		if ( !$is_paused && $this->query_batch_limit > 50 ) {
-			PMPro_Action_Scheduler::instance()->pause();
+		if ( $this->query_batch_limit > 50 ) {
+			PMPro_Action_Scheduler::instance()->halt();
 		}
 
 		do {
@@ -190,9 +189,7 @@ class PMPro_Scheduled_Actions {
 		} while ( count( $expiring_soon ) === $query_limit );
 
 		// If we paused the Action Scheduler, unpause it now.
-		if ( $is_paused ) {
-			PMPro_Action_Scheduler::instance()->unpause();
-		}
+		PMPro_Action_Scheduler::instance()->resume();
 	}
 
 	/**
@@ -261,10 +258,8 @@ class PMPro_Scheduled_Actions {
 
 		// If Action Scheduler is not paused, pause it to prevent other tasks from running 
 		// if there are a lot of expired memberships.
-		$is_paused = PMPro_Action_Scheduler::instance()->is_paused();
-
-		if ( !$is_paused && $this->query_batch_limit > 50 ) {
-			PMPro_Action_Scheduler::instance()->pause();
+		if ( $this->query_batch_limit > 50 ) {
+			PMPro_Action_Scheduler::instance()->halt();
 		}
 
 		do {
@@ -296,9 +291,7 @@ class PMPro_Scheduled_Actions {
 		} while ( count( $expired ) === $query_limit );
 
 		// If we paused the Action Scheduler, unpause it now.
-		if ( $is_paused ) {
-			PMPro_Action_Scheduler::instance()->unpause();
-		}
+		PMPro_Action_Scheduler::instance()->resume();
 	}
 
 	/**
@@ -430,10 +423,8 @@ class PMPro_Scheduled_Actions {
 				continue;
 			}
 
-			// If Action Scheduler is not paused, pause it to prevent running tasks while loading the queue.
-			$is_paused = PMPro_Action_Scheduler::instance()->is_paused();
-			if ( !$is_paused && count( $subscriptions_to_notify ) > 250 ) {
-				PMPro_Action_Scheduler::instance()->pause();
+			if ( count( $subscriptions_to_notify ) > 250 ) {
+				PMPro_Action_Scheduler::instance()->halt();
 			}
 
 			foreach ( $subscriptions_to_notify as $subscription_to_notify ) {
@@ -450,9 +441,7 @@ class PMPro_Scheduled_Actions {
 			$previous_days = $days;
 
 			// If we paused the Action Scheduler, unpause it now.
-			if ( $is_paused ) {
-				PMPro_Action_Scheduler::instance()->unpause();
-			}
+			PMPro_Action_Scheduler::instance()->resume();
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently, there are two ways that the action scheduler can be paused:
- If `pmpro_is_paused()` returns true
- If the Action Scheduler's `pause()` method is called

Based on the results of these two approaches, a function setting the batch size to 0 is dynamically hooked or unhooked. The hooked function is then re-evaluated whenever the status of either pause variable is changed.

In this PR, the two paths to pausing the action scheduler are separated into more distinct flows. To make this distinction clear, the wording for the second flow is altered to halt/resume to avoid re-using the same "pause" lingo which may cause confusion. Finally, this PR eliminates the need for juggling hooks by adding the logic to pause/halt the action scheduler directly to the existing `modify_batch_size()` and `modify_batch_time_limit()` methods.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
