### PR TITLE
Fix wisdom data always sending on the first of the month

### DIFF
--- a/adminpages/advancedsettings.php
+++ b/adminpages/advancedsettings.php
@@ -56,12 +56,6 @@
 		pmpro_setOption("uninstall");
 		pmpro_setOption("site_type");
 
-		// Set up Wisdom tracking if needed.
-		if ( (int)get_option( "pmpro_wisdom_opt_out") === 0 ) {
-			$wisdom_integration = PMPro_Wisdom_Integration::instance();
-			$wisdom_integration->wisdom_tracker->schedule_tracking();
-		}
-
         /**
          * Filter to add custom settings to the advanced settings page.
          * @param array $settings Array of settings, each setting an array with keys field_name, field_type, label, description.

--- a/classes/class-pmpro-wisdom-tracker.php
+++ b/classes/class-pmpro-wisdom-tracker.php
@@ -70,10 +70,8 @@ class PMPro_Wisdom_Tracker {
 		// Schedule / deschedule tracking when activated / deactivated
 		if ( $this->what_am_i == 'theme' ) {
 			// Need to think about scheduling for sites that have already activated the theme
-			add_action( 'after_switch_theme', [ $this, 'schedule_tracking' ] );
 			add_action( 'switch_theme', [ $this, 'deactivate_this_plugin' ] );
 		} else {
-			register_activation_hook( $this->plugin_file, [ $this, 'schedule_tracking' ] );
 			register_deactivation_hook( $this->plugin_file, [ $this, 'deactivate_this_plugin' ] );
 		}
 
@@ -97,7 +95,7 @@ class PMPro_Wisdom_Tracker {
 		}
 
 		// Hook our do_tracking function to Action Scheduler
-		$this->schedule_tracking();
+		add_action( 'pmpro_schedule_daily', [ $this, 'do_tracking' ] );
 
 		// Use this action for local testing
 		// add_action( 'admin_init', array( $this, 'do_tracking' ) );
@@ -119,24 +117,12 @@ class PMPro_Wisdom_Tracker {
 	 * And check if tracking is enabled - perhaps the plugin has been reactivated
 	 *
 	 * @since 1.0.0
+	 * @deprecated TBD - This is now handled by Action Scheduler.
+	 *
 	 * @modified 3.5 Now with Action Scheduler support
 	 */
 	public function schedule_tracking() {
-		$schedule = $this->get_schedule();
-		switch ( $schedule ) {
-			case 'daily':
-				$hook = 'pmpro_schedule_daily';
-				break;
-			case 'weekly':
-				$hook = 'pmpro_schedule_weekly';
-				break;
-			case 'monthly':
-				$hook = 'pmpro_schedule_monthly';
-				break;
-			default:
-				$hook = 'pmpro_schedule_monthly';
-		}
-		add_action( $hook, [ $this, 'do_tracking' ] );
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When integrating with Action Scheduler, we moved Wisdom reporting to run on the `pmpro_schedule_monthly` action by default. Although this is the same frequency as previous versions of PMPro, the difference is that the `pmpro_schedule_monthly` action always runs on the first of each month instead of a month from when the plugin was activated. This causes the wisdom data to all be collected on a single day each month instead of having a constant flow of data.

This PR updates Wisdom to instead use the `pmpro_schedule_daily` hook that fires once each day. Even with this change, the code still has protections in place to ensure that data is only sent once monthly. But this change will give Wisdom the chance to send data each day.

The `schedule_tracking()` method is also being deprecated in this PR. Originally, that method was called to set up a recurring cron `put_do_weekly_action`, but with Action Scheduler, we no longer need to manually set up the recurring task that we are hooking into.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
