### PR TITLE
Allow filtering action links on frontend invoice page

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -171,7 +171,6 @@ class PMProGateway_stripe extends PMProGateway {
 			} else {
 				// Checkout flow for Stripe Checkout.
 				add_filter('pmpro_include_payment_information_fields', array('PMProGateway_stripe', 'show_stripe_checkout_pending_warning'));
-				add_filter( 'pmpro_order_action_links', array( 'PMProGateway_stripe', 'pmpro_order_action_links' ), 10, 2 );
 			}
 		}
 
@@ -4667,48 +4666,5 @@ class PMProGateway_stripe extends PMProGateway {
 		// Clear the global.
 		global $pmpro_review;
 		$pmpro_review = false;
-	}
-
-	/**
-	 * Show a link to the Stripe Invoice for an order.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $action_links The action links for the order.
-	 * @param MemberOrder $order The MemberOrder object.
-	 * @return array The action links with the Stripe Invoice link added.
-	 */
-	public static function pmpro_order_action_links( $action_links, $order ) {
-		// If this is not a Stripe order, bail.
-		if ( 'stripe' !== $order->gateway ) {
-			return $action_links;
-		}
-
-		// Try to get the invoice for this order.
-		try {
-			$invoice = Stripe_Invoice::retrieve( $order->payment_transaction_id );
-		} catch ( \Throwable $e ) {
-			// If we can't get the invoice, bail.
-			return $action_links;
-		} catch ( \Exception $e ) {
-			// If we can't get the invoice, bail.
-			return $action_links;
-		}
-
-		// Add the Stripe Invoice link if we have one.
-		if ( ! empty( $invoice->hosted_invoice_url ) ) {
-			$action_links['stripe_invoice'] = sprintf(
-				'<a href="%s" target="_blank">%s</a>',
-				esc_url( $invoice->hosted_invoice_url ),
-				esc_html__( 'Download Invoice', 'paid-memberships-pro' )
-			);
-
-			// Remove the original "print" link.
-			if ( isset( $action_links['print'] ) ) {
-				unset( $action_links['print'] );
-			}
-		}
-
-		return $action_links;
 	}
 }

--- a/pages/invoice.php
+++ b/pages/invoice.php
@@ -29,10 +29,69 @@
 		<section id="pmpro_order_single" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_section', 'pmpro_order_single' ) ); ?>">
 			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_actions' ) ); ?>">
-					<button class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn-plain pmpro_btn-print' ) ); ?>" onclick="window.print()">
-						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-printer"><polyline points="6 9 6 2 18 2 18 9"></polyline><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"></path><rect x="6" y="14" width="12" height="8"></rect></svg>
-						<?php esc_html_e( 'Print or Save as PDF', 'paid-memberships-pro' ); ?>
-					</button>
+					<?php
+					$pmpro_order_action_links = array();
+					$pmpro_order_action_links['print'] = '<button class="' . esc_attr( pmpro_get_element_class( 'pmpro_btn-plain pmpro_btn-print' ) ) . '" onclick="window.print()">' .
+						'<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-printer"><polyline points="6 9 6 2 18 2 18 9"></polyline><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"></path><rect x="6" y="14" width="12" height="8"></rect></svg>' .
+						esc_html__( 'Print or Save as PDF', 'paid-memberships-pro' ) .
+					'</button>';
+					/**
+					 * Filter the order action links.
+					 *
+					 * @since TBD
+					 *
+					 * @param array $pmpro_order_action_links Array of actions to display.
+					 * @param MemberOrder $pmpro_invoice The PMPro Invoice/Order object.
+					 */
+					$pmpro_order_action_links = apply_filters( 'pmpro_order_action_links', $pmpro_order_action_links, $pmpro_invoice );
+					$allowed_html = array(
+						'a' => array (
+							'class' => array(),
+							'href' => array(),
+							'id' => array(),
+							'target' => array(),
+							'title' => array(),
+							'aria-label' => array(),
+						),
+						'button' => array(
+							'class' => array(),
+							'onclick' => array(),
+						),
+						'path' => array(
+							'd' => array(),
+							'fill' => array(),
+							'stroke' => array(),
+							'stroke-width' => array(),
+							'stroke-linecap' => array(),
+							'stroke-linejoin' => array(),
+						),
+						'polyline' => array(
+							'points' => array(),
+						),
+						'rect' => array(
+							'x' => array(),
+							'y' => array(),
+							'width' => array(),
+							'height' => array(),
+						),
+						'span' => array(
+							'class' => array(),
+						),
+						'svg' => array(
+							'xmlns' => array(),
+							'width' => array(),
+							'height' => array(),
+							'viewbox' => array(),
+							'fill' => array(),
+							'stroke' => array(),
+							'stroke-width' => array(),
+							'stroke-linecap' => array(),
+							'stroke-linejoin' => array(),
+							'class' => array(),
+						),
+					);
+					echo wp_kses( implode( '<span class="' . esc_attr( pmpro_get_element_class( 'pmpro_card_action_separator' ) ) . '">' . pmpro_actions_nav_separator() . '</span>', $pmpro_order_action_links ), $allowed_html );
+					?>
 				</div> <!-- end pmpro_card_actions -->
 				<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_title pmpro_font-x-large' ) ); ?>">
 					<?php echo esc_html( sprintf(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a new filter `pmpro_order_action_links` to allow modifying the action links when viewing an order on the frontend.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
