### PR TITLE
Handling case where _elementor_data is already an array

### DIFF
--- a/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
@@ -183,13 +183,17 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 		}
 
 		// Get the _elementor_data for the post.
-		$elementor_data_string = get_post_meta( $post_id, '_elementor_data', true );
-		if ( empty( $elementor_data_string ) ) {
+		$elementor_data = get_post_meta( $post_id, '_elementor_data', true );
+		if ( empty( $elementor_data ) ) {
 			return;
 		}
 
-		// Decode the _elementor_data.
-		$elementor_data = json_decode( $elementor_data_string, true );
+		// Decode the _elementor_data if needed.
+		if ( is_string( $elementor_data ) ) {
+			$elementor_data = json_decode( $elementor_data, true );
+		}
+
+		// If the data is still empty after decoding, bail.
 		if ( empty( $elementor_data ) ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
There has been a report of the following fatal error:

Fatal error: Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /site/public_html/wp-content/plugins/paid-memberships-pro/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php:192 Stack trace: #0 /site/public_html/wp-content/plugins/paid-memberships-pro/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php(192): json_decode(Array, true) #1 /site/public_html/wp-includes/class-wp-hook.php(324): PMPro_Elementor_Content_Restriction->migrate_settings(Object(WP)) #2 /site/public_html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array) #3 /site/public_html/wp-includes/plugin.php(565): WP_Hook->do_action(Array) #4 /site/public_html/wp-includes/class-wp.php(835): do_action_ref_array('wp', Array) #5 /site/public_html/wp-includes/functions.php(1342): WP->main(Array) #6 /site/public_html/wp-admin/includes/post.php(1312): wp(Array) #7 /site/public_html/wp-admin/includes/class-wp-posts-list-table.php(165): wp_edit_posts_query() #8 /site/public_html/wp-admin/edit.php(235): WP_Posts_List_Table->prepare_items() #9 {main} thrown in /site/public_html/wp-content/plugins/paid-memberships-pro/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php on line 192

This PR accounts for the possibility of `get_post_meta( $post_id, '_elementor_data', true )` already returning an array instead of the expected string. This could be due to different versions of Elementor or potentially third-party code filtering the `get_post_meta()` call.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
