### PR TITLE
Fixed discount codes not saving due to POST redirect in list table referer cleanup

### DIFF
--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -129,7 +129,7 @@ add_action( 'admin_menu', 'pmpro_add_pages' );
  * @since 3.7
  */
 function pmpro_maybe_redirect_list_table_referer() {
-	if ( empty( $_REQUEST['_wp_http_referer'] ) || empty( $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( 'GET' !== $_SERVER['REQUEST_METHOD'] || empty( $_REQUEST['_wp_http_referer'] ) || empty( $_SERVER['REQUEST_URI'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `pmpro_maybe_redirect_list_table_referer()` function introduced in 3.7 was redirecting on POST requests as well as GET requests. Since `wp_nonce_field()` includes a hidden `_wp_http_referer` input by default, submitting the discount code edit form triggered the redirect before the save logic could run, causing both new inserts and updates to silently fail. Restricted the redirect to GET  requests only, which is the only scenario this function was intended to handle. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

BUG FIX: Fixed discount codes not saving due to POST redirect in list table referer cleanup.