### PR TITLE
Hide recurring trial settings behind gateway supports check

### DIFF
--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -6,7 +6,7 @@
 	}
 
 	//vars
-	global $wpdb, $pmpro_currency_symbol, $pmpro_stripe_error, $pmpro_braintree_error, $pmpro_payflow_error, $pmpro_twocheckout_error, $pmpro_pages, $gateway;
+	global $wpdb, $pmpro_currency_symbol, $pmpro_stripe_error, $pmpro_braintree_error, $pmpro_pages, $gateway;
 
 	$now = current_time( 'timestamp' );
 
@@ -664,40 +664,40 @@
 									</td>
 								</tr>
 
-								<tr class="recurring_info" <?php if (!pmpro_isLevelRecurring($level)) echo "style='display:none;'";?>>
-									<th scope="row" valign="top"><label><?php esc_html_e('Custom Trial', 'paid-memberships-pro' );?></label></th>
-									<td>
-										<input id="custom_trial_<?php echo esc_attr( $level->id ); ?>" id="custom_trial_<?php echo esc_attr( $level->id ); ?>" name="custom_trial[]" type="checkbox" value="<?php echo esc_attr( $level->id ); ?>" <?php if ( pmpro_isLevelTrial($level) ) { echo "checked='checked'"; } ?> onclick="if(jQuery(this).prop('checked')) jQuery(this).parent().parent().siblings('.trial_info').show();	else jQuery(this).parent().parent().siblings('.trial_info').hide();" /> <label for="custom_trial_<?php echo esc_attr( $level->id );?>"><?php esc_html_e('Check to add a custom trial period.', 'paid-memberships-pro' );?></label>
-										<?php if($gateway == "twocheckout") { ?>
-											<p class="description"><strong <?php if(!empty($pmpro_twocheckout_error)) { ?>class="pmpro_red"<?php } ?>><?php esc_html_e('2Checkout integration does not support custom trials. You can do one period trials by setting an initial payment different from the billing amount.', 'paid-memberships-pro' );?></strong></p>
-										<?php } ?>
-									</td>
-								</tr>
+								<?php
+								// Only show trial settings if the active gateway supports recurring trials or if the level already has a trial set.
+								$discount_gateway_class = 'PMProGateway_' . $gateway;
+								$discount_gateway_supports_recurring_trials = method_exists( $discount_gateway_class, 'supports' ) && $discount_gateway_class::supports( 'recurring_trials' );
+								if ( $discount_gateway_supports_recurring_trials || pmpro_isLevelTrial( $level ) ) {
+								?>
+									<tr class="recurring_info" <?php if (!pmpro_isLevelRecurring($level)) echo "style='display:none;'";?>>
+										<th scope="row" valign="top"><label><?php esc_html_e('Custom Trial', 'paid-memberships-pro' );?></label></th>
+										<td>
+											<input id="custom_trial_<?php echo esc_attr( $level->id ); ?>" id="custom_trial_<?php echo esc_attr( $level->id ); ?>" name="custom_trial[]" type="checkbox" value="<?php echo esc_attr( $level->id ); ?>" <?php if ( pmpro_isLevelTrial($level) ) { echo "checked='checked'"; } ?> onclick="if(jQuery(this).prop('checked')) jQuery(this).parent().parent().siblings('.trial_info').show();	else jQuery(this).parent().parent().siblings('.trial_info').hide();" /> <label for="custom_trial_<?php echo esc_attr( $level->id );?>"><?php esc_html_e('Check to add a custom trial period.', 'paid-memberships-pro' );?></label>
+											<?php if ( ! $discount_gateway_supports_recurring_trials ) { ?>
+												<p class="description"><strong class="pmpro_red"><?php esc_html_e( 'The current payment gateway does not support recurring trials.', 'paid-memberships-pro' ); ?></strong></p>
+											<?php } ?>
+										</td>
+									</tr>
 
-								<tr class="trial_info recurring_info" <?php if (!pmpro_isLevelTrial($level)) echo "style='display:none;'";?>>
-									<th scope="row" valign="top"><label for="trial_amount"><?php esc_html_e('Trial Billing Amount', 'paid-memberships-pro' );?></label></th>
-									<td>
-										<?php
-										if(pmpro_getCurrencyPosition() == "left")
-											echo wp_kses_post( $pmpro_currency_symbol );
-										?>
-										<input name="trial_amount[]" type="text" size="20" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $level->trial_amount ) );?>" />
-										<?php
-										if(pmpro_getCurrencyPosition() == "right")
-											echo wp_kses_post( $pmpro_currency_symbol );
-										?>
-										<?php esc_html_e('for the first', 'paid-memberships-pro' );?>
-										<input name="trial_limit[]" type="text" size="10" value="<?php echo esc_attr( $level->trial_limit ); ?>" />
-										<?php esc_html_e('subscription payments', 'paid-memberships-pro' );?>.
-										<?php if($gateway == "stripe") { ?>
-											<p class="description"><strong <?php if(!empty($pmpro_stripe_error)) { ?>class="pmpro_red"<?php } ?>><?php esc_html_e('Stripe integration currently does not support trial amounts greater than $0.', 'paid-memberships-pro' );?></strong></p>
-										<?php } elseif($gateway == "braintree") { ?>
-											<p class="description"><strong <?php if(!empty($pmpro_braintree_error)) { ?>class="pmpro_red"<?php } ?>><?php esc_html_e('Braintree integration currently does not support trial amounts greater than $0.', 'paid-memberships-pro' );?></strong></p>
-										<?php } elseif($gateway == "payflowpro") { ?>
-											<p class="description"><strong <?php if(!empty($pmpro_payflow_error)) { ?>class="pmpro_red"<?php } ?>><?php esc_html_e('Payflow integration currently does not support trial amounts greater than $0.', 'paid-memberships-pro' );?></strong></p>
-										<?php } ?>
-									</td>
-								</tr>
+									<tr class="trial_info recurring_info" <?php if (!pmpro_isLevelTrial($level)) echo "style='display:none;'";?>>
+										<th scope="row" valign="top"><label for="trial_amount"><?php esc_html_e('Trial Billing Amount', 'paid-memberships-pro' );?></label></th>
+										<td>
+											<?php
+											if(pmpro_getCurrencyPosition() == "left")
+												echo wp_kses_post( $pmpro_currency_symbol );
+											?>
+											<input name="trial_amount[]" type="text" size="20" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $level->trial_amount ) );?>" />
+											<?php
+											if(pmpro_getCurrencyPosition() == "right")
+												echo wp_kses_post( $pmpro_currency_symbol );
+											?>
+											<?php esc_html_e('for the first', 'paid-memberships-pro' );?>
+											<input name="trial_limit[]" type="text" size="10" value="<?php echo esc_attr( $level->trial_limit ); ?>" />
+											<?php esc_html_e('subscription payments', 'paid-memberships-pro' );?>.
+										</td>
+									</tr>
+								<?php } ?>
 
 								<tr>
 									<th scope="row" valign="top"><label><?php esc_html_e('Membership Expiration', 'paid-memberships-pro' );?></label></th>

--- a/adminpages/discountcodes.php
+++ b/adminpages/discountcodes.php
@@ -142,8 +142,8 @@
 
 			if(!empty($_REQUEST['custom_trial']))
 				$custom_trial_a = array_map( 'intval', $_REQUEST['custom_trial'] );
-			$trial_amount_a = array_map( 'sanitize_text_field', $_REQUEST['trial_amount'] );
-			$trial_limit_a = array_map( 'intval', $_REQUEST['trial_limit'] );
+			$trial_amount_a = ! empty( $_REQUEST['trial_amount'] ) ? array_map( 'sanitize_text_field', $_REQUEST['trial_amount'] ) : array();
+			$trial_limit_a = ! empty( $_REQUEST['trial_limit'] ) ? array_map( 'intval', $_REQUEST['trial_limit'] ) : array();
 
 			if(!empty($_REQUEST['expiration']))
 				$expiration_a = array_map( 'intval', $_REQUEST['expiration'] );
@@ -195,8 +195,8 @@
 
 						if(!empty($custom_trial))
 						{
-							$trial_amount = sanitize_text_field($trial_amount_a[$n]);
-							$trial_limit = intval($trial_limit_a[$n]);
+							$trial_amount = isset( $trial_amount_a[$n] ) ? sanitize_text_field( $trial_amount_a[$n] ) : '';
+							$trial_limit = isset( $trial_limit_a[$n] ) ? intval( $trial_limit_a[$n] ) : '';
 						}
 						else
 						{
@@ -695,6 +695,13 @@
 											<?php esc_html_e('for the first', 'paid-memberships-pro' );?>
 											<input name="trial_limit[]" type="text" size="10" value="<?php echo esc_attr( $level->trial_limit ); ?>" />
 											<?php esc_html_e('subscription payments', 'paid-memberships-pro' );?>.
+										</td>
+									</tr>
+								<?php } else { ?>
+									<tr style="display:none;">
+										<td>
+											<input type="hidden" name="trial_amount[]" value="<?php echo esc_attr( pmpro_filter_price_for_text_field( $level->trial_amount ) ); ?>" />
+											<input type="hidden" name="trial_limit[]" value="<?php echo esc_attr( $level->trial_limit ); ?>" />
 										</td>
 									</tr>
 								<?php } ?>

--- a/adminpages/levels/edit-level.php
+++ b/adminpages/levels/edit-level.php
@@ -448,6 +448,12 @@ if (!empty($page_msg)) { ?>
 			 */
 			do_action('pmpro_membership_level_after_billing_details_settings', $level);
 			?>
+			<?php
+			// Only show trial settings if the active gateway supports recurring trials or if the level already has a trial set.
+			$gateway_class = 'PMProGateway_' . $gateway;
+			$gateway_supports_recurring_trials = method_exists( $gateway_class, 'supports' ) && $gateway_class::supports( 'recurring_trials' );
+			if ( $gateway_supports_recurring_trials || pmpro_isLevelTrial( $level ) ) {
+			?>
 			<table class="form-table">
 				<tr class="recurring_info" <?php if (!pmpro_isLevelRecurring($level)) echo "style='display:none;'"; ?>>
 					<th scope="row" valign="top"><label><?php esc_html_e('Custom Trial', 'paid-memberships-pro'); ?></label></th>
@@ -455,9 +461,8 @@ if (!empty($page_msg)) { ?>
 						<input id="custom_trial" name="custom_trial" type="checkbox" value="yes" <?php if (pmpro_isLevelTrial($level)) {
 																										echo "checked='checked'";
 																									} ?> onclick="jQuery('.trial_info').toggle();" /> <label for="custom_trial"><?php esc_html_e('Check to add a custom trial period.', 'paid-memberships-pro'); ?></label>
-
-						<?php if ($gateway == "twocheckout") { ?>
-							<p class="description"><strong <?php if (!empty($pmpro_twocheckout_error)) { ?>class="pmpro_red" <?php } ?>><?php esc_html_e('2Checkout integration does not support custom trials. You can do one period trials by setting an initial payment different from the billing amount.', 'paid-memberships-pro'); ?></strong></p>
+						<?php if ( ! $gateway_supports_recurring_trials ) { ?>
+							<p class="description"><strong class="pmpro_red"><?php esc_html_e( 'The current payment gateway does not support recurring trials.', 'paid-memberships-pro' ); ?></strong></p>
 						<?php } ?>
 					</td>
 				</tr>
@@ -476,17 +481,11 @@ if (!empty($page_msg)) { ?>
 						<?php esc_html_e('for the first', 'paid-memberships-pro'); ?>
 						<input name="trial_limit" type="text" value="<?php echo esc_attr($level->trial_limit); ?>" class="small-text" />
 						<?php esc_html_e('subscription payments', 'paid-memberships-pro'); ?>.
-						<?php if ($gateway == "stripe") { ?>
-							<p class="description"><strong <?php if (!empty($pmpro_stripe_error)) { ?>class="pmpro_red" <?php } ?>><?php esc_html_e('Stripe integration currently does not support trial amounts greater than $0.', 'paid-memberships-pro'); ?></strong></p>
-						<?php } elseif ($gateway == "braintree") { ?>
-							<p class="description"><strong <?php if (!empty($pmpro_braintree_error)) { ?>class="pmpro_red" <?php } ?>><?php esc_html_e('Braintree integration currently does not support trial amounts greater than $0.', 'paid-memberships-pro'); ?></strong></p>
-						<?php } elseif ($gateway == "payflowpro") { ?>
-							<p class="description"><strong <?php if (!empty($pmpro_payflow_error)) { ?>class="pmpro_red" <?php } ?>><?php esc_html_e('Payflow integration currently does not support trial amounts greater than $0.', 'paid-memberships-pro'); ?></strong></p>
-						<?php } ?>
 					</td>
 				</tr>
 				</tbody>
 			</table>
+			<?php } ?>
 			<?php
 			/**
 			 * Allow adding form fields after the Trial Settings section.

--- a/adminpages/levels/edit-level.php
+++ b/adminpages/levels/edit-level.php
@@ -455,6 +455,7 @@ if (!empty($page_msg)) { ?>
 			if ( $gateway_supports_recurring_trials || pmpro_isLevelTrial( $level ) ) {
 			?>
 			<table class="form-table">
+				<tbody>
 				<tr class="recurring_info" <?php if (!pmpro_isLevelRecurring($level)) echo "style='display:none;'"; ?>>
 					<th scope="row" valign="top"><label><?php esc_html_e('Custom Trial', 'paid-memberships-pro'); ?></label></th>
 					<td>

--- a/adminpages/levels/save-level.php
+++ b/adminpages/levels/save-level.php
@@ -26,8 +26,8 @@ if(!empty($_REQUEST['custom_trial']))
 	$ml_custom_trial = 1;
 else
 	$ml_custom_trial = 0;
-$ml_trial_amount = sanitize_text_field($_REQUEST['trial_amount']);
-$ml_trial_limit = intval($_REQUEST['trial_limit']);
+$ml_trial_amount = isset( $_REQUEST['trial_amount'] ) ? sanitize_text_field( $_REQUEST['trial_amount'] ) : '';
+$ml_trial_limit = isset( $_REQUEST['trial_limit'] ) ? intval( $_REQUEST['trial_limit'] ) : 0;
 if(!empty($_REQUEST['expiration']))
 	$ml_expiration = 1;
 else

--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -46,7 +46,8 @@ class PMProGateway_authorizenet extends PMProGateway
 	public static function supports( $feature ) {
 		$supports = array(
 			'subscription_sync' => true,
-			'payment_method_updates' => 'individual'
+			'payment_method_updates' => 'individual',
+			'recurring_trials' => true,
 		);
 
 		if ( empty( $supports[$feature] ) ) {

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -92,6 +92,7 @@
 			$supports = array(
 				'subscription_sync' => true,
 				'payment_method_updates' => false,
+				'recurring_trials' => true,
 			);
 
 			if ( empty( $supports[$feature] ) ) {

--- a/classes/gateways/class.pmprogateway_paypalwpp.php
+++ b/classes/gateways/class.pmprogateway_paypalwpp.php
@@ -57,6 +57,25 @@
 		}
 
 		/**
+		 * Check whether or not a gateway supports a specific feature.
+		 *
+		 * @since 3.6
+		 *
+		 * @return string|boolean $supports Returns whether or not the gateway supports the requested feature.
+		 */
+		public static function supports( $feature ) {
+			$supports = array(
+				'recurring_trials' => true,
+			);
+
+			if ( empty( $supports[$feature] ) ) {
+				return false;
+			}
+
+			return $supports[$feature];
+		}
+
+		/**
 		 * Get a list of payment options that the this gateway needs/supports.
 		 *
 		 * @since 1.8


### PR DESCRIPTION
## Summary
- Add `recurring_trials` declaration to the gateway `supports()` method for gateways that support charging a different amount for N billing cycles (PayPal Express, PayPal WPP, Authorize.net).
- Hide the Custom Trial settings on the edit level page unless the active gateway declares `recurring_trials` support or the level already has a trial configured.
- When a level has an existing trial but the gateway does not support it, show a generic warning replacing the old hardcoded per-gateway messages.

## Context
The PMPro "Custom Trial" settings allow charging a different recurring amount for the first N billing cycles (e.g., $40/month for 3 months, then $50/month). This is distinct from a simple free trial delay.

The only gateways that ever supported this were:
- **PayPal Express** — deprecated
- **PayPal Website Payments Pro (WPP)** — deprecated
- **Authorize.net** — deprecated

Other gateways like Stripe, Braintree, and Payflow Pro only ever supported free trial delays (`trial_period_days`, `trialPeriod`, profile start date), not different amounts for N cycles. The edit level page previously showed per-gateway warnings for these, but since all gateways that actually use recurring trials are now deprecated, this is the first step toward cleaning up the existing behavior so that we can potentially rebuild trials fresh in an upcoming update.

## Test plan
- [ ] Set gateway to Stripe — verify trial settings are hidden on a new level
- [ ] Set gateway to Authorize.net — verify trial settings are visible
- [ ] Set gateway to Stripe with an existing level that has trial settings — verify the settings show with the red warning
- [ ] Verify the `pmpro_membership_level_after_trial_settings` action still fires regardless of gateway

Generated with [Claude Code](https://claude.com/claude-code)