### PR TITLE
Adding membership_id as template var for admin cancel email

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-cancel-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-cancel-admin.php
@@ -109,6 +109,7 @@ class PMPro_Email_Template_Cancel_Admin extends PMPro_Email_Template {
 			'!!display_name!!' => esc_html__( 'The display name of the user.', 'paid-memberships-pro' ),
 			'!!user_login!!' => esc_html__( 'The username of the user.', 'paid-memberships-pro' ),
 			'!!user_email!!' => esc_html__( 'The email address of the user.', 'paid-memberships-pro' ),
+			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'paid-memberships-pro' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'paid-memberships-pro' ),
 			'!!startdate!!' => esc_html__( 'The start date of the membership level.', 'paid-memberships-pro' ),
 			'!!enddate!!' => esc_html__( 'The end date of the membership level.', 'paid-memberships-pro' )
@@ -157,10 +158,13 @@ class PMPro_Email_Template_Cancel_Admin extends PMPro_Email_Template {
 		);
 
 		if ( empty( $this->cancelled_level_ids ) ) {
+			$email_template_variables['membership_id'] = '';
 			$email_template_variables['membership_level_name'] = esc_html__( 'All Levels', 'paid-memberships-pro' );
 		} elseif ( is_array( $this->cancelled_level_ids ) ) {
+			$email_template_variables['membership_id'] = $this->cancelled_level_ids[0]; // Pass just the first as the level id.
 			$email_template_variables['membership_level_name'] = pmpro_implodeToEnglish( $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id IN('" . implode( "','", $this->cancelled_level_ids ) . "')" ) );
 		} else {
+			$email_template_variables['membership_id'] = $this->cancelled_level_ids;
 			$email_template_variables['membership_level_name'] = pmpro_implodeToEnglish( $wpdb->get_col( "SELECT name FROM $wpdb->pmpro_membership_levels WHERE id = '" . $this->cancelled_level_ids . "'" ) );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
!!membership_id!! was available in the Cancel email sent to user, but not the admin. This adds the variable for admin version of the template as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* ENHANCEMENT: Adding `!!membership_id!!` variable to Cancel (admin) email template.
quest. This will appear in the changelog if accepted.
