### PR TITLE
Fixing dismissing "site paused" and "enable spam protection" banners

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -181,7 +181,7 @@ function pmpro_pause_mode_notice() {
 	if ( pmpro_is_paused() && ! empty( $show_notice ) ) {
 		// Site is paused. Show the notice. ?>
 		<div id="hide_pause_notification" class="notice notice-error pmpro_notification pmpro_notification-error">
-			<button type="button" class="pmpro-notice-button notice-dismiss" value="hide_pause_notification"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></span></button>
+			<button type="button" data-nonce="<?php echo esc_attr( wp_create_nonce( 'pmpro_notification_dismiss_hide_pause_notification' ) ); ?>" class="pmpro-notice-button notice-dismiss" value="hide_pause_notification"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></span></button>
 			<div class="pmpro_notification-icon">
 				<span class="dashicons dashicons-warning"></span>
 			</div>
@@ -227,7 +227,7 @@ function pmpro_spamprotection_notice() {
 	if ( ! is_array( $archived_notifications ) || ! array_key_exists( 'hide_spamprotection_notification', $archived_notifications ) ) {
 		?>
 		<div id="hide_spamprotection_notification" class="notice notice-error pmpro_notification pmpro_notification-error">
-			<button type="button" class="pmpro-notice-button notice-dismiss" value="hide_spamprotection_notification"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></span></button>
+			<button type="button" data-nonce="<?php echo esc_attr( wp_create_nonce( 'pmpro_notification_dismiss_hide_spamprotection_notification' ) ); ?>" class="pmpro-notice-button notice-dismiss" value="hide_spamprotection_notification"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'paid-memberships-pro' ); ?></span></button>
 			<div class="pmpro_notification-icon">
 				<span class="dashicons dashicons-warning"></span>
 			</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixed an issue where the "Site URL Change Detected" and "Enable Spam Protection" banners would come back after being dismissed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
