### PR TITLE
Don't "cancel on next payment date" when there are missed payments

### DIFF
--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -52,6 +52,9 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 	// Store the old next payment date for the subscription for later.
 	$old_next_payment_date = $subscription->get_next_payment_date();
 
+	// Check if this subscription has pending payments.
+	$has_pending_payments = ! empty( $subscription->get_orders( array( 'status' => 'pending', 'limit' => 1 ) ) );
+
 	// Mark the PMPro_Subscription as cancelled (also clears the next payment date).
 	$subscription->set( 'status', 'cancelled' );
 	$subscription->save();
@@ -84,8 +87,8 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 
 	// Check if we want to try to extend the user's membership to the next payment date.
 	if ( apply_filters( 'pmpro_cancel_on_next_payment_date', true, $subscription->get_membership_level_id(), $user->ID ) ) {
-		// Check if $old_next_payment_date is in the future.
-		if ( ! empty( $old_next_payment_date ) && $old_next_payment_date > current_time( 'timestamp' ) ) {
+		// Check if $old_next_payment_date is in the future or if we have pending payments.
+		if ( ( ! empty( $old_next_payment_date ) && $old_next_payment_date > current_time( 'timestamp' ) ) || $has_pending_payments ) {
 			// Set the enddate to the next payment date.
 			pmpro_set_expiration_date( $user->ID, $subscription->get_membership_level_id(), $old_next_payment_date );
 

--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -87,8 +87,8 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 
 	// Check if we want to try to extend the user's membership to the next payment date.
 	if ( apply_filters( 'pmpro_cancel_on_next_payment_date', true, $subscription->get_membership_level_id(), $user->ID ) ) {
-		// Check if $old_next_payment_date is in the future or if we have pending payments.
-		if ( ( ! empty( $old_next_payment_date ) && $old_next_payment_date > current_time( 'timestamp' ) ) && ! $has_pending_payments ) {
+		// Check if $old_next_payment_date is in the future and that we don't have pending payments.
+		if ( ! empty( $old_next_payment_date ) && $old_next_payment_date > current_time( 'timestamp' ) && ! $has_pending_payments ) {
 			// Set the enddate to the next payment date.
 			pmpro_set_expiration_date( $user->ID, $subscription->get_membership_level_id(), $old_next_payment_date );
 

--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -88,7 +88,7 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 	// Check if we want to try to extend the user's membership to the next payment date.
 	if ( apply_filters( 'pmpro_cancel_on_next_payment_date', true, $subscription->get_membership_level_id(), $user->ID ) ) {
 		// Check if $old_next_payment_date is in the future or if we have pending payments.
-		if ( ( ! empty( $old_next_payment_date ) && $old_next_payment_date > current_time( 'timestamp' ) ) || $has_pending_payments ) {
+		if ( ( ! empty( $old_next_payment_date ) && $old_next_payment_date > current_time( 'timestamp' ) ) && ! $has_pending_payments ) {
 			// Set the enddate to the next payment date.
 			pmpro_set_expiration_date( $user->ID, $subscription->get_membership_level_id(), $old_next_payment_date );
 

--- a/pages/cancel.php
+++ b/pages/cancel.php
@@ -74,8 +74,8 @@ $user_levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
 			}
 			$subscriptions = empty( $conpd_levels ) ? null : PMPro_Subscription::get_subscriptions_for_user( $current_user->ID, $conpd_levels );
 			if ( count( $old_level_ids ) <= 1 ) {
-				if ( ! empty( $subscriptions ) ) {
-					// There is a subscription. Show the next payment date.
+				if ( ! empty( $subscriptions ) && empty( $subscriptions[0]->get_orders( array( 'status' => 'pending', 'limit' => 1 ) ) ) ) {
+					// There is a subscription that does not have missed payments. Show the next payment date.
 					$cancellation_behavior_text = sprintf( __( 'Your subscription will be cancelled. You will not be billed again. Your membership will remain active until %s. ', 'paid-memberships-pro' ), $subscriptions[0]->get_next_payment_date( get_option( 'date_format' ) ) );
 				} else {
 					// No subscription. Show a generic message.

--- a/preheaders/cancel.php
+++ b/preheaders/cancel.php
@@ -75,13 +75,14 @@
 
 			$worked = true;
 			foreach($old_level_ids as $old_level_id) {
-				// If the user does have a subscription for this level (possibly multiple), get the furthest next payment date that is after today.
+				// If the user does have a subscription for this level (possibly multiple), get the furthest next payment date that is after today
+				// making sure that there are no "pending" orders representing missed payments.
 				$subscriptions = PMPro_Subscription::get_subscriptions_for_user( $current_user->ID, (int)$old_level_id );
 				$next_payment_date = false;
 				if ( ! empty( $subscriptions ) ) {
 					foreach ( $subscriptions as $sub ) {
 						$sub_next_payment_date = $sub->get_next_payment_date();
-						if ( ! empty( $sub_next_payment_date ) && $sub_next_payment_date > current_time( 'timestamp' ) && ( empty( $next_payment_date ) || $sub_next_payment_date > $next_payment_date ) ) {
+						if ( ! empty( $sub_next_payment_date ) && $sub_next_payment_date > current_time( 'timestamp' ) && ( empty( $next_payment_date ) || $sub_next_payment_date > $next_payment_date ) && empty( $sub->get_orders( array( 'status' => 'pending', 'limit' => 1 ) ) ) ) {
 							$next_payment_date = $sub_next_payment_date;
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In PMPro v3.6, PMPro now tracks failed payments as "pending" orders. This PR updates our "cancel on next payment date" code to immediately terminate memberships when cancelled if they have a missed payment instead of giving the user access to their next payment date.

This prevents cases where a user misses an annual payment on Jan 1, 2025, cancels, and gets access until 2026 for example.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
