### PR TITLE
Action Scheduler: Fix Payment Reminder Emails Date Issue

### DIFF
--- a/classes/class-pmpro-recurring-actions.php
+++ b/classes/class-pmpro-recurring-actions.php
@@ -444,6 +444,7 @@ class PMPro_Recurring_Actions {
 		ksort( $emails, SORT_NUMERIC );
 
 		$previous_days = 0;
+
 		foreach ( $emails as $days => $template ) {
 			$sqlQuery = $wpdb->prepare(
 				"SELECT subscription.*
@@ -510,7 +511,7 @@ class PMPro_Recurring_Actions {
 		$days = floor( ( $subscription_obj->get_next_payment_date() - current_time( 'timestamp' ) ) / DAY_IN_SECONDS );
 
 		if ( empty( $user ) ) {
-			update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date( 'Y-m-d' ) );
+			update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date( 'Y-m-d', false ) );
 			update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_days', $days );
 			return;
 		}
@@ -545,7 +546,7 @@ class PMPro_Recurring_Actions {
 			$pmproemail->sendEmail();
 		}
 
-		update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date( 'Y-m-d' ) );
+		update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date( 'Y-m-d', false ) );
 		update_pmpro_subscription_meta( $subscription_id, 'pmprorm_last_days', $days );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Minor changes to `get_next_payment_date` usage in the `class-pmpro-recurring-actions.php` class.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a problem reported in Support tickets where customers in timezones behind UTC could experience payment reminder emails going out every day because of a time comparison issue.

The subscription object returns `next_payment_date:protected => 2025-08-11 00:00:00`, while `get_next_payment_date('Y-m-d')` in the recurring actions class returns `2025-08-10`.

`get_next_payment_date(‘Y-m-d’, false)` is required to ensure the date stored in subscription meta for `pmprorm_last_next_payment_date` matches the format (UTC) that  `next_payment_date` returns.

### How to test the changes in this Pull Request:

1. After pulling and using this branch, if your WP site was set to a timezone that's behind UTC, you should be able to trigger the pmpro_schedule_daily recurring Action Schedule and not see payment reminders going out for subscriptions that fall within the `pmpro_upcoming_recurring_payment_reminder` window.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes a date mismatch issue which caused payment reminder emails to repeatedly.
