### PR TITLE
Optimize pmpro_getMembershipCategories()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1541,11 +1541,10 @@ function pmpro_updateMembershipCategories( $level, $categories ) {
 /**
  * pmpro_getMembershipCategories() returns the categories for a given level
  *
- * @param int $level_id is a valid membership level ID
- *
- * @return int[]
+ * @param int $level_id The membership level ID.
+ * @return array List of category IDs.
  */
-function pmpro_getMembershipCategories( $level_id ) {
+function pmpro_get_membership_categories( $level_id ) {
 	static $cache = array();
 
 	$level_id = intval( $level_id );
@@ -1564,6 +1563,7 @@ function pmpro_getMembershipCategories( $level_id ) {
 	);
 
 	$cache[ $level_id ] = $categories;
+
 	return $categories;
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1544,7 +1544,7 @@ function pmpro_updateMembershipCategories( $level, $categories ) {
  * @param int $level_id The membership level ID.
  * @return array List of category IDs.
  */
-function pmpro_get_membership_categories( $level_id ) {
+function pmpro_getMembershipCategories( $level_id ) {
 	static $cache = array();
 
 	$level_id = intval( $level_id );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1546,19 +1546,36 @@ function pmpro_updateMembershipCategories( $level, $categories ) {
  * @return int[]
  */
 function pmpro_getMembershipCategories( $level_id ) {
+	static $cache = array();
+
 	$level_id = intval( $level_id );
+	if ( isset( $cache[ $level_id ] ) ) {
+		return $cache[ $level_id ];
+	}
 
 	global $wpdb;
 	$categories = $wpdb->get_col(
-		"SELECT c.category_id
-										FROM {$wpdb->pmpro_memberships_categories} AS c
-										WHERE c.membership_id = '" . esc_sql( $level_id ) . "'"
+		$wpdb->prepare(
+			"SELECT c.category_id
+			 FROM {$wpdb->pmpro_memberships_categories} AS c
+			 WHERE c.membership_id = %d",
+			$level_id
+		)
 	);
 
+	$cache[ $level_id ] = $categories;
 	return $categories;
 }
 
-
+/**
+ * pmpro_isAdmin() checks if a user is an admin.
+ *
+ * @since 1.8.11
+ *
+ * @param int|null $user_id The user ID to check. If null, uses the current user.
+ *
+ * @return bool True if the user is an admin, false otherwise.
+ */
 function pmpro_isAdmin( $user_id = null ) {
 	global $current_user;
 	if ( ! $user_id ) {
@@ -1577,6 +1594,18 @@ function pmpro_isAdmin( $user_id = null ) {
 	}
 }
 
+/**
+ * pmpro_replaceUserMeta() updates user meta values, replacing existing values.
+ *
+ * @since 1.8.11
+ *
+ * @param int $user_id User ID to update.
+ * @param string|array $meta_keys Meta keys to update.
+ * @param string|array $meta_values Meta values to set.
+ * @param string|array|null $prev_values Previous values to check against.
+ *
+ * @return int Number of meta keys updated.
+ */
 function pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values, $prev_values = null ) {
 	// expects all arrays for last 3 params or all strings
 	if ( ! is_array( $meta_keys ) ) {
@@ -1601,6 +1630,14 @@ function pmpro_replaceUserMeta( $user_id, $meta_keys, $meta_values, $prev_values
 	return $i;
 }
 
+/**
+ * pmpro_getMetavalues() returns an object with the meta values from a query.
+ *
+ * @since 1.8.11
+ *
+ * @param string $query SQL query to get meta values.
+ * @return stdClass Object with meta keys and values.
+ */
 function pmpro_getMetavalues( $query ) {
 	global $wpdb;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Optimizes `pmpro_getMembershipCategories()` using in-memory caching to improve performance when called multiple times form the same page.

using Query Monitor or similar you can observe the reduction in queries when `pmpro_getMembershipCategories()` is called on Paid Memberships Pro front-end pages.

Also adds doc blocks for two nearby methods that were missing them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Optimized `pmpro_getMembershipCategories()` method to reduce database queries.
