### PR TITLE
Pulling data from subscription during webhook/ipn handler

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -117,29 +117,25 @@
 				//no? create it
 				if(empty($order->id))
 				{				
-					$old_order = new MemberOrder();
-					$old_order->getLastMemberOrderBySubscriptionTransactionID($invoice->subscription);
-					
-					//still can't find the order
-					if(empty($old_order) || empty($old_order->id))
-					{
+					// Get the subscription from the invoice.
+					$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $invoice->subscription, 'stripe', $livemode ? 'live' : 'sandbox' );
+					if ( empty( $subscription ) ) {
 						$logstr .= "Couldn't find the original subscription.";
 						pmpro_stripeWebhookExit();
 					}
 
-					$user_id = $old_order->user_id;
+					$user_id = $subscription->get_user_id();
 					$user = get_userdata($user_id);
 
 					if ( empty( $user ) ) {
-						$logstr .= "Couldn't find the old order's user. Order ID = " . $old_order->id . ".";
+						$logstr .= "Couldn't find the subscription's user. Subscription ID = " . $subscription->get_id() . ".";
 						pmpro_stripeWebhookExit();
 					}
-					$user->membership_level = pmpro_getMembershipLevelForUser($user_id);
 
 					//alright. create a new order
 					$morder = new MemberOrder();
-					$morder->user_id = $old_order->user_id;
-					$morder->membership_id = $old_order->membership_id;
+					$morder->user_id = $user_id;
+					$morder->membership_id = $subscription->get_membership_id();
 					$morder->timestamp = $invoice->created;
 					
 					global $pmpro_currency;
@@ -164,10 +160,9 @@
 					}
 
 					$morder->payment_transaction_id = $invoice->id;
-					$morder->subscription_transaction_id = $invoice->subscription;
-
-					$morder->gateway = $old_order->gateway;
-					$morder->gateway_environment = $old_order->gateway_environment;
+					$morder->subscription_transaction_id = $subscription->get_subscription_transaction_id();
+					$morder->gateway = $subscription->get_gateway();
+					$morder->gateway_environment = $subscription->get_gateway_environment();
 
 					// Find the payment intent.
 					$payment_intent_args = array(
@@ -223,17 +218,13 @@
 			// Make sure we have the invoice in the desired API version.
 			$invoice = Stripe_Invoice::retrieve( $pmpro_stripe_event->data->object->id );
 
-			// Get the last order for this invoice's subscription.
-			if ( ! empty( $invoice->subscription ) ) {
-				$old_order = new MemberOrder();
-				$old_order->getLastMemberOrderBySubscriptionTransactionID( $invoice->subscription );
-			}
-
-			if( ! empty( $old_order ) && ! empty( $old_order->id ) ) {
-				$user_id = $old_order->user_id;
+			// Get the subscription from the invoice.
+			$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $invoice->subscription, 'stripe', $livemode ? 'live' : 'sandbox' );
+			if( ! empty( $subscription ) ) {
+				$user_id = $subscription->get_user_id();
 				$user = get_userdata($user_id);
 				if ( empty( $user ) ) {
-					$logstr .= "Couldn't find the old order's user. Order ID = " . $old_order->id . ".";
+					$logstr .= "Couldn't find the subscription's user. Subscription ID = " . $subscription->get_id() . ".";
 					pmpro_stripeWebhookExit();
 				}
 
@@ -276,7 +267,7 @@
 				$pmproemail = new PMProEmail();
 				$pmproemail->sendPaymentActionRequiredAdminEmail($user, $morder);
 
-				$logstr .= "Subscription payment for order ID #" . $old_order->id . " requires customer authentication. Sent email to the member and site admin.";
+				$logstr .= "Payment for subscription ID #" . $subscription->get_id() . " requires customer authentication. Sent email to the member and site admin.";
 				pmpro_stripeWebhookExit();
 			}
 			else
@@ -302,33 +293,33 @@
 
 			// If we have an invoice, try to get the subscription ID from it.
 			if ( ! empty( $invoice ) ) {
-				$subscription_id = $invoice->subscription;
+				$subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $invoice->subscription, 'stripe', $livemode ? 'live' : 'sandbox' );
 			} else {
-				$subscription_id = null;
-			}
-
-			// If we have a subscription ID, get the last order for that subscription.
-			if ( ! empty( $subscription_id ) ) {
-				$old_order = new MemberOrder();
-				$old_order->getLastMemberOrderBySubscriptionTransactionID( $subscription_id );
+				$subscription = null;
 			}
 
 			// If we have an old order, email the user that their payment failed.
-			if( ! empty( $old_order ) && ! empty( $old_order->id ) )
+			if( ! empty( $subscription ) )
 			{
+				// Get the old order to pass to the legacy filter.
+				$old_orders = $subscription->get_orders( array(
+					'status' => 'success',
+					'limit'  => 1,
+				) );
+				$old_order = ! empty( $old_orders ) ? reset( $old_orders ) : null;
 				do_action("pmpro_subscription_payment_failed", $old_order);
 
-				$user_id = $old_order->user_id;
+				$user_id = $subscription->get_user_id();
 				$user = get_userdata($user_id);
 				if ( empty( $user ) ) {
-					$logstr .= "Couldn't find the old order's user. Order ID = " . $old_order->id . ".";
+					$logstr .= "Couldn't find the subscription's user. Subscription ID = " . $subscription->get_id() . ".";
 					pmpro_stripeWebhookExit();
 				}
 
 				//prep this order for the failure emails
 				$morder = new MemberOrder();
 				$morder->user_id = $user_id;
-				$morder->membership_id = $old_order->membership_id;
+				$morder->membership_id = $subscription->get_membership_id();
 				
 				// Find the payment intent.
 				$payment_intent_args = array(
@@ -362,7 +353,7 @@
 				$pmproemail = new PMProEmail();
 				$pmproemail->sendBillingFailureAdminEmail(get_bloginfo("admin_email"), $morder);
 
-				$logstr .= "Subscription payment failed on order ID #" . $old_order->id . ". Sent email to the member and site admin.";
+				$logstr .= "Subscription payment failed on subscription ID #" . $subscription->get_id() . ". Sent email to the member and site admin.";
 				pmpro_stripeWebhookExit();
 			}
 			else


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixes issue where the incorrect membership ID can be assigned to renewal orders if the membership level for the subscription had changed.

### How to test the changes in this Pull Request:

1. Check out for a recurring subscription
2. Move the subscription to a new membership level
3. Trigger recurring payments to be made
4. See that before this fix, recurring orders would be created with the old level. With the fix, new orders reflect the new level.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
