### PR TITLE
Fixing bug where levels would be unlinked from groups when searching for levels

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -176,18 +176,21 @@
 		}
 
 		// For each group, make sure that each level in the group still exists. If not, remove the link.
-		foreach ( $level_groups as $level_group ) {
-			$group_level_ids = pmpro_get_level_ids_for_group( $level_group->id );
-			foreach ( $group_level_ids as $group_level_id ) {
-				$level_exists = false;
-				foreach ( $reordered_levels as $reordered_level ) {
-					if ( $group_level_id === $reordered_level->id ) {
-						$level_exists = true;
-						break;
+		// We only want to do this if we are not searching for specific levels, otherwise $reordered_levels may not contain all levels.
+		if ( empty( $s) ) {
+			foreach ( $level_groups as $level_group ) {
+				$group_level_ids = pmpro_get_level_ids_for_group( $level_group->id );
+				foreach ( $group_level_ids as $group_level_id ) {
+					$level_exists = false;
+					foreach ( $reordered_levels as $reordered_level ) {
+						if ( $group_level_id === $reordered_level->id ) {
+							$level_exists = true;
+							break;
+						}
 					}
-				}
-				if ( ! $level_exists ) {
-					$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->pmpro_membership_levels_groups WHERE `group` = %d AND `level` = %d", $level_group->id, $group_level_id ) );
+					if ( ! $level_exists ) {
+						$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->pmpro_membership_levels_groups WHERE `group` = %d AND `level` = %d", $level_group->id, $group_level_id ) );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When searching for a level name that does not exist on the Membership Levels settings page, when the page is reloaded, all levels will be moved to the first level group. This PR fixes that behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
