### PR TITLE
Only allow a single failed payment email to go out daily

### DIFF
--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -284,7 +284,7 @@ function pmpro_handle_recurring_payment_failure_at_gateway( $order_data ) {
 	// Some gateways can perform many retries in a short period of time. To avoid spamming the user/admin, we will only send one email per day.
 	// Check order meta for the last time we sent a failure email for this order.
 	$last_failure_email_sent = get_pmpro_membership_order_meta( $order->id, 'last_failure_email_sent', true );
-	if ( ! empty( $last_failure_email_sent ) && ( time() - intval( $last_failure_email_sent ) ) < DAY_IN_SECONDS - HOUR_IN_SECONDS ) { // Give an hour of wiggle room for payments that are retried at the same time each day.
+	if ( ! empty( $last_failure_email_sent ) && ( time() - intval( $last_failure_email_sent ) ) < 23 * HOUR_IN_SECONDS ) { // 23 hours to give some wiggle room for payments that are retried at the same time each day.
 		return 'Processed failed payment for user with id = ' . $user->ID . '. Subscription transaction id = ' . $subscription_transaction_id . '. Order id = ' . $order->id . '. Already sent failure email within the last 24 hours.';
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Stripe Smart Retries can retry payments at varying intervals, sometimes within the same hour.

This PR ensures that users do not get spammed with payment failed emails by only allowing a single failed payment email to be sent every 24 hours.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
