### PR TITLE
Avoid restricting page contents in beaver builder editor

### DIFF
--- a/includes/compatibility/beaver-builder.php
+++ b/includes/compatibility/beaver-builder.php
@@ -14,7 +14,7 @@ add_action( 'init', 'pmpro_beaver_builder_compatibility' );
  * to avoid conflicts while editing.
  */
 function pmpro_beaver_builder_fl_builder_editing_enabled() {
-	remove_filter('the_content', 'pmpro_membership_content_filter', 15);
+	remove_filter( 'the_content', 'pmpro_membership_content_filter', 15 );
 }
 add_action( 'fl_builder_editing_enabled', 'pmpro_beaver_builder_fl_builder_editing_enabled' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently if a page is restricted to a level that the current user doesn't have, the page contents can't be edited with Beaver Builder. This PR hooks into the Beaver Builder page editor and removes content restrictions when the page is being edited.

### How to test the changes in this Pull Request:

1. Install Beaver Builder
2. Restrict a page
3. Check whether the page contents can be edited with Beaver Builder

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
