### PR TITLE
Hiding links from the Account page if the linked page is not set.

### DIFF
--- a/shortcodes/pmpro_account.php
+++ b/shortcodes/pmpro_account.php
@@ -236,7 +236,7 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 										$pmpro_member_action_links = array();
 
 										$renew_url = pmpro_url( 'checkout', 'level=' . $level->id, 'https' );
-										if ( array_key_exists($level->id, $pmpro_levels) && pmpro_isLevelExpiringSoon( $level ) && ! empty( $renew_url) ) {
+										if ( array_key_exists($level->id, $pmpro_levels) && pmpro_isLevelExpiringSoon( $level ) && ! empty( $renew_url ) ) {
 											$pmpro_member_action_links['renew'] = '<a id="pmpro_actionlink-renew" href="' . esc_url( $renew_url ) . '" aria-label="' . esc_attr( sprintf( esc_html__( 'Renew %1$s Membership', 'paid-memberships-pro' ), $level->name ) ) . '">' . esc_html__( 'Renew', 'paid-memberships-pro' ) . '</a>';
 
 										}
@@ -427,7 +427,6 @@ function pmpro_shortcode_account($atts, $content=null, $code="")
 									</div>
 									<?php
 								}
-								
 							}
 						?>
 					</div> <!-- end pmpro_card -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Hiding links from the Account page if the linked page is not set.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Unset links from the PMPro page settings page
2. Check the membership account page to see that the corresponding links are no longer shown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
