### PR TITLE
Resolve deprecation warnings on PHP 8.5+

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -76,7 +76,7 @@
 	//make sure the tax rate is not > 1
 	$tax_state = get_option( "pmpro_tax_state");
 	$tax_rate = get_option( "pmpro_tax_rate");
-	if((double)$tax_rate > 1)
+	if((float)$tax_rate > 1)
 	{
 		//assume the entered X%
 		$tax_rate = $tax_rate / 100;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1803,7 +1803,7 @@ function pmpro_calculateInitialPaymentRevenue( $s = null, $l = null ) {
 
 	$total = $wpdb->get_var( $sqlQuery );
 
-	return (double) $total;
+	return (float) $total;
 }
 
 function pmpro_calculateRecurringRevenue( $s, $l ) {
@@ -3520,7 +3520,7 @@ function pmpro_round_price( $price, $currency = '' ) {
 		$decimals = intval( $pmpro_currencies[ $currency ]['decimals'] );
 	}
 
-	$rounded = round( (double) $price, $decimals );
+	$rounded = round( (float) $price, $decimals );
 
 	/**
 	 * Filter for result of pmpro_round_price.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Cast names (boolean), (integer), (double), and (binary) have been [deprecated in PHP 8.5](https://www.php.net/manual/en/migration85.deprecated.php)

Updating (double) cast name to (float).

Resolves notice `Non-canonical cast (double) is deprecated, use the (float) cast instead`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed a PHP deprecation warning that may show on sites running PHP 8.5+.
