### PR TITLE
Updating the capability check for admin user fields to pmpro_edit_members

### DIFF
--- a/classes/class-pmpro-field-group.php
+++ b/classes/class-pmpro-field-group.php
@@ -295,7 +295,7 @@ class PMPro_Field_Group {
 				}
 
 				// Check if this field should only be shown to admins.
-				if ( ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_membership_manager' ) ) && in_array( $field->profile, array( 'admins', 'admin', 'only_admin' ), true ) ) {
+				if ( ! current_user_can( pmpro_get_edit_member_capability() ) && in_array( $field->profile, array( 'admins', 'admin', 'only_admin' ), true ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Previously, only users with the `manage_options` capability or the `pmpro_membership_manager` role could view admin-only user fields. This PR updates the check to allow any user with `pmpro_edit_members` to view those fields, which allows for custom roles to be able to view the fields without needing to grant `manage_options`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
