### PR TITLE
Content Disposition header logic for restricted files

### DIFF
--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -56,19 +56,38 @@ function pmpro_restricted_files_check_request() {
 	 * @param bool   $can_access Whether the user can access the file.
 	 * @param string $file_dir   Directory of the restricted file.
 	 * @param string $file       Name of the restricted file.
+	 * @param string $disposition Content disposition (inline or attachment).
 	 */
 	if ( empty( apply_filters( 'pmpro_can_access_restricted_file', false, $file_dir, $file ) ) ) {
 		wp_die( __( 'You do not have permission to access this file.', 'paid-memberships-pro' ), 403 );
 	}
 
-	// Serve the file.
 	$file_path = pmpro_get_restricted_file_path( $file_dir, $file );
 	if ( file_exists( $file_path ) ) {
 		$finfo = finfo_open( FILEINFO_MIME_TYPE );
 		$content_type = finfo_file( $finfo, $file_path );
+
+		/**
+		 * Filter the content disposition for the restricted file. 
+		 * This automatically defaults to inline for images and attachments for non-images. 
+		 * 
+		 * @since TBD
+		 * 
+		 * @param $is_valid_image boolean This is true for image/* and false for anything else.
+		 * @param string $file Name of the restricted file.
+		 * @param string $file_dir Directory of the restricted file.
+		 * @param string $file_path Path to the restricted file.
+		 * 
+		 * @return string $content_disposition "inline" for image/* types, "attachment" for other file types.
+		 */
+		$content_disposition = apply_filters( 'pmpro_restricted_file_content_disposition', file_is_valid_image( $file_path ) ? 'inline' : 'attachment', $file, $file_dir, $file_path );
+		if ( $content_disposition !== 'inline' && $content_disposition !== 'attachment' ) {
+			$content_disposition = 'attachment'; // Default to attachment if not inline and not attachment.
+		}
+
 		finfo_close( $finfo );
 		header( 'Content-Type: ' . $content_type );
-		header( 'Content-Disposition: attachment; filename="' . $file . '"' );
+		header( 'Content-Disposition: ' . $content_disposition . '; filename="' . $file . '"' );
 		readfile( $file_path );
 		exit;
 	} else {


### PR DESCRIPTION
* ENHANCEMENT: Automatically adjust the content-disposition header based on the file type for restricted files folder. This will now automatically load images in the browser instead of automatically downloading them.

* ENHANCEMENT: A new filter `pmpro_restricted_field_disposition` has been added to allow developers to dynamically change how the restricted files are handled by the browser such as download or load images, PDF's, txt files beyond the default logic.

This PR aims to standardize how images are handled, or expected to be handled by browsers and the 'industry standard'. All `image/*` types are set to `inline` which will load them in the browser and not automatically download them. This will allow members access to restricted files within new tabs and not having to download them. This helps resolve some issues where a thumbnail is shown, and right clicking "open in new tab" you would expect it to be loaded and not downloaded.

The filter has been added so developers can tweak this header and can be very granular like for a specific PDF to load it in the browser instead of downloading it automatically. 

The `if` condition after the `pmpro_restricted_field_disposition` is used to sanitize the value in case it has been tweaked to something else as it only supports "attachment" or "inline" and no other value is needed.

To tweak this logic to always just download the images, or any restricted file (how it currently is) you may use the following snippet:

```php
add_filter( 'pmpro_restricted_field_disposition', function( $disposition ) { return 'attachment'; } );
```

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?


### How to test the changes in this Pull Request:

1. Upload an image file to the PMPro restricted folder. Use something like image.png
2. Generate the direct URL to the image.png from step 1 by using this link builder - https://www.paidmembershipspro.com/locking-down-protecting-files-with-pmpro/#generate_url
3. Try view this URL in a new tab and see the image automatically downloads.
4. Apply this PR
5. View the URL again from step 2/3 and see that the image isn't automatically downloaded, but rather displayed in the browser. PDF's, and non-image types should remain unchanged and download automatically if you have relevant access.

Feel free to test this while you shouldn't have access to the restricted file.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

