### PR TITLE
WP Fusion Compatibility

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -78,6 +78,9 @@ function pmpro_compatibility_checker() {
 			include_once( PMPRO_DIR . '/includes/compatibility/' . $value['file'] ) ;
 		}
 	}
+
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion.php' );
+
 }
 add_action( 'plugins_loaded', 'pmpro_compatibility_checker' );
 

--- a/includes/compatibility/wp-fusion.php
+++ b/includes/compatibility/wp-fusion.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * WP Fusion Compatibility
+ * 
+ * @since TBD
+ */
+
+// Running this after plugins_loaded to ensure WP Fusion is loaded.
+function pmpro_wpfusion_compatibility() {
+
+    /**
+     * WP Fusion Lite is not active, we shouldn't run anything WP Fusion related for now.
+     */
+    if( ! class_exists( 'WP_Fusion_Lite' ) ) {
+        return;
+    }
+
+    /**
+     * WP Fusion (which has PMPro in it is running), let their code handle things
+     */
+    if( class_exists( 'WP_Fusion' ) ) {
+        return;
+    }
+
+    /**
+     * ToDo
+     * Rename these classes to prevent any potential conflicts with WP Fusion.
+     */
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion/class-base.php' );
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion/class-pmpro.php' );
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion/class-pmpro-hooks.php' );
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion/class-pmpro-batch.php' );
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion/class-pmpro-approvals.php' );
+    include_once( PMPRO_DIR . '/includes/compatibility/wp-fusion/class-pmpro-admin.php' );
+
+}
+add_action( 'plugins_loaded', 'pmpro_wpfusion_compatibility' );

--- a/includes/compatibility/wp-fusion/class-base.php
+++ b/includes/compatibility/wp-fusion/class-base.php
@@ -1,0 +1,220 @@
+<?php
+
+abstract class PMPro_WPF_Integrations_Base {
+
+	/**
+	 * The slug name for WP Fusion's module tracking.
+	 *
+	 * @var string $slug
+	 */
+	public $slug;
+
+	/**
+	 * The plugin name for WP Fusion's module tracking.
+	 *
+	 * @var string $name
+	 */
+	public $name;
+
+	/**
+	 * The link to the documentation on the WP Fusion website.
+	 *
+	 * @var string|bool $docs_url The URL.
+	 */
+	public $docs_url = false;
+
+	public function __construct() {
+
+		// Make the object globally available.
+
+		if ( $this->slug ) {
+			wp_fusion()->integrations->{$this->slug} = $this;
+		}
+
+		if ( $this->is_integration_active() ) {
+			$this->init();
+		}
+
+		add_filter( 'wpf_compatibility_notices', array( $this, 'compatibility_notices' ) );
+		add_filter( 'wpf_meta_field_groups', array( $this, 'add_meta_field_group' ) );
+		add_filter( 'wpf_meta_fields', array( $this, 'add_meta_fields' ) );
+	}
+
+	/**
+	 * Gets things started
+	 *
+	 * @access  public
+	 * @since   1.0
+	 * @return  void
+	 */
+	abstract protected function init();
+
+	/**
+	 * Adds compatibility notices.
+	 *
+	 * @since 3.44.6
+	 *
+	 * @param array $notices The notices.
+	 */
+	public function compatibility_notices( $notices ) {
+		return $notices;
+	}
+
+	/**
+	 * Adds a meta field group.
+	 *
+	 * @since 3.44.22
+	 *
+	 * @param array $field_groups The field groups.
+	 */
+	public function add_meta_field_group( $field_groups ) {
+		return $field_groups;
+	}
+
+	/**
+	 * Adds meta fields.
+	 *
+	 * @since 3.44.22
+	 *
+	 * @param array $meta_fields The meta fields.
+	 */
+	public function add_meta_fields( $meta_fields ) {
+		return $meta_fields;
+	}
+
+	/**
+	 * Map meta fields collected at registration / profile update to internal fields
+	 *
+	 * @access  public
+	 * @since   3.0
+	 * @return  array Meta Fields
+	 */
+	protected function map_meta_fields( $meta_fields, $field_map ) {
+
+		foreach ( $field_map as $key => $field ) {
+
+			if ( ! empty( $meta_fields[ $key ] ) && empty( $meta_fields[ $field ] ) ) {
+				$meta_fields[ $field ] = $meta_fields[ $key ];
+			}
+		}
+
+		return $meta_fields;
+	}
+
+	/**
+	 * Checks if the integration is active.
+	 *
+	 * @since 3.42.6
+	 *
+	 * @return bool Is the integration active.
+	 */
+	public function is_integration_active() {
+
+		if ( false === $this->docs_url ) {
+			return true; // some integrations don't show up in the settings and can't be disabled.
+		}
+
+		$integrations = wpf_get_option( 'integrations', array() );
+
+		if ( isset( $integrations[ $this->slug ] ) && false === $integrations[ $this->slug ] ) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	/**
+	 * Gets dynamic tags to be applied from update data
+	 *
+	 * @access  public
+	 * @since   3.32.2
+	 * @return  array Tags
+	 */
+	public function get_dynamic_tags( $update_data ) {
+
+		$apply_tags = array();
+
+		if ( ! wp_fusion()->crm->supports( 'add_tags' ) ) {
+			return $apply_tags;
+		}
+
+		foreach ( $update_data as $key => $value ) {
+
+			$crm_field = wp_fusion()->crm->get_crm_field( $key );
+
+			if ( false === $crm_field ) {
+				continue;
+			}
+
+			if ( false !== strpos( $crm_field, 'add_tag_' ) ) {
+
+				if ( is_array( $value ) ) {
+
+					$apply_tags = array_merge( $apply_tags, $value );
+
+				} elseif ( ! empty( $value ) ) {
+
+					$apply_tags[] = $value;
+
+				}
+			}
+		}
+
+		return $apply_tags;
+	}
+
+	/**
+	 * Handles signups from plugins which support guest registrations
+	 *
+	 * @since   3.26.6
+	 *
+	 * @param string $email_address The email address of the contact.
+	 * @param array  $update_data   The update data.
+	 *
+	 * @return string|bool Contact ID on success or false in case of error.
+	 */
+	public function guest_registration( $email_address, $update_data ) {
+
+		$contact_id = wp_fusion()->crm->get_contact_id( $email_address );
+
+		if ( is_wp_error( $contact_id ) ) {
+			wpf_log( $contact_id->get_error_code(), 0, 'Error looking up contact ID for email address <strong>' . $email_address . '</strong>: ' . $contact_id->get_error_message() );
+			return false;
+		}
+
+		$update_data = apply_filters( "wpf_{$this->slug}_guest_registration_data", $update_data, $email_address, $contact_id );
+
+		// Log whether we're creating or updating a contact, with edit link.
+		if ( false !== $contact_id ) {
+			$log_text = ' Updating existing contact #' . $contact_id . ': ';
+		} else {
+			$log_text = ' Creating new contact: ';
+		}
+
+		wpf_log( 'info', 0, $this->name . ' guest registration.' . $log_text, array( 'meta_array' => $update_data ) );
+
+		if ( empty( $contact_id ) ) {
+
+			$contact_id = wp_fusion()->crm->add_contact( $update_data );
+
+			if ( ! is_wp_error( $contact_id ) ) {
+				do_action( 'wpf_guest_contact_created', $contact_id, $email_address );
+			}
+		} else {
+
+			wp_fusion()->crm->update_contact( $contact_id, $update_data );
+
+			do_action( 'wpf_guest_contact_updated', $contact_id, $email_address );
+
+		}
+
+		if ( is_wp_error( $contact_id ) ) {
+
+			wpf_log( $contact_id->get_error_code(), 0, 'Error adding contact: ' . $contact_id->get_error_message() );
+			return false;
+
+		}
+
+		return $contact_id;
+	}
+}

--- a/includes/compatibility/wp-fusion/class-pmpro-admin.php
+++ b/includes/compatibility/wp-fusion/class-pmpro-admin.php
@@ -1,0 +1,582 @@
+<?php
+/**
+ * WP Fusion - Paid Memberships Pro Admin Integration.
+ *
+ * @since TBD
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Handles admin functionality for the Paid Memberships Pro integration.
+ *
+ * @since 3.45.3
+ */
+class PMPro_WPF_PMPro_Admin {
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	public function __construct() {
+
+		// Meta fields.
+		add_filter( 'wpf_meta_field_groups', array( $this, 'add_meta_field_group' ) );
+		add_filter( 'wpf_meta_fields', array( $this, 'add_meta_fields' ) );
+
+		// Admin settings.
+		add_action( 'pmpro_membership_level_before_content_settings', array( $this, 'membership_level_settings' ) );
+		add_action( 'pmpro_save_membership_level', array( $this, 'save_level_settings' ) );
+
+		add_action( 'pmpro_discount_code_after_settings', array( $this, 'discount_code_settings' ) );
+		add_action( 'pmpro_save_discount_code', array( $this, 'save_discount_code_settings' ) );
+	}
+
+
+	/**
+	 * Gets the membership level CRM fields.
+	 *
+	 *
+	 * @return array The membership level CRM fields.
+	 */
+	public function get_membership_level_crm_fields() {
+
+		$fields = array(
+			'pmpro_membership_level'   => array(
+				'label' => 'Membership Level',
+				'type'  => 'text',
+				'group' => 'pmpro',
+			),
+			'pmpro_status'             => array(
+				'label' => 'Membership Status',
+				'type'  => 'text',
+				'group' => 'pmpro',
+			),
+			'pmpro_start_date'         => array(
+				'label' => 'Membership Start Date',
+				'type'  => 'date',
+				'group' => 'pmpro',
+			),
+			'pmpro_expiration_date'    => array(
+				'label' => 'Membership Expiration Date',
+				'type'  => 'date',
+				'group' => 'pmpro',
+			),
+			'pmpro_subscription_price' => array(
+				'label' => 'Subscription Price',
+				'type'  => 'text',
+				'group' => 'pmpro',
+			),
+			'pmpro_next_payment_date'  => array(
+				'label' => 'Next Payment Date',
+				'type'  => 'date',
+				'group' => 'pmpro',
+			),
+		);
+
+		return $fields;
+	}
+
+	/**
+	 * Adds PMPro field group to meta fields list.
+	 *
+	 *
+	 * @param array $field_groups The field groups.
+	 * @return array Field groups.
+	 */
+	public function add_meta_field_group( $field_groups ) {
+
+		$field_groups['pmpro'] = array(
+			'title'  => 'Paid Memberships Pro',
+			'fields' => array(),
+		);
+
+		return $field_groups;
+	}
+
+	/**
+	 * Adds PMPro meta fields to WPF contact fields list.
+	 *
+	 *
+	 * @param array $meta_fields The meta fields.
+	 * @return array Meta fields.
+	 */
+	public function add_meta_fields( $meta_fields = array() ) {
+
+		// Billing fields.
+		$meta_fields['pmpro_bfirstname'] = array(
+			'label' => 'Billing First Name',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_blastname'] = array(
+			'label' => 'Billing Last Name',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_baddress1'] = array(
+			'label' => 'Billing Address 1',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_baddress2'] = array(
+			'label' => 'Billing Address 2',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_bcity'] = array(
+			'label' => 'Billing City',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_bstate'] = array(
+			'label' => 'Billing State',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_bzipcode'] = array(
+			'label' => 'Billing Postal Code',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_bcountry'] = array(
+			'label' => 'Billing Country',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_bphone'] = array(
+			'label' => 'Billing Phone',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_bemail'] = array(
+			'label' => 'Billing Email',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		$meta_fields['pmpro_joined_date'] = array(
+			'label'  => 'Joined Date',
+			'type'   => 'date',
+			'group'  => 'pmpro',
+			'pseudo' => true,
+		);
+
+		// Add membership fields from get_membership_level_crm_fields.
+		$meta_fields = array_merge( $meta_fields, $this->get_membership_level_crm_fields() );
+
+		// Add payment method field (not included in membership level fields).
+		$meta_fields['pmpro_payment_method'] = array(
+			'label' => 'Payment Method',
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		// Add level-specific field mappings for each membership level.
+		$contact_fields = wpf_get_option( 'contact_fields', array() );
+
+		foreach ( $contact_fields as $key => $value ) {
+			if ( ! empty( $value['crm_field'] ) ) {
+				$crm_key = substr( $key, 0, strrpos( $key, '_' ) );
+
+				if ( isset( $membership_fields[ $crm_key ] ) ) {
+					$post_id             = (int) str_replace( $crm_key . '_', '', $key );
+					$meta_fields[ $key ] = array(
+						'label'  => pmpro_getLevel( $post_id )->name . ' - ' . $membership_fields[ $crm_key ]['label'],
+						'type'   => $membership_fields[ $crm_key ]['type'],
+						'pseudo' => true,
+						'group'  => 'pmpro',
+					);
+				}
+			}
+		}
+
+		// Add user fields.
+		global $pmpro_user_fields, $pmprorh_registration_fields;
+
+		$custom_fields = array_merge( (array) $pmpro_user_fields, (array) $pmprorh_registration_fields );
+
+		if ( ! empty( $custom_fields ) ) {
+			foreach ( $custom_fields as $field_group ) {
+				if ( is_array( $field_group ) ) {
+					foreach ( $field_group as $field ) {
+						if ( ! empty( $field->id ) ) {
+							$meta_fields[ $field->id ] = array(
+								'label' => $field->label,
+								'type'  => 'text',
+								'group' => 'pmpro',
+							);
+						}
+					}
+				}
+			}
+		}
+
+		return $meta_fields;
+	}
+
+	/**
+	 * Adds options to PMP membership level settings.
+	 *
+	 *
+	 * @param object $level The level object.
+	 */
+	public function membership_level_settings( $level ) {
+
+		$settings = get_option( 'wpf_pmp_' . $level->id );
+
+		if ( empty( $settings ) ) {
+			$settings = array(
+				'apply_tags'                      => array(),
+				'remove_tags'                     => false,
+				'tag_link'                        => array(),
+				'apply_tags_cancelled'            => array(),
+				'apply_tags_expired'              => array(),
+				'apply_tags_payment_failed'       => array(),
+				'apply_tags_pending_cancellation' => array(),
+			);
+		}
+
+		?>
+
+		<div id="wp-fusion-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div class="pmpro_section_toggle">
+				<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
+					<span class="dashicons dashicons-arrow-up-alt2"></span>
+					<?php esc_html_e( 'WP Fusion Settings', 'wp-fusion' ); ?>
+				</button>
+			</div>
+			<div class="pmpro_section_inside">
+
+				<span class="description">
+					<?php
+					// translators: %1$s: opening link tag, %2$s: closing link tag.
+					printf( esc_html__( 'For more information on these settings, %1$ssee our documentation%2$s.', 'wp-fusion' ), '<a href="https://wpfusion.com/documentation/membership/paid-memberships-pro/" target="_blank">', '</a>' );
+					?>
+				</span>
+
+				<table class="form-table" id="wp_fusion_tab">
+					<tbody>
+					<tr>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Apply Tags', 'wp-fusion' ); ?>:</label></th>
+						<td>
+							<?php
+							wpf_render_tag_multiselect(
+								array(
+									'setting'   => $settings['apply_tags'],
+									'meta_name' => 'wpf-settings',
+									'field_id'  => 'apply_tags',
+								)
+							);
+							?>
+							<br/>
+							<?php if ( 'yes' === get_pmpro_membership_level_meta( $level->id, 'pmprogl_enabled_for_level', true ) ) : ?>
+								<small>
+									<?php
+									// translators: %s: CRM name.
+									printf( esc_html__( 'These tags will be applied to the purchaser in %s upon purchasing this membership for another user. Tags for the gift recipient can be configured on the associated gift level.', 'wp-fusion' ), esc_html( wp_fusion()->crm->name ) );
+									?>
+								</small>
+							<?php else : ?>
+								<small>
+									<?php
+									// translators: %s: CRM name.
+									printf( esc_html__( 'These tags will be applied to the customer in %s upon registering for this membership.', 'wp-fusion' ), esc_html( wp_fusion()->crm->name ) );
+									?>
+								</small>
+							<?php endif; ?>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Remove Tags', 'wp-fusion' ); ?>:</label></th>
+						<td>
+							<input class="checkbox" type="checkbox" id="wpf-remove-tags" name="wpf-settings[remove_tags]"
+								value="1" <?php echo checked( $settings['remove_tags'], 1, false ); ?> />
+							<label for="wpf-remove-tags"><?php esc_html_e( 'Remove original tags (above) when the membership is cancelled or expires.', 'wp-fusion' ); ?></label>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Link with Tag', 'wp-fusion' ); ?>:</label></th>
+						<td>
+							<?php
+							wpf_render_tag_multiselect(
+								array(
+									'setting'   => $settings['tag_link'],
+									'meta_name' => 'wpf-settings',
+									'field_id'  => 'tag_link',
+									'limit'     => 1,
+								)
+							);
+							?>
+							<br/>
+							<small>
+								<?php
+								// translators: %1$s: CRM name, %2$s: CRM name.
+								printf( esc_html__( 'This tag will be applied in %1$s when a member is registered. Likewise, if this tag is applied to a user from within %2$s, they will be automatically enrolled in this membership. If the tag is removed they will be removed from the membership.', 'wp-fusion' ), esc_html( wp_fusion()->crm->name ), esc_html( wp_fusion()->crm->name ) );
+								?>
+							</small>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Apply Tags - Cancelled', 'wp-fusion' ); ?>:</label></th>
+						<td>
+							<?php
+							wpf_render_tag_multiselect(
+								array(
+									'setting'   => $settings['apply_tags_cancelled'],
+									'meta_name' => 'wpf-settings',
+									'field_id'  => 'apply_tags_cancelled',
+								)
+							);
+							?>
+							<br/>
+							<small><?php esc_html_e( 'Apply these tags when a subscription is cancelled. Happens when an admin or user cancels a subscription, or if the payment gateway has canceled the subscription due to too many failed payments (will be removed if the membership is resumed).', 'wp-fusion' ); ?></small>
+						</td>
+					</tr>
+
+					<?php if ( function_exists( 'pmproconpd_pmpro_change_level' ) ) : ?>
+
+						<tr>
+							<th scope="row" valign="top"><label><?php esc_html_e( 'Apply Tags - Pending Cancellation', 'wp-fusion' ); ?>:</label></th>
+							<td>
+								<?php
+								wpf_render_tag_multiselect(
+									array(
+										'setting'   => $settings['apply_tags_pending_cancellation'],
+										'meta_name' => 'wpf-settings',
+										'field_id'  => 'apply_tags_pending_cancellation',
+									)
+								);
+								?>
+								<br/>
+								<small><?php esc_html_e( 'Apply these tags when a subscription has been cancelled and there is still time remaining on the membership (via the <em>Cancel on Next Payment Date</em> extension).', 'wp-fusion' ); ?></small>
+							</td>
+						</tr>
+
+					<?php endif; ?>
+
+					<tr
+					<?php
+					if ( ! function_exists( 'pmpro_next_payment' ) ) {
+						echo 'style="display:none;"';
+					}
+					?>
+					>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Apply Tags - Expired', 'wp-fusion' ); ?>:</label>
+						</th>
+						<td>
+							<?php
+							wpf_render_tag_multiselect(
+								array(
+									'setting'   => $settings['apply_tags_expired'],
+									'meta_name' => 'wpf-settings',
+									'field_id'  => 'apply_tags_expired',
+								)
+							);
+							?>
+							<br/>
+							<small><?php esc_html_e( 'Apply these tags when a membership expires (will be removed if the membership is resumed).', 'wp-fusion' ); ?></small>
+
+							<?php if ( function_exists( 'pmproconpd_pmpro_change_level' ) ) : ?>
+
+								<p><small><?php esc_html_e( 'Note: With the Cancel on Next Payment Date addon active, no tags will immediately be applied or removed when a member cancels their subscription. Then the tags specified for "Apply Tags - Expired" will be applied when the member\'s access actually expires.', 'wp-fusion' ); ?></small></p>
+
+							<?php endif; ?>
+						</td>
+					</tr>
+
+					<tr
+					<?php
+					if ( ! function_exists( 'pmpro_next_payment' ) ) {
+						echo 'style="display:none;"';
+					}
+					?>
+					>
+						<th scope="row" valign="top"><label><?php esc_html_e( 'Apply Tags - Payment Failed', 'wp-fusion' ); ?>:</label></th>
+						<td>
+							<?php
+							wpf_render_tag_multiselect(
+								array(
+									'setting'   => $settings['apply_tags_payment_failed'],
+									'meta_name' => 'wpf-settings',
+									'field_id'  => 'apply_tags_payment_failed',
+								)
+							);
+							?>
+							<br/>
+							<small><?php esc_html_e( 'Apply these tags when a recurring payment fails (will be removed if a payment is made).', 'wp-fusion' ); ?></small>
+						</td>
+					</tr>
+					</tbody>
+
+					<?php
+					// CRM field mapping.
+					$crm_fields = wp_fusion()->settings->get_crm_fields_flat();
+					$crm_fields = array( '' => '- None -' ) + $crm_fields;
+
+					$level_fields = $this->get_membership_level_crm_fields();
+
+					echo '<tr class="header"><td colspan="2"><h3>' . esc_html__( 'Level-Specific Field Mapping', 'wp-fusion' ) . '</h3></td></tr>';
+					echo '<tr><td colspan="2"><p>' . esc_html__( 'This allows you to map level-specific fields to your CRM. For example, if you have a field in your CRM called "Membership Level A Expiration Date", you can map the expiration date for this specific level to that field.', 'wp-fusion' ) . '</p></td></tr>';
+
+					foreach ( $level_fields as $field_id => $field_data ) {
+						$field_label = $field_data['label'];
+						$field_type  = $field_data['type'];
+
+						// Get the saved value.
+						$meta_key = $field_id . '_' . $level->id;
+						$value    = isset( $crm_fields[ $meta_key ] ) ? $crm_fields[ $meta_key ] : '';
+
+						echo '<tr>';
+						echo '<th scope="row"><label for="' . esc_attr( $meta_key ) . '">' . esc_html( $field_label ) . ':</label></th>';
+						echo '<td>';
+						echo '<select id="' . esc_attr( $meta_key ) . '" name="wpf_settings_pmpro_crm_fields[' . esc_attr( $meta_key ) . '][crm_field]" class="select4-crm-field" data-placeholder="' . esc_attr__( 'Select a field', 'wp-fusion' ) . '" data-type="' . esc_attr( $field_type ) . '">';
+
+						foreach ( $crm_fields as $key => $label ) {
+							echo '<option value="' . esc_attr( $key ) . '" ' . selected( $key, $value, false ) . '>' . esc_html( $label ) . '</option>';
+						}
+
+						echo '</select>';
+						echo '</td>';
+						echo '</tr>';
+					}
+					?>
+
+				</table>
+
+				<?php
+				/**
+				 * Fires after the WP Fusion settings section on the PMPro membership level edit screen.
+				 *
+				 * @since 3.45.3
+				 *
+				 * @param object $level The Membership Level object.
+				 */
+				do_action( 'pmpro_membership_level_after_wp_fusion_settings', $level );
+				?>
+			</div> <!-- end pmpro_section_inside -->
+		</div> <!-- end wp-fusion-settings -->
+
+		<?php
+	}
+
+	/**
+	 * Saves changes to membership level settings.
+	 *
+	 *
+	 * @param int $saveid The level ID.
+	 */
+	public function save_level_settings( $saveid ) {
+
+		// Verify nonce for the main settings.
+		if ( ! isset( $_POST['pmpro_membershiplevels_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['pmpro_membershiplevels_nonce'] ), 'save_membershiplevel' ) ) {
+			return;
+		}
+
+		// Save main settings.
+		if ( isset( $_POST['wpf-settings'] ) ) {
+			update_option( 'wpf_pmp_' . $saveid, wpf_clean( wp_unslash( $_POST['wpf-settings'] ) ), false );
+		} else {
+			delete_option( 'wpf_pmp_' . $saveid );
+		}
+
+		// Save CRM field mappings.
+		if ( isset( $_POST['wpf_settings_pmpro_crm_fields'] ) ) {
+			$data = wpf_clean( wp_unslash( $_POST['wpf_settings_pmpro_crm_fields'] ) );
+
+			if ( ! empty( $data ) ) {
+				// Save any CRM fields to the field mapping.
+				$contact_fields = wpf_get_option( 'contact_fields', array() );
+
+				foreach ( $data as $key => $value ) {
+
+					if ( ! empty( $value['crm_field'] ) ) {
+
+						// Get the base field name without the level ID.
+						$field_parts = explode( '_', $key );
+						$level_id    = array_pop( $field_parts );
+						$base_field  = implode( '_', $field_parts );
+
+						// Get the field type from our defined fields.
+						$crm_fields = $this->get_membership_level_crm_fields();
+						$field_type = isset( $crm_fields[ $base_field ] ) ? $crm_fields[ $base_field ]['type'] : 'text';
+
+						$contact_fields[ $key ] = array(
+							'crm_field' => $value['crm_field'],
+							'active'    => true,
+							'type'      => $field_type,
+						);
+					} elseif ( isset( $contact_fields[ $key ] ) ) {
+
+						// If the setting has been removed we can un-list it from the main Contact Fields list.
+						unset( $contact_fields[ $key ] );
+					}
+				}
+
+				wp_fusion()->settings->set( 'contact_fields', $contact_fields );
+			}
+		}
+	}
+
+	/**
+	 * Adds options to PMP discount code settings.
+	 *
+	 *
+	 * @param object $edit The discount code object.
+	 */
+	public function discount_code_settings( $edit ) {
+
+		$settings = get_option( 'wpf_pmp_discount_' . $edit->id );
+
+		if ( empty( $settings ) ) {
+			$settings = array( 'apply_tags' => array() );
+		}
+
+		?>
+		<h3><?php esc_html_e( 'WP Fusion Settings', 'wp-fusion' ); ?></h3>
+		<table class="form-table">
+			<tr>
+				<th scope="row" valign="top"><label><?php esc_html_e( 'Apply Tags', 'wp-fusion' ); ?>:</label></th>
+				<td>
+					<?php
+					wpf_render_tag_multiselect(
+						array(
+							'setting'   => $settings['apply_tags'],
+							'meta_name' => 'wpf-settings',
+							'field_id'  => 'apply_tags',
+						)
+					);
+					?>
+					<br/>
+					<small>Apply the selected tags in <?php echo esc_html( wp_fusion()->crm->name ); ?> when the coupon is used.</small>
+				</td>
+			</tr>
+		</table>
+
+		<?php
+	}
+
+	/**
+	 * Saves changes to discount code settings.
+	 *
+	 *
+	 * @param int $saveid The discount code ID.
+	 */
+	public function save_discount_code_settings( $saveid ) {
+
+		if ( isset( $_POST['wpf-settings'] ) ) {
+			update_option( 'wpf_pmp_discount_' . $saveid, wpf_clean( wp_unslash( $_POST['wpf-settings'] ) ) );
+		}
+	}
+}

--- a/includes/compatibility/wp-fusion/class-pmpro-approvals.php
+++ b/includes/compatibility/wp-fusion/class-pmpro-approvals.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * WP Fusion - PMPro Approvals Class.
+ *
+ * @since TBD
+ */
+class PMPro_WPF_PMPro_Approvals {
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	public function __construct() {
+
+		// Approvals support.
+		add_filter( 'wpf_meta_fields', array( $this, 'prepare_approval_meta_fields' ), 15 ); // 15 so it runs after other meta fields are added.
+		add_action( 'updated_user_meta', array( $this, 'sync_approval_status' ), 10, 4 );
+		add_action( 'added_user_meta', array( $this, 'sync_approval_status' ), 10, 4 );
+
+		// Sync approval with CRM.
+		add_filter( 'wpf_get_user_meta', array( $this, 'get_approval_meta' ), 10, 2 );
+		add_filter( 'wpf_set_user_meta', array( $this, 'set_approval_meta' ), 10, 2 );
+	}
+
+
+	/**
+	 * Adds PMP Approvals meta fields to WPF contact fields list
+	 *
+	 *
+	 * @param array $meta_fields The meta fields.
+	 * @return array The meta fields.
+	 */
+	public function prepare_approval_meta_fields( $meta_fields ) {
+
+		$meta_fields['pmpro_approval'] = array(
+			'label' => __( 'Approval Status', 'wp-fusion' ),
+			'type'  => 'text',
+			'group' => 'pmpro',
+		);
+
+		return $meta_fields;
+	}
+
+
+	/**
+	 * Sync the approval status when it's edited.
+	 *
+	 * @since 3.37.12
+	 *
+	 * @param int    $meta_id     The meta ID.
+	 * @param int    $object_id   The user ID.
+	 * @param string $meta_key    The meta key.
+	 * @param mixed  $_meta_value The meta value.
+	 */
+	public function sync_approval_status( $meta_id, $object_id, $meta_key, $_meta_value ) {
+
+		if ( strpos( $meta_key, 'pmpro_approval_' ) === 0 && isset( $_meta_value['status'] ) ) {
+			wp_fusion()->user->push_user_meta( $object_id, array( 'pmpro_approval' => $_meta_value['status'] ) );
+		}
+	}
+
+
+	/**
+	 * Merge the approval status into the usermeta.
+	 *
+	 * @since  3.37.12
+	 *
+	 * @param  array $user_meta The user meta.
+	 * @param  int   $user_id   The user identifier.
+	 * @return array The user meta.
+	 */
+	public function get_approval_meta( $user_meta, $user_id ) {
+
+		$level = pmpro_getMembershipLevelForUser( $user_id );
+
+		if ( ! empty( $level ) ) {
+
+			$approval_status = get_user_meta( $user_id, 'pmpro_approval_' . $level->id, true );
+
+			if ( ! empty( $approval_status ) ) {
+				$user_meta['pmpro_approval'] = $approval_status['status'];
+			}
+		}
+
+		return $user_meta;
+	}
+
+	/**
+	 * Filter user meta at registration
+	 *
+	 *
+	 * @param array $user_meta The user meta.
+	 * @param int   $user_id   The user ID.
+	 * @return array The user meta.
+	 */
+	public function set_approval_meta( $user_meta, $user_id ) {
+
+		if ( ! empty( $user_meta['pmpro_approval'] ) ) {
+
+			$level = pmpro_getMembershipLevelForUser( $user_id );
+
+			if ( ! empty( $level ) ) {
+
+				$status = get_user_meta( $user_id, 'pmpro_approval_' . $level->id, true );
+
+				$status['status']    = $user_meta['pmpro_approval'];
+				$status['timestamp'] = current_time( 'timestamp' );
+
+				$user_meta[ 'pmpro_approval_' . $level->id ] = $status;
+
+				unset( $user_meta['pmpro_approval'] );
+
+			}
+		}
+
+		return $user_meta;
+	}
+}

--- a/includes/compatibility/wp-fusion/class-pmpro-batch.php
+++ b/includes/compatibility/wp-fusion/class-pmpro-batch.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * WP Fusion - PMPro Batch Class.
+ *
+ * @since TBD
+ */
+class PMPro_WPF_PMPro_Batch {
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	public function __construct() {
+
+		// Batch operations.
+		add_filter( 'wpf_export_options', array( $this, 'export_options' ) );
+		add_filter( 'wpf_batch_pmpro_init', array( $this, 'batch_init' ) );
+		add_action( 'wpf_batch_pmpro', array( $this, 'batch_step' ) );
+
+		// Meta batch operation.
+		add_filter( 'wpf_batch_pmpro_meta_init', array( $this, 'batch_init' ) );
+		add_action( 'wpf_batch_pmpro_meta', array( $this, 'batch_step_meta' ) );
+	}
+
+
+	/**
+	 * Adds PMPro checkbox to available export options.
+	 *
+	 * @since 3.45.3
+	 *
+	 * @param array $options The options.
+	 * @return array The options.
+	 */
+	public function export_options( $options ) {
+
+		$options['pmpro'] = array(
+			'label'   => __( 'Paid Memberships Pro membership statuses', 'wp-fusion' ),
+			'title'   => 'memberships',
+			'tooltip' => __( 'Updates the tags for all members based on their current membership status. Does not create new contact records or sync any fields.', 'wp-fusion' ),
+		);
+
+		$options['pmpro_meta'] = array(
+			'label'   => __( 'Paid Memberships Pro memberships meta', 'wp-fusion' ),
+			'title'   => 'memberships',
+			'tooltip' => __( 'Syncs any enabled membership fields to the CRM, without modifying tags.', 'wp-fusion' ),
+		);
+
+		return $options;
+	}
+
+	/**
+	 * Gets total list of members to be processed.
+	 *
+	 * @since 3.45.3
+	 *
+	 * @return array User IDs.
+	 */
+	public function batch_init() {
+
+		global $wpdb;
+
+		$user_ids = array();
+
+		$result = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DISTINCT u.ID 
+				FROM {$wpdb->users} u
+				LEFT JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id
+				WHERE mu.membership_id IS NOT NULL
+				"
+			),
+			ARRAY_A
+		);
+
+		if ( ! empty( $result ) ) {
+			$user_ids = wp_list_pluck( $result, 'ID' );
+		}
+
+		return $user_ids;
+	}
+
+	/**
+	 * Processes member actions in batches.
+	 *
+	 * @since 3.45.3
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function batch_step( $user_id ) {
+
+		$levels = pmpro_getMembershipLevelsForUser( $user_id, true );
+
+		// We want to process the levels in order of oldest subscription to newest, doing each level only once.
+
+		$processed_levels = array();
+
+		foreach ( $levels as $level ) {
+
+			if ( in_array( $level->id, $processed_levels ) ) {
+				continue;
+			}
+
+			$processed_levels[] = $level->id;
+
+			// Apply tags.
+			wp_fusion()->integrations->pmpro->apply_membership_level_tags( $user_id, $level->id );
+		}
+	}
+
+	/**
+	 * Processes member actions in batches.
+	 *
+	 * @since 3.45.3
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function batch_step_meta( $user_id ) {
+
+		$levels = pmpro_getMembershipLevelsForUser( $user_id, true );
+
+		// This will return all levels but we only want to process the most recent (highest subscription ID).
+		usort(
+			$levels,
+			function ( $a, $b ) {
+				return $b->subscription_id - $a->subscription_id;
+			}
+		);
+
+		if ( ! empty( $levels ) ) {
+			wp_fusion()->integrations->pmpro->sync_membership_level_fields( $user_id, $levels[0] );
+		}
+	}
+}

--- a/includes/compatibility/wp-fusion/class-pmpro-hooks.php
+++ b/includes/compatibility/wp-fusion/class-pmpro-hooks.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * WP Fusion - PMPro Hooks Class.
+ *
+ * @since TBD
+ */
+class PMPro_WPF_PMPro_Hooks {
+
+	/**
+	 * Constructor.
+	 *
+	 */
+	public function __construct() {
+
+		// Membership level changes.
+		add_action( 'pmpro_after_change_membership_level', array( $this, 'after_change_membership_level' ), 10, 2 );
+		add_action( 'pmpro_before_change_membership_level', array( $this, 'before_change_membership_level' ), 10, 4 );
+
+		// Checkout and orders.
+		add_action( 'pmpro_after_checkout', array( $this, 'after_checkout' ), 10, 2 );
+		add_action( 'pmpro_after_order_free_save', array( $this, 'after_checkout' ), 10, 2 );
+		add_action( 'pmpro_subscription_payment_failed', array( $this, 'subscription_payment_failed' ) );
+		add_action( 'pmpro_subscription_payment_completed', array( $this, 'subscription_payment_completed' ) );
+		add_action( 'pmpro_after_order_free_save', array( $this, 'after_redeem' ), 10 );
+
+		// Profile updates.
+		add_action( 'profile_update', array( $this, 'profile_fields_update' ), 10 );
+
+		// Membership expiry.
+		add_action( 'pmpro_membership_post_membership_expiry', array( $this, 'membership_expiry' ), 10, 2 );
+	}
+
+	/**
+	 * Triggered when new order is placed.
+	 *
+	 * @param int   $user_id The user ID.
+	 * @param mixed $order   The order object.
+	 */
+	public function after_checkout( $user_id, $order ) {
+		$user_meta = array(
+			'pmpro_payment_method' => $order->payment_type,
+		);
+
+		wp_fusion()->user->push_user_meta( $user_id, $user_meta );
+
+		// Handle discount codes
+		global $discount_code_id;
+
+		if ( ! empty( $discount_code_id ) ) {
+			$settings = get_option( 'wpf_pmp_discount_' . $discount_code_id );
+
+			if ( ! empty( $settings ) && ! empty( $settings['apply_tags'] ) ) {
+				wp_fusion()->user->apply_tags( $settings['apply_tags'], $user_id );
+			}
+		}
+	}
+
+	/**
+	 * Triggered before a membership level change.
+	 *
+	 * @param int   $level_id     The level ID.
+	 * @param int   $user_id      The user ID.
+	 * @param array $old_levels   The old levels.
+	 * @param bool  $cancel_level Whether the level is being cancelled.
+	 */
+	public function before_change_membership_level( $level_id, $user_id, $old_levels, $cancel_level ) {
+
+		// Disable tag link function.
+		remove_action( 'wpf_tags_modified', array( wp_fusion()->integrations->pmpro, 'update_membership' ) );
+
+		// Check if this is a user profile edit page and remove actions as necessary.
+		global $pagenow;
+
+		if ( 'profile.php' == $pagenow || 'user-edit.php' == $pagenow ) {
+			return;
+		}
+
+		foreach ( $old_levels as $old_level ) {
+			$old_level_settings = get_option( 'wpf_pmp_' . $old_level->ID );
+
+			if ( ! empty( $old_level_settings ) ) {
+				global $pmpro_next_payment_timestamp;
+
+				if ( ! empty( $pmpro_next_payment_timestamp ) && $level_id == $old_level->ID ) {
+					// If the Cancel on Next Payment Date addon is active, and the level is about to be reinstated, don't modify any tags
+					$update_data = array(
+						'pmpro_expiration_date' => gmdate( get_option( 'date_format' ), $pmpro_next_payment_timestamp ),
+					);
+
+					wp_fusion()->user->push_user_meta( $user_id, $update_data );
+					return;
+				}
+
+				// Regular cancellation
+				wpf_log( 'info', $user_id, 'User left Paid Memberships Pro level <a href="' . admin_url( 'admin.php?page=pmpro-membershiplevels&edit=' . $old_level->ID ) . '">' . $old_level->name . '</a>.' );
+
+				wp_fusion()->integrations->pmpro->apply_membership_level_tags( $user_id, $old_level->ID, 'cancelled' );
+			}
+		}
+	}
+
+	/**
+	 * Triggered after a membership level change.
+	 *
+	 * @param int $level_id The level ID.
+	 * @param int $user_id  The user ID.
+	 */
+	public function after_change_membership_level( $level_id, $user_id ) {
+		if ( ! empty( $level_id ) ) {
+
+			$level = pmpro_getSpecificMembershipLevelForUser( $user_id, $level_id );
+
+			wpf_log( 'info', $user_id, 'User joined Paid Memberships Pro level <a href="' . admin_url( 'admin.php?page=pmpro-membershiplevels&edit=' . $level_id ) . '">' . $level->name . '</a>.' );
+
+			wp_fusion()->integrations->pmpro->sync_membership_level_fields( $user_id, $level );
+			wp_fusion()->integrations->pmpro->apply_membership_level_tags( $user_id, $level_id, 'active' );
+		}
+	}
+
+	/**
+	 * Triggered when a recurring subscription payment fails.
+	 *
+	 * @param object $old_order The order object.
+	 */
+	public function subscription_payment_failed( $old_order ) {
+		$user_id = $old_order->user_id;
+		$level   = pmpro_getLevel( $old_order->membership_id );
+
+		if ( ! empty( $level ) ) {
+			$settings = get_option( 'wpf_pmp_' . $level->id );
+
+			if ( ! empty( $settings ) && ! empty( $settings['apply_tags_payment_failed'] ) ) {
+				wp_fusion()->user->apply_tags( $settings['apply_tags_payment_failed'], $user_id );
+			}
+		}
+	}
+
+	/**
+	 * Triggered when a recurring subscription payment succeeds.
+	 *
+	 * @param object $order The order object.
+	 */
+	public function subscription_payment_completed( $order ) {
+		$user_id = $order->user_id;
+		$level   = pmpro_getLevel( $order->membership_id );
+
+		if ( ! empty( $level ) ) {
+			$settings = get_option( 'wpf_pmp_' . $level->id );
+
+			if ( ! empty( $settings ) && ! empty( $settings['apply_tags_payment_failed'] ) ) {
+				wp_fusion()->user->remove_tags( $settings['apply_tags_payment_failed'], $user_id );
+			}
+		}
+	}
+
+	/**
+	 * Triggered when a user's membership expires.
+	 *
+	 * @param int $user_id  The user ID.
+	 * @param int $level_id The level ID.
+	 */
+	public function membership_expiry( $user_id, $level_id ) {
+		// PMPro will remove their level after the expiry, so there's no need to run before_change_membership_level() again
+		remove_action( 'pmpro_before_change_membership_level', array( $this, 'before_change_membership_level' ), 10, 4 );
+
+		// Update level meta
+		$update_data = array(
+			'pmpro_status'          => 'expired',
+			'pmpro_expiration_date' => '',
+		);
+
+		wp_fusion()->user->push_user_meta( $user_id, $update_data );
+
+		// Update tags
+		$settings = get_option( 'wpf_pmp_' . $level_id );
+
+		if ( ! empty( $settings ) ) {
+			wp_fusion()->integrations->pmpro->apply_membership_level_tags( $user_id, $level_id, 'expired' );
+		}
+	}
+
+	/**
+	 * Triggered when profile fields are updated.
+	 *
+	 * @param int $user_id The user ID.
+	 */
+	public function profile_fields_update( $user_id ) {
+		wp_fusion()->integrations->pmpro->sync_membership_level_fields( $user_id, pmpro_getMembershipLevelForUser( $user_id ) );
+	}
+
+	/**
+	 * Triggered after redeeming a gift certificate.
+	 *
+	 * @param object $order The order object.
+	 */
+	public function after_redeem( $order ) {
+		$this->after_checkout( $order->user_id, $order );
+	}
+}

--- a/includes/compatibility/wp-fusion/class-pmpro.php
+++ b/includes/compatibility/wp-fusion/class-pmpro.php
@@ -1,0 +1,482 @@
+<?php
+/**
+ * WP Fusion - Paid Memberships Pro Integration.
+ *
+ * @since TBD
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Handles integration with Paid Memberships Pro.
+ *
+ */
+class PMPro_WPF_PMPro extends PMPro_WPF_Integrations_Base {
+
+	/**
+	 * The slug for WP Fusion's module tracking.
+	 *
+	 * @var string $slug
+	 */
+	public $slug = 'pmpro';
+
+	/**
+	 * The plugin name for WP Fusion's module tracking.
+	 *
+	 * @var string $name
+	 */
+	public $name = 'Paid Memberships Pro';
+
+	/**
+	 * The link to the documentation on the WP Fusion website.
+	 *
+	 * @var string $docs_url
+	 */
+	public $docs_url = 'https://wpfusion.com/documentation/membership/paid-memberships-pro/';
+
+	/**
+	 * Admin class instance.
+	 *
+	 * @var WPF_PMPro_Admin
+	 */
+	public $admin;
+
+	/**
+	 * Hooks class instance.
+	 *
+	 * @var WPF_PMPro_Hooks
+	 */
+	public $hooks;
+
+	/**
+	 * Batch class instance.
+	 *
+	 * @var WPF_PMPro_Batch
+	 */
+	public $batch;
+
+	/**
+	 * Approvals class instance.
+	 *
+	 * @var WPF_PMPro_Approvals
+	 */
+	public $approvals;
+
+	/**
+	 * Gets things started.
+	 *
+	 */
+	public function init() {
+
+		// Load required classes.
+		require_once __DIR__ . '/class-pmpro-admin.php';
+		require_once __DIR__ . '/class-pmpro-hooks.php';
+		require_once __DIR__ . '/class-pmpro-batch.php';
+
+		// Initialize classes.
+		$this->admin = new PMPro_WPF_PMPro_Admin();
+		$this->hooks = new PMPro_WPF_PMPro_Hooks();
+		$this->batch = new PMPro_WPF_PMPro_Batch();
+
+		// Approvals integration.
+		if ( class_exists( 'PMPro_Approvals' ) ) {
+			require_once __DIR__ . '/class-pmpro-approvals.php';
+			$this->approvals = new PMPro_WPF_PMPro_Approvals();
+		}
+
+		// WPF Stuff.
+		add_filter( 'wpf_user_register', array( $this, 'user_register' ) );
+		add_filter( 'wpf_user_update', array( $this, 'user_register' ) );
+		add_action( 'wpf_tags_modified', array( $this, 'update_membership' ), 10, 2 );
+
+		add_action( 'wpf_user_updated', array( $this, 'user_updated' ), 10, 2 );
+		add_action( 'wpf_user_imported', array( $this, 'user_updated' ), 10, 2 );
+	}
+
+
+	/**
+	 * Syncs custom fields for a membership level when a user is added to the level or via the batch process.
+	 *
+	 * @since unknown
+	 *
+	 * @param int         $user_id The user ID.
+	 * @param object|bool $membership_level The user membership level object, or false if no level is found.
+	 */
+	public function sync_membership_level_fields( $user_id, $membership_level ) {
+
+		if ( $membership_level ) {
+
+			$level_id = $membership_level->id;
+
+			// Prepare the data for all available fields.
+			$update_data = array(
+				'pmpro_status'             => $this->get_membership_level_status( $user_id, $level_id ),
+				'pmpro_joined_date'        => $this->get_member_joined_date( $user_id ),
+				'pmpro_start_date'         => date_i18n( get_option( 'date_format' ), intval( $membership_level->startdate ) ),
+				'pmpro_next_payment_date'  => pmpro_next_payment( $user_id ) ? date_i18n( get_option( 'date_format' ), intval( pmpro_next_payment( $user_id ) ) ) : null,
+				'pmpro_expiration_date'    => ! empty( $membership_level->enddate ) ? date_i18n( get_option( 'date_format' ), intval( $membership_level->enddate ) ) : null,
+				'pmpro_membership_level'   => $membership_level->name,
+				'pmpro_subscription_price' => $membership_level->billing_amount,
+			);
+
+			// Approvals.
+			$approval_status = get_user_meta( $user_id, 'pmpro_approval_' . $level_id, true );
+
+			if ( ! empty( $approval_status ) ) {
+				$update_data['pmpro_approval'] = $approval_status['status'];
+			}
+
+			// Set level-specific field mappings.
+			foreach ( $update_data as $meta_key => $meta_value ) {
+				$update_data[ $meta_key . '_' . $level_id ] = $meta_value;
+			}
+		} else {
+
+			// No level.
+			$update_data = array(
+				'pmpro_membership_level'   => null,
+				'pmpro_expiration_date'    => null,
+				'pmpro_subscription_price' => null,
+				'pmpro_next_payment_date'  => null,
+				'pmpro_status'             => $this->get_membership_level_status( $user_id ),
+			);
+		}
+
+		wp_fusion()->user->push_user_meta( $user_id, $update_data );
+	}
+
+	/**
+	 * Applies tags based on a user's current status in a membership level, either from being added to a level or via a batch operation.
+	 *
+	 *
+	 * @param int         $user_id The user ID.
+	 * @param int         $level_id The level ID.
+	 * @param string|bool $status The status of the user in the level.
+	 */
+	public function apply_membership_level_tags( $user_id, $level_id, $status = false ) {
+
+		// New level apply tags.
+		$settings = get_option( 'wpf_pmp_' . $level_id );
+
+		if ( empty( $settings ) ) {
+			return;
+		}
+
+		if ( false === $status ) {
+			$status = $this->get_membership_level_status( $user_id, $level_id );
+		}
+
+		if ( empty( $status ) ) {
+			return;
+		}
+
+		$apply_keys  = array();
+		$remove_keys = array();
+
+		if ( 'active' === $status ) {
+
+			// Active.
+
+			$apply_keys  = array( 'apply_tags', 'tag_link' );
+			$remove_keys = array( 'apply_tags_expired', 'apply_tags_cancelled', 'apply_tags_payment_failed', 'apply_tags_pending_cancellation' );
+
+		} elseif ( 'expired' === $status ) {
+
+			// Expired.
+
+			$apply_keys  = array( 'apply_tags_expired' );
+			$remove_keys = array( 'tag_link' );
+
+			if ( $settings['remove_tags'] ) {
+				$remove_keys[] = 'apply_tags';
+			}
+		} elseif ( 'cancelled' === $status ) {
+
+			// Cancelled.
+
+			$apply_keys  = array( 'apply_tags_cancelled' );
+			$remove_keys = array( 'tag_link' );
+
+			if ( $settings['remove_tags'] ) {
+				$remove_keys[] = 'apply_tags';
+			}
+		} elseif ( 'inactive' === $status ) {
+
+			// Inactive.
+
+			$remove_keys = array( 'tag_link' );
+
+			if ( $settings['remove_tags'] ) {
+				$remove_keys[] = 'apply_tags';
+			}
+		}
+
+		$apply_tags  = array();
+		$remove_tags = array();
+
+		// Figure out which tags to apply and remove.
+
+		foreach ( $apply_keys as $key ) {
+
+			if ( ! empty( $settings[ $key ] ) ) {
+
+				$apply_tags = array_merge( $apply_tags, $settings[ $key ] );
+
+			}
+		}
+
+		foreach ( $remove_keys as $key ) {
+
+			if ( ! empty( $settings[ $key ] ) ) {
+
+				$remove_tags = array_merge( $remove_tags, $settings[ $key ] );
+
+			}
+		}
+
+		$apply_tags  = apply_filters( 'wpf_pmpro_membership_status_apply_tags', $apply_tags, $status, $user_id, $level_id );
+		$remove_tags = apply_filters( 'wpf_pmpro_membership_status_remove_tags', $remove_tags, $status, $user_id, $level_id );
+
+		// Disable tag link function.
+		remove_action( 'wpf_tags_modified', array( $this, 'update_membership' ) );
+
+		if ( ! empty( $remove_tags ) ) {
+			wp_fusion()->user->remove_tags( $remove_tags, $user_id );
+		}
+
+		if ( ! empty( $apply_tags ) ) {
+			wp_fusion()->user->apply_tags( $apply_tags, $user_id );
+		}
+
+		add_action( 'wpf_tags_modified', array( $this, 'update_membership' ), 10, 2 );
+	}
+
+
+	/**
+	 * Get a user's most recent membership status in a given level, or most recent status overall if no level ID is specified.
+	 *
+	 * @param int      $user_id  The user ID.
+	 * @param int|bool $level_id The level ID, or false to get most recent status.
+	 * @return string|null
+	 */
+	public function get_membership_level_status( $user_id, $level_id = false ) {
+
+		global $wpdb;
+
+		if ( $level_id ) {
+			// Get status for specific level.
+			$query = $wpdb->prepare(
+				"SELECT status 
+				FROM {$wpdb->pmpro_memberships_users}
+				WHERE user_id = %d 
+				AND membership_id = %d
+				ORDER BY id DESC
+				LIMIT 1",
+				$user_id,
+				$level_id
+			);
+		} else {
+			// Get most recent status from any level.
+			$query = $wpdb->prepare(
+				"SELECT status
+				FROM {$wpdb->pmpro_memberships_users}
+				WHERE user_id = %d
+				ORDER BY id DESC
+				LIMIT 1",
+				$user_id
+			);
+		}
+
+		$level_status = $wpdb->get_var( $query );
+
+		return ! empty( $level_status ) ? $level_status : null;
+	}
+
+	/**
+	 * Gets the first membership start date for a user.
+	 *
+	 * @since 3.45.5
+	 *
+	 * @param int $user_id The user ID.
+	 * @return string|null The first membership start date, or null if no memberships are found.
+	 */
+	public function get_member_joined_date( $user_id ) {
+
+		$levels = pmpro_getMembershipLevelsForUser( $user_id, true );
+
+		if ( empty( $levels ) ) {
+			return null;
+		}
+
+		// Get the start date of the first membership.
+		return date_i18n( get_option( 'date_format' ), intval( $levels[0]->startdate ) );
+	}
+
+
+	/**
+	 * Updates user meta after checkout.
+	 *
+	 *
+	 * @param array $post_data The post data.
+	 * @return array Post data.
+	 */
+	public function user_register( $post_data ) {
+
+		$field_map = array(
+			'bfirstname'      => 'first_name',
+			'blastname'       => 'last_name',
+			'bemail'          => 'user_email',
+			'username'        => 'user_login',
+			'password'        => 'user_pass',
+			'baddress1'       => 'pmpro_baddress1',
+			'baddress2'       => 'pmpro_baddress2',
+			'bcity'           => 'pmpro_bcity',
+			'bstate'          => 'pmpro_bstate',
+			'bzipcode'        => 'pmpro_bzipcode',
+			'bcountry'        => 'pmpro_bcountry',
+			'bphone'          => 'pmpro_bphone',
+			'CardType'        => 'pmpro_CardType',
+			'AccountNumber'   => 'pmpro_AccountNumber',
+			'ExpirationMonth' => 'pmpro_ExpirationMonth',
+			'ExpirationYear'  => 'pmpro_ExpirationYear',
+			'CVV'             => 'pmpro_CVV',
+		);
+
+		$post_data = $this->map_meta_fields( $post_data, $field_map );
+
+		return $post_data;
+	}
+
+
+	/**
+	 * Updates user's memberships if a linked tag is added/removed.
+	 *
+	 *
+	 * @param int   $user_id   The user ID.
+	 * @param array $user_tags The user tags.
+	 */
+	public function update_membership( $user_id, $user_tags ) {
+
+		// Don't bother if PMPro isn't active.
+		if ( ! function_exists( 'pmpro_hasMembershipLevel' ) ) {
+			return;
+		}
+
+		// Don't run while PMPro is adding / removing levels.
+		if ( did_action( 'pmpro_before_change_membership_level' ) && ! did_action( 'pmpro_after_change_membership_level' ) ) {
+			return;
+		}
+
+		// Update role based on user tags.
+		$membership_levels = get_option( 'wpf_pmpro_tag_link' );
+
+		if ( empty( $membership_levels ) ) {
+			return;
+		}
+
+		foreach ( $membership_levels as $level ) {
+
+			$level_id = str_replace( 'wpf_pmp_', '', $level[0] );
+			$tag_id   = $level[1];
+
+			if ( empty( $tag_id ) ) {
+				continue;
+			}
+
+			if ( in_array( $tag_id, $user_tags ) && pmpro_hasMembershipLevel( $level_id, $user_id ) == false ) {
+
+				$pmpro_level = pmpro_getLevel( $level_id );
+
+				// Set up level data.
+				$level_data = array(
+					'user_id'         => $user_id,
+					'membership_id'   => $level_id,
+					'code_id'         => 0,
+					'initial_payment' => $pmpro_level->initial_payment,
+					'billing_amount'  => $pmpro_level->billing_amount,
+					'cycle_number'    => $pmpro_level->cycle_number,
+					'cycle_period'    => $pmpro_level->cycle_period,
+					'billing_limit'   => $pmpro_level->billing_limit,
+					'trial_amount'    => $pmpro_level->trial_amount,
+					'trial_limit'     => $pmpro_level->trial_limit,
+					'startdate'       => current_time( 'mysql' ),
+					'enddate'         => '0000-00-00 00:00:00',
+				);
+
+				// Logger.
+				wpf_log( 'info', $user_id, 'Adding user to PMPro membership <a href="' . admin_url( 'admin.php?page=pmpro-membershiplevels&edit=' . $level_id ) . '">' . $pmpro_level->name . '</a> by tag <strong>' . wp_fusion()->user->get_tag_label( $tag_id ) . '</strong>' );
+
+				// Add user to level.
+				pmpro_changeMembershipLevel( $level_data, $user_id, 'inactive', null );
+
+			} elseif ( ! in_array( $tag_id, $user_tags ) && pmpro_hasMembershipLevel( $level_id, $user_id ) == true ) {
+
+				$pmpro_level = pmpro_getLevel( $level_id );
+
+				// Logger.
+				wpf_log( 'info', $user_id, 'Removing user from PMPro membership <a href="' . admin_url( 'admin.php?page=pmpro-membershiplevels&edit=' . $level_id ) . '">' . $pmpro_level->name . '</a> by tag <strong>' . wp_fusion()->user->get_tag_label( $tag_id ) . '</strong>' );
+
+				// Remove user from level.
+				pmpro_cancelMembershipLevel( $level_id, $user_id, 'inactive' );
+
+			}
+		}
+	}
+
+	/**
+	 * Runs when meta data is loaded from the CRM. Updates the start date and expiry date if found.
+	 *
+	 *
+	 * @param int   $user_id   The user ID.
+	 * @param array $user_meta The user meta.
+	 */
+	public function user_updated( $user_id, $user_meta ) {
+
+		global $wpdb;
+
+		if ( ! function_exists( 'pmpro_getMembershipLevelForUser' ) ) {
+			return;
+		}
+
+		$membership_level = pmpro_getMembershipLevelForUser( $user_id );
+
+		if ( ! empty( $membership_level ) && ! empty( $membership_level->subscription_id ) ) {
+
+			// Start date.
+			if ( ! empty( $user_meta['pmpro_start_date'] ) ) {
+
+				$start_date = strtotime( $user_meta['pmpro_start_date'] );
+
+				if ( ! empty( $start_date ) ) {
+
+					$start_date = gmdate( 'Y-m-d 00:00:00', $start_date );
+
+					$wpdb->query(
+						$wpdb->prepare(
+							"UPDATE $wpdb->pmpro_memberships_users SET `startdate`=%s WHERE `id`=%d",
+							array(
+								$start_date,
+								$membership_level->subscription_id,
+							)
+						)
+					);
+				}
+			}
+
+			// Expiry date.
+			if ( ! empty( $user_meta['pmpro_expiration_date'] ) ) {
+
+				$expiration_date = strtotime( $user_meta['pmpro_expiration_date'] );
+
+				if ( $expiration_date > time() ) {
+					// Only set it if it's in the future.
+					pmpro_set_expiration_date( $user_id, $membership_level->id, $expiration_date );
+				}
+			}
+		}
+	}
+}
+
+new PMPro_WPF_PMPro();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements compatibility with WP Fusion. 

If WP Fusion Lite is enabled, we'll enable this by default. 

If WP Fusion Pro is enabled, we'll default to the Pro version's PMPro functionality and not load our own.

Resolves XXX.

### How to test the changes in this Pull Request:

1. Install WP Fusion Lite
2. Select a CRM (I tested with MailPoet)
3. Fill in settings on a level under the WP Fusion section and run a test checkout with that level
4. WP Fusion should subscribe the member to a Mailpoet list in this case

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
