### PR TITLE
Fix content-disposition error on direct access

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@
 * ENHANCEMENT: Now updating the email address for customers in Stripe when the corresponding user is updated in WordPress. #3454 (@dparker1005)
 * ENHANCEMENT: General improvements to the Add Ons page including filters for active and inactive Add Ons. #3488 (@dalemugford)
 * ENHANCEMENT: Now automatically adjusting the content-disposition header for restricted files based on the file type. #3473 (@andrewlimaza)
-* ENHANCEMENT: Added a new filter `pmpro_restricted_field_disposition` to dynamically adjust the content-disposition header for restricted files. #3473 (@andrewlimaza)
+* ENHANCEMENT: Added a new filter `pmpro_restricted_file_content_disposition` to dynamically adjust the content-disposition header for restricted files. #3473 (@andrewlimaza)
 * ENHANCEMENT: Added a new filter `pmpro_order_action_links` to allow modifying the action links when viewing an order on the frontend. #3465 (@dparker1005)
 * ENHANCEMENT: Added a new action `pmpro_after_updating_post_level_restrictions` to run code after the level restrictions for a post is updated. #3462 (@dparker1005)
 * ENHANCEMENT: Now repairing membership-based course enrollments when LifterLMS courses are saved while streamline is enabled. #3462 (@dparker1005)

--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -80,7 +80,7 @@ function pmpro_restricted_files_check_request() {
 		 * 
 		 * @return string $content_disposition "inline" for image/* types, "attachment" for other file types.
 		 */
-		$content_disposition = apply_filters( 'pmpro_restricted_file_content_disposition', file_is_valid_image( $file_path ) ? 'inline' : 'attachment', $file, $file_dir, $file_path );
+		$content_disposition = apply_filters( 'pmpro_restricted_file_content_disposition', wp_getimagesize( $file_path ) ? 'inline' : 'attachment', $file, $file_dir, $file_path );
 		if ( $content_disposition !== 'inline' && $content_disposition !== 'attachment' ) {
 			$content_disposition = 'attachment'; // Default to attachment if not inline and not attachment.
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -217,7 +217,7 @@ Not sure? You can find out by doing a bit a research.
 * ENHANCEMENT: Now updating the email address for customers in Stripe when the corresponding user is updated in WordPress. #3454 (@dparker1005)
 * ENHANCEMENT: General improvements to the Add Ons page including filters for active and inactive Add Ons. #3488 (@dalemugford)
 * ENHANCEMENT: Now automatically adjusting the content-disposition header for restricted files based on the file type. #3473 (@andrewlimaza)
-* ENHANCEMENT: Added a new filter `pmpro_restricted_field_disposition` to dynamically adjust the content-disposition header for restricted files. #3473 (@andrewlimaza)
+* ENHANCEMENT: Added a new filter `pmpro_restricted_file_content_disposition` to dynamically adjust the content-disposition header for restricted files. #3473 (@andrewlimaza)
 * ENHANCEMENT: Added a new filter `pmpro_order_action_links` to allow modifying the action links when viewing an order on the frontend. #3465 (@dparker1005)
 * ENHANCEMENT: Added a new action `pmpro_after_updating_post_level_restrictions` to run code after the level restrictions for a post is updated. #3462 (@dparker1005)
 * ENHANCEMENT: Now repairing membership-based course enrollments when LifterLMS courses are saved while streamline is enabled. #3462 (@dparker1005)


### PR DESCRIPTION
* BUG FIX: Fixes an issue when accessing a file directly in the browser (in a new tab) outside of WordPress pages/posts.

Adjusted the changelog/readme.txt filter typo.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?