### PR TITLE
Remove input error CSS class on keyup fix.

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -172,8 +172,8 @@ jQuery(document).ready(function(){
 	});
 
 	//unhighlight error fields when the user edits them
-	jQuery('.pmpro_error').bind("change keyup input", function() {
-		jQuery(this).removeClass('pmpro_error');
+	jQuery('.pmpro_form_input-error').bind("change keyup input", function() {
+		jQuery(this).removeClass('pmpro_form_input-error');
 	});
 
 	//click apply button on enter in discount code box


### PR DESCRIPTION
* BUG FIX: Resolved an issue where correcting data in fields with validation errors did not clear the error border from the input.

I found this while working in the field class and seeing how things are built. It looks like we missed updating this CSS selector in this Javascript code.

The `.pmpro_form_input-error` class (red border around the input) is now removed as soon as you start typing in the field. This applies to required fields that were left empty at checkout when a submission was attempted.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?