### PR TITLE
Fix: Count state awareness for new Active & Inactive tabs in Add On Management

### DIFF
--- a/adminpages/addons.php
+++ b/adminpages/addons.php
@@ -522,15 +522,19 @@
 					var inactiveCount = $('.add-on-container.add-on-inactive').length;
 					var updateCount = $('.add-on-container.add-on-needs-update').length;
 
-					setCount($('.filter-links a[data-view="active"]'), activeCount, false);
-					setCount($('.filter-links a[data-view="inactive"]'), inactiveCount, false);
+					// Hide tabs whose count is zero.
+					setCount($('.filter-links a[data-view="active"]'), activeCount, true);
+					setCount($('.filter-links a[data-view="inactive"]'), inactiveCount, true);
 					setCount($('.filter-links a[data-view="update"]'), updateCount, true);
 
-					// If the Update view is active (or in the URL) but no updates exist, switch to All.
-					if (updateCount === 0) {
-						var $updateLink = $('.filter-links a[data-view="update"]');
-						var updateIsActive = $updateLink.hasClass('current') || window.location.hash === '#update';
-						if (updateIsActive) {
+					// If the current view is now hidden (count = 0), switch to All.
+					var $currentLink = $('.filter-links a.current');
+					if ($currentLink.length && !$currentLink.closest('li').is(':visible')) {
+						$('.filter-links a[data-view="all"]').trigger('click');
+					} else if (window.location.hash) {
+						var hashView = window.location.hash.replace('#','');
+						var $hashLink = $('.filter-links a[data-view="' + hashView + '"]');
+						if ($hashLink.length && !$hashLink.closest('li').is(':visible')) {
 							$('.filter-links a[data-view="all"]').trigger('click');
 						}
 					}

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -791,7 +791,7 @@ jQuery(document).ready(function () {
 				var activeCount = jQuery('.add-on-container.add-on-active').length;
 				var inactiveCount = jQuery('.add-on-container.add-on-inactive').length;
 				var updateCount = jQuery('.add-on-container.add-on-needs-update').length;
-				function setCount($link, count, hide){
+					function setCount($link, count, hide){
 					if(!$link.length){return;}
 					var baseLabel = $link.data('baseLabel');
 					if(!baseLabel){
@@ -799,17 +799,23 @@ jQuery(document).ready(function () {
 						$link.data('baseLabel', baseLabel);
 					}
 					$link.text(count>0? baseLabel+' ('+count+')': baseLabel);
-					if(hide){ $link.closest('li').toggle(count>0); }
+						if(hide){ $link.closest('li').toggle(count>0); }
 				}
-				setCount(jQuery('.filter-links a[data-view="active"]'), activeCount, false);
-				setCount(jQuery('.filter-links a[data-view="inactive"]'), inactiveCount, false);
-				setCount(jQuery('.filter-links a[data-view="update"]'), updateCount, true);
-				if(updateCount===0){
-					var $updateLink = jQuery('.filter-links a[data-view="update"]');
-					if($updateLink.hasClass('current') || window.location.hash === '#update'){
+					// Hide tabs whose count is zero for all three: active, inactive, update.
+					setCount(jQuery('.filter-links a[data-view="active"]'), activeCount, true);
+					setCount(jQuery('.filter-links a[data-view="inactive"]'), inactiveCount, true);
+					setCount(jQuery('.filter-links a[data-view="update"]'), updateCount, true);
+					// If current link becomes hidden, switch to All.
+					var $currentLink = jQuery('.filter-links a.current');
+					if ($currentLink.length && !$currentLink.closest('li').is(':visible')) {
 						jQuery('.filter-links a[data-view="all"]').trigger('click');
+					} else if (window.location.hash) {
+						var hashView = window.location.hash.replace('#','');
+						var $hashLink = jQuery('.filter-links a[data-view="' + hashView + '"]');
+						if ($hashLink.length && !$hashLink.closest('li').is(':visible')) {
+							jQuery('.filter-links a[data-view="all"]').trigger('click');
+						}
 					}
-				}
 			},
 			applyCurrentFilter: function(){
 				var $current = jQuery('.filter-links a.current');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds count state awareness to new Active & Inactive tabs.

### How to test the changes in this Pull Request:

1. Install the branch and activate/deactivate add ons.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
