### PR TITLE
Support Elementor caching

### DIFF
--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -64,7 +64,7 @@ add_action( 'pmpro_save_membership_level', 'pmpro_elementor_clear_level_cache' )
 /**
  * Add compatibility for the Elementor Caching to avoid caching any dynamic content based on Paid Memberships Pro compatibility.
  *
- * @since TBD
+ * @since 2.6.0
  * 
  * @param bool $is_dynamic_content Whether the content is dynamic or not.
  * @param array $element_raw_data The element's raw data.


### PR DESCRIPTION
* ENHANCEMENT: Added support for Elementors caching for restricted content or content that may contain PMPro shortcodes.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Create various containers or elements that show or hide based on the membership level - https://www.paidmembershipspro.com/documentation/compatibility/page-builders/elementor/. You can also add `[pmpro_member field="user_email]` via an Elementor Shortcode element.
2. Be sure to clear Elementors cache manually, this often helps clear caching for existing pages. (Go to Elementor > Tools > Clear Cache )
3. View the page/post from step 1 and toggle the View As option as an admin or login and logout using the same browser session and ensure the data changes dynamically.