### PR TITLE
Removing the "edit member" panel cache

### DIFF
--- a/adminpages/member-edit.php
+++ b/adminpages/member-edit.php
@@ -45,6 +45,7 @@ function pmpro_member_edit_get_panels() {
 	$panels = apply_filters( 'pmpro_member_edit_panels', $panels );
 
 	// Build array to return with slug as key.
+	$panels_return = array();
 	foreach ( $panels as $panel ) {
 		$panels_return[ $panel->get_slug() ] = $panel;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removed caching in the `pmpro_member_edit_get_panels()` function.

This fixes an issue where if a user field group is restricted to a specific level, if the user is manually given that level by an admin, the user field panel will not show in the sidebar in the subsequent page load. The page would need to be refreshed for the sidebar element to appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
