### PR TITLE
Move Expiration Logic and Expiration Reminders to run every 15 minutes.

### DIFF
--- a/classes/class-pmpro-recurring-actions.php
+++ b/classes/class-pmpro-recurring-actions.php
@@ -132,7 +132,7 @@ class PMPro_Recurring_Actions {
 
 		global $wpdb;
 
-		$today = date( 'Y-m-d 00:00:00', current_time( 'timestamp' ) );
+		$today = date( 'Y-m-d H:i:s', current_time( 'timestamp' ) );
 
 		// Get the number of days before expiration to send the email. Filterable.
 		// Default is 7 days.
@@ -140,7 +140,7 @@ class PMPro_Recurring_Actions {
 
 		// Configure the interval to select records from
 		$interval_start = $today;
-		$interval_end   = date( 'Y-m-d 00:00:00', strtotime( "+{$pmpro_email_days_before_expiration} days", current_time( 'timestamp' ) ) );
+		$interval_end   = date( 'Y-m-d H:i:s', strtotime( "+{$pmpro_email_days_before_expiration} days", current_time( 'timestamp' ) ) );
 
 		// look for memberships that are going to expire within one week (but we haven't emailed them within a week)
 		$sqlQuery = $wpdb->prepare(


### PR DESCRIPTION
### Changelog entry

* BUG FIX: Resolves an issue where hourly memberships would not cancel on time. This moves the scheduled expiring and expiration notices to run every 15 minutes.

### All Submissions:
* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/paid-memberships-pro/issues/3544.

### How to test the changes in this Pull Request:

1. Create an hourly membership that expires in X hours. (1 Hour is a good option to test).
2. Checkout for this membership level.
3. Wait an hour to ensure the scheduled action clears the level or run it manually. The email should be sent to the member that their level is expiring soon and once they reach the 1 hour expiration it should remove their membership level.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?