### PR TITLE
Now adding new lines before appending items to order notes

### DIFF
--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -1412,7 +1412,7 @@
 			} else {
 				//The refund failed, so lets return the gateway message
 
-				// translators: %1$s is the Transaction ID. %2$s is the Gateway Error
+				// translators: %1$s is the Transaction ID. %2$s is the Gateway Error.
 				$morder->notes = trim( $morder->notes . sprintf( __( 'Admin: There was a problem processing a refund for transaction ID %1$s. Gateway Error: %2$s.', 'paid-memberships-pro' ), $transaction_id, $httpParsedResponseAr['L_LONGMESSAGE0'] ) );
 			}
 

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -1384,6 +1384,11 @@
 
 			$httpParsedResponseAr = $morder->Gateway->PPHttpPost( 'RefundTransaction', '&TRANSACTIONID='.$transaction_id );		
 
+			// Add new lines to order notes if not empty.
+			if ( ! empty( $morder->notes ) ) {
+				$morder->notes .= "\n\n";
+			}
+
 			if ( 'success' === strtolower( $httpParsedResponseAr['ACK'] ) ) {
 				
 				$success = true;
@@ -1392,8 +1397,8 @@
 
 				global $current_user;
 
-				// translators: %1$s is the Transaction ID. %2$s is the user display name that initiated the refund.
-				$morder->notes = trim( $morder->notes . ' ' . sprintf( __('Admin: Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );
+				// translators: %1$s is the date, %2$s is the Transaction ID. %3$s is the user display name that initiated the refund.
+				$morder->notes = trim( $morder->notes . sprintf( __('Admin: Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );
 
 				$user = get_user_by( 'id', $morder->user_id );
 				//send an email to the member
@@ -1406,9 +1411,9 @@
 
 			} else {
 				//The refund failed, so lets return the gateway message
-				
-				// translators: %1$s is the Transaction ID. %1$s is the Gateway Error
-				$morder->notes = trim( $morder->notes .' '. sprintf( __( 'Admin: There was a problem processing a refund for transaction ID %1$s. Gateway Error: %2$s.', 'paid-memberships-pro' ), $transaction_id, $httpParsedResponseAr['L_LONGMESSAGE0'] ) );
+
+				// translators: %1$s is the Transaction ID. %2$s is the Gateway Error
+				$morder->notes = trim( $morder->notes . sprintf( __( 'Admin: There was a problem processing a refund for transaction ID %1$s. Gateway Error: %2$s.', 'paid-memberships-pro' ), $transaction_id, $httpParsedResponseAr['L_LONGMESSAGE0'] ) );
 			}
 
 			$morder->SaveOrder();

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -4480,6 +4480,11 @@ class PMProGateway_stripe extends PMProGateway {
 
 		$success = false;
 
+		// Add new lines to order notes if not empty.
+		if ( ! empty( $order->notes ) ) {
+			$order->notes .= "\n\n";
+		}
+
 		//attempt refund
 		try {
 			
@@ -4510,7 +4515,8 @@ class PMProGateway_stripe extends PMProGateway {
 			
 				global $current_user;
 
-				$order->notes = trim( $order->notes.' '.sprintf( __('Admin: Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );	
+				// translators: %1$s is the date. %2$s is the Transaction ID. %3$s is the user display name that initiated the refund.
+				$order->notes = trim( $order->notes . sprintf( __('Admin: Order successfully refunded on %1$s for transaction ID %2$s by %3$s.', 'paid-memberships-pro' ), date_i18n('Y-m-d H:i:s'), $transaction_id, $current_user->display_name ) );
 
 				$user = get_user_by( 'id', $order->user_id );
 				//send an email to the member
@@ -4522,14 +4528,14 @@ class PMProGateway_stripe extends PMProGateway {
 				$myemail->sendRefundedAdminEmail( $user, $order );
 
 			} else {
-				$order->notes = trim( $order->notes . ' ' . __('Admin: An error occurred while attempting to process this refund.', 'paid-memberships-pro' ) );
+				$order->notes = trim( $order->notes . __('Admin: An error occurred while attempting to process this refund.', 'paid-memberships-pro' ) );
 			}
 
 		} catch ( \Throwable $e ) {			
-			$order->notes = trim( $order->notes . ' ' . __( 'Admin: There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );	
+			$order->notes = trim( $order->notes . __( 'Admin: There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );
 		} catch ( \Exception $e ) {
-			$order->notes = trim( $order->notes . ' ' . __( 'Admin: There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );
-		}		
+			$order->notes = trim( $order->notes . __( 'Admin: There was a problem processing the refund', 'paid-memberships-pro' ) . ' ' . $e->getMessage() );
+		}
 
 		$order->saveOrder();
 

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -334,7 +334,12 @@ if ( strtolower( $payment_status ) === 'refunded' ) {
 		// Handle partial refunds. Only updating the log and notes for now.
 		if ( abs( (float)$_POST['mc_gross'] ) < (float)$morder->total ) {				
 			ipnlog( sprintf( 'IPN: Order was partially refunded on %1$s for transaction ID %2$s at the gateway. The order will need to be updated in the WP dashboard.', date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
-			$morder->notes = trim( $morder->notes . ' ' . sprintf( 'IPN: Order was partially refunded on %1$s for transaction ID %2$s at the gateway. The order will need to be updated in the WP dashboard.', date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+
+			// Add new lines to order notes if not empty.
+			if ( ! empty( $morder->notes ) ) {
+				$morder->notes .= "\n\n";
+			}
+			$morder->notes = trim( $morder->notes . sprintf( 'IPN: Order was partially refunded on %1$s for transaction ID %2$s at the gateway. The order will need to be updated in the WP dashboard.', date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 			$morder->SaveOrder();
 			pmpro_ipnExit();
 		}
@@ -342,8 +347,12 @@ if ( strtolower( $payment_status ) === 'refunded' ) {
 		// Full refund.
 		$morder->status = 'refunded';
 
-		// translators: %1$s is the date. %2$s is the transaction ID.
-		$morder->notes = trim( $morder->notes .' '. sprintf( 'IPN: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+		// Add new lines to order notes if not empty.
+		if ( ! empty( $morder->notes ) ) {
+			$morder->notes .= "\n\n";
+		}
+
+		$morder->notes = trim( $morder->notes . sprintf( 'IPN: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 
 		ipnlog( sprintf( 'IPN: Order successfully refunded on %1$s for transaction ID %2$s at the gateway.', date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -395,7 +395,12 @@
 				// Handle partial refunds. Only updating the log and notes for now.
 				if ( $pmpro_stripe_event->data->object->amount_refunded < $pmpro_stripe_event->data->object->amount ) {
 					$logstr .= sprintf( 'Webhook: Order ID %1$s with transaction ID %2$s was partially refunded. The order will need to be updated in the WP dashboard.', $morder->id, $payment_transaction_id );
-					$morder->notes = trim( $morder->notes . ' ' . sprintf( 'Webhook: Order ID %1$s was partially refunded on %2$s for transaction ID %3$s at the gateway.', $morder->id, date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+
+					// Add new lines to order notes if not empty.
+					if ( ! empty( $morder->notes ) ) {
+						$morder->notes .= "\n\n";
+					}
+					$morder->notes = trim( $morder->notes . sprintf( 'Webhook: Order ID %1$s was partially refunded on %2$s for transaction ID %3$s at the gateway.', $morder->id, date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 					$morder->SaveOrder();
 					pmpro_stripeWebhookExit();
 				}
@@ -405,8 +410,13 @@
 				
 				$logstr .= sprintf( 'Webhook: Order ID %1$s successfully refunded on %2$s for transaction ID %3$s at the gateway.', $morder->id, date_i18n('Y-m-d H:i:s'), $payment_transaction_id );
 
+				// Add new lines to order notes if not empty.
+				if ( ! empty( $morder->notes ) ) {
+					$morder->notes .= "\n\n";
+				}
+
 				// Add to order notes.
-				$morder->notes = trim( $morder->notes . ' ' . sprintf( 'Webhook: Order ID %1$s successfully refunded on %2$s for transaction ID %3$s at the gateway.', $morder->id, date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
+				$morder->notes = trim( $morder->notes . sprintf( 'Webhook: Order ID %1$s successfully refunded on %2$s for transaction ID %3$s at the gateway.', $morder->id, date_i18n('Y-m-d H:i:s'), $payment_transaction_id ) );
 
 				$morder->SaveOrder();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This update improves the readability of order notes generated by automated processes. Specifically, it ensures that new data appended to an order note begins on a new line, making the notes easier to scan and understand.

This work also lays the groundwork for future improvements to how order notes are displayed in the admin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Improved readability of order notes by adding line breaks before appending data via automated processes.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
