### PR TITLE
Fix missing payment method data on failed Stripe payment orders

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -219,7 +219,7 @@
 				pmpro_stripeWebhookExit();
 			}
 
-			$logstr .= pmpro_handle_recurring_payment_failure_at_gateway( pmpro_stripe_webhook_get_order_data_from_invoice( $invoice ) );
+			$logstr .= pmpro_handle_recurring_payment_failure_at_gateway( pmpro_stripe_webhook_get_order_data_from_invoice( $invoice, $charge->payment_method ) );
 			pmpro_stripeWebhookExit();
 		}
 		elseif($pmpro_stripe_event->type == "customer.subscription.deleted")
@@ -705,10 +705,12 @@ function pmpro_stripe_webhook_populate_order_from_payment( $order, $payment_meth
  *
  * @since 3.6
  *
- * @param Stripe_Invoice $invoice The invoice object from Stripe.
+ * @param Stripe_Invoice $invoice   The invoice object from Stripe.
+ * @param string         $payment_method_id Optional payment method ID to retrieve from Stripe.
+ *                                          Useful for failed payments where the invoice has no payment data.
  * @return array The order data array.
  */
-function pmpro_stripe_webhook_get_order_data_from_invoice( $invoice ) {
+function pmpro_stripe_webhook_get_order_data_from_invoice( $invoice, $payment_method_id = '' ) {
 	global $pmpro_currency, $pmpro_currencies;
 
 	// Build the order data array.
@@ -733,8 +735,17 @@ function pmpro_stripe_webhook_get_order_data_from_invoice( $invoice ) {
 	$order_data['total'] = (! empty($invoice->total) ? $invoice->total / $currency_unit_multiplier : 0);
 
 	// Set payment information data.
-	// Find the payment intent.
-	if ( ! empty( $invoice->payments->data[0]->payment->payment_intent ) ) {
+	// Find the payment method.
+	$payment_method = null;
+
+	// If we have a payment method ID, retrieve it directly from Stripe.
+	// This is needed for failed payments where the invoice has no payment data.
+	if ( ! empty( $payment_method_id ) ) {
+		$payment_method = \Stripe\PaymentMethod::retrieve( $payment_method_id );
+	}
+
+	// If we don't have a payment method yet, try to get it from the invoice's payment intent.
+	if ( empty( $payment_method ) && ! empty( $invoice->payments->data[0]->payment->payment_intent ) ) {
 		$payment_intent_args = array(
 			'id'     => $invoice->payments->data[0]->payment->payment_intent,
 			'expand' => array(
@@ -744,8 +755,6 @@ function pmpro_stripe_webhook_get_order_data_from_invoice( $invoice ) {
 		);
 		$payment_intent = \Stripe\PaymentIntent::retrieve( $payment_intent_args );
 
-		// Find the payment method.
-		$payment_method = null;
 		if ( ! empty( $payment_intent->payment_method ) ) {
 			$payment_method = $payment_intent->payment_method;
 		} elseif( ! empty( $payment_intent->latest_charge ) ) {


### PR DESCRIPTION
## Summary
- When a Stripe recurring payment fails, the pending order was missing card info (type, last4, expiration) and billing address because the invoice has no `payments` data for failed payments.
- Added an optional `$payment_method_id` parameter to `pmpro_stripe_webhook_get_order_data_from_invoice()`. The `charge.failed` handler now passes `$charge->payment_method` so the function can retrieve the PaymentMethod directly from Stripe.
- The `invoice.payment_succeeded` path is unchanged (no second argument, existing logic applies).

## Test plan
- [ ] Trigger a failed recurring payment in Stripe test mode
- [ ] Verify the pending order in PMPro has card type, last4, expiration month/year, and billing address populated
- [ ] Verify the billing failure email contains the payment method variables
- [ ] Verify successful recurring payments still process correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)