### PR TITLE
Deprecate read usage of pmpro_doing_webhook()

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4203,6 +4203,7 @@ function pmpro_insert_or_replace( $table, $data, $format, $primary_key = 'id' ) 
 /**
  * Checks if a webhook is running
  * @since 2.5
+ * @since TBD Calling this function to read webhook status is deprecated.
  * @param string $gateway If passed in, requires that specific gateway.
  * @param bool $set Set to true to set the constant and fire the action hook.
  * @return bool True or false if a PMPro webhook set the constant or not.
@@ -4216,6 +4217,13 @@ function pmpro_doing_webhook( $gateway = null, $set = false ){
 		do_action( 'pmpro_doing_webhook', $gateway );
 		return true;
 	}
+
+	// Reading webhook status through this function is deprecated.
+	_deprecated_argument(
+		__FUNCTION__,
+		'TBD',
+		esc_html__( 'Reading webhook status via pmpro_doing_webhook() is deprecated and will be removed in a future version of Paid Memberships Pro.', 'paid-memberships-pro' )
+	);
 
 	// Otherwise, check if we were already set up.
 	if( defined( 'PMPRO_DOING_WEBHOOK' ) && !empty ( PMPRO_DOING_WEBHOOK ) ){


### PR DESCRIPTION
## Context
PMPro currently uses `pmpro_doing_webhook()` in two modes:
- **write mode**: `pmpro_doing_webhook( $gateway, true )` to set webhook context
- **read mode**: `pmpro_doing_webhook()` (or with a gateway arg) to detect webhook context later in the same request

As part of long-term cleanup, we want to phase this API out in stages instead of removing it abruptly.

## Core Issue (Why This Is Needed)
The function stores webhook context in the `PMPRO_DOING_WEBHOOK` **constant**.

That creates a structural limitation:
- constants are immutable once defined in a request,
- so the first writer effectively wins,
- and subsequent webhook processing in the same request cannot safely represent a changed context.

In other words, read calls are dependent on a global, single-assignment flag that cannot accurately model modern multi-handler/async execution realities.

This constant-based design is the key reason we are deprecating **read usage** first.

## Additional Problem Details
Historically, callers used read mode as a general context switch. In modern PMPro flows (async/offsite + multiple handlers), request-level webhook context is not a dependable abstraction for business logic branching.

We have already started removing read-path dependencies in add-ons/customizations for this reason.

## What This PR Changes
In `includes/functions.php`, `pmpro_doing_webhook()` now:
- keeps existing setter behavior unchanged when `$set` is truthy.
- triggers `_deprecated_argument()` when called in read mode (`$set` false/default).
- documents the deprecation in the function docblock.

Version markers for this upcoming release are intentionally set to `TBD` per PMPro release process.

## Deprecation Plan
1. Deprecate read usage now.
2. Deprecate write usage in a future update.
3. Remove function once downstream usage has migrated.

## Why This Approach
- Minimal-risk core change with no behavior change to current webhook execution.
- Gives developers explicit deprecation notice while preserving compatibility.
- Supports incremental migration instead of abrupt breaking removal.

## Behavioral Impact
- No runtime behavior change to webhook processing.
- Read calls still return the same true/false values as before.
- Developers in environments surfacing deprecation notices will now see guidance that read usage is deprecated.

## Risk Assessment
Low risk.
- Write paths used by webhook handlers are untouched.
- Return values and control flow are unchanged.
- Change is additive (deprecation signal only) for read mode.

## Testing
- `php -l includes/functions.php`
- Verified updated function logic and unchanged read return branches.
- Confirmed core handler usage remains write mode (`pmpro_doing_webhook( ..., true )`).
