### PR TITLE
Move to new hook `enqueue_block_assets`

### DIFF
--- a/includes/blocks.php
+++ b/includes/blocks.php
@@ -56,6 +56,12 @@ add_action( 'init', 'pmpro_register_block_types' );
  * Enqueue block editor only CSS.
  */
 function pmpro_block_editor_assets() {
+
+	// Only load this in the editor view and not the frontend.
+	if ( ! is_admin() ) {
+		return;
+	}
+
 	// Enqueue the CSS file css/blocks.editor.css.
 	wp_enqueue_style(
 		'pmpro-block-editor-css',
@@ -96,7 +102,7 @@ function pmpro_block_editor_assets() {
 	wp_enqueue_script( 'pmpro-component-content-visibility-script' );
 
 }
-add_action( 'enqueue_block_editor_assets', 'pmpro_block_editor_assets' );
+add_action( 'enqueue_block_assets', 'pmpro_block_editor_assets' );
 
 /**
  * Register post meta needed for our blocks.


### PR DESCRIPTION
* BUG FIX: Fixes a warning in the developer console for WordPress 6.3+ for enqueuing assets incorrectly for blocks.

Moving to using the 'enqueue_block_assets' resolves the console warning but also comes with a catch that it can enqueue it for the frontend as well. To prevent this from loading on the frontend, utilizing the `is_admin` condition helps.

Reference: https://make.wordpress.org/core/2023/07/18/miscellaneous-editor-changes-in-wordpress-6-3/#post-editor-iframed

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?