### PR TITLE
Installation Wizard: Don't prompt the user to install the PMPro Upgrade Manager if it's already active.

### DIFF
--- a/adminpages/wizard/advanced.php
+++ b/adminpages/wizard/advanced.php
@@ -13,6 +13,7 @@ $wisdom_tracking = get_option( 'pmpro_wisdom_opt_out' );
 			<h2><?php esc_html_e( 'Advanced Settings', 'paid-memberships-pro' ); ?></h2>
 			<p><?php esc_html_e( 'Configure advanced settings relating to your membership site. You can configure additional settings later.', 'paid-memberships-pro' ); ?></p>
 		</div>		
+		<?php if ( ! defined( 'PMPROUM_VERSION' ) ) : ?>
 		<div class="pmpro-wizard__field">
 			<label for="updatemanager" class="pmpro-wizard__label-block">
 				<?php esc_html_e( 'Install Update Manager', 'paid-memberships-pro' ); ?>
@@ -23,6 +24,7 @@ $wisdom_tracking = get_option( 'pmpro_wisdom_opt_out' );
 				<option value="1"><?php esc_html_e( 'No - I\'ll install and activate it manually later.', 'paid-memberships-pro' ); ?></option>
 			</select><br><br>
 		</div>
+		<?php endif; ?>
 		<div class="pmpro-wizard__field">
 			<label for="filterqueries" class="pmpro-wizard__label-block">
 				<?php esc_html_e( 'Filter searches and archives?', 'paid-memberships-pro' ); ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a conditional to the wizard so if the update manager is already installed and active, it doesn't prompt the user to install and activate it.

While this does mean that [in the processing script it will try to install it](https://github.com/strangerstudios/paid-memberships-pro/blob/35a0b3d92c1b774bfe10c0c15583939e80b83f29/adminpages/wizard/save-steps.php#L262), it will just [short out as it's already active](https://github.com/strangerstudios/paid-memberships-pro/blob/35a0b3d92c1b774bfe10c0c15583939e80b83f29/adminpages/wizard/save-steps.php#L316-L321).

Unsure if it would be better to tweak this conditional to not rely on the constant from the update manager but do a `is_plugin_active` check.  The constant would catch configurations where it lives in mu-plugins, but that's probably not ideal as it's harder to update.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Installation Wizard: Don't prompt the user to install the PMPro Upgrade Manager if it's already active.
