### PR TITLE
Security: Gate unverified Stripe webhook event fallback behind filter

### DIFF
--- a/services/stripe-webhook.php
+++ b/services/stripe-webhook.php
@@ -79,8 +79,24 @@
 		catch(Exception $e)
 		{
 			$logstr .= "Could not find an event with ID #" . $event_id . ". " . $e->getMessage();
-			// pmpro_stripeWebhookExit();
-			$pmpro_stripe_event = $post_event;			//for testing you may want to assume that the passed in event is legit
+
+			/**
+			 * Filter whether the Stripe webhook handler can trust a posted event payload
+			 * when retrieving the event from Stripe fails.
+			 *
+			 * @since TBD
+			 *
+			 * @param bool        $allow_unverified_post_event Whether to trust the posted event payload fallback.
+			 * @param object|null $post_event                  Parsed event payload from the request body.
+			 * @param string      $event_id                    Stripe event ID being retrieved.
+			 */
+			$allow_unverified_post_event = (bool) apply_filters( 'pmpro_stripe_webhook_allow_unverified_post_event', false, $post_event, $event_id );
+
+			// This fallback is intended for controlled testing/debug scenarios only.
+			if ( $allow_unverified_post_event && ! empty( $post_event ) && ! empty( $post_event->id ) && sanitize_text_field( $post_event->id ) === $event_id ) {
+				$pmpro_stripe_event = $post_event;
+				$logstr .= ' Falling back to the unverified posted event payload.';
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When `Stripe_Event::retrieve()` fails, the catch block previously fell back to the raw POST body unconditionally, trusting unverified event data
- This change gates that fallback behind the `pmpro_stripe_webhook_allow_unverified_post_event` filter, which defaults to `false`
- The unverified payload is only used when the filter is explicitly enabled AND the payload ID matches the expected event ID

## Test plan
- [ ] Confirm webhook processing works normally when Stripe event retrieval succeeds (no change in behavior)
- [ ] Confirm that when event retrieval fails, the webhook exits gracefully without falling back to unverified data
- [ ] Confirm that adding `add_filter( 'pmpro_stripe_webhook_allow_unverified_post_event', '__return_true' )` restores the old fallback behavior for testing


🤖 Generated with [Claude Code](https://claude.com/claude-code)