### PR TITLE
Fixing the "Recent Members" metabox for sites that do not use the `wp_` prefix

### DIFF
--- a/adminpages/metaboxes/recent-members.php
+++ b/adminpages/metaboxes/recent-members.php
@@ -34,14 +34,14 @@ function pmpro_dashboard_report_recent_members_callback() {
 			UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate,
 			m.name as membership
 		FROM wp_users u
-		INNER JOIN wp_pmpro_memberships_users mu
+		INNER JOIN $wpdb->pmpro_memberships_users mu
 			ON u.ID = mu.user_id
 			AND mu.status = 'active'
-		INNER JOIN wp_pmpro_membership_levels m
+		INNER JOIN $wpdb->pmpro_membership_levels m
 			ON mu.membership_id = m.id
 		INNER JOIN (
 			SELECT user_id, MAX(startdate) AS max_startdate
-			FROM wp_pmpro_memberships_users
+			FROM $wpdb->pmpro_memberships_users
 			WHERE status = 'active'
 			GROUP BY user_id
 		) mu2 ON mu.user_id = mu2.user_id AND mu.startdate = mu2.max_startdate


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Resolves #3433 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
