### PR TITLE
Update Stripe customer on profile update

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2300,13 +2300,14 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @since 2.7.0
 	 *
 	 * @param int $user_id to get Stripe_Customer for.
+	 * @param bool $find_existing If true, will try to find an existing customer for the user if one does not exist in user meta.
 	 * @return Stripe_Customer|null
 	 */
-	public function get_customer_for_user( $user_id ) {
+	public function get_customer_for_user( $user_id, $find_existing = true ) {
 		// Pull Stripe customer ID from user meta.
 		$customer_id = get_user_meta( $user_id, 'pmpro_stripe_customerid', true );
 
-		if ( empty( $customer_id ) ) {
+		if ( empty( $customer_id ) && $find_existing ) {
 			// Try to figure out the customer ID from their subscription.
 			$subscription_search_params = array(
 				'user_id' => $user_id,
@@ -2413,7 +2414,7 @@ class PMProGateway_stripe extends PMProGateway {
 		$stripe = new PMProGateway_stripe();
 
 		// Get the existing customer from Stripe.
-		$customer = $stripe->get_customer_for_user( $user_id );
+		$customer = $stripe->get_customer_for_user( $user_id, false ); // False to improve performance if customer ID does not exist in user meta.
 		if ( empty( $customer ) ) {
 			// If we don't have a customer, don't update.
 			// This is important in case Stripe isn't used on the site.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Sync name and email with Stripe when the user profile is updated in WordPress.

The `update_customer_from_user()` method is being deprecated because we need a `static` method to hook to. The `pmpro_stripe_update_customer_from_user` filter is being deprecated to match the new method name.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
