### PR TITLE
Stops emptying error messages on checkout

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -631,9 +631,9 @@ if ( $submit && $pmpro_msgt != "pmpro_error" && ! empty( $pmpro_review ) ) {
 		do_action( 'pmpro_checkout_processing_failed', $pmpro_review );
 
 		// Make sure we have an error message.
-                if( ! empty( $pmpro_review->error ) ) {
-                    $pmpro_msg = $pmpro_review->error;
-                }
+		if( ! empty( $pmpro_review->error ) ) {
+			$pmpro_msg = $pmpro_review->error;
+		}
 		
 		if ( empty( $pmpro_msg ) ) {
 			$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", 'paid-memberships-pro' );

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -631,7 +631,10 @@ if ( $submit && $pmpro_msgt != "pmpro_error" && ! empty( $pmpro_review ) ) {
 		do_action( 'pmpro_checkout_processing_failed', $pmpro_review );
 
 		// Make sure we have an error message.
-		$pmpro_msg = !empty( $pmpro_review->error ) ? $pmpro_review->error : null;
+                if( ! empty( $pmpro_review->error ) ) {
+                    $pmpro_msg = $pmpro_review->error;
+                }
+		
 		if ( empty( $pmpro_msg ) ) {
 			$pmpro_msg = __( "Unknown error generating account. Please contact us to set up your membership.", 'paid-memberships-pro' );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of emptying the message variable if the review value is empty, allow the value that was set before to be used. 

Resolves #3355.

### How to test the changes in this Pull Request:

Any errors that originate from Stripe https://github.com/strangerstudios/paid-memberships-pro/blob/dev/classes/gateways/class.pmprogateway_stripe.php#L2121-L2125 - would result in a generic error message being shown. 

These errors can be caused by a bad configuration in a Stripe account or tax settings. 

To force the error, I added these two lines in the try block to trigger the error. 

```
pmpro_setMessage( __( 'Session Created. ', 'paid-memberships-pro' ), 'pmpro_error', true );
return;
```

This results in the error being shown correctly

<img width="1666" height="764" alt="image" src="https://github.com/user-attachments/assets/bffb1b55-024f-4308-a6ca-334b6eb944fc" />

Without this fix in place, the generic `Unknown error generating account. Please contact us to set up your membership.` error is thrown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

