### PR TITLE
Add week-passed cleanup to Library Conflicts

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -199,6 +199,7 @@ function pmpro_track_library_conflict( $name, $path, $version ) {
 	$library_conflicts[ $name ][ $path ]['timestamp'] = $now;
 
 	// Cleanup.
+	$seven_days_ago = strtotime( '-7 days' );
 	foreach ( $library_conflicts as $lib_name => $paths ) {
 		// If no paths, remove the library entry.
 		if ( empty( $paths ) ) {
@@ -207,10 +208,16 @@ function pmpro_track_library_conflict( $name, $path, $version ) {
 		}
 		// Check each path's timestamp. If older than 7 days, remove it.
 		foreach ( $paths as $lib_path => $info ) {
-			if ( ! empty( $info['timestamp'] ) && ( strtotime( $info['timestamp'] ) < strtotime( '-7 days' ) ) ) {
+			if ( ! empty( $info['timestamp'] ) && ( strtotime( $info['timestamp'] ) < $seven_days_ago ) ) {
 				unset( $library_conflicts[ $lib_name ][ $lib_path ] );
 			}
 		}
+
+		// If all paths were removed, clean up the library entry.
+		if ( empty( $library_conflicts[ $lib_name ] ) ) {
+			unset( $library_conflicts[ $lib_name ] );
+		}
 	}
+	
 	update_option( 'pmpro_library_conflicts', $library_conflicts, false );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Kim Coleman found this issue and surfaced it on Slack on Dec 23rd. Essentially she was seeing conflicts listed that pointed to inactive plugins, revealing that our tracker was holding on to stale conflicts.

Library conflicts are tracked prior to PMPro loading its libraries, and stored in an option in the database. They are referenced/displayed in Site Health. However, _there's no explicit code to cleanup stale library conflicts that may have been resolved through deactivation, or plugin update, etc._

This PR adds a small amount of code to loop through and unset entries older than 7 days when `pmpro_track_library_conflict` is invoked.

If we're particularly concerned about doing too much work here, we could alternatively schedule a cleanup to run separately either with Action Scheduler or hook to a Site Health action.

```
	// Remove conflicts if older than 7 days.
	foreach ( $library_conflicts as $lib_name => $paths ) {
		foreach ( $paths as $lib_path => $info ) {
			if ( ! empty( $info['timestamp'] ) && ( strtotime( $info['timestamp'] ) < strtotime( '-7 days', strtotime( $now ) ) ) ) {
				unset( $library_conflicts[ $lib_name ][ $lib_path ] );
			}
		}
	}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Paid Memberships Pro now removes plugin library conflicts tracked over a week ago from its conflict tracker. 
