### PR TITLE
Always save the Stripe invoice ID as the payment transaction ID when there is an invoice

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -462,7 +462,7 @@
 						),
 					);
 					$payment_intent = \Stripe\PaymentIntent::retrieve( $payment_intent_args );
-					$order->payment_transaction_id = $payment_intent->latest_charge->id;
+					$order->payment_transaction_id = empty( $checkout_session->invoice ) ? $payment_intent->latest_charge->id : $checkout_session->invoice;
 					if ( ! empty( $payment_intent->payment_method ) ) {
 						$payment_method = $payment_intent->payment_method;
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Historically, the "payment transaction ID" stored for Stripe initial payments would be the ID of a Stripe Charge (starting with `ch_`) whereas recurring payments would be the ID of a Stripe Invoice (starting with `in_`). This is a result of how the on-site Stripe payment flow is coded where the initial payment is charged separately from setting up a subscription. In this flow, an invoice is not created for the initial payment charge.

With Stripe Checkout, we set up the Checkout Session such that a Stripe Invoice is created for all payments, including initial payments. The primary motivation for creating invoices is so that they show in the "Payments" section of the Stripe Customer Portal. Even though we are creating an Invoice though, we are currently still saving the Charge ID in PMPro orders to match the on-site payment flow; however, this PR changes that functionality to always save the Invoice ID when using Stripe Checkout.

The benefit of having the Invoice ID is twofold:
- The same type of Stripe object would be referenced by the "payment transaction ID" across all orders
- Having the Invoice ID makes it easier to link to a Stripe Invoice if we want to allow customers to download invoices formatted by Stripe.

Note that this change only affects Stripe Checkout as the on-site flow still charges initial payments separately from subscriptions and does not create an invoice.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out for a membership with an initial payment via Stripe Checkout
2. See that the invoice ID is now stored in the newly created order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
