### PR TITLE
Fix issue with "+" in username when login fails.

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -1029,7 +1029,7 @@ add_filter( 'wp_new_user_notification_email', 'pmpro_password_reset_email_filter
 		if ( $error ) {
 				$error_args = array(
 					'action' => urlencode( $error ),
-					'username' => sanitize_text_field( $username )
+					'username' => urlencode( sanitize_text_field( $username ) )
 				);
 				wp_redirect( add_query_arg( $error_args, pmpro_login_url() ) );
 			} else {
@@ -1065,7 +1065,7 @@ function pmpro_login_failed( $username, $error = null ) {
 			// If an error was passed, get the code from there.
 			$error_code = is_wp_error( $error ) ? $error->get_error_code() : 'failed';
 
-			$redirect_url = add_query_arg( array( 'action'=> $error_code, 'username' => sanitize_text_field( $username ), 'redirect_to' => urlencode( $redirect_to ) ), pmpro_login_url() );
+			$redirect_url = add_query_arg( array( 'action'=> $error_code, 'username' => urlencode( sanitize_text_field( $username ) ), 'redirect_to' => urlencode( $redirect_to ) ), pmpro_login_url() );
 		} else {
 			$redirect_url = add_query_arg( 'action', 'loggedout', pmpro_login_url() );			
 		}


### PR DESCRIPTION
* BUG FIX: Fixes an issue when a username has a `+` in the name. This would be converted to a space.

Steps to replicate:
1. Create a user with an email like test+1@local.co
2. Try to login with test+1@local.co as the username but use an incorrect password.
3. Login page reloads but shows "test 1@local.co" as the username with the error message.
4. Apply this PR and run the 2 step again.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

