### PR TITLE
Fix PHP 8.1+ depreciation Notice

### DIFF
--- a/adminpages/memberslist-csv.php
+++ b/adminpages/memberslist-csv.php
@@ -523,8 +523,8 @@
 
 	exit;
 
-	function pmpro_enclose($s)
-	{
+	function pmpro_enclose($s) {
+		$s = (string) $s;
 		return "\"" . str_replace("\"", "\\\"", $s) . "\"";
 	}
 


### PR DESCRIPTION
Fixes:

PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in …paid-memberships-pro/adminpages/memberslist-csv.php on line 528

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Resolves a rare notice when performing exports from the admin.