### PR TITLE
Additional changes to the gateway settings overhaul work

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -137,8 +137,8 @@
 								</th>
 								<td>
 									<select id="gateway_environment" name="gateway_environment">
-										<option value="sandbox" <?php if( $gateway_environment == "sandbox") { ?>selected="selected"<?php } ?>><?php esc_html_e('Sandbox', 'paid-memberships-pro' );?></option>
-										<option value="live" <?php if( $gateway_environment == "live") { ?>selected="selected"<?php } ?>><?php esc_html_e('Live', 'paid-memberships-pro' );?></option>
+										<option value="sandbox" <?php if( $gateway_environment == "sandbox") { ?>selected="selected"<?php } ?>><?php esc_html_e('Sandbox/Testing', 'paid-memberships-pro' );?></option>
+										<option value="live" <?php if( $gateway_environment == "live") { ?>selected="selected"<?php } ?>><?php esc_html_e('Live/Production', 'paid-memberships-pro' );?></option>
 									</select>
 									<p class="description">
 										<?php esc_html_e( 'Most gateways have a sandbox (test) and live environment. You can test transactions using the sandbox.', 'paid-memberships-pro' ); ?>
@@ -208,7 +208,7 @@
 									</td>
 									<td class="column-status">
 										<?php
-											$gateway_status_html = pmpro_getOption( 'gateway' ) === $gateway_slug ? '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-success">' . esc_html__( 'Enabled (Primary Gateway)', 'paid-memberships-pro' ) . '</span>' : esc_html__( '&#8212;', 'paid-memberships-pro' );
+											$gateway_status_html = pmpro_getOption( 'gateway' ) === $gateway_slug ? '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-info">' . esc_html__( 'Enabled (Primary Gateway)', 'paid-memberships-pro' ) . '</span>' : esc_html__( '&#8212;', 'paid-memberships-pro' );
 
 											// Special Cases for Add Ons that add secondary gateways. These will be removed when core natively supports multiple gateways.
 											if (
@@ -221,7 +221,7 @@
 													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-info">' . esc_html__( 'Enabled (Primary Gateway & via Add On)', 'paid-memberships-pro' ) . '</span>';
 												} else {
 													// Show this as a secondary gateway.
-													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-success">' . esc_html__( 'Enabled (via Add On)', 'paid-memberships-pro' ) . '</span>';
+													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-info">' . esc_html__( 'Enabled (via Add On)', 'paid-memberships-pro' ) . '</span>';
 												}	
 											}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2906,7 +2906,7 @@ class PMProGateway_stripe extends PMProGateway {
 								</td>
 							</tr>
 						<?php } ?>
-						<?php if ( self::using_legacy_keys() && ! self::has_connect_credentials( $environment ) ) { ?>
+						<?php if ( self::using_legacy_keys() && ! self::has_connect_credentials( $environment ) && $active_environment ) { ?>
 							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
 								<td colspan="2">
 									<div class="notice notice-large notice-warning inline">
@@ -2918,7 +2918,7 @@ class PMProGateway_stripe extends PMProGateway {
 									</div>
 								</td>
 							</tr>
-						<?php } elseif ( self::using_api_keys() && self::has_connect_credentials( $environment ) ) {  ?>
+						<?php } elseif ( self::using_api_keys() && self::has_connect_credentials( $environment ) && $active_environment ) {  ?>
 							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
 								<td colspan="2">
 									<div class="notice notice-large notice-warning inline">

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -783,6 +783,7 @@ class PMProGateway_stripe extends PMProGateway {
 									$working_webhooks = array();
 									// For sites that tracked "last webhook received" before we started tracking webhook events individually,
 									// we want to ignore events that were sent by Stripe before site was updated to start tracking individual events.
+									$environment = get_option( 'pmpro_gateway_environment' );
 									$legacy_last_webhook_received_timestamp = get_option( 'pmpro_stripe_last_webhook_received_' . $environment );
 									foreach ( $required_webhook_events as $required_webhook_event ) {
 										$event_data = array( 'name' => $required_webhook_event );

--- a/css/admin.css
+++ b/css/admin.css
@@ -1673,7 +1673,6 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	display: inline-block;
 	font-size: 14px;
 	font-weight: 500;
-	margin-left: 5px;
 	padding: .25em .5em;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
* changed the contextual color for the enabled gateways on main page to blue so we do not imply "functionally working" with green
* adjustments to the Stripe payment settings edit experience to only show fee info for live mode, move API keys methods inside the connection boxes, and move webhook settings into its own box.