### PR TITLE
PMPro Wizard: Update Manager via PMPro_AddOns

### DIFF
--- a/classes/class-pmpro-addons.php
+++ b/classes/class-pmpro-addons.php
@@ -249,7 +249,7 @@ class PMPro_AddOns {
 	 * @return array $incorrect_folder_names An array of Add Ons with incorrect folder names. The key is the installed folder name, the value is the Add On data.
 	 */
 	public function get_add_ons_with_incorrect_folder_names() {
-		// Make an easily searchable array of installed plugins to reduce computational compexity.
+		// Make an easily searchable array of installed plugins to reduce computational complexity.
 		// The key of the array is the plugin filename, the value is the folder name.
 		$installed_plugins = array();
 

--- a/classes/class-pmpro-addons.php
+++ b/classes/class-pmpro-addons.php
@@ -276,7 +276,7 @@ class PMPro_AddOns {
 
 			// Check if the Add On is installed with an incorrect folder name.
 			if ( array_key_exists( $addon_filename, $installed_plugins ) && $addon_folder !== $installed_plugins[ $addon_filename ] ) {
-				// The Add On is installed with the wrong folder nane. Add it to the array.
+				// The Add On is installed with the wrong folder name. Add it to the array.
 				$installed_name                            = $installed_plugins[ $addon_filename ] . '/' . $addon_filename;
 				$incorrect_folder_names[ $installed_name ] = $addon;
 			}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -4255,6 +4255,7 @@ class PMProGateway_stripe extends PMProGateway {
 		// countries, we should set the percentage to 0. This is a temporary fix until we
 		// have a better solution or until all countries allow us to use application fees.
 		$countries_to_disable_application_fees = array(
+			'BR', // Brazil.
 			'IN', // India.
 			'MX', // Mexico.
 			'MY', // Malaysia.

--- a/includes/email-templates.php
+++ b/includes/email-templates.php
@@ -16,13 +16,13 @@ $pmpro_email_templates_defaults = array(
 	'footer' => array(
 		'subject' => '',
 		'description' => esc_html__( 'Email Footer', 'paid-memberships-pro'),
-		'body' => wp_kses_post( '<p>Respectfully,<br />!!sitename!! </p>', 'paid-memberships-pro' ),
+		'body' => wp_kses_post( '<p>' . esc_html__( 'Respectfully,', 'paid-memberships-pro' ) . '<br />!!sitename!! </p>' ),
 		'help_text' => esc_html__( 'This is the closing message included in every email sent to members and the site administrator through Paid Memberships Pro.', 'paid-memberships-pro' )
 	),
 	'header' => array(
 		'subject'     => '',
 		'description' => esc_html__( 'Email Header', 'paid-memberships-pro'),
-		'body' => wp_kses_post( '<p>Dear !!header_name!!,</p>', 'paid-memberships-pro' ),
+		'body' => wp_kses_post( sprintf( '<p>%s</p>', esc_html__( 'Dear !!header_name!!,', 'paid-memberships-pro' ) ) ),
 		'help_text' => esc_html__( 'This is the opening message included in every email sent to members and the site administrator through Paid Memberships Pro.', 'paid-memberships-pro' )
 	),
 );

--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -513,7 +513,7 @@
 			$currency_unit_multiplier = pow( 10, intval( $currency['decimals'] ) );
 
 			$order->total    = (float) $checkout_session->amount_total / $currency_unit_multiplier;
-			if ( ! empty( get_option( 'pmpro_stripe_tax_id_collection_enabled' ) ) ) {
+			if ( in_array( get_option( 'pmpro_stripe_tax' ), array( 'inclusive', 'exclusive' ) ) ) {
 				// If Stripe calculated tax, use that. Otherwise, keep the tax calculated by PMPro.
 				$order->subtotal = (float) $checkout_session->amount_subtotal / $currency_unit_multiplier;
 				$order->tax      = (float) $checkout_session->total_details->amount_tax / $currency_unit_multiplier;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change the update manager install/activate code in the PMPro Wizard to use the new PMPro_AddOns class.

### How to test the changes in this Pull Request:

1. If installed and activated, deactivate and uninstall Update Manager.
2. Visit the wizard admin page `/wp-admin/admin.php?page=pmpro-wizard&step=advanced` and click _Submit and Continue_
3. Visit the WP Plugins admin page and check that Update Manager has been installed and activated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update Manager install routine in the Wizard uses the new `PMPro_AddOns` php class to handle install and activation.