### PR TITLE
Add cache-clearing for field changes

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1052,6 +1052,23 @@ function pmpro_get_user_fields_settings() {
 }
 
 /**
+ * Clear cached user field settings in object cache when adding, updating or deleting option.
+ * 
+ * @since TBD
+ * @param mixed $old_value The old value of the option.
+ * @param mixed $value The new value of the option.
+ * @param string $option The name of the option.
+ * @return void
+ */
+function pmpro_clear_user_fields_settings_cache( $old_value = null, $value = null, $option = null ) {
+	wp_cache_delete( 'pmpro_user_fields_settings', 'options' );
+	wp_cache_delete( 'alloptions', 'options' );
+}
+add_action( 'add_option_pmpro_user_fields_settings', 'pmpro_clear_user_fields_settings_cache', 10, 2 );
+add_action( 'update_option_pmpro_user_fields_settings', 'pmpro_clear_user_fields_settings_cache', 10, 3 );
+add_action( 'delete_option_pmpro_user_fields_settings', 'pmpro_clear_user_fields_settings_cache' );
+
+/**
  * Load user field settings into the fields global var.
  */
 function pmpro_load_user_fields_from_settings() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

@ideadude Demonstrated an replicable issue with user fields and Object Caching.

> Editing user fields don't automatically show up on the frontend until the cache is cleared. We should detect this and clear object caches.
> Have object caching set up with W3 total cache and redis or APC/etc.
> Load the checkout page for a level.
> Add a user field to that level.
> Load the checkout page, the field may or may not be there (might be the first time).
> Add another field.
> Reload the checkout page, the field shouldn't be there if the object cache hasn't been cleared.
> Clear the object cache.
> Note the field is now there.

To prevent this issue, we should clear the object cache when CUD operations are performed on user fields. This PR adds hooks to accomplish the cache clearing on create, update and delete operations against user fields.

### How to test the changes in this Pull Request:

1. Replicate the issue as described by @ideadude 
2. Switch to this branch
3. Re-test the issue steps.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolves an issue with user fields and object caching.
