### PR TITLE
Make sure that PMPRO_STRIPE_API_VERSION is set when processing webhooks

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -11,15 +11,16 @@
 
 	// For compatibility with old library (Namespace Alias)
 	use Stripe\Invoice as Stripe_Invoice;
+	use Stripe\Charge as Stripe_Charge;
 	use Stripe\Event as Stripe_Event;
 	use Stripe\PaymentMethod as Stripe_PaymentMethod;
 	use Stripe\Customer as Stripe_Customer;
+	use Stripe\Checkout\Session as Stripe_Checkout_Session;
 
 	global $logstr;	
 
-	if(!class_exists("Stripe\Stripe")) {
-		require_once( PMPRO_DIR . "/includes/lib/Stripe/init.php" );
-	}
+	// Make sure that Stripe is loaded and is the correct API version.
+	$stripe = new PMProGateway_stripe();
 
 	// Sets the PMPRO_DOING_WEBHOOK constant and fires the pmpro_doing_webhook action.
 	pmpro_doing_webhook( 'stripe', true );
@@ -103,17 +104,20 @@
 		//check what kind of event it is
 		if($pmpro_stripe_event->type == "invoice.payment_succeeded")
 		{
-			if($pmpro_stripe_event->data->object->amount_due > 0)
+			// Make sure we have the invoice in the desired API version.
+			$invoice = Stripe_Invoice::retrieve( $pmpro_stripe_event->data->object->id );
+
+			if($invoice->amount_due > 0)
 			{
 				//do we have this order yet? (check status too)
 				$order = new MemberOrder();
-				$order->getMemberOrderByPaymentTransactionID( $pmpro_stripe_event->data->object->id );
+				$order->getMemberOrderByPaymentTransactionID( $invoice->id );
 
 				//no? create it
 				if(empty($order->id))
 				{				
 					$old_order = new MemberOrder();
-					$old_order->getLastMemberOrderBySubscriptionTransactionID($pmpro_stripe_event->data->object->subscription);
+					$old_order->getLastMemberOrderBySubscriptionTransactionID($invoice->subscription);
 					
 					//still can't find the order
 					if(empty($old_order) || empty($old_order->id))
@@ -130,8 +134,6 @@
 						pmpro_stripeWebhookExit();
 					}
 					$user->membership_level = pmpro_getMembershipLevelForUser($user_id);
-
-					$invoice = $pmpro_stripe_event->data->object;
 
 					//alright. create a new order
 					$morder = new MemberOrder();
@@ -217,7 +219,8 @@
 			}
 		}
 		elseif($pmpro_stripe_event->type == "invoice.payment_action_required") {
-			$invoice = $pmpro_stripe_event->data->object;
+			// Make sure we have the invoice in the desired API version.
+			$invoice = Stripe_Invoice::retrieve( $pmpro_stripe_event->data->object->id );
 
 			// Get the last order for this invoice's subscription.
 			if ( ! empty( $invoice->subscription ) ) {
@@ -278,12 +281,13 @@
 			else
 			{
 				$logstr .= "Could not find the related subscription for event with ID #" . $pmpro_stripe_event->id . ".";
-				if(!empty($pmpro_stripe_event->data->object->customer))
+				if(!empty($invoice->customer))
 					$logstr .= " Customer ID #" . $invoice->customer . ".";
 				pmpro_stripeWebhookExit();
 			}
 		} elseif($pmpro_stripe_event->type == "charge.failed") {
-			$charge = $pmpro_stripe_event->data->object;
+			// Make sure we have the charge in the desired API version.
+			$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
 
 			// Get the invoice for this charge if it exists.
 			if ( ! empty( $charge->invoice ) ) {
@@ -327,7 +331,7 @@
 				
 				// Find the payment intent.
 				$payment_intent_args = array(
-					'id'     => $pmpro_stripe_event->data->object->payment_intent,
+					'id'     => $charge->payment_intent,
 					'expand' => array(
 						'payment_method',
 						'latest_charge',
@@ -344,7 +348,7 @@
 					$payment_method = $payment_intent->latest_charge->payment_method_details;
 				}				
 				if ( empty( $payment_method ) ) {
-					$logstr .= "Could not find payment method for charge " . $pmpro_stripe_event->data->object->id . ".";
+					$logstr .= "Could not find payment method for charge " . $charge->id . ".";
 				}
 				// Update payment method and billing address on order.
 				pmpro_stripe_webhook_populate_order_from_payment( $morder, $payment_method, $payment_intent->customer );
@@ -363,8 +367,8 @@
 			else
 			{
 				$logstr .= "Could not find the related subscription for event with ID #" . $pmpro_stripe_event->id . ".";
-				if(!empty($pmpro_stripe_event->data->object->customer))
-					$logstr .= " Customer ID #" . $pmpro_stripe_event->data->object->customer . ".";
+				if(!empty($charge->customer))
+					$logstr .= " Customer ID #" . $charge->customer . ".";
 				pmpro_stripeWebhookExit();
 			}
 		}
@@ -374,14 +378,17 @@
 			pmpro_stripeWebhookExit();
 		}
 		elseif( $pmpro_stripe_event->type == "charge.refunded" )
-		{			
-			$payment_transaction_id = $pmpro_stripe_event->data->object->id;
+		{
+			// Make sure we have the charge in the desired API version.
+			$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
+
+			$payment_transaction_id = $charge->id;
 			$morder = new MemberOrder();
       		$morder->getMemberOrderByPaymentTransactionID( $payment_transaction_id );
 		
 			// Initial payment orders are stored using the invoice ID, so check that value too.
-			if ( empty( $morder->id ) && ! empty( $pmpro_stripe_event->data->object->invoice ) ) {
-				$payment_transaction_id = $pmpro_stripe_event->data->object->invoice;
+			if ( empty( $morder->id ) && ! empty( $charge->invoice ) ) {
+				$payment_transaction_id = $charge->invoice;
 				$morder->getMemberOrderByPaymentTransactionID( $payment_transaction_id );
 			}
 
@@ -435,8 +442,8 @@
 		}
 		elseif($pmpro_stripe_event->type == "checkout.session.completed")
 		{
-			// First, let's get the checkout session.
-			$checkout_session = $pmpro_stripe_event->data->object;
+			// Make sure we have the checkout session in the desired API version.
+			$checkout_session = Stripe_Checkout_Session::retrieve( $pmpro_stripe_event->data->object->id );
 
 			// Let's then find the PMPro order for the checkout session.
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT pmpro_membership_order_id FROM $wpdb->pmpro_membership_ordermeta WHERE meta_key = 'stripe_checkout_session_id' AND meta_value = %s LIMIT 1", $checkout_session->id ) );
@@ -537,8 +544,8 @@
 		}
 		elseif($pmpro_stripe_event->type == "checkout.session.async_payment_succeeded")
 		{
-			// First, let's get the checkout session.
-			$checkout_session = $pmpro_stripe_event->data->object;
+			// Make sure we have the checkout session in the desired API version.
+			$checkout_session = Stripe_Checkout_Session::retrieve( $pmpro_stripe_event->data->object->id );
 
 			// Let's then find the PMPro order for the checkout session.
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT pmpro_membership_order_id FROM $wpdb->pmpro_membership_ordermeta WHERE meta_key = 'stripe_checkout_session_id' AND meta_value = %s LIMIT 1", $checkout_session->id ) );
@@ -569,8 +576,8 @@
 		}
 		elseif($pmpro_stripe_event->type == "checkout.session.async_payment_failed")
 		{
-			// First, let's get the checkout session.
-			$checkout_session = $pmpro_stripe_event->data->object;
+			// Make sure we have the checkout session in the desired API version.
+			$checkout_session = Stripe_Checkout_Session::retrieve( $pmpro_stripe_event->data->object->id );
 
 			// Let's then find the PMPro order for the checkout session.
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT pmpro_membership_order_id FROM $wpdb->pmpro_membership_ordermeta WHERE meta_key = 'stripe_checkout_session_id' AND meta_value = %s LIMIT 1", $checkout_session->id ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Alternative to #3408

On some sites that are not using Stripe Connect and that are using a newer version of the Stripe API, recurring payments are not being recorded correctly in PMPro.

When PMPro uses the Stripe API, we typically set the API version so that we know the format that Stripe will send the data back in. When processing webhooks, however, the API version was not being set. This means that the API version for the Stripe account is used which may not be compatible with the PMPro webhook handler.

This PR updates the webhook handler by setting the API version through `$stripe = new PMProGateway_stripe();`. Upon further testing, it became clear that the data sent in `$pmpro_stripe_event->data->object` does not respect the set API version, so this PR also updates the webhook handler code for each event type to obtain a fresh copy of `$pmpro_stripe_event->data->object` in the desired API version.

Going forward, having the API version set for webhooks should keep the webhook handler stable regardless of the API version set on the Stripe account.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a new Stripe account
2. Connect to PMPro via API keys
3. Set up a subscription
4. See that before this PR, recurring orders are not created. After this PR, they are.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
