### PR TITLE
Add Divi 5 compatibility for PMPro module-level restrictions

### DIFF
--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -1,18 +1,348 @@
 <?php
 
-class PMProDivi{
+class PMProDivi {
 
-	function __construct(){
+	function __construct() {
 
-		if ( empty( $_GET['page'] ) || 'et_divi_role_editor' !== $_GET['page'] ) {
-			add_filter( 'et_builder_get_parent_modules', array( __CLASS__, 'toggle' ) );
-			add_filter( 'et_pb_module_content', array( __CLASS__, 'restrict_content' ), 10, 4 );
-			add_filter( 'et_pb_all_fields_unprocessed_et_pb_row', array( __CLASS__, 'row_settings' ) );
-			add_filter( 'et_pb_all_fields_unprocessed_et_pb_section', array( __CLASS__, 'row_settings' ) );			
+		$is_d5 = function_exists( 'et_builder_d5_enabled' ) && et_builder_d5_enabled();
+
+		if ( $is_d5 ) {
+
+			// Divi 5: use the native Display Conditions system for hide/show logic.
+			// The condition name 'pmproMembershipLevel' is evaluated server-side here.
+			add_filter( 'divi_module_options_conditions_is_custom_condition_true', array( __CLASS__, 'd5_condition_check' ), 10, 4 );
+
+			// Divi 5: intercept module wrapper output to inject the no-access message.
+			// This runs before the displayable check so we can replace the content rather
+			// than return an empty string when showNoAccessMessage is enabled.
+			add_filter( 'divi_module_wrapper_render', array( __CLASS__, 'd5_no_access_message' ), 1, 2 );
+
+			// Divi 5: enqueue the VB conditions UI script and register the membership
+			// levels REST endpoint used by that script.
+			add_action( 'divi_visual_builder_assets_before_enqueue_scripts', array( __CLASS__, 'd5_enqueue_vb_script' ) );
+			add_action( 'rest_api_init', array( __CLASS__, 'd5_register_rest_routes' ) );
+
+			// Divi 5: D4 → D5 migration. Mark our D4 attrs as legacy so they don't
+			// get preserved as unknownAttributes (which would keep the module as a
+			// shortcode-module fallback). Then convert them to native D5 conditions.
+			add_filter( 'divi.conversion.legacyAttributeNames', array( __CLASS__, 'd5_legacy_attribute_names' ) );
+			add_filter( 'divi.conversion.postConvertAttrs', array( __CLASS__, 'd5_migrate_d4_attrs' ), 10, 4 );
+
 		}
-		
+
+		// Always register the D4 hooks for two reasons:
+		//   1. When Divi 4 is the active builder (! $is_d5).
+		//   2. When Divi 5 is active but a page contains migrated D4 content — Divi 5 wraps
+		//      rows/sections that have unknown third-party attributes (like paid-memberships-pro)
+		//      in a `divi/shortcode-module` fallback block which bootstraps the full D4 shortcode
+		//      engine and fires et_pb_module_content. Without these hooks that legacy content
+		//      would lose its membership restriction silently.
+		if ( empty( $_GET['page'] ) || 'et_divi_role_editor' !== $_GET['page'] ) {
+			// UI settings hooks are only useful in Divi 4 mode.
+			if ( ! $is_d5 ) {
+				add_filter( 'et_builder_get_parent_modules', array( __CLASS__, 'toggle' ) );
+				add_filter( 'et_pb_all_fields_unprocessed_et_pb_row', array( __CLASS__, 'row_settings' ) );
+				add_filter( 'et_pb_all_fields_unprocessed_et_pb_section', array( __CLASS__, 'row_settings' ) );
+			}
+
+			// Content restriction must run in both modes.
+			add_filter( 'et_pb_module_content', array( __CLASS__, 'restrict_content' ), 10, 4 );
+		}
+
 		add_action( 'pmpro_element_class', array( __CLASS__, 'pmpro_element_class' ), 10, 2 );
 	}
+
+	// -------------------------------------------------------------------------
+	// Divi 5 methods
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Evaluate the custom 'pmproMembershipLevel' condition for the Divi 5
+	 * Display Conditions system.
+	 *
+	 * Expected conditionSettings keys:
+	 *   levelIds           string  Comma-separated membership level IDs, e.g. "1,2,3".
+	 *   displayRule        string  'hasMembership' (default) or 'doesNotHaveMembership'.
+	 *   showNoAccessMessage string 'on' | 'off'. When 'on', this filter returns true so
+	 *                              the module still renders and d5_no_access_message() can
+	 *                              swap the output for the no-access notice.
+	 *
+	 * Hooked into divi_module_options_conditions_is_custom_condition_true.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool|null $is_condition_true  Null if not yet handled, bool if handled.
+	 * @param string    $condition_name     The condition identifier.
+	 * @param array     $condition_settings The condition configuration.
+	 * @param string    $condition_id       The unique condition instance ID.
+	 *
+	 * @return bool|null
+	 */
+	public static function d5_condition_check( $is_condition_true, $condition_name, $condition_settings, $condition_id ) {
+
+		if ( 'pmproMembershipLevel' !== $condition_name ) {
+			return $is_condition_true;
+		}
+
+		$level_ids   = isset( $condition_settings['levelIds'] ) ? trim( $condition_settings['levelIds'] ) : '';
+		$display_rule = isset( $condition_settings['displayRule'] ) ? $condition_settings['displayRule'] : 'hasMembership';
+		$show_message = isset( $condition_settings['showNoAccessMessage'] ) ? $condition_settings['showNoAccessMessage'] : 'off';
+
+		if ( empty( $level_ids ) || '0' === $level_ids ) {
+			return $is_condition_true;
+		}
+
+		$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
+
+		if ( empty( $levels ) ) {
+			return $is_condition_true;
+		}
+
+		$has_level     = pmpro_hasMembershipLevel( $levels );
+		$should_display = ( 'hasMembership' === $display_rule ) ? $has_level : ! $has_level;
+
+		// When a no-access message is requested we must not return false here — if we did
+		// Divi would skip the render callback entirely and d5_no_access_message() would
+		// never get a chance to swap the output.  Return true so the module renders, then
+		// let d5_no_access_message() replace the HTML with the notice.
+		if ( ! $should_display && 'on' === $show_message ) {
+			return true;
+		}
+
+		return $should_display;
+	}
+
+	/**
+	 * Replace a restricted module's rendered output with the PMPro no-access message.
+	 *
+	 * This only fires when a 'pmproMembershipLevel' condition is present with
+	 * showNoAccessMessage = 'on' and the current user lacks the required level.
+	 *
+	 * Applies to divi/row and divi/section only.
+	 *
+	 * Hooked into divi_module_wrapper_render at priority 1 so it runs before any
+	 * other modifications to the wrapper output.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $output The rendered module HTML.
+	 * @param array  $args   Filter arguments including 'name' and 'attrs'.
+	 *
+	 * @return string
+	 */
+	public static function d5_no_access_message( $output, $args ) {
+
+		$name = isset( $args['name'] ) ? $args['name'] : '';
+
+		if ( ! in_array( $name, array( 'divi/row', 'divi/section' ), true ) ) {
+			return $output;
+		}
+
+		$conditions = isset( $args['attrs']['module']['decoration']['conditions']['desktop']['value'] )
+			? $args['attrs']['module']['decoration']['conditions']['desktop']['value']
+			: array();
+
+		if ( empty( $conditions ) ) {
+			return $output;
+		}
+
+		foreach ( $conditions as $condition ) {
+
+			if ( 'pmproMembershipLevel' !== ( isset( $condition['conditionName'] ) ? $condition['conditionName'] : '' ) ) {
+				continue;
+			}
+
+			$settings     = isset( $condition['conditionSettings'] ) ? $condition['conditionSettings'] : array();
+			$show_message = isset( $settings['showNoAccessMessage'] ) ? $settings['showNoAccessMessage'] : 'off';
+
+			if ( 'on' !== $show_message ) {
+				continue;
+			}
+
+			$level_ids    = isset( $settings['levelIds'] ) ? trim( $settings['levelIds'] ) : '';
+			$display_rule = isset( $settings['displayRule'] ) ? $settings['displayRule'] : 'hasMembership';
+
+			if ( empty( $level_ids ) || '0' === $level_ids ) {
+				continue;
+			}
+
+			$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
+
+			if ( empty( $levels ) ) {
+				continue;
+			}
+
+			$has_level      = pmpro_hasMembershipLevel( $levels );
+			$should_display = ( 'hasMembership' === $display_rule ) ? $has_level : ! $has_level;
+
+			if ( ! $should_display ) {
+				return pmpro_get_no_access_message( null, $levels );
+			}
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Enqueue the Visual Builder JavaScript that registers the PMPro condition
+	 * type in the Divi 5 conditions panel.
+	 *
+	 * Hooked into divi_visual_builder_assets_before_enqueue_scripts.
+	 *
+	 * @since TBD
+	 */
+	public static function d5_enqueue_vb_script() {
+		wp_enqueue_script(
+			'pmpro-divi-vb',
+			plugins_url( 'js/pmpro-divi-5.js', PMPRO_BASE_FILE ),
+			array( 'divi-hooks', 'divi-vendor-react', 'divi-vendor-wp-hooks', 'divi-vendor-wp-i18n', 'divi-field-library', 'divi-modal' ),
+			PMPRO_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Register the REST endpoint that returns available PMPro membership levels.
+	 *
+	 * Endpoint: GET /divi/v1/pmpro/membership-levels
+	 * Response: [ { label: 'Gold', value: '1' }, … ]
+	 *
+	 * Hooked into rest_api_init.
+	 *
+	 * @since TBD
+	 */
+	public static function d5_register_rest_routes() {
+		register_rest_route(
+			'divi/v1',
+			'/pmpro/membership-levels',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'd5_rest_membership_levels' ),
+				'permission_callback' => array( __CLASS__, 'd5_rest_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * REST callback: return all active PMPro membership levels.
+	 *
+	 * @since TBD
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function d5_rest_membership_levels() {
+		$data   = array();
+		$levels = pmpro_getAllLevels();
+
+		if ( ! empty( $levels ) ) {
+			foreach ( $levels as $level ) {
+				$data[] = array(
+					'label' => esc_html( $level->name ),
+					'value' => (string) $level->id,
+				);
+			}
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * REST permission callback: only VB-capable users may fetch levels.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public static function d5_rest_permission() {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * D4 → D5 migration: mark PMPro D4 attributes as legacy so they are not
+	 * preserved as unknownAttributes during conversion.
+	 *
+	 * Without this, Divi 5 sees 'paid-memberships-pro' as an unrecognised
+	 * attribute and wraps the whole row/section in a shortcode-module fallback,
+	 * making it uneditable in the D5 Visual Builder.
+	 *
+	 * Hooked into divi.conversion.legacyAttributeNames.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $attrs Existing list of legacy attribute names.
+	 *
+	 * @return array
+	 */
+	public static function d5_legacy_attribute_names( $attrs ) {
+		$attrs[] = 'paid-memberships-pro';
+		$attrs[] = 'pmpro_show_no_access_message';
+		return $attrs;
+	}
+
+	/**
+	 * D4 → D5 migration: convert PMPro D4 row/section attributes to native
+	 * D5 Display Conditions format.
+	 *
+	 * Reads the old 'paid-memberships-pro' and 'pmpro_show_no_access_message'
+	 * D4 attributes and injects an equivalent pmproMembershipLevel condition
+	 * into the converted D5 attribute tree.
+	 *
+	 * Hooked into divi.conversion.postConvertAttrs at priority 10.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $converted  The converted D5 attribute array.
+	 * @param string $module     Module name, e.g. 'divi/row' or 'divi/section'.
+	 * @param array  $attrs      Original D4 attribute array.
+	 * @param bool   $is_preset  Whether this is a preset conversion.
+	 *
+	 * @return array
+	 */
+	public static function d5_migrate_d4_attrs( $converted, $module, $attrs, $is_preset ) {
+
+		if ( ! in_array( $module, array( 'divi/row', 'divi/section' ), true ) ) {
+			return $converted;
+		}
+
+		$level_ids = isset( $attrs['paid-memberships-pro'] ) ? trim( $attrs['paid-memberships-pro'] ) : '';
+
+		if ( empty( $level_ids ) || '0' === $level_ids ) {
+			return $converted;
+		}
+
+		$show_message = isset( $attrs['pmpro_show_no_access_message'] ) ? $attrs['pmpro_show_no_access_message'] : 'off';
+
+		$condition = array(
+			'id'                => wp_generate_uuid4(),
+			'conditionName'     => 'pmproMembershipLevel',
+			'conditionSettings' => array(
+				'levelIds'            => $level_ids,
+				'displayRule'         => 'hasMembership',
+				'showNoAccessMessage' => $show_message,
+				'enableCondition'     => 'on',
+			),
+			'operator'          => 'OR',
+		);
+
+		// Merge with any existing D5 conditions rather than overwriting them.
+		$existing = isset( $converted['module']['decoration']['conditions']['desktop']['value'] )
+			? $converted['module']['decoration']['conditions']['desktop']['value']
+			: array();
+
+		if ( ! is_array( $existing ) ) {
+			$existing = array();
+		}
+
+		$existing[] = $condition;
+
+		$converted['module']['decoration']['conditions']['desktop']['value'] = $existing;
+
+		return $converted;
+	}
+
+	// -------------------------------------------------------------------------
+	// Divi 4 methods (unchanged)
+	// -------------------------------------------------------------------------
 
 	public static function toggle( $modules ) {
 
@@ -25,77 +355,79 @@ class PMProDivi{
 		}
 
 		return $modules;
-
 	}
 
 	public static function row_settings( $settings ) {
 
 		$settings['paid-memberships-pro'] = array(
-			'tab_slug' => 'custom_css',
-			'label' => __( 'Restrict Row by Level', 'paid-memberships-pro' ),
-			'description' => __( 'Enter comma-separated level IDs.', 'paid-memberships-pro' ),
-			'type' => 'text',
-			'default' => '',
+			'tab_slug'        => 'custom_css',
+			'label'           => __( 'Restrict Row by Level', 'paid-memberships-pro' ),
+			'description'     => __( 'Enter comma-separated level IDs.', 'paid-memberships-pro' ),
+			'type'            => 'text',
+			'default'         => '',
 			'option_category' => 'configuration',
-			'toggle_slug' => 'paid-memberships-pro',
-	    );
+			'toggle_slug'     => 'paid-memberships-pro',
+		);
 
 		$settings['pmpro_show_no_access_message'] = array(
-			'tab_slug' => 'custom_css',
-			'label' => __( 'Show no access message', 'paid-memberships-pro' ),
+			'tab_slug'    => 'custom_css',
+			'label'       => __( 'Show no access message', 'paid-memberships-pro' ),
 			'description' => __( 'Displays a no access message to non-members.', 'paid-memberships-pro' ),
-			'type' => 'yes_no_button',
-			'options' => array(
+			'type'        => 'yes_no_button',
+			'options'     => array(
 				'off' => __( 'No', 'paid-memberships-pro' ),
-				'on' => __( 'Yes', 'paid-memberships-pro' ),
+				'on'  => __( 'Yes', 'paid-memberships-pro' ),
 			),
 			'toggle_slug' => 'paid-memberships-pro',
 		);
 
 		return $settings;
-
 	}
-  
-  	public static function restrict_content( $output, $props, $attrs, $slug ) {
 
-	    if ( et_fb_is_enabled() ) {
+	public static function restrict_content( $output, $props, $attrs, $slug ) {
+
+		if ( et_fb_is_enabled() ) {
 			return $output;
-	    }
+		}
 
-	    if( !isset( $props['paid-memberships-pro'] ) ){
-	    	return $output;
-	    }
-		
+		if ( ! isset( $props['paid-memberships-pro'] ) ) {
+			return $output;
+		}
+
 		$level = $props['paid-memberships-pro'];
-		
+
 		if ( empty( trim( $level ) ) || trim( $level ) === '0' ) {
 			return $output;
 		}
-		
-		if( strpos( $level, "," ) ) {
-		   //they specified many levels
-		   $levels = explode( ",", $level );
+
+		if ( strpos( $level, ',' ) ) {
+			$levels = explode( ',', $level );
 		} else {
-		   //they specified just one level
-		   $levels = array( $level );
+			$levels = array( $level );
 		}
 
-	    if( pmpro_hasMembershipLevel( $levels ) ){
-	    	return $output;
-	    } else {
+		if ( pmpro_hasMembershipLevel( $levels ) ) {
+			return $output;
+		} else {
 			if ( ! empty( $props['pmpro_show_no_access_message'] ) && 'on' === $props['pmpro_show_no_access_message'] ) {
-				return pmpro_get_no_access_message( NULL, $levels );
+				return pmpro_get_no_access_message( null, $levels );
 			} else {
 				return '';
 			}
-	    	
-	    }
+		}
 	}
-	
+
+	// -------------------------------------------------------------------------
+	// Shared
+	// -------------------------------------------------------------------------
+
 	/**
-	 * Filter the element classes added to the no_access messages for improved appearance in Divi.
+	 * Filter the element classes added to the no_access messages for improved
+	 * appearance in Divi (both v4 and v5).
+	 *
 	 * Hooked into pmpro_element_class.
-	 * @since 2.8.2	 
+	 *
+	 * @since 2.8.2
 	 */
 	public static function pmpro_element_class( $class, $element ) {
 		if ( in_array( 'pmpro_content_message', $class ) ) {

--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -60,15 +60,40 @@ class PMProDivi {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * Translate Divi 5 pmproMembershipLevel condition settings into the
+	 * argument shape expected by pmpro_apply_block_visibility().
+	 *
+	 * @since TBD
+	 *
+	 * @param array $settings D5 conditionSettings array.
+	 *
+	 * @return array Params suitable for pmpro_apply_block_visibility().
+	 */
+	private static function d5_visibility_params_from_settings( $settings ) {
+
+		$segment = isset( $settings['segment'] ) ? $settings['segment'] : 'all';
+
+		$levels = array();
+		if ( 'specific' === $segment && ! empty( $settings['levelIds'] ) ) {
+			$levels = array_filter( array_map( 'trim', explode( ',', $settings['levelIds'] ) ) );
+		}
+
+		return array(
+			'segment'             => $segment,
+			'levels'              => $levels,
+			'invert_restrictions' => isset( $settings['displayRule'] ) && 'doesNotHaveMembership' === $settings['displayRule'],
+			'show_noaccess'       => isset( $settings['showNoAccessMessage'] ) && 'on' === $settings['showNoAccessMessage'],
+		);
+	}
+
+	/**
 	 * Evaluate the custom 'pmproMembershipLevel' condition for the Divi 5
 	 * Display Conditions system.
 	 *
-	 * Expected conditionSettings keys:
-	 *   levelIds           string  Comma-separated membership level IDs, e.g. "1,2,3".
-	 *   displayRule        string  'hasMembership' (default) or 'doesNotHaveMembership'.
-	 *   showNoAccessMessage string 'on' | 'off'. When 'on', this filter returns true so
-	 *                              the module still renders and d5_no_access_message() can
-	 *                              swap the output for the no-access notice.
+	 * Delegates to pmpro_apply_block_visibility() so behavior stays in sync
+	 * with the Content Visibility block. Returns true when the helper produces
+	 * any output — either the real content (user has access) or the no-access
+	 * message (which d5_no_access_message() swaps in).
 	 *
 	 * Hooked into divi_module_options_conditions_is_custom_condition_true.
 	 *
@@ -87,43 +112,19 @@ class PMProDivi {
 			return $is_condition_true;
 		}
 
-		$level_ids    = isset( $condition_settings['levelIds'] ) ? trim( $condition_settings['levelIds'] ) : '';
-		$display_rule = isset( $condition_settings['displayRule'] ) ? $condition_settings['displayRule'] : 'hasMembership';
-		$show_message = isset( $condition_settings['showNoAccessMessage'] ) ? $condition_settings['showNoAccessMessage'] : 'off';
-		$segment      = isset( $condition_settings['segment'] ) ? $condition_settings['segment'] : 'all';
+		$params = self::d5_visibility_params_from_settings( $condition_settings );
 
-		// Determine whether the user matches the membership criteria based on segment.
-		if ( 'logged_in' === $segment ) {
-			$has_level = is_user_logged_in();
-		} elseif ( 'specific' === $segment ) {
-			$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
-			// Specific with no levels selected is treated as "all levels".
-			$has_level = empty( $levels ) ? pmpro_hasMembershipLevel() : pmpro_hasMembershipLevel( $levels );
-		} else {
-			// 'all' — any membership level.
-			$has_level = pmpro_hasMembershipLevel();
-		}
-
-		$should_display = ( 'hasMembership' === $display_rule ) ? $has_level : ! $has_level;
-
-		// Returns true here so the d5_no_access_message() function can swap the module output for the no-access message.
-		if ( ! $should_display && 'on' === $show_message ) {
-			return true;
-		}
-
-		return $should_display;
+		return ! empty( pmpro_apply_block_visibility( $params, 'sample content' ) );
 	}
 
 	/**
 	 * Replace a restricted module's rendered output with the PMPro no-access message.
 	 *
-	 * This only fires when a 'pmproMembershipLevel' condition is present with
-	 * showNoAccessMessage = 'on' and the current user lacks the required level.
+	 * Only fires when a 'pmproMembershipLevel' condition has showNoAccessMessage = 'on'
+	 * and the current user lacks the required level. Applies to any module type
+	 * (rows, sections, text blocks, etc.).
 	 *
-	 * Applies to any module type (rows, sections, text blocks, etc.).
-	 *
-	 * Hooked into divi_module_wrapper_render at priority 1 so it runs before any
-	 * other modifications to the wrapper output.
+	 * Hooked into divi_module_wrapper_render at priority 1.
 	 *
 	 * @since TBD
 	 *
@@ -150,35 +151,21 @@ class PMProDivi {
 				continue;
 			}
 
-			$settings     = isset( $condition['conditionSettings'] ) ? $condition['conditionSettings'] : array();
-			$show_message = isset( $settings['showNoAccessMessage'] ) ? $settings['showNoAccessMessage'] : 'off';
+			$settings = isset( $condition['conditionSettings'] ) ? $condition['conditionSettings'] : array();
+			$params   = self::d5_visibility_params_from_settings( $settings );
 
-			if ( 'on' !== $show_message ) {
+			if ( ! $params['show_noaccess'] ) {
 				continue;
 			}
 
-			$level_ids    = isset( $settings['levelIds'] ) ? trim( $settings['levelIds'] ) : '';
-			$display_rule = isset( $settings['displayRule'] ) ? $settings['displayRule'] : 'hasMembership';
-			$segment      = isset( $settings['segment'] ) ? $settings['segment'] : 'all';
+			// Probe the block helper with a placeholder: if it returns a non-empty
+			// result that differs from the placeholder, the user failed the check
+			// and the return value is the no-access message.
+			$placeholder = 'pmpro-divi-access-probe';
+			$result      = pmpro_apply_block_visibility( $params, $placeholder );
 
-			// Determine membership match based on segment.
-			if ( 'logged_in' === $segment ) {
-				$has_level = is_user_logged_in();
-				$levels    = array();
-			} elseif ( 'specific' === $segment ) {
-				$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
-				// Specific with no levels selected is treated as "all levels".
-				$has_level = empty( $levels ) ? pmpro_hasMembershipLevel() : pmpro_hasMembershipLevel( $levels );
-			} else {
-				// 'all' — any membership level.
-				$has_level = pmpro_hasMembershipLevel();
-				$levels    = array();
-			}
-
-			$should_display = ( 'hasMembership' === $display_rule ) ? $has_level : ! $has_level;
-
-			if ( ! $should_display ) {
-				return pmpro_get_no_access_message( null, $levels );
+			if ( ! empty( $result ) && $result !== $placeholder ) {
+				return $result;
 			}
 		}
 

--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -120,7 +120,7 @@ class PMProDivi {
 	 * This only fires when a 'pmproMembershipLevel' condition is present with
 	 * showNoAccessMessage = 'on' and the current user lacks the required level.
 	 *
-	 * Applies to divi/row and divi/section only.
+	 * Applies to any module type (rows, sections, text blocks, etc.).
 	 *
 	 * Hooked into divi_module_wrapper_render at priority 1 so it runs before any
 	 * other modifications to the wrapper output.
@@ -135,10 +135,6 @@ class PMProDivi {
 	public static function d5_no_access_message( $output, $args ) {
 
 		$name = isset( $args['name'] ) ? $args['name'] : '';
-
-		if ( ! in_array( $name, array( 'divi/row', 'divi/section' ), true ) ) {
-			return $output;
-		}
 
 		$conditions = isset( $args['attrs']['module']['decoration']['conditions']['desktop']['value'] )
 			? $args['attrs']['module']['decoration']['conditions']['desktop']['value']

--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -135,8 +135,6 @@ class PMProDivi {
 	 */
 	public static function d5_no_access_message( $output, $args ) {
 
-		$name = isset( $args['name'] ) ? $args['name'] : '';
-
 		$conditions = isset( $args['attrs']['module']['decoration']['conditions']['desktop']['value'] )
 			? $args['attrs']['module']['decoration']['conditions']['desktop']['value']
 			: array();
@@ -152,7 +150,13 @@ class PMProDivi {
 			}
 
 			$settings = isset( $condition['conditionSettings'] ) ? $condition['conditionSettings'] : array();
-			$params   = self::d5_visibility_params_from_settings( $settings );
+
+			// Respect Divi's Enable Condition toggle — matches native is_displayable() behavior.
+			if ( isset( $settings['enableCondition'] ) && 'off' === $settings['enableCondition'] ) {
+				continue;
+			}
+
+			$params = self::d5_visibility_params_from_settings( $settings );
 
 			if ( ! $params['show_noaccess'] ) {
 				continue;

--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -2,6 +2,11 @@
 
 class PMProDivi {
 
+	/**
+	 * Constructor. Registers Divi 4 and Divi 5 hooks for membership content restriction.
+	 *
+	 * @since 2.8.2
+	 */
 	function __construct() {
 
 		$is_d5 = function_exists( 'et_builder_d5_enabled' ) && et_builder_d5_enabled();
@@ -17,10 +22,8 @@ class PMProDivi {
 			// than return an empty string when showNoAccessMessage is enabled.
 			add_filter( 'divi_module_wrapper_render', array( __CLASS__, 'd5_no_access_message' ), 1, 2 );
 
-			// Divi 5: enqueue the VB conditions UI script and register the membership
-			// levels REST endpoint used by that script.
+			// Divi 5: enqueue the VB conditions UI script.
 			add_action( 'divi_visual_builder_assets_before_enqueue_scripts', array( __CLASS__, 'd5_enqueue_vb_script' ) );
-			add_action( 'rest_api_init', array( __CLASS__, 'd5_register_rest_routes' ) );
 
 			// Divi 5: D4 → D5 migration. Mark our D4 attrs as legacy so they don't
 			// get preserved as unknownAttributes (which would keep the module as a
@@ -84,27 +87,26 @@ class PMProDivi {
 			return $is_condition_true;
 		}
 
-		$level_ids   = isset( $condition_settings['levelIds'] ) ? trim( $condition_settings['levelIds'] ) : '';
+		$level_ids    = isset( $condition_settings['levelIds'] ) ? trim( $condition_settings['levelIds'] ) : '';
 		$display_rule = isset( $condition_settings['displayRule'] ) ? $condition_settings['displayRule'] : 'hasMembership';
 		$show_message = isset( $condition_settings['showNoAccessMessage'] ) ? $condition_settings['showNoAccessMessage'] : 'off';
+		$segment      = isset( $condition_settings['segment'] ) ? $condition_settings['segment'] : 'all';
 
-		if ( empty( $level_ids ) || '0' === $level_ids ) {
-			return $is_condition_true;
+		// Determine whether the user matches the membership criteria based on segment.
+		if ( 'logged_in' === $segment ) {
+			$has_level = is_user_logged_in();
+		} elseif ( 'specific' === $segment ) {
+			$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
+			// Specific with no levels selected is treated as "all levels".
+			$has_level = empty( $levels ) ? pmpro_hasMembershipLevel() : pmpro_hasMembershipLevel( $levels );
+		} else {
+			// 'all' — any membership level.
+			$has_level = pmpro_hasMembershipLevel();
 		}
 
-		$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
-
-		if ( empty( $levels ) ) {
-			return $is_condition_true;
-		}
-
-		$has_level     = pmpro_hasMembershipLevel( $levels );
 		$should_display = ( 'hasMembership' === $display_rule ) ? $has_level : ! $has_level;
 
-		// When a no-access message is requested we must not return false here — if we did
-		// Divi would skip the render callback entirely and d5_no_access_message() would
-		// never get a chance to swap the output.  Return true so the module renders, then
-		// let d5_no_access_message() replace the HTML with the notice.
+		// Returns true here so the d5_no_access_message() function can swap the module output for the no-access message.
 		if ( ! $should_display && 'on' === $show_message ) {
 			return true;
 		}
@@ -161,18 +163,22 @@ class PMProDivi {
 
 			$level_ids    = isset( $settings['levelIds'] ) ? trim( $settings['levelIds'] ) : '';
 			$display_rule = isset( $settings['displayRule'] ) ? $settings['displayRule'] : 'hasMembership';
+			$segment      = isset( $settings['segment'] ) ? $settings['segment'] : 'all';
 
-			if ( empty( $level_ids ) || '0' === $level_ids ) {
-				continue;
+			// Determine membership match based on segment.
+			if ( 'logged_in' === $segment ) {
+				$has_level = is_user_logged_in();
+				$levels    = array();
+			} elseif ( 'specific' === $segment ) {
+				$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
+				// Specific with no levels selected is treated as "all levels".
+				$has_level = empty( $levels ) ? pmpro_hasMembershipLevel() : pmpro_hasMembershipLevel( $levels );
+			} else {
+				// 'all' — any membership level.
+				$has_level = pmpro_hasMembershipLevel();
+				$levels    = array();
 			}
 
-			$levels = array_filter( array_map( 'trim', explode( ',', $level_ids ) ) );
-
-			if ( empty( $levels ) ) {
-				continue;
-			}
-
-			$has_level      = pmpro_hasMembershipLevel( $levels );
 			$should_display = ( 'hasMembership' === $display_rule ) ? $has_level : ! $has_level;
 
 			if ( ! $should_display ) {
@@ -199,62 +205,20 @@ class PMProDivi {
 			PMPRO_VERSION,
 			true
 		);
-	}
 
-	/**
-	 * Register the REST endpoint that returns available PMPro membership levels.
-	 *
-	 * Endpoint: GET /divi/v1/pmpro/membership-levels
-	 * Response: [ { label: 'Gold', value: '1' }, … ]
-	 *
-	 * Hooked into rest_api_init.
-	 *
-	 * @since TBD
-	 */
-	public static function d5_register_rest_routes() {
-		register_rest_route(
-			'divi/v1',
-			'/pmpro/membership-levels',
-			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => array( __CLASS__, 'd5_rest_membership_levels' ),
-				'permission_callback' => array( __CLASS__, 'd5_rest_permission' ),
-			)
-		);
-	}
-
-	/**
-	 * REST callback: return all active PMPro membership levels.
-	 *
-	 * @since TBD
-	 *
-	 * @return \WP_REST_Response
-	 */
-	public static function d5_rest_membership_levels() {
-		$data   = array();
-		$levels = pmpro_getAllLevels();
-
-		if ( ! empty( $levels ) ) {
-			foreach ( $levels as $level ) {
-				$data[] = array(
-					'label' => esc_html( $level->name ),
-					'value' => (string) $level->id,
-				);
-			}
+		$all_levels = pmpro_getAllLevels( true, true );
+		$levels_data = array();
+		foreach ( $all_levels as $level ) {
+			$levels_data[] = array(
+				'value' => (string) $level->id,
+				'label' => esc_html( $level->name ),
+			);
 		}
 
-		return rest_ensure_response( $data );
-	}
+		wp_localize_script( 'pmpro-divi-vb', 'pmproDivi', array(
+			'levels' => $levels_data,
+		) );
 
-	/**
-	 * REST permission callback: only VB-capable users may fetch levels.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool
-	 */
-	public static function d5_rest_permission() {
-		return current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -318,6 +282,7 @@ class PMProDivi {
 			'conditionSettings' => array(
 				'levelIds'            => $level_ids,
 				'displayRule'         => 'hasMembership',
+				'segment'             => 'specific',
 				'showNoAccessMessage' => $show_message,
 				'enableCondition'     => 'on',
 			),
@@ -344,6 +309,17 @@ class PMProDivi {
 	// Divi 4 methods (unchanged)
 	// -------------------------------------------------------------------------
 
+	/**
+	 * Add a "Paid Memberships Pro" toggle to the Divi 4 row and section settings modals.
+	 *
+	 * Hooked into et_builder_get_parent_modules.
+	 *
+	 * @since 2.8.2
+	 *
+	 * @param array $modules Array of Divi module objects.
+	 *
+	 * @return array
+	 */
 	public static function toggle( $modules ) {
 
 		if ( isset( $modules['et_pb_row'] ) && is_object( $modules['et_pb_row'] ) ) {
@@ -357,6 +333,18 @@ class PMProDivi {
 		return $modules;
 	}
 
+	/**
+	 * Add PMPro membership restriction fields to Divi 4 row and section settings.
+	 *
+	 * Hooked into et_pb_all_fields_unprocessed_et_pb_row and
+	 * et_pb_all_fields_unprocessed_et_pb_section.
+	 *
+	 * @since 2.8.2
+	 *
+	 * @param array $settings Array of field definitions.
+	 *
+	 * @return array
+	 */
 	public static function row_settings( $settings ) {
 
 		$settings['paid-memberships-pro'] = array(
@@ -384,6 +372,24 @@ class PMProDivi {
 		return $settings;
 	}
 
+	/**
+	 * Restrict Divi 4 row/section content based on membership level.
+	 *
+	 * Returns empty string or the no-access message when the current user
+	 * does not have the required membership level. Skipped inside the
+	 * Divi front-end builder.
+	 *
+	 * Hooked into et_pb_module_content.
+	 *
+	 * @since 2.8.2
+	 *
+	 * @param string $output The module HTML output.
+	 * @param array  $props  Module properties including PMPro attributes.
+	 * @param array  $attrs  Module attributes.
+	 * @param string $slug   Module slug.
+	 *
+	 * @return string
+	 */
 	public static function restrict_content( $output, $props, $attrs, $slug ) {
 
 		if ( et_fb_is_enabled() ) {
@@ -416,10 +422,6 @@ class PMProDivi {
 			}
 		}
 	}
-
-	// -------------------------------------------------------------------------
-	// Shared
-	// -------------------------------------------------------------------------
 
 	/**
 	 * Filter the element classes added to the no_access messages for improved

--- a/includes/compatibility/divi.php
+++ b/includes/compatibility/divi.php
@@ -78,11 +78,13 @@ class PMProDivi {
 			$levels = array_filter( array_map( 'trim', explode( ',', $settings['levelIds'] ) ) );
 		}
 
+		$invert_restrictions = isset( $settings['displayRule'] ) && 'doesNotHaveMembership' === $settings['displayRule'];
+
 		return array(
 			'segment'             => $segment,
 			'levels'              => $levels,
-			'invert_restrictions' => isset( $settings['displayRule'] ) && 'doesNotHaveMembership' === $settings['displayRule'],
-			'show_noaccess'       => isset( $settings['showNoAccessMessage'] ) && 'on' === $settings['showNoAccessMessage'],
+			'invert_restrictions' => $invert_restrictions,
+			'show_noaccess'       => ! $invert_restrictions && isset( $settings['showNoAccessMessage'] ) && 'on' === $settings['showNoAccessMessage'],
 		);
 	}
 
@@ -92,8 +94,9 @@ class PMProDivi {
 	 *
 	 * Delegates to pmpro_apply_block_visibility() so behavior stays in sync
 	 * with the Content Visibility block. Returns true when the helper produces
-	 * any output — either the real content (user has access) or the no-access
-	 * message (which d5_no_access_message() swaps in).
+	 * any output — either the real content (user has access) or, for positive
+	 * access requirements, the no-access message (which d5_no_access_message()
+	 * swaps in).
 	 *
 	 * Hooked into divi_module_options_conditions_is_custom_condition_true.
 	 *
@@ -273,7 +276,7 @@ class PMProDivi {
 				'showNoAccessMessage' => $show_message,
 				'enableCondition'     => 'on',
 			),
-			'operator'          => 'OR',
+			'operator'          => 'AND',
 		);
 
 		// Merge with any existing D5 conditions rather than overwriting them.

--- a/js/pmpro-divi-5.js
+++ b/js/pmpro-divi-5.js
@@ -1,0 +1,322 @@
+/**
+ * PMPro Divi 5 Visual Builder — Membership Level Condition
+ *
+ * Registers a custom "Membership Level" condition type in the Divi 5 Display
+ * Conditions panel.  The server-side evaluation is handled in divi.php.
+ *
+ * Hooks used (all via wp.hooks / window.vendor.wp.hooks):
+ *   divi.fieldLibrary.conditionalDisplay.conditionsStore    — adds condition to dropdown
+ *   divi.fieldLibrary.conditionalDisplay.initialCustomItemEdit — default state on add
+ *   divi.fieldLibrary.conditionalDisplay.customSettingsComponent — settings panel UI
+ *   divi.fieldLibrary.conditionalDisplay.customTitle        — summary label in list
+ */
+( function () {
+	'use strict';
+
+	// Guard: require Divi 5 hooks and React.
+	var wpHooks = window.vendor && window.vendor.wp && window.vendor.wp.hooks;
+	var React   = window.vendor && window.vendor.React;
+
+	if ( ! wpHooks || ! wpHooks.addFilter || ! React ) {
+		return;
+	}
+
+	var createElement = React.createElement;
+	var Fragment      = React.Fragment;
+	var useState      = React.useState;
+	var useEffect     = React.useEffect;
+
+	var __        = ( window.vendor && window.vendor.wp && window.vendor.wp.i18n && window.vendor.wp.i18n.__ ) || function ( s ) { return s; };
+	var addFilter = wpHooks.addFilter;
+
+	// window.divi.modal.FieldWrapper provides the labelled row wrapper used by
+	// all other condition settings panels.
+	var FieldWrapper = window.divi && window.divi.modal && window.divi.modal.FieldWrapper;
+
+	// REST endpoint registered by divi.php for fetching available levels.
+	var LEVELS_REST_ROUTE = '/divi/v1/pmpro/membership-levels';
+
+	// -------------------------------------------------------------------------
+	// 1. Add condition to the dropdown list
+	// -------------------------------------------------------------------------
+	addFilter(
+		'divi.fieldLibrary.conditionalDisplay.conditionsStore',
+		'pmpro/divi/conditions-store',
+		function ( conditions ) {
+			return conditions.concat( [ {
+				name:     'pmproMembershipLevel',
+				label:    __( 'Membership Level', 'paid-memberships-pro' ),
+				category: 'user',
+			} ] );
+		}
+	);
+
+	// -------------------------------------------------------------------------
+	// 2. Default condition state when user selects it from the dropdown
+	// -------------------------------------------------------------------------
+	addFilter(
+		'divi.fieldLibrary.conditionalDisplay.initialCustomItemEdit',
+		'pmpro/divi/initial-item',
+		function ( initial, conditionName, id, operator ) {
+			if ( 'pmproMembershipLevel' !== conditionName ) {
+				return initial;
+			}
+			return {
+				id:               id,
+				conditionName:    'pmproMembershipLevel',
+				conditionSettings: {
+					displayRule:         'hasMembership',
+					levelIds:            '',
+					showNoAccessMessage: 'off',
+					enableCondition:     'on',
+				},
+				operator: operator,
+			};
+		}
+	);
+
+	// -------------------------------------------------------------------------
+	// 3. Summary title shown in the collapsed condition row
+	// -------------------------------------------------------------------------
+	addFilter(
+		'divi.fieldLibrary.conditionalDisplay.customTitle',
+		'pmpro/divi/custom-title',
+		function ( title, condition ) {
+			if ( ! condition || 'pmproMembershipLevel' !== condition.conditionName ) {
+				return title;
+			}
+			var s        = condition.conditionSettings || {};
+			var ruleText = s.displayRule === 'doesNotHaveMembership'
+				? __( "Doesn't Have", 'paid-memberships-pro' )
+				: __( 'Has', 'paid-memberships-pro' );
+			var levelText = s.levelIds
+				? 'ID: ' + s.levelIds
+				: __( 'Any Level', 'paid-memberships-pro' );
+			return __( 'Membership Level', 'paid-memberships-pro' ) + ' — ' + ruleText + ' ' + levelText;
+		}
+	);
+
+	// -------------------------------------------------------------------------
+	// 4. Settings panel React component
+	// -------------------------------------------------------------------------
+
+	/**
+	 * PMPro membership level condition settings component.
+	 *
+	 * @param {Object} props
+	 * @param {Object} props.condition   - Full condition object (id, conditionName, conditionSettings, operator).
+	 * @param {Function} props.onChange  - setState-style setter: fn( prev => newState ).
+	 */
+	function PMProConditionSettings( props ) {
+		var condition = props.condition;
+		var onChange  = props.onChange;
+		var settings  = ( condition && condition.conditionSettings ) || {};
+
+		// Levels loaded from the REST endpoint.
+		var levelsState = useState( [] );
+		var levels      = levelsState[ 0 ];
+		var setLevels   = levelsState[ 1 ];
+
+		var loadingState = useState( true );
+		var loading      = loadingState[ 0 ];
+		var setLoading   = loadingState[ 1 ];
+
+		useEffect( function () {
+			var restBase = window.wpApiSettings && window.wpApiSettings.root
+				? window.wpApiSettings.root.replace( /\/$/, '' )
+				: '';
+			var nonce = window.wpApiSettings && window.wpApiSettings.nonce
+				? window.wpApiSettings.nonce
+				: '';
+
+			fetch( restBase + LEVELS_REST_ROUTE, {
+				headers: {
+					'X-WP-Nonce': nonce,
+				},
+			} )
+				.then( function ( r ) { return r.json(); } )
+				.then( function ( data ) {
+					if ( Array.isArray( data ) ) {
+						setLevels( data );
+					}
+					setLoading( false );
+				} )
+				.catch( function () {
+					setLoading( false );
+				} );
+		}, [] );
+
+		/**
+		 * Merge changes into conditionSettings and call the parent setter.
+		 *
+		 * @param {Object} changes
+		 */
+		function update( changes ) {
+			onChange( function ( prev ) {
+				return Object.assign( {}, prev, {
+					conditionSettings: Object.assign( {}, prev.conditionSettings, changes ),
+				} );
+			} );
+		}
+
+		var displayRuleOptions = [
+			{ value: 'hasMembership',          label: __( 'Has Membership Level', 'paid-memberships-pro' ) },
+			{ value: 'doesNotHaveMembership',   label: __( 'Does Not Have Membership Level', 'paid-memberships-pro' ) },
+		];
+
+		var yesNoOptions = [
+			{ value: 'off', label: __( 'No', 'paid-memberships-pro' ) },
+			{ value: 'on',  label: __( 'Yes', 'paid-memberships-pro' ) },
+		];
+
+		var enableOptions = [
+			{ value: 'on',  label: __( 'Yes', 'paid-memberships-pro' ) },
+			{ value: 'off', label: __( 'No', 'paid-memberships-pro' ) },
+		];
+
+		function renderSelect( name, value, options, onChangeFn ) {
+			return createElement(
+				'select',
+				{
+					name:      name,
+					value:     value,
+					className: 'et-vb-field-input et-vb-field-input-select',
+					onChange:  function ( e ) { onChangeFn( e.target.value ); },
+					style:     { width: '100%' },
+				},
+				options.map( function ( opt ) {
+					return createElement( 'option', { key: opt.value, value: opt.value }, opt.label );
+				} )
+			);
+		}
+
+		// Build the levels multi-select (or a text fallback if no levels loaded).
+		function renderLevelSelect() {
+			if ( loading ) {
+				return createElement( 'span', null, __( 'Loading levels…', 'paid-memberships-pro' ) );
+			}
+
+			if ( ! levels.length ) {
+				// Fallback: plain text input for manual IDs.
+				return createElement(
+					Fragment,
+					null,
+					createElement( 'input', {
+						type:        'text',
+						className:   'et-vb-field-input et-vb-field-input-text',
+						placeholder: __( 'e.g. 1,2,3', 'paid-memberships-pro' ),
+						value:       settings.levelIds || '',
+						style:       { width: '100%' },
+						onChange:    function ( e ) { update( { levelIds: e.target.value } ); },
+					} ),
+					createElement(
+						'p',
+						{ className: 'et-vb-field-description', style: { marginTop: '4px' } },
+						__( 'Enter comma-separated membership level IDs.', 'paid-memberships-pro' )
+					)
+				);
+			}
+
+			// Multi-select: Ctrl/Cmd-click to pick multiple levels.
+			// We store them as a comma-separated string to match the PHP side.
+			var selectedSet = new Set(
+				( settings.levelIds || '' ).split( ',' ).map( function ( id ) { return id.trim(); } ).filter( Boolean )
+			);
+
+			return createElement(
+				Fragment,
+				null,
+				createElement(
+					'select',
+					{
+						multiple:  true,
+						className: 'et-vb-field-input et-vb-field-input-select',
+						style:     { width: '100%', minHeight: '80px' },
+						value:     Array.from( selectedSet ),
+						onChange:  function ( e ) {
+							var selected = Array.from( e.target.selectedOptions ).map( function ( o ) { return o.value; } );
+							update( { levelIds: selected.join( ',' ) } );
+						},
+					},
+					levels.map( function ( level ) {
+						return createElement( 'option', { key: level.value, value: level.value }, level.label );
+					} )
+				),
+				createElement(
+					'p',
+					{ className: 'et-vb-field-description', style: { marginTop: '4px' } },
+					__( 'Hold Ctrl / Cmd to select multiple levels.', 'paid-memberships-pro' )
+				)
+			);
+		}
+
+		function wrapField( label, content ) {
+			if ( FieldWrapper ) {
+				return createElement( FieldWrapper, { label: label }, content );
+			}
+			// Plain fallback if FieldWrapper isn't available.
+			return createElement(
+				'div',
+				{ className: 'et-vb-option-container', style: { marginBottom: '8px' } },
+				createElement( 'label', { className: 'et-vb-option-label', style: { display: 'block', marginBottom: '4px', fontWeight: 600 } }, label ),
+				content
+			);
+		}
+
+		return createElement(
+			Fragment,
+			null,
+
+			// Display Rule
+			wrapField(
+				__( 'Display Rule', 'paid-memberships-pro' ),
+				renderSelect(
+					'pmpro-display-rule',
+					settings.displayRule || 'hasMembership',
+					displayRuleOptions,
+					function ( val ) { update( { displayRule: val } ); }
+				)
+			),
+
+			// Membership Level(s)
+			wrapField(
+				__( 'Membership Level(s)', 'paid-memberships-pro' ),
+				renderLevelSelect()
+			),
+
+			// Show No Access Message
+			wrapField(
+				__( 'Show No Access Message', 'paid-memberships-pro' ),
+				renderSelect(
+					'pmpro-show-no-access',
+					settings.showNoAccessMessage || 'off',
+					yesNoOptions,
+					function ( val ) { update( { showNoAccessMessage: val } ); }
+				)
+			),
+
+			// Enable Condition
+			wrapField(
+				__( 'Enable Condition', 'paid-memberships-pro' ),
+				renderSelect(
+					'pmpro-enable-condition',
+					settings.enableCondition || 'on',
+					enableOptions,
+					function ( val ) { update( { enableCondition: val } ); }
+				)
+			)
+		);
+	}
+
+	addFilter(
+		'divi.fieldLibrary.conditionalDisplay.customSettingsComponent',
+		'pmpro/divi/settings-component',
+		function ( component, condition, onChange ) {
+			if ( ! condition || 'pmproMembershipLevel' !== condition.conditionName ) {
+				return component;
+			}
+			return createElement( PMProConditionSettings, { condition: condition, onChange: onChange } );
+		}
+	);
+
+}() );

--- a/js/pmpro-divi-5.js
+++ b/js/pmpro-divi-5.js
@@ -23,8 +23,6 @@
 
 	var createElement = React.createElement;
 	var Fragment      = React.Fragment;
-	var useState      = React.useState;
-	var useEffect     = React.useEffect;
 
 	var __        = ( window.vendor && window.vendor.wp && window.vendor.wp.i18n && window.vendor.wp.i18n.__ ) || function ( s ) { return s; };
 	var addFilter = wpHooks.addFilter;
@@ -33,27 +31,35 @@
 	// all other condition settings panels.
 	var FieldWrapper = window.divi && window.divi.modal && window.divi.modal.FieldWrapper;
 
-	// REST endpoint registered by divi.php for fetching available levels.
-	var LEVELS_REST_ROUTE = '/divi/v1/pmpro/membership-levels';
+	// Membership levels localized from PHP via wp_localize_script.
+	var allLevels = ( window.pmproDivi && window.pmproDivi.levels ) || [];
 
-	// -------------------------------------------------------------------------
-	// 1. Add condition to the dropdown list
-	// -------------------------------------------------------------------------
+	// Register our custom category "PMPro" and condition type "Content Visibility" in the dropdown.
+	addFilter(
+		'divi.fieldLibrary.conditionalDisplay.conditionCategories',
+		'pmpro/divi/condition-categories',
+		function ( categories ) {
+			categories.pmpro = {
+				label:   __( 'PMPro', 'paid-memberships-pro' ),
+				options: {},
+			};
+			return categories;
+		}
+	);
+
 	addFilter(
 		'divi.fieldLibrary.conditionalDisplay.conditionsStore',
 		'pmpro/divi/conditions-store',
 		function ( conditions ) {
 			return conditions.concat( [ {
 				name:     'pmproMembershipLevel',
-				label:    __( 'Membership Level', 'paid-memberships-pro' ),
-				category: 'user',
+				label:    __( 'Content Visibility', 'paid-memberships-pro' ),
+				category: 'pmpro',
 			} ] );
 		}
 	);
 
-	// -------------------------------------------------------------------------
-	// 2. Default condition state when user selects it from the dropdown
-	// -------------------------------------------------------------------------
+	// Add defaults to the content visibility Divi 5 condition.
 	addFilter(
 		'divi.fieldLibrary.conditionalDisplay.initialCustomItemEdit',
 		'pmpro/divi/initial-item',
@@ -66,6 +72,7 @@
 				conditionName:    'pmproMembershipLevel',
 				conditionSettings: {
 					displayRule:         'hasMembership',
+					segment:             'all',
 					levelIds:            '',
 					showNoAccessMessage: 'off',
 					enableCondition:     'on',
@@ -75,9 +82,7 @@
 		}
 	);
 
-	// -------------------------------------------------------------------------
-	// 3. Summary title shown in the collapsed condition row
-	// -------------------------------------------------------------------------
+	// Show summary/title when condition is collapsed.
 	addFilter(
 		'divi.fieldLibrary.conditionalDisplay.customTitle',
 		'pmpro/divi/custom-title',
@@ -87,18 +92,20 @@
 			}
 			var s        = condition.conditionSettings || {};
 			var ruleText = s.displayRule === 'doesNotHaveMembership'
-				? __( "Doesn't Have", 'paid-memberships-pro' )
-				: __( 'Has', 'paid-memberships-pro' );
-			var levelText = s.levelIds
-				? 'ID: ' + s.levelIds
-				: __( 'Any Level', 'paid-memberships-pro' );
-			return __( 'Membership Level', 'paid-memberships-pro' ) + ' — ' + ruleText + ' ' + levelText;
+				? __( 'Hide from', 'paid-memberships-pro' )
+				: __( 'Show to', 'paid-memberships-pro' );
+			var segment  = s.segment || 'all';
+			var segmentText;
+			if ( segment === 'logged_in' ) {
+				segmentText = __( 'Logged-In Users', 'paid-memberships-pro' );
+			} else if ( segment === 'specific' && s.levelIds ) {
+				segmentText = __( 'Levels', 'paid-memberships-pro' ) + ' ' + s.levelIds;
+			} else {
+				segmentText = __( 'All Members', 'paid-memberships-pro' );
+			}
+			return 'PMPro — ' + ruleText + ' ' + segmentText;
 		}
 	);
-
-	// -------------------------------------------------------------------------
-	// 4. Settings panel React component
-	// -------------------------------------------------------------------------
 
 	/**
 	 * PMPro membership level condition settings component.
@@ -112,39 +119,8 @@
 		var onChange  = props.onChange;
 		var settings  = ( condition && condition.conditionSettings ) || {};
 
-		// Levels loaded from the REST endpoint.
-		var levelsState = useState( [] );
-		var levels      = levelsState[ 0 ];
-		var setLevels   = levelsState[ 1 ];
-
-		var loadingState = useState( true );
-		var loading      = loadingState[ 0 ];
-		var setLoading   = loadingState[ 1 ];
-
-		useEffect( function () {
-			var restBase = window.wpApiSettings && window.wpApiSettings.root
-				? window.wpApiSettings.root.replace( /\/$/, '' )
-				: '';
-			var nonce = window.wpApiSettings && window.wpApiSettings.nonce
-				? window.wpApiSettings.nonce
-				: '';
-
-			fetch( restBase + LEVELS_REST_ROUTE, {
-				headers: {
-					'X-WP-Nonce': nonce,
-				},
-			} )
-				.then( function ( r ) { return r.json(); } )
-				.then( function ( data ) {
-					if ( Array.isArray( data ) ) {
-						setLevels( data );
-					}
-					setLoading( false );
-				} )
-				.catch( function () {
-					setLoading( false );
-				} );
-		}, [] );
+		// Levels localized from PHP.
+		var levels = allLevels;
 
 		/**
 		 * Merge changes into conditionSettings and call the parent setter.
@@ -160,21 +136,22 @@
 		}
 
 		var displayRuleOptions = [
-			{ value: 'hasMembership',          label: __( 'Has Membership Level', 'paid-memberships-pro' ) },
-			{ value: 'doesNotHaveMembership',   label: __( 'Does Not Have Membership Level', 'paid-memberships-pro' ) },
+			{ value: 'hasMembership',          label: __( 'Show', 'paid-memberships-pro' ) },
+			{ value: 'doesNotHaveMembership',   label: __( 'Hide', 'paid-memberships-pro' ) },
+		];
+
+		var segmentOptions = [
+			{ value: 'all',      label: __( 'All Members', 'paid-memberships-pro' ) },
+			{ value: 'specific', label: __( 'Specific Membership Levels', 'paid-memberships-pro' ) },
+			{ value: 'logged_in', label: __( 'Logged-In Users', 'paid-memberships-pro' ) },
 		];
 
 		var yesNoOptions = [
-			{ value: 'off', label: __( 'No', 'paid-memberships-pro' ) },
-			{ value: 'on',  label: __( 'Yes', 'paid-memberships-pro' ) },
+			{ value: 'off', label: __( 'No - Hide this content if the user does not have access', 'paid-memberships-pro' ) },
+			{ value: 'on',  label: __( "Yes - Show the 'no access' message if the user does not have access", 'paid-memberships-pro' ) },
 		];
 
-		var enableOptions = [
-			{ value: 'on',  label: __( 'Yes', 'paid-memberships-pro' ) },
-			{ value: 'off', label: __( 'No', 'paid-memberships-pro' ) },
-		];
-
-		function renderSelect( name, value, options, onChangeFn ) {
+function renderSelect( name, value, options, onChangeFn ) {
 			return createElement(
 				'select',
 				{
@@ -190,12 +167,8 @@
 			);
 		}
 
-		// Build the levels multi-select (or a text fallback if no levels loaded).
+		// Build the levels checkboxes (or a text fallback if no levels loaded).
 		function renderLevelSelect() {
-			if ( loading ) {
-				return createElement( 'span', null, __( 'Loading levels…', 'paid-memberships-pro' ) );
-			}
-
 			if ( ! levels.length ) {
 				// Fallback: plain text input for manual IDs.
 				return createElement(
@@ -217,35 +190,67 @@
 				);
 			}
 
-			// Multi-select: Ctrl/Cmd-click to pick multiple levels.
-			// We store them as a comma-separated string to match the PHP side.
 			var selectedSet = new Set(
 				( settings.levelIds || '' ).split( ',' ).map( function ( id ) { return id.trim(); } ).filter( Boolean )
 			);
 
+			function toggleLevel( value ) {
+				var newSet = new Set( selectedSet );
+				if ( newSet.has( value ) ) {
+					newSet.delete( value );
+				} else {
+					newSet.add( value );
+				}
+				update( { levelIds: Array.from( newSet ).join( ',' ) } );
+			}
+
+			function selectAllLevels() {
+				update( { levelIds: levels.map( function ( l ) { return l.value; } ).join( ',' ) } );
+			}
+
+			function selectNone() {
+				update( { levelIds: '' } );
+			}
+
 			return createElement(
 				Fragment,
 				null,
-				createElement(
-					'select',
-					{
-						multiple:  true,
-						className: 'et-vb-field-input et-vb-field-input-select',
-						style:     { width: '100%', minHeight: '80px' },
-						value:     Array.from( selectedSet ),
-						onChange:  function ( e ) {
-							var selected = Array.from( e.target.selectedOptions ).map( function ( o ) { return o.value; } );
-							update( { levelIds: selected.join( ',' ) } );
-						},
-					},
-					levels.map( function ( level ) {
-						return createElement( 'option', { key: level.value, value: level.value }, level.label );
-					} )
-				),
+				// Select All | None links
 				createElement(
 					'p',
-					{ className: 'et-vb-field-description', style: { marginTop: '4px' } },
-					__( 'Hold Ctrl / Cmd to select multiple levels.', 'paid-memberships-pro' )
+					{ style: { margin: '0 0 8px' } },
+					__( 'Select', 'paid-memberships-pro' ),
+					' ',
+					createElement( 'a', {
+						href:    '#',
+						onClick: function ( e ) { e.preventDefault(); selectAllLevels(); },
+					}, __( 'All', 'paid-memberships-pro' ) ),
+					' | ',
+					createElement( 'a', {
+						href:    '#',
+						onClick: function ( e ) { e.preventDefault(); selectNone(); },
+					}, __( 'None', 'paid-memberships-pro' ) )
+				),
+				// Scrollable checkbox list
+				createElement(
+					'div',
+					{ className: 'pmpro-divi-vb-scrollable', style: { height: '170px', overflow: 'auto', padding: '8px' } },
+					levels.map( function ( level ) {
+						var isChecked = selectedSet.has( level.value );
+						return createElement(
+							'label',
+							{
+								key:   level.value,
+								style: { display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '4px', cursor: 'pointer' },
+							},
+							createElement( 'input', {
+								type:     'checkbox',
+								checked:  isChecked,
+								onChange: function () { toggleLevel( level.value ); },
+							} ),
+							level.label
+						);
+					} )
 				)
 			);
 		}
@@ -263,48 +268,62 @@
 			);
 		}
 
+		var currentSegment    = settings.segment || 'all';
+		var currentRule       = settings.displayRule || 'hasMembership';
+
 		return createElement(
 			Fragment,
 			null,
 
-			// Display Rule
+			// Display Rule (Show / Hide)
 			wrapField(
 				__( 'Display Rule', 'paid-memberships-pro' ),
 				renderSelect(
 					'pmpro-display-rule',
-					settings.displayRule || 'hasMembership',
+					currentRule,
 					displayRuleOptions,
 					function ( val ) { update( { displayRule: val } ); }
 				)
 			),
 
-			// Membership Level(s)
+			// Segment (All Members / Specific Levels / Logged-In Users)
 			wrapField(
-				__( 'Membership Level(s)', 'paid-memberships-pro' ),
+				currentRule === 'doesNotHaveMembership'
+					? __( 'Hide content from:', 'paid-memberships-pro' )
+					: __( 'Show content to:', 'paid-memberships-pro' ),
+				renderSelect(
+					'pmpro-segment',
+					currentSegment,
+					segmentOptions,
+					function ( val ) { update( { segment: val, levelIds: '' } ); }
+				)
+			),
+
+			// Membership Level(s) — only when segment is 'specific'
+			currentSegment === 'specific' ? wrapField(
+				__( 'Membership Levels', 'paid-memberships-pro' ),
 				renderLevelSelect()
-			),
+			) : null,
 
-			// Show No Access Message
-			wrapField(
+			// Show No Access Message — only in "show" mode
+			currentRule === 'hasMembership' ? wrapField(
 				__( 'Show No Access Message', 'paid-memberships-pro' ),
-				renderSelect(
-					'pmpro-show-no-access',
-					settings.showNoAccessMessage || 'off',
-					yesNoOptions,
-					function ( val ) { update( { showNoAccessMessage: val } ); }
+				createElement(
+					Fragment,
+					null,
+					renderSelect(
+						'pmpro-show-no-access',
+						settings.showNoAccessMessage || 'off',
+						yesNoOptions,
+						function ( val ) { update( { showNoAccessMessage: val } ); }
+					),
+					createElement(
+						'p',
+						{ className: 'et-vb-field-description', style: { marginTop: '4px' } },
+						__( "Modify the 'no access' message on the Memberships > Advanced Settings page.", 'paid-memberships-pro' )
+					)
 				)
-			),
-
-			// Enable Condition
-			wrapField(
-				__( 'Enable Condition', 'paid-memberships-pro' ),
-				renderSelect(
-					'pmpro-enable-condition',
-					settings.enableCondition || 'on',
-					enableOptions,
-					function ( val ) { update( { enableCondition: val } ); }
-				)
-			)
+			) : null
 		);
 	}
 

--- a/js/pmpro-divi-5.js
+++ b/js/pmpro-divi-5.js
@@ -34,7 +34,7 @@
 	// Membership levels localized from PHP via wp_localize_script.
 	var allLevels = ( window.pmproDivi && window.pmproDivi.levels ) || [];
 
-	// Register our custom category "PMPro" and condition type "Content Visibility" in the dropdown.
+	// Register our custom category "PMPro" and condition type in the dropdown.
 	addFilter(
 		'divi.fieldLibrary.conditionalDisplay.conditionCategories',
 		'pmpro/divi/condition-categories',
@@ -53,7 +53,7 @@
 		function ( conditions ) {
 			return conditions.concat( [ {
 				name:     'pmproMembershipLevel',
-				label:    __( 'Content Visibility', 'paid-memberships-pro' ),
+				label:    __( 'Membership Access', 'paid-memberships-pro' ),
 				category: 'pmpro',
 			} ] );
 		}
@@ -90,20 +90,27 @@
 			if ( ! condition || 'pmproMembershipLevel' !== condition.conditionName ) {
 				return title;
 			}
-			var s        = condition.conditionSettings || {};
-			var ruleText = s.displayRule === 'doesNotHaveMembership'
-				? __( 'Hide from', 'paid-memberships-pro' )
-				: __( 'Show to', 'paid-memberships-pro' );
-			var segment  = s.segment || 'all';
-			var segmentText;
+			var s             = condition.conditionSettings || {};
+			var rule          = s.displayRule || 'hasMembership';
+			var segment       = s.segment || 'all';
+			var isNegative    = rule === 'doesNotHaveMembership';
+			var predicateText = isNegative
+				? __( 'User does not have', 'paid-memberships-pro' )
+				: __( 'User has', 'paid-memberships-pro' );
+
 			if ( segment === 'logged_in' ) {
-				segmentText = __( 'Logged-In Users', 'paid-memberships-pro' );
-			} else if ( segment === 'specific' && s.levelIds ) {
-				segmentText = __( 'Levels', 'paid-memberships-pro' ) + ' ' + s.levelIds;
-			} else {
-				segmentText = __( 'All Members', 'paid-memberships-pro' );
+				return isNegative
+					? __( 'PMPro - User is not logged in', 'paid-memberships-pro' )
+					: __( 'PMPro - User is logged in', 'paid-memberships-pro' );
 			}
-			return 'PMPro — ' + ruleText + ' ' + segmentText;
+
+			var segmentText;
+			if ( segment === 'specific' && s.levelIds ) {
+				segmentText = __( 'level(s)', 'paid-memberships-pro' ) + ' ' + s.levelIds;
+			} else {
+				segmentText = __( 'any membership level', 'paid-memberships-pro' );
+			}
+			return 'PMPro - ' + predicateText + ' ' + segmentText;
 		}
 	);
 
@@ -136,22 +143,22 @@
 		}
 
 		var displayRuleOptions = [
-			{ value: 'hasMembership',          label: __( 'Show', 'paid-memberships-pro' ) },
-			{ value: 'doesNotHaveMembership',   label: __( 'Hide', 'paid-memberships-pro' ) },
+			{ value: 'hasMembership',          label: __( 'User has required access', 'paid-memberships-pro' ) },
+			{ value: 'doesNotHaveMembership',  label: __( 'User does not have required access', 'paid-memberships-pro' ) },
 		];
 
 		var segmentOptions = [
-			{ value: 'all',      label: __( 'All Members', 'paid-memberships-pro' ) },
-			{ value: 'specific', label: __( 'Specific Membership Levels', 'paid-memberships-pro' ) },
-			{ value: 'logged_in', label: __( 'Logged-In Users', 'paid-memberships-pro' ) },
+			{ value: 'all',       label: __( 'Any membership level', 'paid-memberships-pro' ) },
+			{ value: 'specific',  label: __( 'Specific membership levels', 'paid-memberships-pro' ) },
+			{ value: 'logged_in', label: __( 'Logged-in user', 'paid-memberships-pro' ) },
 		];
 
 		var yesNoOptions = [
-			{ value: 'off', label: __( 'No - Hide this content if the user does not have access', 'paid-memberships-pro' ) },
-			{ value: 'on',  label: __( "Yes - Show the 'no access' message if the user does not have access", 'paid-memberships-pro' ) },
+			{ value: 'off', label: __( 'Hide restricted content', 'paid-memberships-pro' ) },
+			{ value: 'on',  label: __( 'Replace restricted content with the no access message', 'paid-memberships-pro' ) },
 		];
 
-function renderSelect( name, value, options, onChangeFn ) {
+		function renderSelect( name, value, options, onChangeFn ) {
 			return createElement(
 				'select',
 				{
@@ -275,9 +282,9 @@ function renderSelect( name, value, options, onChangeFn ) {
 			Fragment,
 			null,
 
-			// Display Rule (Show / Hide)
+			// Predicate.
 			wrapField(
-				__( 'Display Rule', 'paid-memberships-pro' ),
+				__( 'Condition', 'paid-memberships-pro' ),
 				renderSelect(
 					'pmpro-display-rule',
 					currentRule,
@@ -286,11 +293,9 @@ function renderSelect( name, value, options, onChangeFn ) {
 				)
 			),
 
-			// Segment (All Members / Specific Levels / Logged-In Users)
+			// Access requirement.
 			wrapField(
-				currentRule === 'doesNotHaveMembership'
-					? __( 'Hide content from:', 'paid-memberships-pro' )
-					: __( 'Show content to:', 'paid-memberships-pro' ),
+				__( 'Requirement', 'paid-memberships-pro' ),
 				renderSelect(
 					'pmpro-segment',
 					currentSegment,
@@ -305,9 +310,9 @@ function renderSelect( name, value, options, onChangeFn ) {
 				renderLevelSelect()
 			) : null,
 
-			// Show No Access Message — only in "show" mode
+			// No access message only applies to positive access requirements.
 			currentRule === 'hasMembership' ? wrapField(
-				__( 'Show No Access Message', 'paid-memberships-pro' ),
+				__( 'No Access Message', 'paid-memberships-pro' ),
 				createElement(
 					Fragment,
 					null,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for Divi 5 and migrates the old values from Divi 4 to the new fields

- Detects Divi 5 via et_builder_d5_enabled() and registers D5-specific hooks
- Server-side condition evaluation via divi_module_options_conditions_is_custom_condition_true
- No-access message injection via divi_module_wrapper_render
- REST endpoint GET /divi/v1/pmpro/membership-levels for the VB level selector
- pmpro-divi-5.js registers the pmproMembershipLevel condition type in the D5 VB conditions panel
- D4 to D5 migration converts legacy PMPro attrs to native D5 conditions on upgrade
- D4 hooks remain active in both modes to support shortcode-module fallback content

<img width="365" height="538" alt="image" src="https://github.com/user-attachments/assets/90365475-2edc-416e-bc40-4249bdc0a9ad" />


### How to test the changes in this Pull Request:

1. Restrict a row in Divi 4 as normal
2. Upgrade to Divi 5
3. Edit the same element. It should move the old settings into the new Advanced > Conditions section in the Divi 5 Editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
