### PR TITLE
Adding !!renew_url!! to appropriate email templates

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-cancel.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel.php
@@ -106,6 +106,7 @@ class PMPro_Email_Template_Cancel extends PMPro_Email_Template {
 			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
+			'!!renew_url!!' => esc_html__( 'The URL of the Membership Checkout page for the cancelled level.', 'paid-memberships-pro' ),
 		);
 	}
 
@@ -151,12 +152,15 @@ class PMPro_Email_Template_Cancel extends PMPro_Email_Template {
 		if ( empty( $this->cancelled_level_ids ) ) {
 			$email_template_variables['membership_id'] = '';
 			$email_template_variables['membership_level_name'] = esc_html__( 'All Levels', 'paid-memberships-pro' );
+			$email_template_variables['renew_url'] = pmpro_url( 'levels' );
 		} elseif ( is_array( $this->cancelled_level_ids ) ) {
 			$email_template_variables['membership_id'] = $this->cancelled_level_ids[0]; // Pass just the first as the level id.
 			$email_template_variables['membership_level_name'] = pmpro_implodeToEnglish( $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode( "','", $this->cancelled_level_ids ) . "')" ) );
+			$email_template_variables['renew_url'] = pmpro_url( 'levels' );
 		} else {
 			$email_template_variables['membership_id'] = $this->cancelled_level_ids;
 			$email_template_variables['membership_level_name'] = pmpro_implodeToEnglish( $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id = '" . $this->cancelled_level_ids . "'" ) );
+			$email_template_variables['renew_url'] = pmpro_url( 'checkout', '?pmpro_level=' . $this->cancelled_level_ids );
 		}
 
 		return $email_template_variables;

--- a/classes/email-templates/class-pmpro-email-template-membership-expired.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expired.php
@@ -126,6 +126,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
+			'!!renew_url!!' => esc_html__( 'The URL of the Membership Checkout page for the expired level.', 'paid-memberships-pro' ),
 		);
 	}
 
@@ -169,6 +170,7 @@ class PMPro_Email_Template_Membership_Expired extends PMPro_Email_Template {
 			"user_email" => $this->user->user_email,
 			"membership_id" => ( ! empty( $membership_level ) && ! empty( $membership_level->id ) ) ? $membership_level->id : 0,
 			"membership_level_name" => ( ! empty( $membership_level ) && ! empty( $membership_level->name ) ) ? $membership_level->name : '[' . esc_html( 'deleted', 'paid-memberships-pro' ) . ']',
+			"renew_url" => ( ! empty( $membership_level ) && ! empty( $membership_level->id ) ) ? pmpro_url( 'checkout', '?pmpro_level=' . $membership_level->id ) : pmpro_url( 'levels' ),
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-membership-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-membership-expiring.php
@@ -127,6 +127,7 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
 			'!!enddate!!' => esc_html__( 'The expiration date of the membership level.', 'paid-memberships-pro' ),
+			'!!renew_url!!' => esc_html__( 'The URL of the Membership Checkout page for the expiring level.', 'paid-memberships-pro' ),
 		);
 	}
 
@@ -175,6 +176,7 @@ class PMPro_Email_Template_Membership_Expiring extends PMPro_Email_Template {
 			"membership_id" => ( ! empty( $membership_level ) && ! empty( $membership_level->id ) ) ? $membership_level->id : 0,
 			"membership_level_name" => ( ! empty( $membership_level ) && ! empty( $membership_level->name ) ) ? $membership_level->name : '[' . esc_html( 'deleted', 'paid-memberships-pro' ) . ']',
 			"enddate" => date_i18n( get_option('date_format'), $membership_level->enddate ),
+			"renew_url" => ( ! empty( $membership_level ) && ! empty( $membership_level->id ) ) ? pmpro_url( 'checkout', '?pmpro_level=' . $membership_level->id ) : pmpro_url( 'levels' ),
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This update takes the "code recipe" logic in this post (https://www.paidmembershipspro.com/expiring-emails-renewal-links/) and brings it into core PMPro.

The user emails for membership cancelled, membership expiring, and membership expired now all support the variable !!renew_url!!. This will show as a full URL to checkout for the membership level that was cancelled or is set for expiration.

If there are multiple level IDs and we cannot know it's for a "specific" level ID, the URL will instead pull in the Membership Levels page.

There is a chance the level is no longer publicly available. Core PMPro already has logic to redirect back to levels page if this is the case so we aren't account for this in this code.

Also not checking that pmpro_url( 'checkout' ) or pmpro_url( 'levels' ) exist. We don't do this in the main email template class. I think we may eventually want some support for this but it might be done at the pmpro_url() function level.

These variables are available to use in these templates but will not be added to the default content of the emails. Admin have to manually add these to their templates.

### How to test the changes in this Pull Request:

1. Give yourself a membership that has expiration in the next few days.
2. Edit your expiring template and add the !!renew_url!! variable.
3. Run the scheduled action for expirations to trigger the email to sent.
4. Verify the contents of the email that is sent.

You can repeat this for all three templates that are adjusted using similar steps.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

FEATURE: Added `!!renew_url!!` variable to user emails for cancelled, expiring, and expired memberships. Outputs renewal link or falls back to Levels page.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
