### PR TITLE
Preventing continuously creating orders when saving after "copy"

### DIFF
--- a/adminpages/orders/save-order.php
+++ b/adminpages/orders/save-order.php
@@ -118,6 +118,8 @@ if ( false !== $order->saveOrder() ) {
 	$pmpro_msg .= '</a>';
 	$pmpro_msgt = 'pmpro_success';
 
+	// Make sure that $_REQUEST['id'] is set for the order edit page to avoid infinitely creating new orders when copying.
+	$_REQUEST['id'] = $order->id;
 } else {
 	$pmpro_msg  = __( 'Error saving order.', 'paid-memberships-pro' );
 	$pmpro_msgt = 'pmpro_error';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
After a copied order is saved, ensure that we are then editing the new order, not creating a new copied order.

### How to test the changes in this Pull Request:

1. Select "copy" for an order
2. Save the new order
3. Save again
4. See that before this fix, 2 orders are created. After, only the one.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
