### PR TITLE
Using MemberOrder->add_order_note() to save IPN ID in order notes

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -704,7 +704,6 @@ function pmpro_ipnSaveOrder( $txn_id, $subscription ) {
 	// Get the data that should be used to create the order.
 	$order_data = pmpro_ipn_get_order_data( $subscription );
 	$order_data['payment_transaction_id'] = $txn_id;
-	$order_data['notes'] = isset( $ipn_id ) ? "[IPN_ID]{$ipn_id}[/IPN_ID]" : '';
 
 	// Process the recurring payment.
 	ipnlog( pmpro_handle_recurring_payment_succeeded_at_gateway( $order_data ) );
@@ -715,6 +714,12 @@ function pmpro_ipnSaveOrder( $txn_id, $subscription ) {
 	if ( empty( $morder ) || empty( $morder->id ) ) {
 		ipnlog( "ERROR: Could not find order just created for this recurring payment (" . $subscription->get_subscription_transaction_id() . ")." );
 		return false;
+	}
+
+	// Add an order note with the IPN ID.
+	if ( ! empty( $ipn_id ) ) {
+		$morder->add_order_note( "[IPN_ID]{$ipn_id}[/IPN_ID]" );
+		$morder->SaveOrder();
 	}
 
 	// Get card info if appropriate.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Using MemberOrder->add_order_note() to save IPN ID in order notes. This adds a timestamp to the entry.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
