### PR TITLE
Fixing deprecation warning for passing null to trim()

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -221,8 +221,8 @@ if ($submit) {
 
         //other values
         $pmpro_billing_order->billing->name = $bfirstname . " " . $blastname;
-        $pmpro_billing_order->billing->street = trim( $baddress1 );
-        $pmpro_billing_order->billing->street2 = trim( $baddress2 );
+        $pmpro_billing_order->billing->street = empty( $baddress1 ) ? '' : trim( $baddress1 );
+        $pmpro_billing_order->billing->street2 = empty( $baddress2 ) ? '' : trim( $baddress2 );
         $pmpro_billing_order->billing->city = $bcity;
         $pmpro_billing_order->billing->state = $bstate;
         $pmpro_billing_order->billing->country = $bcountry;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing deprecation warning for passing `null` to `trim()`.

### How to test the changes in this Pull Request:
Update billing info for a Stripe subscription with billing address disabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
