### PR TITLE
Encode pmpro_last_known_url option

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4733,6 +4733,9 @@ function pmpro_decode_last_known_url( $value ) {
 	// Check if the value is base64 encoded.
 	if ( strpos( $value, 'b64:' ) === 0 ) {
 		$value = base64_decode( substr( $value, 4 ) );
+	} else {
+		// If the value is not encoded, then it is an old value. Encode it now.
+		update_option( 'pmpro_last_known_url', $value );
 	}
 	return $value;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4703,6 +4703,42 @@ function pmpro_compare_siteurl() {
 }
 
 /**
+ * When the pmpro_last_known_url option is updated, base64 encode it to
+ * prevent string replacements from changing it when the site is migrated.
+ *
+ * @since TBD
+ *
+ * @param string $new_value The new value for the option.
+ * @return string The encoded value for the option.
+ */
+function pmpro_encode_last_known_url( $new_value ) {
+	// Only encode non-empty values.
+	if ( ! empty( $new_value ) ) {
+		$new_value = 'b64:' . base64_encode( $new_value );
+	}
+	return $new_value;
+}
+add_filter( 'pre_update_option_pmpro_last_known_url', 'pmpro_encode_last_known_url' );
+
+/**
+ * When the pmpro_last_known_url option is retrieved, if it
+ * is base64 encoded, decode it.
+ *
+ * @since TBD
+ *
+ * @param string $value The value of the option.
+ * @return string The decoded value of the option.
+ */
+function pmpro_decode_last_known_url( $value ) {
+	// Check if the value is base64 encoded.
+	if ( strpos( $value, 'b64:' ) === 0 ) {
+		$value = base64_decode( substr( $value, 4 ) );
+	}
+	return $value;
+}
+add_filter( 'option_pmpro_last_known_url', 'pmpro_decode_last_known_url' );
+
+/**
  * Determine if the site is in pause mode or not
  *
  * @since 2.10

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4707,6 +4707,7 @@ function pmpro_compare_siteurl() {
  * prevent string replacements from changing it when the site is migrated.
  *
  * @since TBD
+ * @link https://developer.wordpress.org/reference/hooks/pre_update_option_option/
  *
  * @param string $new_value The new value for the option.
  * @return string The encoded value for the option.
@@ -4725,6 +4726,7 @@ add_filter( 'pre_update_option_pmpro_last_known_url', 'pmpro_encode_last_known_u
  * is base64 encoded, decode it.
  *
  * @since TBD
+ * @link https://developer.wordpress.org/reference/hooks/option_option/
  *
  * @param string $value The value of the option.
  * @return string The decoded value of the option.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Alternative to #3376

Previously, if the site change was made using wp-cli search-replace or similar (hosting migration tools working the same way), even the `pmpro_last_known_url` option saved w/o obfuscation/hashing was updated. Then, the site change was not detected, and the pause mode not triggered.

This PR encodes the `pmpro_last_known_url ` option when saving to the database and decodes it when pulling from the database.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
