### PR TITLE
Fixing object cache issues

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -26,8 +26,15 @@ class PMPro_Widget_Member_Login extends WP_Widget {
 
 	function widget( $args, $instance ) {
 		$cache = array();
+		$cache_key_parts = array(
+			'args'            => $args,
+			'logged_in'       => is_user_logged_in(),
+			'current_user_id' => get_current_user_id(),
+			'is_login_page'   => pmpro_is_login_page(),
+		);
+		$cache_key = 'pml_' . md5( wp_json_encode( $cache_key_parts ) );
 		if ( ! $this->is_preview() ) {
-			$cache = wp_cache_get( 'widget_pmpro_member_login', 'widget' );
+			$cache = wp_cache_get( $cache_key, 'pmpro_widget_member_login' );
 		}
 
 		if ( ! is_array( $cache ) ) {
@@ -39,12 +46,11 @@ class PMPro_Widget_Member_Login extends WP_Widget {
 		}
 
 		if ( isset( $cache[ $args['widget_id'] ] ) ) {
-			echo wp_kses_post( $cache[ $args['widget_id'] ] );
+			echo $cache[ $args['widget_id'] ];
 			return;
 		}
 
 		ob_start(); ?>
-		
 		<?php
 			// Get widget settings for this instance.
 			extract( $args );
@@ -69,7 +75,7 @@ class PMPro_Widget_Member_Login extends WP_Widget {
 			
 		<?php if ( ! $this->is_preview() ) {
 			$cache[ $args['widget_id'] ] = ob_get_flush();
-			wp_cache_set( 'widget_pmpro_member_login', $cache, 'widget' );
+			wp_cache_set( $cache_key, $cache, 'widget' );
 		} else {
 			ob_end_flush();
 		}
@@ -83,16 +89,11 @@ class PMPro_Widget_Member_Login extends WP_Widget {
 
 		$this->flush_widget_cache();
 
-		$alloptions = wp_cache_get( 'alloptions', 'options' );
-		if ( isset( $alloptions['widget_pmpro_member_login'] ) ) {
-			delete_option( 'widget_pmpro_member_login' );
-		}
-
 		return $instance;
 	}
 
 	function flush_widget_cache() {
-		wp_cache_delete( 'widget_pmpro_member_login', 'widget' );
+		wp_cache_flush_group( 'pmpro_widget_member_login' );
 	}
 
 	function form( $instance ) { 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set up object caching with something like W3 Total Cache.
2. Add the login form widget to the sidebar of a page.
3. Clear all cache.
4. Visit that page while logged in.
5. Visit that page while logged out.
6. Note that the logged in version of the widget will show up instead of the logged out one.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

Note that I removed the escaping of the cached version of the widget. We will want to add some escaping back that supports form elements.

We can't rely on wp_cache_flush_group to work.

We maybe shouldn't be caching this at all. It's not too heavy and probably already covered by page caches.

Do we want some other way to track the cache key/groups we create so we can flush better?

Are there other times to flush here?

There are some other spots in our code that are using wp_cache_get/set. We should make sure those are working well too.

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX/ENHANCEMENT: Fixed issues with the login form widget when using object caching.
