### PR TITLE
Restoring removed parameter for filter pmpro_email_template

### DIFF
--- a/classes/email-templates/class-pmpro-email-template.php
+++ b/classes/email-templates/class-pmpro-email-template.php
@@ -44,7 +44,7 @@ abstract class PMPro_Email_Template {
 		$pmpro_email->subject  = $this->get_default_subject(); // This will be overridden if there is a subject saved in the database.
 		$pmpro_email->body     = $this->get_default_body();
 		$pmpro_email->data     = array_merge( $this->get_base_email_template_variables(), $this->get_email_template_variables() );
-		$pmpro_email->template = apply_filters_deprecated( 'pmpro_email_template', array( $this->get_template_slug() ), '3.4', 'pmpro_email_body' );
+		$pmpro_email->template = apply_filters_deprecated( 'pmpro_email_template', array( $this->get_template_slug(), $pmpro_email ), '3.4', 'pmpro_email_body' );
 		return $pmpro_email->sendEmail();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding back the second parameter for the `pmpro_email_template` filter that was lost when the filter was deprecated in PMPro v3.4.

As this filter is deprecated, it will be removed in a future version of Paid Memberships Pro. If you would like to dynamically modify the contents of an email, this should be done using the `pmpro_email_body` filter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
