### PR TITLE
Initial work for showing gateway deprecation warnings

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -92,6 +92,7 @@
 
 	// Get a list of all gateways with human readable names.
 	$pmpro_gateways = pmpro_gateways();
+	$deprecated_gateways = pmpro_get_deprecated_gateways();
 
 	require_once(dirname(__FILE__) . "/admin_header.php");
 ?>
@@ -225,6 +226,11 @@
 												}	
 											}
 
+											// Special case for deprecated gateways.
+											if ( in_array( $gateway_slug, $deprecated_gateways, true ) && $gateway_slug === pmpro_getOption( 'gateway' ) ) {
+												$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Enabled (Not Supported)', 'paid-memberships-pro' ) . '</span>';
+											}
+
 											echo wp_kses_post( $gateway_status_html );
 										?>
 										</td>
@@ -327,7 +333,24 @@
 				?>
 			</h1>
 			<?php
-				call_user_func( array( $gateway_class_name, 'show_settings_fields' ) );
+			// If this gateway is deprecated, show a warning.
+			if ( in_array( $edit_gateway, $deprecated_gateways, true ) ) {
+				?>
+				<div class="notice notice-alt notice-error inline">
+					<p>
+						<?php
+						// translators: %s is the gateway name.
+						printf(
+							esc_html__('The %s gateway is deprecated and no longer supported. Please consider switching to a different gateway.', 'paid-memberships-pro'),
+							esc_html( $pmpro_gateways[ $edit_gateway ] )
+						);
+						?>
+				</div>
+				<?php
+			}
+
+			// Show the settings for the specific gateway.
+			call_user_func( array( $gateway_class_name, 'show_settings_fields' ) );
 			?>
 			<p class="submit">
 				<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e('Save Settings', 'paid-memberships-pro' );?>" />

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1008,13 +1008,30 @@ add_action( 'admin_notices', 'pmpro_check_for_deprecated_add_ons' );
 add_filter( 'plugin_action_links', 'pmpro_deprecated_add_ons_action_links', 10, 2 );
 
 /**
+ * Get the list of deprecated gateways.
+ *
  * The 2Checkout gateway was deprecated in v2.6.
  * Cybersource was deprecated in 2.10.
  * PayPal Website Payments Pro was deprecated in 2.10.
  * Authorize.net was deprecated in 3.2.
  * PayFlow, PayPal Standard, and Braintree were deprecated in 3.4.
  *
- * This code will add it back those gateways if it was the selected gateway.
+ * @since TBD
+ */
+function pmpro_get_deprecated_gateways() {
+	return array(
+		'twocheckout',
+		'cybersource',
+		'paypal',
+		'authorizenet',
+		'payflowpro',
+		'paypalstandard',
+		'braintree',
+	);
+}
+
+/**
+ * Adds back deprecated gateways if they have ever been the selected gateway.
  * In future versions, we will remove gateway code entirely.
  * And you will have to use a stand alone add on for those gateways
  * or choose a new gateway.
@@ -1029,7 +1046,7 @@ function pmpro_check_for_deprecated_gateways() {
 	}
 	$default_gateway = get_option( 'pmpro_gateway' );
 
-	$deprecated_gateways = array( 'twocheckout', 'cybersource', 'paypal', 'authorizenet', 'payflowpro', 'paypalstandard', 'braintree' );
+	$deprecated_gateways = pmpro_get_deprecated_gateways();
 	foreach ( $deprecated_gateways as $deprecated_gateway ) {
 		if ( $default_gateway === $deprecated_gateway || in_array( $deprecated_gateway, $undeprecated_gateways ) ) {
 			require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_' . $deprecated_gateway . '.php' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Show error/warning messages for deprecated gateways.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Comment out one of the deprecated gateways so that it shows in the list of gateways
2. Switch to using that payment gateway and save payment settings
3. Uncomment the deprecated gateway
4. See the deprecation warning in the gateway list

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
