### PR TITLE
PMPro IPN - Checking the subscription status before canceling to avoid double cancel email

### DIFF
--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -272,10 +272,12 @@ if ( $txn_type == 'recurring_payment_profile_cancel' || $txn_type == 'recurring_
 
 	// Double-check the subscription status to ensure that it is cancelled.
 	$gateway_obj = new PMProGateway_paypalexpress();
-	$subscription_status_array = $gateway_obj->getSubscriptionStatus( $recurring_payment_id, $gateway_environment );
-	if ( ! empty( $subscription_status_array ) && isset( $subscription_status_array['status'] ) && $subscription_status_array['status'] != 'Cancelled' ) {
+	$temp_order  = new MemberOrder(); // Fake an order to pass to getSubscriptionStatus.
+	$temp_order->subscription_transaction_id = $recurring_payment_id;
+	$subscription_status_array = $gateway_obj->getSubscriptionStatus( $temp_order );
+	if ( ! empty( $subscription_status_array ) && isset( $subscription_status_array['STATUS'] ) && $subscription_status_array['STATUS'] != 'Cancelled' ) {
 		// If the subscription is not cancelled, cancel it at the gateway.
-		ipnlog( 'Subscription status is ' . $subscription_status_array['status'] . '. Cancelling subscription at gateway.' );
+		ipnlog( 'Subscription status is ' . $subscription_status_array['STATUS'] . '. Cancelling subscription at gateway.' );
 		$pmpro_subscription = PMPro_Subscription::get_subscription_from_subscription_transaction_id( $recurring_payment_id, 'paypalexpress', $gateway_environment );
 		if ( ! empty( $pmpro_subscription ) ) { 
 			$pmpro_subscription->cancel_at_gateway();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In PMPro v3.5.4, we added code to the PayPal "subscription cancelled" IPN handler that sends an additional subscription cancellation request to ensure that the payment subscription is completely cancelled and not just paused or suspended.

That change caused an error email to sometimes be sent to administrators if PMPro tries to cancel a subscription that is already marked as cancelled in PayPal.

This PR updates our logic to first check whether the payment subscription is already cancelled in the gateway and, if so, avoids sending another cancellation request.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
