### PR TITLE
Add auth and nonce checks to Stripe webhook AJAX handlers

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1096,9 +1096,56 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
+	 * Validate access to Stripe webhook AJAX handlers.
+	 *
+	 * @since 3.2.6
+	 *
+	 * @param bool $silent Whether to return errors instead of exiting.
+	 * @return true|array
+	 */
+	private static function authorize_stripe_webhook_request( $silent = false ) {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			$r = array(
+				'success' => false,
+				'notice' => 'error',
+				'message' => esc_html__( 'You do not have permission to perform this action.', 'paid-memberships-pro' ),
+			);
+
+			if ( $silent ) {
+				return $r;
+			}
+
+			echo wp_json_encode( $r ); // Values escaped above.
+			exit;
+		}
+
+		if ( wp_doing_ajax() && false === check_ajax_referer( 'pmpro_stripe_webhook_nonce', 'nonce', false ) ) {
+			$r = array(
+				'success' => false,
+				'notice' => 'error',
+				'message' => esc_html__( 'Your session has expired. Please refresh and try again.', 'paid-memberships-pro' ),
+			);
+
+			if ( $silent ) {
+				return $r;
+			}
+
+			echo wp_json_encode( $r ); // Values escaped above.
+			exit;
+		}
+
+		return true;
+	}
+
+	/**
 	 * AJAX callback to create webhooks.
 	 */
 	public static function wp_ajax_pmpro_stripe_create_webhook( $silent = false ) {
+		$access_check = self::authorize_stripe_webhook_request( $silent );
+		if ( true !== $access_check ) {
+			return $access_check;
+		}
+
 		$stripe = new PMProGateway_stripe();
 		$update_webhook_response = $stripe->update_webhook_events();
 
@@ -1129,6 +1176,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 * AJAX callback to disable webhooks.
 	 */
 	public static function wp_ajax_pmpro_stripe_delete_webhook( $silent = false ) {
+		$access_check = self::authorize_stripe_webhook_request( $silent );
+		if ( true !== $access_check ) {
+			return $access_check;
+		}
+
 		$stripe = new PMProGateway_stripe();
 		$webhook = $stripe->does_webhook_exist();
 
@@ -1162,6 +1214,9 @@ class PMProGateway_stripe extends PMProGateway {
 	 * AJAX callback to rebuild webhook.
 	 */
 	public static function wp_ajax_pmpro_stripe_rebuild_webhook() {
+		// This handler always sends its own response, so we do not need silent auth handling here.
+		self::authorize_stripe_webhook_request();
+
 		// First try to delete the webhook.
 		$r = self::wp_ajax_pmpro_stripe_delete_webhook( true ) ;
 		if ( $r['success'] ) {

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -156,6 +156,7 @@ function pmpro_admin_enqueue_scripts() {
 			'all_levels_formatted_text' => $all_levels_formatted_text,
 			'all_level_values_and_labels' => $all_level_values_and_labels,
 			'checkout_url' => pmpro_url( 'checkout' ),
+			'stripe_webhook_nonce' => wp_create_nonce( 'pmpro_stripe_webhook_nonce' ),
 			'user_fields_blank_group' => $empty_field_group_html,
 			'user_fields_blank_field' => $empty_field_html,
 			// We want the core WP translation so we can check for it in JS.

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -148,6 +148,7 @@ jQuery(document).ready(function () {
 
 		var postData = {
 			action: 'pmpro_stripe_create_webhook',
+			nonce: pmpro.stripe_webhook_nonce,
 			secretkey: pmpro_stripe_get_secretkey(),
 		}
 		jQuery.ajax({
@@ -180,6 +181,7 @@ jQuery(document).ready(function () {
 
 		var postData = {
 			action: 'pmpro_stripe_delete_webhook',
+			nonce: pmpro.stripe_webhook_nonce,
 			secretkey: pmpro_stripe_get_secretkey(),
 		}
 
@@ -213,6 +215,7 @@ jQuery(document).ready(function () {
 
 		var postData = {
 			action: 'pmpro_stripe_rebuild_webhook',
+			nonce: pmpro.stripe_webhook_nonce,
 			secretkey: pmpro_stripe_get_secretkey(),
 		}
 


### PR DESCRIPTION
## Summary
- add a shared authorization check for the Stripe webhook AJAX handlers
- require the existing PMPro payment settings capability or manage_options before create/delete/rebuild actions
- add and send a nonce for the Stripe webhook admin AJAX requests

## Testing
- php -l classes/gateways/class.pmprogateway_stripe.php
- php -l includes/scripts.php