### PR TITLE
Fixing the "delete" action when viewing an order in the admin

### DIFF
--- a/adminpages/orders/view-order.php
+++ b/adminpages/orders/view-order.php
@@ -533,7 +533,7 @@ $subscription = $order->get_subscription();
 						?>
 						<a
 							<?php if ( ! empty( $action['title'] ) ) : ?>title="<?php echo esc_attr( $action['title'] ); ?>"<?php endif; ?>
-							<?php if ( ! empty( $action['href'] ) ) : ?>href="<?php echo esc_url( $action['href'] ); ?>"<?php endif; ?>
+							<?php if ( ! empty( $action['href'] ) ) : ?>href="<?php echo esc_attr( $action['href'] ); ?>"<?php endif; ?>
 							<?php if ( ! empty( $action['target'] ) ) : ?>target="<?php echo esc_attr( $action['target'] ); ?>"<?php endif; ?>
 							<?php if ( ! empty( $action['class'] ) ) : ?>class="<?php echo esc_attr( $action['class'] ); ?>"<?php endif; ?>
 							<?php if ( ! empty( $action['data-order'] ) ) : ?>data-order="<?php echo esc_attr( $action['data-order'] ); ?>"<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Now escaping with `esc_attr()` instead of `esc_url()` to support cases where the `href` contains JavaScript.

### How to test the changes in this Pull Request:

1. Select an order to view
2. Click the "Delete" button
3. See that before this fix, the order is not deleted. After the fix, it is.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
