### PR TITLE
Rename deprecated WPP gateway slug from paypal to paypalwpp

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -609,7 +609,7 @@ class PMPro_Site_Health {
 			'braintree' => [
 				'PMPRO_BRAINTREE_WEBHOOK_DEBUG'   => __( 'Braintree Webhook Debug Mode', 'paid-memberships-pro' ),
 			],
-			'paypal' => [
+			'paypalwpp' => [
 				'PMPRO_IPN_DEBUG'                 => __( 'PayPal IPN Debug Mode', 'paid-memberships-pro' ),
 			],
 			'paypalexpress' => [

--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -420,7 +420,7 @@ class PMPro_Wisdom_Integration {
 			'braintree'      => get_option( 'pmpro_braintree_merchantid' ),
 			'cybersource'    => get_option( 'pmpro_cybersource_merchantid' ),
 			'payflowpro'     => get_option( 'pmpro_payflow_user' ),
-			'paypal'         => get_option( 'pmpro_apiusername' ),
+			'paypalwpp'      => get_option( 'pmpro_apiusername' ),
 			'paypalexpress'  => get_option( 'paypalexpress_skip_confirmation' ),
 			'paypalstandard' => get_option( 'gateway_email' ),
 			'stripe'         => $stripe_using_legacy_keys || $stripe_using_api_keys || $stripe_has_connect_credentials,

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -153,7 +153,7 @@
 		{
 			_deprecated_function( __METHOD__, '3.5' );
 		?>
-		<tr class="pmpro_settings_divider gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypal" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
+		<tr class="pmpro_settings_divider gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
 			<td colspan="2">
 				<hr />
 				<h2 class="title"><?php esc_html_e( 'PayPal Settings', 'paid-memberships-pro' ); ?></h2>
@@ -177,7 +177,7 @@
 				</div>
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypal" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 			</th>
@@ -185,7 +185,7 @@
 				<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr($values['gateway_email'])?>" class="regular-text code" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="apiusername"><?php esc_html_e('API Username', 'paid-memberships-pro' );?></label>
 			</th>
@@ -193,7 +193,7 @@
 				<input type="text" id="apiusername" name="apiusername" value="<?php echo esc_attr($values['apiusername'])?>" class="regular-text code" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="apipassword"><?php esc_html_e('API Password', 'paid-memberships-pro' );?></label>
 			</th>
@@ -201,7 +201,7 @@
 				<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="apisignature"><?php esc_html_e('API Signature', 'paid-memberships-pro' );?></label>
 			</th>
@@ -209,7 +209,7 @@
 				<input type="text" id="apisignature" name="apisignature" value="<?php echo esc_attr($values['apisignature'])?>" class="regular-text code" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="paypalexpress_skip_confirmation"><?php esc_html_e('Confirmation Step', 'paid-memberships-pro' );?></label>
 			</th>
@@ -220,7 +220,7 @@
 				</select>
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypal" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 			</th>
@@ -258,7 +258,7 @@
 				<div class="pmpro_section_inside">
 					<table class="form-table">
 						<tbody>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 								</th>
@@ -266,7 +266,7 @@
 									<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr( get_option( 'pmpro_gateway_email' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apiusername"><?php esc_html_e('API Username', 'paid-memberships-pro' );?></label>
 								</th>
@@ -274,7 +274,7 @@
 									<input type="text" id="apiusername" name="apiusername" value="<?php echo esc_attr( get_option( 'pmpro_apiusername' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apipassword"><?php esc_html_e('API Password', 'paid-memberships-pro' );?></label>
 								</th>
@@ -282,7 +282,7 @@
 									<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr( get_option( 'pmpro_apipassword' ) ); ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apisignature"><?php esc_html_e('API Signature', 'paid-memberships-pro' );?></label>
 								</th>
@@ -290,7 +290,7 @@
 									<input type="text" id="apisignature" name="apisignature" value="<?php echo esc_attr( get_option( 'pmpro_apisignature' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="paypalexpress_skip_confirmation"><?php esc_html_e('Confirmation Step', 'paid-memberships-pro' );?></label>
 								</th>
@@ -301,7 +301,7 @@
 									</select>
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 								</th>

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -149,7 +149,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 								</th>
@@ -157,7 +157,7 @@
 									<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr( get_option( 'pmpro_gateway_email' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 								</th>

--- a/classes/gateways/class.pmprogateway_paypalwpp.php
+++ b/classes/gateways/class.pmprogateway_paypalwpp.php
@@ -3,9 +3,9 @@
 	require_once(dirname(__FILE__) . "/class.pmprogateway.php");
 
 	//load classes init method
-	add_action('init', array('PMProGateway_paypal', 'init'));
+	add_action('init', array('PMProGateway_paypalwpp', 'init'));
 
-	class PMProGateway_paypal extends PMProGateway
+	class PMProGateway_paypalwpp extends PMProGateway
 	{
 		function __construct($gateway = NULL)
 		{
@@ -21,15 +21,15 @@
 		static function init()
 		{
 			//make sure PayPal Website Payments Pro is a gateway option
-			add_filter('pmpro_gateways', array('PMProGateway_paypal', 'pmpro_gateways'));
+			add_filter('pmpro_gateways', array('PMProGateway_paypalwpp', 'pmpro_gateways'));
 
 			//code to add at checkout
 			$gateway = pmpro_getGateway();
-			if($gateway == "paypal")
+			if($gateway == "paypalwpp")
 			{
-				add_action('pmpro_checkout_preheader', array('PMProGateway_paypal', 'pmpro_checkout_preheader'));
-				add_filter('pmpro_checkout_default_submit_button', array('PMProGateway_paypal', 'pmpro_checkout_default_submit_button'));
-				add_action('http_api_curl', array('PMProGateway_paypal', 'http_api_curl'), 10, 3);
+				add_action('pmpro_checkout_preheader', array('PMProGateway_paypalwpp', 'pmpro_checkout_preheader'));
+				add_filter('pmpro_checkout_default_submit_button', array('PMProGateway_paypalwpp', 'pmpro_checkout_default_submit_button'));
+				add_action('http_api_curl', array('PMProGateway_paypalwpp', 'http_api_curl'), 10, 3);
 			}
 		}
 
@@ -50,8 +50,8 @@
 		 */
 		static function pmpro_gateways($gateways)
 		{
-			if(empty($gateways['paypal']))
-				$gateways['paypal'] = __('PayPal Website Payments Pro', 'paid-memberships-pro' );
+			if(empty($gateways['paypalwpp']))
+				$gateways['paypalwpp'] = __('PayPal Website Payments Pro', 'paid-memberships-pro' );
 
 			return $gateways;
 		}
@@ -96,7 +96,7 @@
 		{
 			_deprecated_function( __METHOD__, '3.5' );
 			//get options
-			$paypal_options = PMProGateway_paypal::getGatewayOptions();
+			$paypal_options = PMProGateway_paypalwpp::getGatewayOptions();
 
 			//merge with others.
 			$options = array_merge($paypal_options, $options);
@@ -122,7 +122,7 @@
 		 */
 		public static function show_settings_fields() {
 			?>
-			<div id="pmpro_paypal" class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div id="pmpro_paypalwpp" class="pmpro_section" data-visibility="shown" data-activated="true">
 				<div class="pmpro_section_toggle">
 					<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
 						<span class="dashicons dashicons-arrow-up-alt2"></span>
@@ -132,7 +132,7 @@
 				<div class="pmpro_section_inside">
 					<table class="form-table">
 						<tbody>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 								</th>
@@ -140,7 +140,7 @@
 									<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr( get_option( 'pmpro_gateway_email' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apiusername"><?php esc_html_e('API Username', 'paid-memberships-pro' );?></label>
 								</th>
@@ -148,7 +148,7 @@
 									<input type="text" id="apiusername" name="apiusername" value="<?php echo esc_attr( get_option( 'pmpro_apiusername' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apipassword"><?php esc_html_e('API Password', 'paid-memberships-pro' );?></label>
 								</th>
@@ -156,7 +156,7 @@
 									<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr( get_option( 'pmpro_apipassword' ) ); ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apisignature"><?php esc_html_e('API Signature', 'paid-memberships-pro' );?></label>
 								</th>
@@ -164,7 +164,7 @@
 									<input type="text" id="apisignature" name="apisignature" value="<?php echo esc_attr( get_option( 'pmpro_apisignature' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="paypalexpress_skip_confirmation"><?php esc_html_e('Confirmation Step', 'paid-memberships-pro' );?></label>
 								</th>
@@ -175,7 +175,7 @@
 									</select>
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 								</th>
@@ -221,7 +221,7 @@
 			global $gateway, $gateway_environment, $pmpro_level;
 			$default_gateway = get_option("pmpro_gateway");
 
-			if ( $gateway == 'paypal' || $default_gateway == 'paypal' ) {
+			if ( $gateway == 'paypalwpp' || $default_gateway == 'paypalwpp' ) {
 				$dependencies = array( 'jquery' );
 				$paypal_enable_3dsecure = get_option( 'pmpro_paypal_enable_3dsecure' );
 				$data = array();
@@ -267,7 +267,7 @@
 
 			//show our submit buttons
 			?>
-			<?php if($gateway == "paypal" || $gateway == "paypalexpress" || $gateway == "paypalstandard") { ?>
+			<?php if($gateway == "paypalwpp" || $gateway == "paypalexpress" || $gateway == "paypalstandard") { ?>
 			<span id="pmpro_paypalexpress_checkout" <?php if(($gateway != "paypalexpress" && $gateway != "paypalstandard") || !$pmpro_requirebilling) { ?>style="display: none;"<?php } ?>>
 				<input type="hidden" name="submit-checkout" value="1" />
 				<button type="submit" id="pmpro_btn-submit-paypalexpress" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout pmpro_btn-submit-checkout-paypal' ) ); ?>">

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1022,7 +1022,7 @@ function pmpro_get_deprecated_gateways() {
 	return apply_filters( 'pmpro_deprecated_gateways', array(
 		'twocheckout',
 		'cybersource',
-		'paypal',
+		'paypalwpp',
 		'authorizenet',
 		'payflowpro',
 		'paypalstandard',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3163,7 +3163,7 @@ function pmpro_is_ready() {
 			} else {
 				$pmpro_gateway_ready = false;
 			}
-		} elseif ( $gateway == 'paypal' || $gateway == 'paypalexpress' ) {
+		} elseif ( $gateway == 'paypalwpp' || $gateway == 'paypalexpress' ) {
 			if ( $gateway_environment && get_option( 'pmpro_gateway_email' ) && get_option( 'pmpro_apiusername' ) && get_option( 'pmpro_apipassword' ) && get_option( 'pmpro_apisignature' ) ) {
 				$pmpro_gateway_ready = true;
 			} else {

--- a/includes/updates/upgrade_1_4_2.php
+++ b/includes/updates/upgrade_1_4_2.php
@@ -7,7 +7,7 @@ function pmpro_upgrade_1_4_2()
 		PayPal Express and the test gateway (no gateway) will default to not use ssl.
 	*/
 	$gateway = get_option( "pmpro_gateway");
-	if($gateway == "paypal" || $gateway == "authorizenet" || $gateway == "stripe")
+	if($gateway == "paypalwpp" || $gateway == "authorizenet" || $gateway == "stripe")
 		update_option("pmpro_use_ssl", 1);
 	else
 		update_option("pmpro_use_ssl", 0);

--- a/includes/updates/upgrade_3_2.php
+++ b/includes/updates/upgrade_3_2.php
@@ -7,7 +7,7 @@
  * @since 3.1
  */
 function pmpro_upgrade_3_2() {
-	if ( 'paypal' === pmpro_getGateway() ) {
+	if ( 'paypalwpp' === pmpro_getGateway() ) {
 		// Set an option to show the notice about the PPE option being removed.
 		update_option( 'pmpro_upgrade_3_2_notice_wpp', true );
 	}

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -12,7 +12,7 @@ global $wpdb, $gateway_environment, $logstr;
 $logstr = "";    //will put debug info here and write to ipnlog.txt
 
 // Sets the PMPRO_DOING_WEBHOOK constant and fires the pmpro_doing_webhook action.
-pmpro_doing_webhook( 'paypal', true );
+pmpro_doing_webhook( 'paypalwpp', true );
 
 //validate?
 if ( ! pmpro_ipnValidate() ) {
@@ -723,7 +723,7 @@ function pmpro_ipnSaveOrder( $txn_id, $subscription ) {
 	}
 
 	// Get card info if appropriate.
-	if ( $morder->gateway == "paypal" ) {   //website payments pro
+	if ( $morder->gateway == "paypalwpp" ) {   //website payments pro
 		//Updates this order with the most recent orders payment method information and saves it. 
 		pmpro_update_order_with_recent_payment_method( $morder );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Renames the deprecated Website Payments Pro (WPP) gateway slug from `paypal` to `paypalwpp`, freeing up the `paypal` slug for the new PayPal REST API add-on plugin (`pmpro-paypal`).

The old WPP gateway has held the `paypal` slug since the early days of PMPro, but it uses the deprecated NVP/SOAP API and is already listed as a deprecated gateway. Renaming it to `paypalwpp` allows the new modern PayPal integration (Orders V2 + Subscriptions API v1) to claim the clean `paypal` slug as an add-on gateway.

**Files changed (10):**

| File | Change |
|------|--------|
| `class.pmprogateway_paypal.php` → `class.pmprogateway_paypalwpp.php` | File renamed. Class `PMProGateway_paypal` → `PMProGateway_paypalwpp`. All self-references, gateway slug checks, and CSS classes updated. |
| `class.pmprogateway_paypalexpress.php` | Shared settings row CSS classes: `gateway_paypal` → `gateway_paypalwpp` |
| `class.pmprogateway_paypalstandard.php` | Same shared CSS class update |
| `class-pmpro-site-health.php` | `'paypal' =>` → `'paypalwpp' =>` in gateway constants map |
| `class-pmpro-wisdom-integration.php` | `'paypal' =>` → `'paypalwpp' =>` in gateway settings detection |
| `deprecated.php` | `'paypal'` → `'paypalwpp'` in `pmpro_get_deprecated_gateways()` |
| `functions.php` | `$gateway == 'paypal'` → `$gateway == 'paypalwpp'` in gateway ready check |
| `ipnhandler.php` | `pmpro_doing_webhook('paypal')` → `'paypalwpp'`; `$morder->gateway == "paypal"` → `"paypalwpp"` |
| `upgrade_1_4_2.php` | `$gateway == "paypal"` → `"paypalwpp"` in SSL default check |
| `upgrade_3_2.php` | `'paypal'` → `'paypalwpp'` in upgrade check |

**NOT changed:** `PAYPAL_BN_CODE` constant (static partner attribution ID, not a gateway slug). Hook names like `pmpro_paypal_handle_http_post_response` and `pmpro_paypal_level_description` are left as-is since they are public API. The `stripos($order_data['gateway'], "paypal")` check in `ipnhandler.php` is also left as-is since it intentionally catches all PayPal gateway variants.

**⚠️ Migration Note:** This PR does **not** include a database upgrade routine to migrate existing WPP users from the `paypal` slug to `paypalwpp`. That should be handled in a separate upgrade routine when this ships. Sites currently using WPP will need their `pmpro_gateway` option updated from `paypal` to `paypalwpp`, and historical orders in `pmpro_membership_orders` with `gateway = 'paypal'` should also be updated for IPN processing to continue working.

Replaces #3579 (which bundled this rename with the avatar feature, now merged separately in v3.7).

### How to test the changes in this Pull Request:

1. On a test site with PMPro active and gateway set to "PayPal Website Payments Pro", verify the gateway continues to appear in the settings dropdown after applying this branch.
2. Confirm the settings page renders correctly with the renamed CSS classes (fields show/hide when selecting the gateway).
3. Verify that the IPN handler still loads correctly at `admin-ajax.php?action=ipnhandler`.
4. Search the codebase for any remaining `== 'paypal'` or `== "paypal"` references that should have been renamed (excluding `paypalexpress`, `paypalstandard`, the `PAYPAL_BN_CODE` constant, and Braintree/Stripe lib files).
5. Confirm no PHP syntax errors: `php -l` on all changed files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Renamed the deprecated Website Payments Pro gateway slug from `paypal` to `paypalwpp` to free up the `paypal` slug for the new PayPal REST API add-on plugin.