### PR TITLE
Action Scheduler Cleanup on Deactivate/Uninstall

### DIFF
--- a/classes/class-pmpro-action-scheduler.php
+++ b/classes/class-pmpro-action-scheduler.php
@@ -74,6 +74,9 @@ class PMPro_Action_Scheduler {
 		// Add custom hooks for quarter-hourly, hourly, daily and weekly tasks.
 		add_action( 'action_scheduler_init', array( $this, 'add_recurring_hooks' ) );
 
+		// Remove recurring hooks if PMPro is deactivated.
+		add_action( 'pmpro_deactivation', array( $this, 'remove_recurring_hooks' ) );
+
 		// Handle the monthly
 		add_action( 'pmpro_trigger_monthly', array( $this, 'handle_monthly_tasks' ) );
 
@@ -483,6 +486,29 @@ class PMPro_Action_Scheduler {
 		if ( ! $this->has_existing_task( 'pmpro_trigger_monthly', array(), 'pmpro_recurring_tasks' ) ) {
 			$first = self::as_strtotime( 'first day of next month 8:00am' );
 			as_schedule_single_action( $first, 'pmpro_trigger_monthly', array(), 'pmpro_recurring_tasks' );
+		}
+	}
+
+	/**
+	 * Remove all recurring hooks from Action Scheduler.
+	 *
+	 * This method unschedules all recurring tasks that were registered by PMPro.
+	 *
+	 * @access public
+	 * @since 3.5.3
+	 */
+	public function remove_recurring_hooks(){
+		// Find all hooks that belong to the group 'pmpro_recurring_tasks'.
+		$hooks = as_get_scheduled_actions(
+			array(
+				'group' => 'pmpro_recurring_tasks',
+				'status' => ActionScheduler_Store::STATUS_PENDING,
+			),
+			ARRAY_A
+		);
+
+		foreach ( $hooks as $hook ) {
+			as_unschedule_all_actions( $hook, array(), 'pmpro_recurring_tasks' );
 		}
 	}
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -64,4 +64,8 @@ if ( get_option( 'pmpro_uninstall', 0 ) ) {
 	global $wpdb;
 	$sqlQuery = "DELETE FROM $wpdb->options WHERE option_name LIKE 'pmpro_%'";
 	$wpdb->query($sqlQuery);
+
+	//  Delete all Action Scheduler scheduled actions
+	$wpdb->query("DELETE FROM {$wpdb->prefix}actionscheduler_actions WHERE hook LIKE 'pmpro_%'");
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Hook into deactivation and removed scheduled hooks.
- On uninstall, delete all PMPro actions from the AS table.

Removes orphaned PMPro Action Scheduled tasks upon deactivation, and all tasks on plugin uninstall.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Removes orphaned PMPro Action Scheduled tasks upon deactivation, and all tasks on plugin uninstall.
