### PR TITLE
Fix PHP 8.1 deprecations in restricted files on Windows servers

### DIFF
--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -132,7 +132,14 @@ function pmpro_get_restricted_file_path( $file_dir = '', $file = '' ) {
 	}
 
 	// Get the directory path.
-	$uploads_dir = trailingslashit( wp_upload_dir()['basedir'] );
+	$upload_dir_info = wp_upload_dir();
+
+	// Bail if we can't get a valid uploads basedir (e.g. misconfigured Windows servers).
+	if ( empty( $upload_dir_info['basedir'] ) ) {
+		return '';
+	}
+
+	$uploads_dir = trailingslashit( $upload_dir_info['basedir'] );
 	$restricted_file_path = $uploads_dir . 'pmpro-' . $random_string . '/';
 	if ( ! empty( $file_dir ) ) {
 		$restricted_file_path .= $file_dir . '/';
@@ -161,6 +168,11 @@ function pmpro_get_restricted_file_path( $file_dir = '', $file = '' ) {
 function pmpro_is_restricted_directory_protected() {
 	$restricted_dir = pmpro_get_restricted_file_path();
 
+	// Can't test if we couldn't determine the restricted directory path.
+	if ( empty( $restricted_dir ) ) {
+		return null;
+	}
+
 	// Can't test if directory doesn't exist.
 	if ( ! is_dir( $restricted_dir ) ) {
 		return null;
@@ -174,6 +186,11 @@ function pmpro_is_restricted_directory_protected() {
 
 	// Convert file path to URL.
 	$wp_upload_dir = wp_upload_dir();
+
+	// Bail if we can't get a valid basedir (e.g. misconfigured Windows servers).
+	if ( empty( $wp_upload_dir['basedir'] ) ) {
+		return null;
+	}
 
 	// Normalize paths to ensure consistent separators.
 	$normalized_test_file = wp_normalize_path( $test_file );

--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -8,6 +8,12 @@
 function pmpro_set_up_restricted_files_directory() {
 	// Create restricted folder if it doesn't exist.
 	$restricted_file_directory = pmpro_get_restricted_file_path();
+
+	// Bail if we couldn't determine a valid path (e.g. misconfigured Windows servers).
+	if ( empty( $restricted_file_directory ) ) {
+		return;
+	}
+
 	if ( ! file_exists( $restricted_file_directory ) ) {
 		wp_mkdir_p( $restricted_file_directory );
 	}
@@ -251,7 +257,7 @@ function pmpro_find_testable_file( $directory ) {
 				$filename = $current->getFilename();
 
 				// Skip dotfiles and dot directories (e.g. .DS_Store, .htaccess).
-				return '' === $filename || '.' !== $filename[0];
+				return ! empty( $filename ) && '.' !== $filename[0];
 			}
 		);
 		$iterator = new RecursiveIteratorIterator( $filtered_iterator, RecursiveIteratorIterator::SELF_FIRST );


### PR DESCRIPTION
## Problem

On Windows servers with misconfigured upload directories, `wp_upload_dir()['basedir']` can return an empty/null value. Two functions introduced in 3.7 pass this directly to `wp_normalize_path()` (via `trailingslashit()` or directly), which internally calls `str_replace()` and `strpos()` with a null argument — triggering PHP 8.1 deprecation warnings:

```
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
```

Reported by a customer running a Windows test server after upgrading to 3.7.

Also fixes an unrelated edge case in the restricted files iterator: changed '' === $filename || '.' !== $filename[0] to ! empty( $filename ) && '.' !== $filename[0] to prevent empty filenames from passing the filter.

## Fix

Three guards added — two-layer defense at the source and the consumer:

1. **`pmpro_get_restricted_file_path()`** — Store `wp_upload_dir()` result, bail early with `''` if `basedir` is empty.
2. **`pmpro_is_restricted_directory_protected()`** — Bail early if `$restricted_dir` is empty (catches fix #1 propagating up).
3. **`pmpro_is_restricted_directory_protected()`** — Guard the second independent `wp_upload_dir()` call later in the same function before passing `basedir` to `wp_normalize_path()`.

## How to Test

1. On a Windows server (or by temporarily patching `wp_upload_dir()` to return an empty `basedir`), activate PMPro 3.7+ with `WP_DEBUG` enabled.
2. Visit any admin page.
3. **Before fix:** PHP 8.1 deprecation warnings appear.
4. **After fix:** No warnings. The restricted files check fails gracefully (returns `null`) without noise.
