### PR TITLE
Syncing subscription when payment fails

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -1392,6 +1392,7 @@ class PMPro_Subscription {
 } // end of class
 
 // @todo Move this into another location outside of the bottom of the class file.
-// Update the subscription status when a recurring payment is successful.
+// Update the subscription status when a recurring payment is successful or fails.
 // Cancellations during IPNs/Webhooks are handled when the order is "changed" to 'cancelled' status, which is passed through to the sub.
 add_action( 'pmpro_subscription_payment_completed', [ 'PMPro_Subscription', 'update_subscription_for_order' ] );
+add_action( 'pmpro_subscription_payment_failed', [ 'PMPro_Subscription', 'update_subscription_for_order' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When a payment fails, we still want to sync the subscription info with the gateway because the subscription will likely have a new "next payment date" set. This will prevent PMPro subscriptions showing "next payment dates" in the past.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
