### PR TITLE
Avoid hardcoded prefix in Recent Members metabox

### DIFF
--- a/adminpages/metaboxes/recent-members.php
+++ b/adminpages/metaboxes/recent-members.php
@@ -33,7 +33,7 @@ function pmpro_dashboard_report_recent_members_callback() {
 			UNIX_TIMESTAMP(CONVERT_TZ(mu.startdate, '+00:00', @@global.time_zone)) as startdate,
 			UNIX_TIMESTAMP(CONVERT_TZ(mu.enddate, '+00:00', @@global.time_zone)) as enddate,
 			m.name as membership
-		FROM wp_users u
+		FROM $wpdb->users u
 		INNER JOIN $wpdb->pmpro_memberships_users mu
 			ON u.ID = mu.user_id
 			AND mu.status = 'active'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes the Recent Members metabox for sites that do not use the default `wp_` database prefix.

Continuation of #3434 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
