### PR TITLE
fix #3455 - handle zero immediate payment on a stripe checkout

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -510,7 +510,7 @@
 			}
 
 			// Was the checkout session successful?
-			if ( $checkout_session->payment_status == "paid" ) {
+			if ( $checkout_session->payment_status == "paid" || $checkout_session->payment_status == "no_payment_required" ) {
 				// Yes. But did we already process this order?
 				if ( ! in_array( $order->status , array( 'token', 'pending' ) ) ) {
 					$logstr .= "Order #" . $order->id . " for Checkout Session " . $checkout_session->id . " has already been processed. Ignoring.";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using Stripe checkout, if your subscription is set up so that no immediate payment is required, the "status" returned in the webhook is "no_payment_required", but the webhook script checks only for "paid".

(our use case was actually slightly more complex - migrating old subscriptions, and using code to set the date of renewal to a specific date in the future, with zero due now, but still wanting the user to set up a Stripe subscription)

Resolves #3455 

### How to test the changes in this Pull Request:

1. set up a subscription level with zero immediate payment, then a payment due after X days
2. set up Stripe checkout as the payment method
3. go through the checkout
4. it should complete the checkout successfully, and your order should show as "success" in the back end, and one Stripe subscription should be set up.

### Changelog entry

> Handle Stripe Checkout payment when zero immediate payment is due.
