### PR TITLE
Show gateway nicename on frontend.

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -114,11 +114,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 								<?php
 								// Logic to get the gateway name and output it neatly.
 									if ( ! empty( $order->gateway ) ) {
-										if ( ! empty( $pmpro_gateways[$order->gateway] ) ) {
-											$gateway = esc_html( $pmpro_gateways[$order->gateway] );
-										} else {
-											$gateway = esc_html( ucwords( $order->gateway ) );
-										}
+										$gateway = pmpro_get_gateway_nicename( $order->gateway );
 										if ( $order->gateway_environment == 'sandbox' ) {
 											$gateway .= ' (' . esc_html__( 'test', 'paid-memberships-pro' ) . ')';
 										}

--- a/adminpages/metaboxes/recent-orders.php
+++ b/adminpages/metaboxes/recent-orders.php
@@ -79,7 +79,7 @@ function pmpro_dashboard_report_recent_orders_callback() {
 						</td>
 						<td><?php echo pmpro_escape_price( $order->get_formatted_total() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 						<td>
-							<?php echo esc_html( $order->gateway ); ?>
+							<?php echo esc_html( pmpro_get_gateway_nicename( $order->gateway ) ); ?>
 							<?php if ( $order->gateway_environment == 'test' ) {
 								echo '(test)';
 							} ?>

--- a/adminpages/orders/view-order.php
+++ b/adminpages/orders/view-order.php
@@ -279,7 +279,7 @@ $subscription = $order->get_subscription();
 				<ul class="pmpro_list pmpro_list-plain pmpro_list-with-labels pmpro_cols-2">
 					<li class="pmpro_list_item">
 						<span class="pmpro_list_item_label"><?php esc_html_e( 'Gateway', 'paid-memberships-pro' ); ?></span>
-						<?php echo esc_html( $order->gateway ); ?>
+						<?php echo esc_html( pmpro_get_gateway_nicename( $order->gateway ) ); ?>
 					</li>
 					<li class="pmpro_list_item">
 						<span class="pmpro_list_item_label"><?php esc_html_e( 'Environment', 'paid-memberships-pro' ); ?></span>

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -260,6 +260,26 @@ function pmpro_gateways() {
 	return apply_filters( 'pmpro_gateways', $pmpro_gateways );
 }
 
+/**
+ * Returns the gateway nicename.
+ * Used for outputting the gateway's label value for customers.
+ * 
+ * @since TBD
+ * 
+ * @param string $gateway The gateway's internal slug (i.e. paypalexpress).
+ * @return string The gateway's nicename (i.e. PayPal Express).
+ */
+function pmpro_get_gateway_nicename( $gateway ) {
+	$gateways = pmpro_gateways();
+	if ( array_key_exists( $gateway, $gateways ) ) {
+		$gateway_nicename =  $gateways[ $gateway ];
+	} else {
+		$gateway_nicename = ucwords( $gateway );
+	}
+
+	return $gateway_nicename;
+}
+
 
 // when checking levels for users, we save the info here for caching. each key is a user id for level object for that user.
 global $all_membership_levels;


### PR DESCRIPTION
* ENHANCEMENT: Improved logic to show the label of the gateway on the frontend or outputting the name of the gateway (i.e. View Order, Recent Orders and any other frontend facing areas).

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?