### PR TITLE
Rename WPP gateway slug (paypal → paypalwpp) and deprecate PayPal Express

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -354,6 +354,9 @@
 						?>
 					</p>
 					<p>
+						<?php if ( 'paypalexpress' === $edit_gateway ) { ?>
+							<a class="button button-secondary" href="https://www.paidmembershipspro.com/paypal-express-deprecation-hub/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=blog&utm_content=paypal-express-deprecation" target="_blank" rel="nofollow noopener"><?php esc_html_e('Learn More', 'paid-memberships-pro' ); ?></a>
+						<?php } ?>
 						<a class="button button-secondary" href="https://www.paidmembershipspro.com/documentation/compatibility/incompatible-deprecated-add-ons/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=deprecated-gateways#deprecated-payment-gateways" target="_blank" rel="nofollow noopener"><?php esc_html_e('About Deprecated Gateways', 'paid-memberships-pro' ); ?></a>
 						<a class="button" href="https://www.paidmembershipspro.com/switching-payment-gateways/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=blog&utm_content=switching-payment-gateways" target="_blank" rel="nofollow noopener"><?php esc_html_e('How to Switch Payment Gateways', 'paid-memberships-pro' ); ?></a>
 					</p>

--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -228,8 +228,13 @@
 											}
 
 											// Special case for deprecated gateways.
-											if ( in_array( $gateway_slug, $deprecated_gateways, true ) && $gateway_slug === pmpro_getOption( 'gateway' ) ) {
-												$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Enabled (Not Supported)', 'paid-memberships-pro' ) . '</span>';
+											if ( in_array( $gateway_slug, $deprecated_gateways, true ) ) {
+												if ( pmpro_getOption( 'gateway' ) === $gateway_slug ) {
+													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Enabled (Not Supported)', 'paid-memberships-pro' ) . '</span>';
+												} elseif ( $gateway_status_html !== esc_html__( '&#8212;', 'paid-memberships-pro' ) ) {
+													// Gateway is enabled (e.g. via Add PayPal Express Add On) but deprecated.
+													$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Not Supported', 'paid-memberships-pro' ) . '</span>';
+												}
 											}
 
 											echo wp_kses_post( $gateway_status_html );

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -662,7 +662,7 @@ class PMPro_Site_Health {
 			'braintree' => [
 				'PMPRO_BRAINTREE_WEBHOOK_DEBUG'   => __( 'Braintree Webhook Debug Mode', 'paid-memberships-pro' ),
 			],
-			'paypal' => [
+			'paypalwpp' => [
 				'PMPRO_IPN_DEBUG'                 => __( 'PayPal IPN Debug Mode', 'paid-memberships-pro' ),
 			],
 			'paypalexpress' => [

--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -420,7 +420,7 @@ class PMPro_Wisdom_Integration {
 			'braintree'      => get_option( 'pmpro_braintree_merchantid' ),
 			'cybersource'    => get_option( 'pmpro_cybersource_merchantid' ),
 			'payflowpro'     => get_option( 'pmpro_payflow_user' ),
-			'paypal'         => get_option( 'pmpro_apiusername' ),
+			'paypalwpp'      => get_option( 'pmpro_apiusername' ),
 			'paypalexpress'  => get_option( 'paypalexpress_skip_confirmation' ),
 			'paypalstandard' => get_option( 'gateway_email' ),
 			'stripe'         => $stripe_using_legacy_keys || $stripe_using_api_keys || $stripe_has_connect_credentials,

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -78,8 +78,7 @@
 		 * @return string
 		 */
 		public static function get_description_for_gateway_settings() {
-			return '<strong>' . esc_html__( 'PayPal Express is deprecated.', 'paid-memberships-pro' ) . '</strong> '
-				. esc_html__( 'PayPal is retiring the NVP/SOAP API that PayPal Express relies on. We recommend switching to the Paid Memberships Pro - PayPal Gateway Add On or Stripe for new and ongoing payment processing.', 'paid-memberships-pro' );
+			return esc_html__( 'With PayPal, members can pay with their PayPal balance, credit/debit cards, linked bank accounts, or local payment methods. PayPal is accepted worldwide and offers multi-currency support for 200+ markets and 25+ currencies.', 'paid-memberships-pro' );
 		}
 
 		/**

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -78,7 +78,8 @@
 		 * @return string
 		 */
 		public static function get_description_for_gateway_settings() {
-			return esc_html__( 'With PayPal, members can pay with their PayPal balance, credit/debit cards, linked bank accounts, or local payment methods. PayPal is accepted worldwide and offers multi-currency support for 200+ markets and 25+ currencies.', 'paid-memberships-pro' );
+			return '<strong>' . esc_html__( 'PayPal Express is deprecated.', 'paid-memberships-pro' ) . '</strong> '
+				. esc_html__( 'PayPal is retiring the NVP/SOAP API that PayPal Express relies on. We recommend switching to the Paid Memberships Pro - PayPal Gateway Add On or Stripe for new and ongoing payment processing.', 'paid-memberships-pro' );
 		}
 
 		/**
@@ -153,7 +154,7 @@
 		{
 			_deprecated_function( __METHOD__, '3.5' );
 		?>
-		<tr class="pmpro_settings_divider gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypal" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
+		<tr class="pmpro_settings_divider gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
 			<td colspan="2">
 				<hr />
 				<h2 class="title"><?php esc_html_e( 'PayPal Settings', 'paid-memberships-pro' ); ?></h2>
@@ -177,7 +178,7 @@
 				</div>
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypal" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 			</th>
@@ -185,7 +186,7 @@
 				<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr($values['gateway_email'])?>" class="regular-text code" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="apiusername"><?php esc_html_e('API Username', 'paid-memberships-pro' );?></label>
 			</th>
@@ -193,7 +194,7 @@
 				<input type="text" id="apiusername" name="apiusername" value="<?php echo esc_attr($values['apiusername'])?>" class="regular-text code" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="apipassword"><?php esc_html_e('API Password', 'paid-memberships-pro' );?></label>
 			</th>
@@ -201,7 +202,7 @@
 				<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr($values['apipassword'])?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="apisignature"><?php esc_html_e('API Signature', 'paid-memberships-pro' );?></label>
 			</th>
@@ -209,7 +210,7 @@
 				<input type="text" id="apisignature" name="apisignature" value="<?php echo esc_attr($values['apisignature'])?>" class="regular-text code" />
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress" <?php if($gateway != "paypal" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label for="paypalexpress_skip_confirmation"><?php esc_html_e('Confirmation Step', 'paid-memberships-pro' );?></label>
 			</th>
@@ -220,7 +221,7 @@
 				</select>
 			</td>
 		</tr>
-		<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypal" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
+		<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard" <?php if($gateway != "paypalwpp" && $gateway != "paypalexpress" && $gateway != "paypalstandard") { ?>style="display: none;"<?php } ?>>
 			<th scope="row" valign="top">
 				<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 			</th>
@@ -248,7 +249,7 @@
 					);
 				?>
 			</p>
-			<div id="pmpro_paypal" class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div id="pmpro_paypalexpress" class="pmpro_section" data-visibility="shown" data-activated="true">
 				<div class="pmpro_section_toggle">
 					<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
 						<span class="dashicons dashicons-arrow-up-alt2"></span>
@@ -258,7 +259,7 @@
 				<div class="pmpro_section_inside">
 					<table class="form-table">
 						<tbody>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 								</th>
@@ -266,7 +267,7 @@
 									<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr( get_option( 'pmpro_gateway_email' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apiusername"><?php esc_html_e('API Username', 'paid-memberships-pro' );?></label>
 								</th>
@@ -274,7 +275,7 @@
 									<input type="text" id="apiusername" name="apiusername" value="<?php echo esc_attr( get_option( 'pmpro_apiusername' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apipassword"><?php esc_html_e('API Password', 'paid-memberships-pro' );?></label>
 								</th>
@@ -282,7 +283,7 @@
 									<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr( get_option( 'pmpro_apipassword' ) ); ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apisignature"><?php esc_html_e('API Signature', 'paid-memberships-pro' );?></label>
 								</th>
@@ -290,7 +291,7 @@
 									<input type="text" id="apisignature" name="apisignature" value="<?php echo esc_attr( get_option( 'pmpro_apisignature' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="paypalexpress_skip_confirmation"><?php esc_html_e('Confirmation Step', 'paid-memberships-pro' );?></label>
 								</th>
@@ -301,7 +302,7 @@
 									</select>
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 								</th>

--- a/classes/gateways/class.pmprogateway_paypalstandard.php
+++ b/classes/gateways/class.pmprogateway_paypalstandard.php
@@ -94,11 +94,13 @@
 		static function pmpro_payment_options($options)
 		{
 			_deprecated_function( __METHOD__, '3.5' );
-			//get stripe options
-			$paypal_options = PMProGateway_paypalexpress::getGatewayOptions();
+			if ( class_exists( 'PMProGateway_paypalexpress' ) ) {
+				//get options
+				$paypal_options = PMProGateway_paypalexpress::getGatewayOptions();
 
-			//merge with others.
-			$options = array_merge($paypal_options, $options);
+				//merge with others.
+				$options = array_merge($paypal_options, $options);
+			}
 
 			return $options;
 		}
@@ -111,7 +113,9 @@
 		 */
 		static function pmpro_payment_option_fields($values, $gateway) {
 			_deprecated_function( __FUNCTION__, '3.1', 'PMProGateway_paypalexpress::pmpro_payment_option_fields()' );
-			PMProGateway_paypalexpress::pmpro_payment_option_fields( $values, $gateway );
+			if ( class_exists( 'PMProGateway_paypalexpress' ) ) {
+				PMProGateway_paypalexpress::pmpro_payment_option_fields( $values, $gateway );
+			}
 		}
 
 		/**
@@ -149,7 +153,7 @@
 									</div>
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 								</th>
@@ -157,7 +161,7 @@
 									<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr( get_option( 'pmpro_gateway_email' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 								</th>

--- a/classes/gateways/class.pmprogateway_paypalwpp.php
+++ b/classes/gateways/class.pmprogateway_paypalwpp.php
@@ -3,9 +3,9 @@
 	require_once(dirname(__FILE__) . "/class.pmprogateway.php");
 
 	//load classes init method
-	add_action('init', array('PMProGateway_paypal', 'init'));
+	add_action('init', array('PMProGateway_paypalwpp', 'init'));
 
-	class PMProGateway_paypal extends PMProGateway
+	class PMProGateway_paypalwpp extends PMProGateway
 	{
 		function __construct($gateway = NULL)
 		{
@@ -21,15 +21,15 @@
 		static function init()
 		{
 			//make sure PayPal Website Payments Pro is a gateway option
-			add_filter('pmpro_gateways', array('PMProGateway_paypal', 'pmpro_gateways'));
+			add_filter('pmpro_gateways', array('PMProGateway_paypalwpp', 'pmpro_gateways'));
 
 			//code to add at checkout
 			$gateway = pmpro_getGateway();
-			if($gateway == "paypal")
+			if($gateway == "paypalwpp")
 			{
-				add_action('pmpro_checkout_preheader', array('PMProGateway_paypal', 'pmpro_checkout_preheader'));
-				add_filter('pmpro_checkout_default_submit_button', array('PMProGateway_paypal', 'pmpro_checkout_default_submit_button'));
-				add_action('http_api_curl', array('PMProGateway_paypal', 'http_api_curl'), 10, 3);
+				add_action('pmpro_checkout_preheader', array('PMProGateway_paypalwpp', 'pmpro_checkout_preheader'));
+				add_filter('pmpro_checkout_default_submit_button', array('PMProGateway_paypalwpp', 'pmpro_checkout_default_submit_button'));
+				add_action('http_api_curl', array('PMProGateway_paypalwpp', 'http_api_curl'), 10, 3);
 			}
 		}
 
@@ -50,8 +50,8 @@
 		 */
 		static function pmpro_gateways($gateways)
 		{
-			if(empty($gateways['paypal']))
-				$gateways['paypal'] = __('PayPal Website Payments Pro', 'paid-memberships-pro' );
+			if(empty($gateways['paypalwpp']))
+				$gateways['paypalwpp'] = __('PayPal Website Payments Pro', 'paid-memberships-pro' );
 
 			return $gateways;
 		}
@@ -96,7 +96,7 @@
 		{
 			_deprecated_function( __METHOD__, '3.5' );
 			//get options
-			$paypal_options = PMProGateway_paypal::getGatewayOptions();
+			$paypal_options = PMProGateway_paypalwpp::getGatewayOptions();
 
 			//merge with others.
 			$options = array_merge($paypal_options, $options);
@@ -112,7 +112,9 @@
 		 */
 		static function pmpro_payment_option_fields($values, $gateway) {
 			_deprecated_function( __FUNCTION__, '3.1', 'PMProGateway_paypalexpress::pmpro_payment_option_fields()' );
-			PMProGateway_paypalexpress::pmpro_payment_option_fields( $values, $gateway );
+			if ( class_exists( 'PMProGateway_paypalexpress' ) ) {
+				PMProGateway_paypalexpress::pmpro_payment_option_fields( $values, $gateway );
+			}
 		}
 
 		/**
@@ -122,7 +124,7 @@
 		 */
 		public static function show_settings_fields() {
 			?>
-			<div id="pmpro_paypal" class="pmpro_section" data-visibility="shown" data-activated="true">
+			<div id="pmpro_paypalwpp" class="pmpro_section" data-visibility="shown" data-activated="true">
 				<div class="pmpro_section_toggle">
 					<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
 						<span class="dashicons dashicons-arrow-up-alt2"></span>
@@ -132,7 +134,7 @@
 				<div class="pmpro_section_inside">
 					<table class="form-table">
 						<tbody>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label for="gateway_email"><?php esc_html_e('Gateway Account Email', 'paid-memberships-pro' );?></label>
 								</th>
@@ -140,7 +142,7 @@
 									<input type="text" id="gateway_email" name="gateway_email" value="<?php echo esc_attr( get_option( 'pmpro_gateway_email' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apiusername"><?php esc_html_e('API Username', 'paid-memberships-pro' );?></label>
 								</th>
@@ -148,7 +150,7 @@
 									<input type="text" id="apiusername" name="apiusername" value="<?php echo esc_attr( get_option( 'pmpro_apiusername' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apipassword"><?php esc_html_e('API Password', 'paid-memberships-pro' );?></label>
 								</th>
@@ -156,7 +158,7 @@
 									<input type="text" id="apipassword" name="apipassword" value="<?php echo esc_attr( get_option( 'pmpro_apipassword' ) ); ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="apisignature"><?php esc_html_e('API Signature', 'paid-memberships-pro' );?></label>
 								</th>
@@ -164,7 +166,7 @@
 									<input type="text" id="apisignature" name="apisignature" value="<?php echo esc_attr( get_option( 'pmpro_apisignature' ) ); ?>" class="regular-text code" />
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress">
 								<th scope="row" valign="top">
 									<label for="paypalexpress_skip_confirmation"><?php esc_html_e('Confirmation Step', 'paid-memberships-pro' );?></label>
 								</th>
@@ -175,7 +177,7 @@
 									</select>
 								</td>
 							</tr>
-							<tr class="gateway gateway_paypal gateway_paypalexpress gateway_paypalstandard">
+							<tr class="gateway gateway_paypalwpp gateway_paypalexpress gateway_paypalstandard">
 								<th scope="row" valign="top">
 									<label><?php esc_html_e('IPN Handler URL', 'paid-memberships-pro' );?></label>
 								</th>
@@ -221,7 +223,7 @@
 			global $gateway, $gateway_environment, $pmpro_level;
 			$default_gateway = get_option("pmpro_gateway");
 
-			if ( $gateway == 'paypal' || $default_gateway == 'paypal' ) {
+			if ( $gateway == 'paypalwpp' || $default_gateway == 'paypalwpp' ) {
 				$dependencies = array( 'jquery' );
 				$paypal_enable_3dsecure = get_option( 'pmpro_paypal_enable_3dsecure' );
 				$data = array();
@@ -267,7 +269,7 @@
 
 			//show our submit buttons
 			?>
-			<?php if($gateway == "paypal" || $gateway == "paypalexpress" || $gateway == "paypalstandard") { ?>
+			<?php if($gateway == "paypalwpp" || $gateway == "paypalexpress" || $gateway == "paypalstandard") { ?>
 			<span id="pmpro_paypalexpress_checkout" <?php if(($gateway != "paypalexpress" && $gateway != "paypalstandard") || !$pmpro_requirebilling) { ?>style="display: none;"<?php } ?>>
 				<input type="hidden" name="submit-checkout" value="1" />
 				<button type="submit" id="pmpro_btn-submit-paypalexpress" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout pmpro_btn-submit-checkout-paypal' ) ); ?>">

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -1019,6 +1019,8 @@ add_filter( 'plugin_action_links', 'pmpro_deprecated_add_ons_action_links', 10, 
  * PayPal Website Payments Pro was deprecated in 2.10.
  * Authorize.net was deprecated in 3.2.
  * PayFlow, PayPal Standard, and Braintree were deprecated in 3.4.
+ * PayPal Express was deprecated in 3.7.1.
+ * PayPal Website Payments Pro was renamed from 'paypal' to 'paypalwpp' in 3.7.1.
  *
  * @since 3.5
  */
@@ -1026,11 +1028,12 @@ function pmpro_get_deprecated_gateways() {
 	return apply_filters( 'pmpro_deprecated_gateways', array(
 		'twocheckout',
 		'cybersource',
-		'paypal',
+		'paypalwpp',
 		'authorizenet',
 		'payflowpro',
 		'paypalstandard',
 		'braintree',
+		'paypalexpress',
 	) );
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3166,7 +3166,7 @@ function pmpro_is_ready() {
 			} else {
 				$pmpro_gateway_ready = false;
 			}
-		} elseif ( $gateway == 'paypal' || $gateway == 'paypalexpress' ) {
+		} elseif ( $gateway == 'paypalwpp' || $gateway == 'paypalexpress' ) {
 			if ( $gateway_environment && get_option( 'pmpro_gateway_email' ) && get_option( 'pmpro_apiusername' ) && get_option( 'pmpro_apipassword' ) && get_option( 'pmpro_apisignature' ) ) {
 				$pmpro_gateway_ready = true;
 			} else {

--- a/includes/updates/upgrade_1_4_2.php
+++ b/includes/updates/upgrade_1_4_2.php
@@ -7,7 +7,7 @@ function pmpro_upgrade_1_4_2()
 		PayPal Express and the test gateway (no gateway) will default to not use ssl.
 	*/
 	$gateway = get_option( "pmpro_gateway");
-	if($gateway == "paypal" || $gateway == "authorizenet" || $gateway == "stripe")
+	if($gateway == "paypal" || $gateway == "authorizenet" || $gateway == "stripe") // Note: 'paypal' was renamed to 'paypalwpp' in 3.7.1, but this upgrade path is long past.
 		update_option("pmpro_use_ssl", 1);
 	else
 		update_option("pmpro_use_ssl", 0);

--- a/includes/updates/upgrade_3_7_1.php
+++ b/includes/updates/upgrade_3_7_1.php
@@ -12,21 +12,6 @@
 function pmpro_upgrade_3_7_1() {
 	global $wpdb;
 
-	// Rename the WPP gateway slug in orders.
-	$wpdb->query(
-		"UPDATE {$wpdb->pmpro_membership_orders} SET gateway = 'paypalwpp' WHERE gateway = 'paypal'"
-	);
-
-	// Rename the WPP gateway slug in subscriptions.
-	$wpdb->query(
-		"UPDATE {$wpdb->pmpro_subscriptions} SET gateway = 'paypalwpp' WHERE gateway = 'paypal'"
-	);
-
-	// If the default gateway is 'paypal' (WPP), update it to 'paypalwpp'.
-	if ( 'paypal' === get_option( 'pmpro_gateway' ) ) {
-		update_option( 'pmpro_gateway', 'paypalwpp' );
-	}
-
 	// Get the current undeprecated gateways list.
 	$undeprecated_gateways = get_option( 'pmpro_undeprecated_gateways' );
 	if ( empty( $undeprecated_gateways ) ) {
@@ -35,10 +20,42 @@ function pmpro_upgrade_3_7_1() {
 		$undeprecated_gateways = explode( ',', $undeprecated_gateways );
 	}
 
-	// Rename 'paypal' to 'paypalwpp' in undeprecated gateways.
-	$paypal_key = array_search( 'paypal', $undeprecated_gateways, true );
-	if ( false !== $paypal_key ) {
-		$undeprecated_gateways[ $paypal_key ] = 'paypalwpp';
+	/**
+	 * Only migrate 'paypal' data to 'paypalwpp' if 'paypal' is listed as an
+	 * undeprecated gateway, meaning this site was using legacy WPP before
+	 * this upgrade.
+	 *
+	 * We don't check the default gateway option here because the new PayPal
+	 * REST API Add On also uses the 'paypal' slug as its default gateway.
+	 * If this script were to rerun after that add-on is active, checking the
+	 * default gateway would incorrectly migrate the new add-on's data.
+	 *
+	 * The undeprecated gateways list is safe because pmpro_check_for_deprecated_gateways()
+	 * populates it on every page load, so any site that had WPP active will
+	 * have 'paypal' in this list before the upgrade runs. The new add-on
+	 * would never add 'paypal' to this list since it's deprecated in core.
+	 */
+	if ( in_array( 'paypal', $undeprecated_gateways, true ) ) {
+		// Rename the WPP gateway slug in orders.
+		$wpdb->query(
+			"UPDATE {$wpdb->pmpro_membership_orders} SET gateway = 'paypalwpp' WHERE gateway = 'paypal'"
+		);
+
+		// Rename the WPP gateway slug in subscriptions.
+		$wpdb->query(
+			"UPDATE {$wpdb->pmpro_subscriptions} SET gateway = 'paypalwpp' WHERE gateway = 'paypal'"
+		);
+
+		// Update the default gateway option if needed.
+		if ( 'paypal' === get_option( 'pmpro_gateway' ) ) {
+			update_option( 'pmpro_gateway', 'paypalwpp' );
+		}
+
+		// Rename 'paypal' to 'paypalwpp' in undeprecated gateways.
+		$paypal_key = array_search( 'paypal', $undeprecated_gateways, true );
+		if ( false !== $paypal_key ) {
+			$undeprecated_gateways[ $paypal_key ] = 'paypalwpp';
+		}
 	}
 
 	/**

--- a/includes/updates/upgrade_3_7_1.php
+++ b/includes/updates/upgrade_3_7_1.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Upgrade to version 3.7.1
+ *
+ * Rename the Website Payments Pro gateway slug from 'paypal' to 'paypalwpp'
+ * so that the 'paypal' slug can be used by the new PayPal Add On.
+ *
+ * Deprecate PayPal Express and ensure it keeps loading for sites that use it.
+ *
+ * @since 3.7.1
+ */
+function pmpro_upgrade_3_7_1() {
+	global $wpdb;
+
+	// Rename the WPP gateway slug in orders.
+	$wpdb->query(
+		"UPDATE {$wpdb->pmpro_membership_orders} SET gateway = 'paypalwpp' WHERE gateway = 'paypal'"
+	);
+
+	// Rename the WPP gateway slug in subscriptions.
+	$wpdb->query(
+		"UPDATE {$wpdb->pmpro_subscriptions} SET gateway = 'paypalwpp' WHERE gateway = 'paypal'"
+	);
+
+	// If the default gateway is 'paypal' (WPP), update it to 'paypalwpp'.
+	if ( 'paypal' === get_option( 'pmpro_gateway' ) ) {
+		update_option( 'pmpro_gateway', 'paypalwpp' );
+	}
+
+	// Get the current undeprecated gateways list.
+	$undeprecated_gateways = get_option( 'pmpro_undeprecated_gateways' );
+	if ( empty( $undeprecated_gateways ) ) {
+		$undeprecated_gateways = array();
+	} elseif ( is_string( $undeprecated_gateways ) ) {
+		$undeprecated_gateways = explode( ',', $undeprecated_gateways );
+	}
+
+	// Rename 'paypal' to 'paypalwpp' in undeprecated gateways.
+	$paypal_key = array_search( 'paypal', $undeprecated_gateways, true );
+	if ( false !== $paypal_key ) {
+		$undeprecated_gateways[ $paypal_key ] = 'paypalwpp';
+	}
+
+	/**
+	 * Explicitly add 'paypalexpress' to undeprecated gateways if the site
+	 * has any PPE orders, subscriptions, or uses it as the default gateway.
+	 *
+	 * This is necessary because many sites use PayPal Express as a secondary
+	 * gateway alongside Stripe. The runtime detection in
+	 * pmpro_check_for_deprecated_gateways() only checks the default gateway,
+	 * so sites using PPE as a secondary option would lose access to it.
+	 */
+	if ( ! in_array( 'paypalexpress', $undeprecated_gateways, true ) ) {
+		$has_ppe = false;
+
+		// Check if PPE is the default gateway.
+		if ( 'paypalexpress' === get_option( 'pmpro_gateway' ) ) {
+			$has_ppe = true;
+		}
+
+		// Check if there are any PPE orders.
+		if ( ! $has_ppe ) {
+			$has_ppe = (bool) $wpdb->get_var(
+				"SELECT 1 FROM {$wpdb->pmpro_membership_orders} WHERE gateway = 'paypalexpress' LIMIT 1"
+			);
+		}
+
+		// Check if there are any PPE subscriptions.
+		if ( ! $has_ppe ) {
+			$has_ppe = (bool) $wpdb->get_var(
+				"SELECT 1 FROM {$wpdb->pmpro_subscriptions} WHERE gateway = 'paypalexpress' LIMIT 1"
+			);
+		}
+
+		if ( $has_ppe ) {
+			$undeprecated_gateways[] = 'paypalexpress';
+		}
+	}
+
+	update_option( 'pmpro_undeprecated_gateways', $undeprecated_gateways );
+}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -427,6 +427,17 @@ function pmpro_checkForUpgrades() {
 		update_option( 'pmpro_db_version', '3.7001' );
 	}
 
+	/**
+	 * Version 3.7.1
+	 * Rename the Website Payments Pro gateway slug from 'paypal' to 'paypalwpp'.
+	 * Deprecate PayPal Express and add it to undeprecated gateways for existing sites.
+	 */
+	if ( $pmpro_db_version < 3.71 ) {
+		require_once( PMPRO_DIR . "/includes/updates/upgrade_3_7_1.php" );
+		pmpro_upgrade_3_7_1();
+		update_option( 'pmpro_db_version', '3.71' );
+	}
+
 }
 
 function pmpro_db_delta() {

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -169,7 +169,6 @@ require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway.php' ); // loade
 require_once( PMPRO_DIR . '/classes/class-pmpro-discount-codes.php' ); // loaded by memberorder class when needed
 
 require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_check.php' );
-require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_paypalexpress.php' );
 
 pmpro_check_for_deprecated_gateways();
 
@@ -255,7 +254,6 @@ function pmpro_gateways() {
 		''                  => esc_html__( 'Testing Only', 'paid-memberships-pro' ),
 		'check'             => esc_html__( 'Pay by Check', 'paid-memberships-pro' ),
 		'stripe'            => esc_html__( 'Stripe', 'paid-memberships-pro' ),
-		'paypalexpress'     => esc_html__( 'PayPal Express', 'paid-memberships-pro' ),
 	);
 
 	if ( pmpro_onlyFreeLevels() ) {
@@ -284,7 +282,25 @@ function pmpro_get_gateway_nicename( $gateway ) {
 	if ( array_key_exists( $gateway, $gateways ) ) {
 		$gateway_nicename =  $gateways[ $gateway ];
 	} else {
-		$gateway_nicename = ucwords( $gateway );
+		// Fallback nicenames for gateway slugs that may appear in
+		// historical orders/subscriptions even when the gateway
+		// class is not loaded.
+		$legacy_nicenames = array(
+			'paypalwpp'      => __( 'PayPal Website Payments Pro', 'paid-memberships-pro' ),
+			'paypalexpress'  => __( 'PayPal Express', 'paid-memberships-pro' ),
+			'paypalstandard' => __( 'PayPal Standard', 'paid-memberships-pro' ),
+			'authorizenet'   => __( 'Authorize.net', 'paid-memberships-pro' ),
+			'payflowpro'     => __( 'PayPal Payflow Pro', 'paid-memberships-pro' ),
+			'braintree'      => __( 'Braintree', 'paid-memberships-pro' ),
+			'twocheckout'    => __( '2Checkout', 'paid-memberships-pro' ),
+			'cybersource'    => __( 'CyberSource', 'paid-memberships-pro' ),
+		);
+
+		if ( array_key_exists( $gateway, $legacy_nicenames ) ) {
+			$gateway_nicename = $legacy_nicenames[ $gateway ];
+		} else {
+			$gateway_nicename = ucwords( $gateway );
+		}
 	}
 
 	return $gateway_nicename;

--- a/services/ipnhandler.php
+++ b/services/ipnhandler.php
@@ -723,7 +723,7 @@ function pmpro_ipnSaveOrder( $txn_id, $subscription ) {
 	}
 
 	// Get card info if appropriate.
-	if ( $morder->gateway == "paypal" ) {   //website payments pro
+	if ( $morder->gateway == "paypalwpp" ) {   //website payments pro
 		//Updates this order with the most recent orders payment method information and saves it. 
 		pmpro_update_order_with_recent_payment_method( $morder );
 	}


### PR DESCRIPTION
## Summary

PayPal is actively retiring the NVP/SOAP API that powers PayPal Express. This PR prepares core PMPro for the new **pmpro-paypal** add-on (REST API integration) by:

- **Freeing the `paypal` gateway slug** — renames the deprecated Website Payments Pro gateway from `paypal` to `paypalwpp` (file, class, all references)
- **Deprecating PayPal Express** — moves `paypalexpress` from the base gateways list to the deprecated gateways mechanism, adds a deprecation notice in settings
- **Upgrade script** (`upgrade_3_7_1.php`) that migrates orders, subscriptions, the default gateway option, and the undeprecated gateways list

### Bigger picture

This is one half of a two-part change for PMPro 3.7.1:

1. **This PR (core PMPro)** — renames WPP slug and deprecates PPE
2. **pmpro-paypal PR** — adds a version gate so the new PayPal add-on only activates after this upgrade has run

The new pmpro-paypal add-on uses the `paypal` gateway slug with PayPal's modern REST API (Orders V2 + Subscriptions API v1). Without this rename, new orders created by the add-on would collide with legacy WPP orders and potentially get incorrectly rewritten by a late-running upgrade script.

## Changes

| File | What changed |
|------|-------------|
| `includes/updates/upgrade_3_7_1.php` | **New** — renames gateway=paypal to paypalwpp in orders/subs, migrates options, explicitly adds paypalexpress to undeprecated gateways for sites using PPE as a secondary gateway |
| `includes/upgradecheck.php` | Registers the 3.71 upgrade block |
| `classes/gateways/class.pmprogateway_paypalwpp.php` | **Renamed** from class.pmprogateway_paypal.php — class, slug, and CSS references updated |
| `includes/deprecated.php` | paypal to paypalwpp, added paypalexpress to deprecated list |
| `paid-memberships-pro.php` | Removed paypalexpress from base gateways, removed eager PPE require_once, added legacy nicenames map |
| `classes/gateways/class.pmprogateway_paypalexpress.php` | Deprecation notice in settings, updated CSS classes |
| `classes/gateways/class.pmprogateway_paypalstandard.php` | Updated CSS classes, guarded deprecated cross-class calls |
| `services/ipnhandler.php` | Updated WPP gateway check |
| `includes/functions.php` | Updated gateway-ready check |
| `classes/class-pmpro-site-health.php` | Updated debug constant mapping |
| `classes/class-pmpro-wisdom-integration.php` | Updated Wisdom tracking key |

## Key design decisions

- **PPE explicitly added to undeprecated gateways in upgrade script** — Many sites use PPE as a secondary gateway alongside Stripe. The runtime detection only checks the default gateway, so these sites would silently lose PPE access without the explicit migration.
- **class_exists() guards on deprecated cross-class calls** — WPP and PayPal Standard have deprecated methods that delegate to PMProGateway_paypalexpress. Since PPE is no longer eagerly loaded, these would fatal without guards.
- **Legacy nicenames map** — Ensures paypalwpp displays as "PayPal Website Payments Pro" in admin views even when the gateway class is not loaded.

## Test plan

- [ ] **Fresh install**: Verify paypalwpp and paypalexpress do not appear in gateway dropdown. Only Testing, Check, and Stripe show.
- [ ] **Upgrade (WPP site)**: Set pmpro_gateway to paypal, create test orders/subs with gateway=paypal, trigger upgrade. Verify all rows migrated to paypalwpp, option updated, WPP still functions.
- [ ] **Upgrade (PPE site)**: Set pmpro_gateway to paypalexpress, trigger upgrade. Verify PPE still loads, deprecation notice shows in settings, existing subscriptions unaffected.
- [ ] **Upgrade (PPE as secondary)**: Set default gateway to stripe, but have PPE orders in DB. Verify paypalexpress is added to undeprecated gateways.
- [ ] **Nicename display**: View orders with gateway=paypalwpp in admin — should show "PayPal Website Payments Pro".

🤖 Generated with [Claude Code](https://claude.com/claude-code)