### PR TITLE
Fix Stripe Checkout tax not being saved on PMPro orders

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -513,7 +513,7 @@
 			$currency_unit_multiplier = pow( 10, intval( $currency['decimals'] ) );
 
 			$order->total    = (float) $checkout_session->amount_total / $currency_unit_multiplier;
-			if ( ! empty( get_option( 'pmpro_stripe_tax_id_collection_enabled' ) ) ) {
+			if ( in_array( get_option( 'pmpro_stripe_tax' ), array( 'inclusive', 'exclusive' ) ) ) {
 				// If Stripe calculated tax, use that. Otherwise, keep the tax calculated by PMPro.
 				$order->subtotal = (float) $checkout_session->amount_subtotal / $currency_unit_multiplier;
 				$order->tax      = (float) $checkout_session->total_details->amount_tax / $currency_unit_multiplier;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Before saving the tax amount calculated by Stripe Checkout to a PMPro order, we wanted to make sure that Stripe Checkout was set up to calculate tax. This is important in case tax is being calculated onsite by the PMPro Vat Add On, for example, so that Stripe Checkout doesn't wipe that value.

Currently, this behavior is broken since the code is checking whether collecting tax IDs is enabled, not whether automatic tax calculations are enabled. This PR fixes that logic to check whether tax is being calculated by Stripe Checkout.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
