### PR TITLE
Configure Polish zloty (PLN) currency according to local rules

### DIFF
--- a/includes/currencies.php
+++ b/includes/currencies.php
@@ -76,7 +76,14 @@
 		'NZD' => __('New Zealand Dollar (&#36;)', 'paid-memberships-pro' ),
 		'NOK' => __('Norwegian Krone', 'paid-memberships-pro' ),
 		'PHP' => __('Philippine Pesos', 'paid-memberships-pro' ),
-		'PLN' => __('Polish Zloty', 'paid-memberships-pro' ),
+		'PLN' => array(
+			'name'                => __('Polish Zloty', 'paid-memberships-pro' ),
+			'decimals'            => '2',
+			'thousands_separator' => '&nbsp;',
+			'decimal_separator'   => ',',
+			'symbol'              => '&nbsp;zł',
+			'position'            => 'right',
+		),
 		'RON' => array(	
 				'name' => __( 'Romanian Leu', 'paid-memberships-pro' ),
 				'decimals' => '2',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Polish zloty currency was defined just with ISO 4217 in `currencies.php`. This caused the currency to be displayed on the left and with 'PLN', instead of on the right and with 'zł' symbol.

### How to test the changes in this Pull Request:

1. Go to Memberships> Settings > Payments.
2. Set Currency to Polish zloty.
3. Create a new membership level, find a payment field with a currency symbol next to it.
4. Verify the "zł" is displayed on the right side of the text field.
5. Put value e.g. 2137 per year. Save the level.
6. Open this membership level at checkout.
7. Verify that a non-breakin space is displayed for thousands operator and a comma for decimal operator (`2 137,00 zł`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Configure Polish zloty (PLN) currency according to local rules
