### PR TITLE
Fix dependencies for content visibility component

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -68,7 +68,7 @@ function pmpro_block_editor_assets() {
 		wp_register_script(
 			'pmpro-sidebar-editor-script',
 			PMPRO_URL . '/blocks/build/sidebar/index.js',
-			array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-i18n', 'wp-editor', 'wp-api-request', 'wp-plugins', 'wp-edit-post' )
+			array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-i18n', 'wp-block-editor', 'wp-api-request', 'wp-plugins', 'wp-edit-post' )
 		);
 		wp_localize_script(
 			'pmpro-sidebar-editor-script',
@@ -83,7 +83,7 @@ function pmpro_block_editor_assets() {
 	wp_register_script(
 		'pmpro-component-content-visibility-script',
 		PMPRO_URL . '/blocks/build/component-content-visibility/index.js',
-		array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-i18n', 'wp-editor', 'wp-api-request', 'wp-plugins', 'wp-edit-post' )
+		array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-i18n', 'wp-block-editor', 'wp-api-request', 'wp-plugins' )
 	);
 
 	wp_localize_script(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Changing `wp-editor` dependency to `wp-block-editor` which is where we are actually importing `InspectorControls` from.

Removing `wp-edit-post` as it isn't needed for the content visibility component. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
