### PR TITLE
Now returning early with a better message if the site is connected to Stripe with API keys

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -607,12 +607,18 @@
 			$logstr .= "Order #" . $order->id . " for Checkout Session " . $checkout_session->id . " could not be processed.";
 			pmpro_stripeWebhookExit();
 		} elseif ( $pmpro_stripe_event->type == 'invoice.created' ) {
-      // Make sure we have the invoice in the desired API version.
+			// Make sure we have the invoice in the desired API version.
 			$invoice = Stripe_Invoice::retrieve( $pmpro_stripe_event->data->object->id );
 
 			// If the invoice is not in draft status, we don't need to do anything.
 			if ( $invoice->status !== 'draft' ) {
 				$logstr .= "Invoice " . $invoice->id . " is not in draft status. No action taken.";
+				pmpro_stripeWebhookExit();
+			}
+
+			// If the site is using API keys, we don't need to update the application fee.
+			if ( $stripe->using_api_keys() ) {
+				$logstr .= "Using API keys, so not updating application fee for invoice " . $invoice->id . ".";
 				pmpro_stripeWebhookExit();
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adjusts the new logic to adjust application fees on the Stripe invoice.created event to only proceed for sites that are Connected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?