### PR TITLE
Add multi-gateway support

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -41,7 +41,6 @@
 		} else {
 			// Save the global settings.
 			$global_settings = array(
-				'gateway',
 				'gateway_environment',
 				'currency',
 				'tax_state',
@@ -51,6 +50,22 @@
 			foreach ( $global_settings as $setting ) {
 				pmpro_setOption( $setting );
 			}
+
+			// Save enabled gateways.
+			$enabled_gateways = ! empty( $_REQUEST['enabled_gateways'] ) && is_array( $_REQUEST['enabled_gateways'] )
+				? array_map( 'sanitize_text_field', $_REQUEST['enabled_gateways'] )
+				: array();
+
+			// If nothing is enabled, default to testing only.
+			if ( empty( $enabled_gateways ) ) {
+				$enabled_gateways = array( '' );
+			}
+
+			$enabled_gateways = array_values( array_unique( $enabled_gateways ) );
+			update_option( 'pmpro_enabled_gateways', $enabled_gateways );
+
+			// Keep pmpro_gateway in sync for backward compatibility (first enabled gateway).
+			pmpro_setOption( 'gateway', $enabled_gateways[0] );
 		}
 
 		/**
@@ -106,6 +121,19 @@
 			// Show the table of gateways and global settings.
 			?>
 			<h1><?php esc_html_e( 'Payment Settings', 'paid-memberships-pro' );?></h1>
+			<?php
+				$enabled_gateways = pmpro_get_enabled_gateways();
+				// Filter out the empty testing gateway from active list for display.
+				$active_gateways = array_values( array_filter( $enabled_gateways, function( $slug ) { return $slug !== ''; } ) );
+
+				// Build list of available (non-active) gateways, excluding the empty testing gateway.
+				$available_gateways = array();
+				foreach ( $pmpro_gateways as $slug => $name ) {
+					if ( $slug !== '' && ! in_array( $slug, $active_gateways, true ) ) {
+						$available_gateways[ $slug ] = $name;
+					}
+				}
+			?>
 			<div id="global-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
 				<div class="pmpro_section_toggle">
 					<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
@@ -118,147 +146,259 @@
 						<tbody>
 							<tr>
 								<th scope="row" valign="top">
-									<label for="gateway"><?php esc_html_e( 'Payment Gateway', 'paid-memberships-pro' );?></label>
-								</th>
-								<td>
-									<select id="gateway" name="gateway">
-										<?php
-											foreach ( $pmpro_gateways as $gateway_slug => $gateway_name ) {
-												?>
-												<option value="<?php echo esc_attr( $gateway_slug );?>" <?php selected( pmpro_getOption( 'gateway' ), $gateway_slug ); ?>><?php echo esc_html( $gateway_name );?></option>
-												<?php
-											}
-										?>
-									</select>
-									<p class="description"><?php esc_html_e( 'Select the primary payment gateway for membership checkouts on this site. Before switching, ensure the selected gateway is fully configured for the chosen environment (live or test).', 'paid-memberships-pro' ); ?></p>
-								</td>
-							</tr>
-							<tr>
-								<th scope="row" valign="top">
 									<label for="gateway_environment"><?php esc_html_e( 'Gateway Environment', 'paid-memberships-pro' );?></label>
 								</th>
 								<td>
 									<select id="gateway_environment" name="gateway_environment">
-										<option value="sandbox" <?php if( $gateway_environment == "sandbox") { ?>selected="selected"<?php } ?>><?php esc_html_e('Sandbox/Testing', 'paid-memberships-pro' );?></option>
-										<option value="live" <?php if( $gateway_environment == "live") { ?>selected="selected"<?php } ?>><?php esc_html_e('Live/Production', 'paid-memberships-pro' );?></option>
+										<option value="sandbox" <?php selected( $gateway_environment, 'sandbox' ); ?>><?php esc_html_e( 'Sandbox/Testing', 'paid-memberships-pro' );?></option>
+										<option value="live" <?php selected( $gateway_environment, 'live' ); ?>><?php esc_html_e( 'Live/Production', 'paid-memberships-pro' );?></option>
 									</select>
 									<p class="description">
 										<?php esc_html_e( 'Most gateways have a sandbox (test) and live environment. You can test transactions using the sandbox.', 'paid-memberships-pro' ); ?>
 										<?php
 											$gateway_testing_link = '<a title="' . esc_attr__( 'Paid Memberships Pro - Testing Your Payment Gateway', 'paid-memberships-pro' ) . '" target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/payment-testing/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=testing-your-payment-gateway">' . esc_html__( 'testing your payment gateway for more information', 'paid-memberships-pro' ) . '</a>';
 											// translators: %s: Link to Testing Your Payment Gateway doc.
-											printf( esc_html__('Gateway settings must be configured for each environment. Refer to our guide on %s.', 'paid-memberships-pro' ), $gateway_testing_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+											printf( esc_html__( 'Gateway settings must be configured for each environment. Refer to our guide on %s.', 'paid-memberships-pro' ), $gateway_testing_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 										?>
 									</p>
 								</td>
 							</tr>
 						</tbody>
 					</table>
-					<p class="submit">
-						<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e('Save All Settings', 'paid-memberships-pro' );?>" />
-					</p>
-				</div> <!-- end pmpro_section_inside -->
-			</div> <!-- end pmpro_section -->
-			<div id="choose-gateway" class="pmpro_section" data-visibility="shown" data-activated="true">
-				<div class="pmpro_section_toggle">
-					<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">
-						<span class="dashicons dashicons-arrow-up-alt2"></span>
-						<?php esc_html_e( 'Payment Gateway Settings', 'paid-memberships-pro' ); ?>
-					</button>
-				</div>
-				<div class="pmpro_section_inside">
-					<p>
-						<?php esc_html_e( 'Installed payment gateways are listed below. Select a gateway to manage settings in live or sandbox (test) mode.', 'paid-memberships-pro' ); ?>
-						<?php			
-						$gateway_settings_link = '<a title="' . esc_attr__( 'Paid Memberships Pro - Payment Gateway Settings', 'paid-memberships-pro' ) . '" target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/documentation/admin/payment-gateway-settings/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=payment-gateway-settings">' . esc_html__( 'Payment Gateway Settings', 'paid-memberships-pro' ) . '</a>';
-						// translators: %s: Link to Payment Gateway Settings doc.
-						printf( esc_html__('Learn more about %s.', 'paid-memberships-pro' ), $gateway_settings_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						?>
-					</p>
-					<table class="wp-list-table widefat striped">
-						<thead>
-							<tr>
-								<th class="manage-column column-gateway" scope="col">
-									<?php esc_html_e( 'Gateway', 'paid-memberships-pro' ); ?>
-								</th>
-								<th class="manage-column column-status" scope="col">
-									<?php esc_html_e( 'Status', 'paid-memberships-pro' ); ?>
-								</th>
-								<th class="manage-column column-description" scope="col">
-									<?php esc_html_e( 'Description', 'paid-memberships-pro' ); ?>
-								</th>
-								<th class="manage-column column-edit" scope="col">
-									<span class="screen-reader-text"><?php esc_html_e( 'Actions', 'paid-memberships-pro' );?></span>
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php
-							foreach ( $pmpro_gateways as $gateway_slug => $gateway_name ) {
-								// Get information about what the gateway 'supports'.
-								$gateway_class_name = 'PMProGateway_' . $gateway_slug;
-								if ( class_exists( $gateway_class_name ) && method_exists( $gateway_class_name, 'supports' ) ) {
-									$gateway_instance = new $gateway_class_name();
-								}
 
-								// Add a description for the default gateway.
-								$gateway_description = $gateway_slug === '' ? esc_html__( 'This gateway is for membership sites with Free levels or for sites that accept payment offline. The default gateway is not connected to a live gateway environment and cannot accept payments.', 'paid-memberships-pro' ) : $gateway_description;
-								?>
-								<tr class="gateway gateway_<?php echo esc_attr( $gateway_slug );?>">
-									<td class="column-gateway">
-										<?php echo ! empty( $gateway_instance ) ? '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => esc_attr( $gateway_slug ) ), admin_url( 'admin.php' ) ) ) . '">' . esc_html( $gateway_name ) . '</a>' : esc_html( $gateway_name ); ?>
-									</td>
-									<td class="column-status">
-										<?php
-											$gateway_status_html = pmpro_getOption( 'gateway' ) === $gateway_slug ? '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-info">' . esc_html__( 'Enabled (Primary Gateway)', 'paid-memberships-pro' ) . '</span>' : esc_html__( '&#8212;', 'paid-memberships-pro' );
-
-											// Special Cases for Add Ons that add secondary gateways. These will be removed when core natively supports multiple gateways.
-											if (
-												( function_exists( 'pmproappe_pmpro_valid_gateways' ) && $gateway_slug === 'paypalexpress' ) || // Add PayPal Express Add On.
-												( defined( 'PMPROPBC_VER' ) && $gateway_slug === 'check' ) // Pay by Check Add On.
-											) {
-												// The Add On is active for the gateway being shown.
-												if ( pmpro_getOption( 'gateway' ) === $gateway_slug ) {
-													// If this is the primary gateway, add an alert.
-													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-info">' . esc_html__( 'Enabled (Primary Gateway & via Add On)', 'paid-memberships-pro' ) . '</span>';
-												} else {
-													// Show this as a secondary gateway.
-													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-info">' . esc_html__( 'Enabled (via Add On)', 'paid-memberships-pro' ) . '</span>';
-												}	
-											}
-
-											// Special case for deprecated gateways.
-											if ( in_array( $gateway_slug, $deprecated_gateways, true ) ) {
-												if ( pmpro_getOption( 'gateway' ) === $gateway_slug ) {
-													$gateway_status_html = '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Enabled (Not Supported)', 'paid-memberships-pro' ) . '</span>';
-												} elseif ( $gateway_status_html !== esc_html__( '&#8212;', 'paid-memberships-pro' ) ) {
-													// Gateway is enabled (e.g. via Add PayPal Express Add On) but deprecated.
-													$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Not Supported', 'paid-memberships-pro' ) . '</span>';
-												}
-											}
-
-											echo wp_kses_post( $gateway_status_html );
-										?>
-										</td>
-									<td class="column-description">
-										<?php echo ! empty( $gateway_instance ) ? esc_html( $gateway_instance->get_description_for_gateway_settings() ) : esc_html__( '&#8212;', 'paid-memberships-pro' ); ?>
-									</td>
-									<td class="column-edit">
-										<?php echo ! empty( $gateway_instance ) ? '<a class="button button-secondary" href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => esc_attr( $gateway_slug ) ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Edit Settings', 'paid-memberships-pro' ) . '</a>' : esc_html__( '&#8212;', 'paid-memberships-pro' ); ?>
-									</td>
+					<h3><?php esc_html_e( 'Active Gateways', 'paid-memberships-pro' ); ?></h3>
+					<p><?php esc_html_e( 'Active gateways are available for membership checkouts. Drag to reorder — the first gateway is the default at checkout.', 'paid-memberships-pro' ); ?></p>
+					<?php if ( ! empty( $active_gateways ) ) { ?>
+						<table id="pmpro_active_gateways_table" class="wp-list-table widefat striped">
+							<thead>
+								<tr>
+									<th class="manage-column column-sort" scope="col" style="width: 30px;"></th>
+									<th class="manage-column column-gateway" scope="col"><?php esc_html_e( 'Gateway', 'paid-memberships-pro' ); ?></th>
+									<th class="manage-column column-description" scope="col"><?php esc_html_e( 'Description', 'paid-memberships-pro' ); ?></th>
+									<th class="manage-column column-actions" scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Actions', 'paid-memberships-pro' );?></span></th>
 								</tr>
-								<?php
-								$gateway_class_name = '';
-							}
+							</thead>
+							<tbody>
+								<?php foreach ( $active_gateways as $gateway_slug ) {
+									$gateway_name = isset( $pmpro_gateways[ $gateway_slug ] ) ? $pmpro_gateways[ $gateway_slug ] : ucwords( $gateway_slug );
+									$gateway_class_name = 'PMProGateway_' . $gateway_slug;
+									$gateway_instance = class_exists( $gateway_class_name ) ? new $gateway_class_name() : null;
+									$is_deprecated = in_array( $gateway_slug, $deprecated_gateways, true );
+								?>
+									<tr class="gateway gateway_<?php echo esc_attr( $gateway_slug ); ?>" data-gateway="<?php echo esc_attr( $gateway_slug ); ?>">
+										<td class="column-sort" style="width: 30px; cursor: move;">
+											<span class="dashicons dashicons-menu" title="<?php esc_attr_e( 'Drag to reorder', 'paid-memberships-pro' ); ?>"></span>
+											<input type="hidden" name="enabled_gateways[]" value="<?php echo esc_attr( $gateway_slug ); ?>" />
+										</td>
+										<td class="column-gateway">
+											<?php
+											echo ! empty( $gateway_instance )
+												? '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => $gateway_slug ), admin_url( 'admin.php' ) ) ) . '">' . esc_html( $gateway_name ) . '</a>'
+												: esc_html( $gateway_name );
+											if ( $is_deprecated ) {
+												echo ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Not Supported', 'paid-memberships-pro' ) . '</span>';
+											}
+											?>
+										</td>
+										<td class="column-description"><?php echo ! empty( $gateway_instance ) ? esc_html( $gateway_instance->get_description_for_gateway_settings() ) : esc_html__( '&#8212;', 'paid-memberships-pro' ); ?></td>
+										<td class="column-actions">
+											<?php if ( ! empty( $gateway_instance ) ) { ?>
+												<a class="button button-secondary" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => $gateway_slug ), admin_url( 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Edit Settings', 'paid-memberships-pro' ); ?></a>
+											<?php } ?>
+											<button type="button" class="button pmpro_gateway_deactivate" data-gateway="<?php echo esc_attr( $gateway_slug ); ?>"><?php esc_html_e( 'Deactivate', 'paid-memberships-pro' ); ?></button>
+										</td>
+									</tr>
+								<?php } ?>
+							</tbody>
+						</table>
+					<?php } else { ?>
+						<div class="notice notice-info inline" id="pmpro_no_active_gateways_notice">
+							<p><?php esc_html_e( 'No active gateways. The site is operating in testing mode. Activate a gateway below to accept payments.', 'paid-memberships-pro' ); ?></p>
+						</div>
+					<?php } ?>
+
+					<details id="available-gateways" <?php if ( empty( $active_gateways ) ) { ?>open<?php } ?>>
+						<summary><strong><?php esc_html_e( 'Available Gateways', 'paid-memberships-pro' ); ?></strong></summary>
+						<p>
+							<?php esc_html_e( 'Installed gateways that are not currently active. Activate a gateway to make it available at checkout.', 'paid-memberships-pro' ); ?>
+							<?php
+							$gateway_settings_link = '<a title="' . esc_attr__( 'Paid Memberships Pro - Payment Gateway Settings', 'paid-memberships-pro' ) . '" target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/documentation/admin/payment-gateway-settings/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=documentation&utm_content=payment-gateway-settings">' . esc_html__( 'Payment Gateway Settings', 'paid-memberships-pro' ) . '</a>';
+							// translators: %s: Link to Payment Gateway Settings doc.
+							printf( esc_html__( 'Learn more about %s.', 'paid-memberships-pro' ), $gateway_settings_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 							?>
-						</tbody>
-					</table>
-					<br />
-					<p>
-						<a target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/add-on-category/payment/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=add-ons&utm_content=other-payment-gateways"><?php esc_html_e( 'Discover other payment gateways available as Paid Memberships Pro Add Ons', 'paid-memberships-pro' ); ?></a>
+						</p>
+						<?php if ( ! empty( $available_gateways ) ) { ?>
+							<table id="pmpro_available_gateways_table" class="wp-list-table widefat striped">
+								<thead>
+									<tr>
+										<th class="manage-column column-gateway" scope="col"><?php esc_html_e( 'Gateway', 'paid-memberships-pro' ); ?></th>
+										<th class="manage-column column-description" scope="col"><?php esc_html_e( 'Description', 'paid-memberships-pro' ); ?></th>
+										<th class="manage-column column-actions" scope="col"><span class="screen-reader-text"><?php esc_html_e( 'Actions', 'paid-memberships-pro' );?></span></th>
+									</tr>
+								</thead>
+								<tbody>
+									<?php foreach ( $available_gateways as $gateway_slug => $gateway_name ) {
+										$gateway_class_name = 'PMProGateway_' . $gateway_slug;
+										$gateway_instance = class_exists( $gateway_class_name ) ? new $gateway_class_name() : null;
+										$is_deprecated = in_array( $gateway_slug, $deprecated_gateways, true );
+									?>
+										<tr class="gateway gateway_<?php echo esc_attr( $gateway_slug ); ?>" data-gateway="<?php echo esc_attr( $gateway_slug ); ?>">
+											<td class="column-gateway">
+												<?php
+												echo ! empty( $gateway_instance )
+													? '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => $gateway_slug ), admin_url( 'admin.php' ) ) ) . '">' . esc_html( $gateway_name ) . '</a>'
+													: esc_html( $gateway_name );
+												if ( $is_deprecated ) {
+													echo ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Not Supported', 'paid-memberships-pro' ) . '</span>';
+												}
+												?>
+											</td>
+											<td class="column-description"><?php echo ! empty( $gateway_instance ) ? esc_html( $gateway_instance->get_description_for_gateway_settings() ) : esc_html__( '&#8212;', 'paid-memberships-pro' ); ?></td>
+											<td class="column-actions">
+												<?php if ( ! empty( $gateway_instance ) ) { ?>
+													<a class="button button-secondary" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => $gateway_slug ), admin_url( 'admin.php' ) ) ); ?>"><?php esc_html_e( 'Edit Settings', 'paid-memberships-pro' ); ?></a>
+												<?php } ?>
+												<button type="button" class="button button-primary pmpro_gateway_activate" data-gateway="<?php echo esc_attr( $gateway_slug ); ?>"><?php esc_html_e( 'Activate', 'paid-memberships-pro' ); ?></button>
+											</td>
+										</tr>
+									<?php } ?>
+								</tbody>
+							</table>
+						<?php } else { ?>
+							<p><em><?php esc_html_e( 'All installed gateways are currently active.', 'paid-memberships-pro' ); ?></em></p>
+						<?php } ?>
+						<p>
+							<a target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/add-on-category/payment/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=add-ons&utm_content=other-payment-gateways"><?php esc_html_e( 'Discover other payment gateways available as Paid Memberships Pro Add Ons', 'paid-memberships-pro' ); ?></a>
+						</p>
+					</details> <!-- end available-gateways -->
+
+					<p class="submit">
+						<input name="savesettings" type="submit" class="button button-primary" value="<?php esc_attr_e( 'Save All Settings', 'paid-memberships-pro' );?>" />
 					</p>
-				</div> <!-- end pmpro_section_inside -->
-			</div> <!-- end pmpro_section -->
+				</div> <!-- end global-settings pmpro_section_inside -->
+			</div> <!-- end global-settings pmpro_section -->
+			<script>
+				jQuery(document).ready(function($) {
+					// Sort helper to preserve column widths during drag.
+					var fixHelper = function(e, ui) {
+						ui.children().each(function() {
+							$(this).width($(this).width());
+						});
+						return ui;
+					};
+
+					// Make active gateways table sortable.
+					if ( $('#pmpro_active_gateways_table tbody tr').length > 1 ) {
+						$('#pmpro_active_gateways_table tbody').sortable({
+							axis: 'y',
+							helper: fixHelper,
+							handle: '.column-sort',
+							placeholder: 'ui-sortable-placeholder',
+							forcePlaceholderSize: true
+						});
+					}
+
+					// Activate gateway button.
+					$(document).on('click', '.pmpro_gateway_activate', function(e) {
+						e.preventDefault();
+						var gateway = $(this).data('gateway');
+						var row = $(this).closest('tr');
+
+						// Create active table if it doesn't exist yet.
+						var $activeTable = $('#pmpro_active_gateways_table');
+						if ( ! $activeTable.length ) {
+							$('#pmpro_no_active_gateways_notice').remove();
+							var tableHtml = '<table id="pmpro_active_gateways_table" class="wp-list-table widefat striped">' +
+								'<thead><tr>' +
+								'<th class="manage-column column-sort" scope="col" style="width: 30px;"></th>' +
+								'<th class="manage-column column-gateway" scope="col"><?php echo esc_js( __( 'Gateway', 'paid-memberships-pro' ) ); ?></th>' +
+								'<th class="manage-column column-description" scope="col"><?php echo esc_js( __( 'Description', 'paid-memberships-pro' ) ); ?></th>' +
+								'<th class="manage-column column-actions" scope="col"></th>' +
+								'</tr></thead><tbody></tbody></table>';
+							$('#available-gateways').before( tableHtml );
+							$activeTable = $('#pmpro_active_gateways_table');
+						}
+
+						// Build new row for active table.
+						var gatewayTd = row.find('.column-gateway').html();
+						var descTd = row.find('.column-description').html();
+						var editBtn = row.find('.column-actions a.button-secondary').length ? row.find('.column-actions a.button-secondary')[0].outerHTML : '';
+						var newRow = '<tr class="gateway gateway_' + gateway + '" data-gateway="' + gateway + '">' +
+							'<td class="column-sort" style="width: 30px; cursor: move;"><span class="dashicons dashicons-menu"></span>' +
+							'<input type="hidden" name="enabled_gateways[]" value="' + gateway + '" /></td>' +
+							'<td class="column-gateway">' + gatewayTd + '</td>' +
+							'<td class="column-description">' + descTd + '</td>' +
+							'<td class="column-actions">' + editBtn +
+							' <button type="button" class="button pmpro_gateway_deactivate" data-gateway="' + gateway + '"><?php echo esc_js( __( 'Deactivate', 'paid-memberships-pro' ) ); ?></button></td>' +
+							'</tr>';
+						$activeTable.find('tbody').append(newRow);
+
+						// Remove from available table.
+						row.remove();
+						if ( ! $('#pmpro_available_gateways_table tbody tr').length ) {
+							$('#pmpro_available_gateways_table').replaceWith('<p><em><?php echo esc_js( __( 'All installed gateways are currently active.', 'paid-memberships-pro' ) ); ?></em></p>');
+						}
+
+						// Re-init sortable if multiple rows.
+						if ( $activeTable.find('tbody tr').length > 1 ) {
+							$activeTable.find('tbody').sortable({
+								axis: 'y',
+								helper: fixHelper,
+								handle: '.column-sort',
+								placeholder: 'ui-sortable-placeholder',
+								forcePlaceholderSize: true
+							});
+						}
+					});
+
+					// Deactivate gateway button.
+					$(document).on('click', '.pmpro_gateway_deactivate', function(e) {
+						e.preventDefault();
+						var gateway = $(this).data('gateway');
+						var row = $(this).closest('tr');
+
+						// Create available table if it doesn't exist yet.
+						var $availTable = $('#pmpro_available_gateways_table');
+						if ( ! $availTable.length ) {
+							$('#available-gateways p > em').closest('p').remove();
+							var $discoverP = $('#available-gateways p:last');
+							var tableHtml = '<table id="pmpro_available_gateways_table" class="wp-list-table widefat striped">' +
+								'<thead><tr>' +
+								'<th class="manage-column column-gateway" scope="col"><?php echo esc_js( __( 'Gateway', 'paid-memberships-pro' ) ); ?></th>' +
+								'<th class="manage-column column-description" scope="col"><?php echo esc_js( __( 'Description', 'paid-memberships-pro' ) ); ?></th>' +
+								'<th class="manage-column column-actions" scope="col"></th>' +
+								'</tr></thead><tbody></tbody></table>';
+							$discoverP.before( tableHtml );
+							$availTable = $('#pmpro_available_gateways_table');
+						}
+
+						// Build new row for available table.
+						var gatewayTd = row.find('.column-gateway').html();
+						var descTd = row.find('.column-description').html();
+						var editBtn = row.find('.column-actions a.button-secondary').length ? row.find('.column-actions a.button-secondary')[0].outerHTML : '';
+						var newRow = '<tr class="gateway gateway_' + gateway + '" data-gateway="' + gateway + '">' +
+							'<td class="column-gateway">' + gatewayTd + '</td>' +
+							'<td class="column-description">' + descTd + '</td>' +
+							'<td class="column-actions">' + editBtn +
+							' <button type="button" class="button button-primary pmpro_gateway_activate" data-gateway="' + gateway + '"><?php echo esc_js( __( 'Activate', 'paid-memberships-pro' ) ); ?></button></td>' +
+							'</tr>';
+						$availTable.find('tbody').append(newRow);
+
+						// Open the available gateways details so user sees where it went.
+						$('#available-gateways').attr('open', '');
+
+						// Remove from active table.
+						row.remove();
+						if ( ! $('#pmpro_active_gateways_table tbody tr').length ) {
+							$('#pmpro_active_gateways_table').replaceWith(
+								'<div class="notice notice-info inline" id="pmpro_no_active_gateways_notice">' +
+								'<p><?php echo esc_js( __( 'No active gateways. The site is operating in testing mode. Activate a gateway below to accept payments.', 'paid-memberships-pro' ) ); ?></p>' +
+								'</div>'
+							);
+						}
+					});
+				});
+			</script>
 			<div id="other-settings" class="pmpro_section" data-visibility="shown" data-activated="true">
 				<div class="pmpro_section_toggle">
 					<button class="pmpro_section-toggle-button" type="button" aria-expanded="true">

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -334,6 +334,45 @@
 		}
 
 		/**
+		 * Find a legacy callback for a gateway class on a given filter hook.
+		 *
+		 * First checks if the callback is hooked to the filter (covers cases where
+		 * init() added it for the active gateway). Then falls back to checking if the
+		 * gateway class has a static method by that name (covers secondary gateways
+		 * whose init() didn't fire for this page load).
+		 *
+		 * @since TBD
+		 *
+		 * @param string $gateway_class The gateway class name (e.g. 'PMProGateway_stripe').
+		 * @param string $filter_name   The filter hook name to check.
+		 * @return callable|false The callback if found, false otherwise.
+		 */
+		private static function get_legacy_gateway_callback( $gateway_class, $filter_name ) {
+			if ( $gateway_class === 'PMProGateway' ) {
+				return false;
+			}
+
+			// First, check if the gateway has hooked this filter (active gateway path).
+			global $wp_filter;
+			if ( ! empty( $wp_filter[ $filter_name ]->callbacks ) ) {
+				foreach ( $wp_filter[ $filter_name ]->callbacks as $priority => $filters ) {
+					foreach ( $filters as $filter ) {
+						if ( is_array( $filter['function'] ) && $gateway_class === $filter['function'][0] ) {
+							return $filter['function'];
+						}
+					}
+				}
+			}
+
+			// Fall back to checking if the class has a method by that name (secondary gateway path).
+			if ( method_exists( $gateway_class, $filter_name ) ) {
+				return array( $gateway_class, $filter_name );
+			}
+
+			return false;
+		}
+
+		/**
 		 * Get a description for this gateway.
 		 *
 		 * @since 3.5
@@ -342,5 +381,210 @@
 		 */
 		public static function get_description_for_gateway_settings() {
 			return esc_html__( '&#8212;', 'paid-memberships-pro' );
+		}
+
+		/**
+		 * Get the human-readable label for the gateway at checkout.
+		 *
+		 * Used for the radio button label when multiple gateways are available.
+		 * Override in subclasses for a friendlier label (e.g., "Pay with Credit Card").
+		 *
+		 * @since TBD
+		 *
+		 * @return string The checkout label for this gateway.
+		 */
+		public static function get_checkout_label() {
+			$gateways = pmpro_gateways();
+			$gateway_slug = str_replace( 'PMProGateway_', '', get_called_class() );
+			if ( get_called_class() === 'PMProGateway' ) {
+				$gateway_slug = '';
+			}
+			if ( isset( $gateways[ $gateway_slug ] ) ) {
+				return $gateways[ $gateway_slug ];
+			}
+			return ucwords( $gateway_slug );
+		}
+
+		/**
+		 * Enqueue gateway-specific scripts and styles for checkout.
+		 *
+		 * Called by the checkout preheader for each enabled gateway so that
+		 * all necessary JS/CSS is loaded when multiple gateways are available.
+		 * Override in subclasses to enqueue gateway-specific assets.
+		 *
+		 * @since TBD
+		 */
+		public static function enqueue_checkout_scripts() {
+			// Base class does nothing. Gateways override to enqueue their scripts.
+		}
+
+		/**
+		 * Render the payment fields for this gateway at checkout.
+		 *
+		 * Called by the checkout page inside a gateway-specific container div.
+		 * The default implementation first checks if the gateway has hooked
+		 * `pmpro_include_payment_information_fields` (legacy pattern) and uses
+		 * that if found. Otherwise, renders the standard credit card fields.
+		 *
+		 * Gateways that use their own fields (e.g., Stripe Elements) should
+		 * override this method. Offsite gateways should override to render
+		 * nothing or their redirect/submit button.
+		 *
+		 * @since TBD
+		 */
+		public static function show_checkout_fields() {
+			global $wp_filter, $pmpro_requirebilling, $pmpro_show_discount_code, $discount_code,
+				$CardType, $AccountNumber, $ExpirationMonth, $ExpirationYear;
+
+			// Check if this gateway has a legacy pmpro_include_payment_information_fields callback
+			// (for gateways that haven't been updated to override show_checkout_fields).
+			// First check hooked filters, then check for a class method by that name.
+			$gateway_class = get_called_class();
+			$legacy_callback = self::get_legacy_gateway_callback( $gateway_class, 'pmpro_include_payment_information_fields' );
+			if ( $legacy_callback ) {
+				call_user_func( $legacy_callback, true );
+				return;
+			}
+			?>
+			<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling || apply_filters( 'pmpro_hide_payment_information_fields', false ) ) { ?>style="display: none;"<?php } ?>>
+				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+						<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
+							<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e( 'Payment Information', 'paid-memberships-pro' ); ?></h2>
+						</legend>
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+							<input type="hidden" id="CardType" name="CardType" value="<?php echo esc_attr( $CardType ); ?>" />
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-account-number', 'pmpro_payment-account-number' ) ); ?>">
+								<label for="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Card Number', 'paid-memberships-pro' ); ?></label>
+								<input id="AccountNumber" name="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'AccountNumber' ) ); ?>" type="text" value="<?php echo esc_attr( $AccountNumber ); ?>" data-encrypted-name="number" autocomplete="off" />
+							</div>
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ); ?>">
+								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-select pmpro_payment-expiration', 'pmpro_payment-expiration' ) ); ?>">
+									<label for="ExpirationMonth" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Expiration Date', 'paid-memberships-pro' ); ?></label>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields-inline' ) ); ?>">
+										<select id="ExpirationMonth" name="ExpirationMonth" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'ExpirationMonth' ) ); ?>">
+											<?php for ( $i = 1; $i <= 12; $i++ ) {
+												$val = str_pad( $i, 2, '0', STR_PAD_LEFT ); ?>
+												<option value="<?php echo esc_attr( $val ); ?>" <?php selected( $ExpirationMonth, $val ); ?>><?php echo esc_html( $val ); ?></option>
+											<?php } ?>
+										</select>/<select id="ExpirationYear" name="ExpirationYear" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'ExpirationYear' ) ); ?>">
+										<?php
+											$num_years = apply_filters( 'pmpro_num_expiration_years', 10 );
+											for ( $i = date_i18n( 'Y' ); $i < intval( date_i18n( 'Y' ) ) + intval( $num_years ); $i++ ) {
+												?>
+												<option value="<?php echo esc_attr( $i ); ?>" <?php if ( $ExpirationYear == $i ) { ?>selected="selected"<?php } elseif ( $i == date_i18n( 'Y' ) + 1 ) { ?>selected="selected"<?php } ?>><?php echo esc_html( $i ); ?></option>
+												<?php
+											}
+										?>
+										</select>
+									</div> <!-- end pmpro_form_fields-inline -->
+								</div>
+								<?php
+									$pmpro_show_cvv = apply_filters( 'pmpro_show_cvv', true );
+									if ( $pmpro_show_cvv ) { ?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-cvv', 'pmpro_payment-cvv' ) ); ?>">
+										<label for="CVV" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Security Code (CVC)', 'paid-memberships-pro' ); ?></label>
+										<input id="CVV" name="CVV" type="text" size="4" value="<?php if ( ! empty( $_REQUEST['CVV'] ) ) { echo esc_attr( sanitize_text_field( $_REQUEST['CVV'] ) ); } ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'CVV' ) ); ?>" />
+									</div>
+								<?php } ?>
+							</div> <!-- end pmpro_cols-2 -->
+							<?php if ( $pmpro_show_discount_code ) { ?>
+								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-discount-code', 'pmpro_payment-discount-code' ) ); ?>">
+										<label for="pmpro_discount_code" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Discount Code', 'paid-memberships-pro' ); ?></label>
+										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields-inline' ) ); ?>">
+											<input class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text pmpro_alter_price', 'discount_code' ) ); ?>" id="pmpro_discount_code" name="pmpro_discount_code" type="text" size="10" value="<?php echo esc_attr( $discount_code ); ?>" />
+											<input aria-label="<?php esc_html_e( 'Apply discount code', 'paid-memberships-pro' ); ?>" type="button" id="discount_code_button" name="discount_code_button" value="<?php esc_attr_e( 'Apply', 'paid-memberships-pro' ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-discount-code', 'other_discount_code_button' ) ); ?>" />
+										</div> <!-- end pmpro_form_fields-inline -->
+										<div id="discount_code_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message', 'discount_code_message' ) ); ?>" style="display: none;"></div>
+									</div>
+								</div> <!-- end pmpro_cols-2 -->
+							<?php } ?>
+						</div> <!-- end pmpro_form_fields -->
+					</div> <!-- end pmpro_card_content -->
+				</div> <!-- end pmpro_card -->
+			</fieldset> <!-- end pmpro_payment_information_fields -->
+			<?php
+		}
+
+		/**
+		 * Whether this gateway requires billing address fields at checkout.
+		 *
+		 * Used by the checkout JS to toggle billing address visibility when
+		 * switching between gateways. Override in subclasses to return false
+		 * for gateways that don't need billing address (e.g., PayPal, Check).
+		 *
+		 * @since TBD
+		 *
+		 * @return bool True if billing address fields should be shown, false otherwise.
+		 */
+		public static function requires_billing_address() {
+			// Check for legacy pmpro_include_billing_address_fields callback.
+			$gateway_class = get_called_class();
+			$legacy_callback = self::get_legacy_gateway_callback( $gateway_class, 'pmpro_include_billing_address_fields' );
+			if ( $legacy_callback ) {
+				return (bool) call_user_func( $legacy_callback, true );
+			}
+
+			return true;
+		}
+
+		/**
+		 * Modify the required billing fields for this gateway.
+		 *
+		 * Called by the checkout preheader to let the selected gateway remove
+		 * fields it doesn't need (e.g., an offsite gateway removes all card fields,
+		 * a gateway using hosted fields removes card fields since validation is remote).
+		 *
+		 * The default implementation checks if the gateway has hooked the legacy
+		 * `pmpro_required_billing_fields` filter and calls that if found.
+		 * Otherwise, returns the fields unchanged (all fields required).
+		 *
+		 * @since TBD
+		 *
+		 * @param array $fields Associative array of field_name => value.
+		 * @return array Modified array of required fields.
+		 */
+		public static function get_required_billing_fields( $fields ) {
+			// Check for legacy pmpro_required_billing_fields callback.
+			$gateway_class = get_called_class();
+			$legacy_callback = self::get_legacy_gateway_callback( $gateway_class, 'pmpro_required_billing_fields' );
+			if ( $legacy_callback ) {
+				return call_user_func( $legacy_callback, $fields );
+			}
+
+			return $fields;
+		}
+
+		/**
+		 * Render the submit button for this gateway at checkout.
+		 *
+		 * The default implementation renders the standard "Submit and Check Out"
+		 * button. Offsite gateways (PayPal, etc.) should override this to render
+		 * their branded redirect button instead.
+		 *
+		 * The default implementation checks if the gateway has hooked the legacy
+		 * `pmpro_checkout_default_submit_button` filter and calls that if found.
+		 *
+		 * @since TBD
+		 */
+		public static function show_submit_button() {
+			global $pmpro_requirebilling;
+
+			// Check for legacy pmpro_checkout_default_submit_button callback.
+			$gateway_class = get_called_class();
+			$legacy_callback = self::get_legacy_gateway_callback( $gateway_class, 'pmpro_checkout_default_submit_button' );
+			if ( $legacy_callback ) {
+				call_user_func( $legacy_callback, true );
+				return;
+			}
+
+			// Default submit button.
+			?>
+			<span id="pmpro_submit_span">
+				<input type="hidden" name="submit-checkout" value="1" />
+				<input type="submit" id="pmpro_btn-submit" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ) ); ?>" value="<?php if ( $pmpro_requirebilling ) { esc_attr_e( 'Submit and Check Out', 'paid-memberships-pro' ); } else { esc_attr_e( 'Submit and Confirm', 'paid-memberships-pro' ); } ?>" />
+			</span>
+			<?php
 		}
 	}

--- a/classes/gateways/class.pmprogateway_check.php
+++ b/classes/gateways/class.pmprogateway_check.php
@@ -26,15 +26,6 @@
 			//add fields to payment settings
 			add_filter('pmpro_checkout_after_payment_information_fields', array('PMProGateway_check', 'pmpro_checkout_after_payment_information_fields'));
 			add_action( 'pmpro_order_single_before_order_details', array( 'PMProGateway_check', 'pmpro_order_single_before_order_details' ) );
-
-			//code to add at checkout
-			$gateway = pmpro_getGateway();
-			if($gateway == "check")
-			{
-				add_filter('pmpro_include_billing_address_fields', '__return_false');
-				add_filter('pmpro_include_payment_information_fields', '__return_false');
-				add_filter('pmpro_required_billing_fields', array('PMProGateway_check', 'pmpro_required_billing_fields'));
-			}
 		}
 		
 		/**
@@ -59,6 +50,65 @@
 		 */
 		public static function get_description_for_gateway_settings() {
 			return esc_html__( 'Allow members to pay by check or other manual payment methods like Bank Transfer or Venmo. After receiving a payment, you must manually update the order status to "success" in order to activate the membership.', 'paid-memberships-pro' );
+		}
+
+		/**
+		 * Get the checkout label for this gateway.
+		 *
+		 * @since TBD
+		 *
+		 * @return string
+		 */
+		public static function get_checkout_label() {
+			$check_gateway_label = get_option( 'pmpro_check_gateway_label' );
+			if ( ! empty( $check_gateway_label ) ) {
+				return esc_html( sprintf( __( 'Pay by %s', 'paid-memberships-pro' ), $check_gateway_label ) );
+			}
+			return esc_html__( 'Pay by Check', 'paid-memberships-pro' );
+		}
+
+		/**
+		 * Render checkout fields for the Check gateway.
+		 *
+		 * The check gateway has no payment fields -- just shows instructions.
+		 *
+		 * @since TBD
+		 */
+		public static function show_checkout_fields() {
+			$instructions = get_option( 'pmpro_instructions' );
+			if ( ! empty( $instructions ) ) {
+				?>
+				<div id="pmpro_check_instructions" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_check_instructions' ) ); ?>">
+					<?php echo wp_kses_post( wpautop( $instructions ) ); ?>
+				</div>
+				<?php
+			}
+		}
+
+		/**
+		 * The Check gateway does not require billing address fields.
+		 *
+		 * @since TBD
+		 *
+		 * @return bool
+		 */
+		public static function requires_billing_address() {
+			return false;
+		}
+
+		/**
+		 * Modify the required billing fields for the Check gateway.
+		 *
+		 * Removes all billing address and card fields since check payments
+		 * don't require any of them.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $fields Associative array of field_name => value.
+		 * @return array Modified array of required fields.
+		 */
+		public static function get_required_billing_fields( $fields ) {
+			return self::pmpro_required_billing_fields( $fields );
 		}
 
 		/**

--- a/classes/gateways/class.pmprogateway_paypalexpress.php
+++ b/classes/gateways/class.pmprogateway_paypalexpress.php
@@ -33,16 +33,8 @@
 			//make sure PayPal Express is a gateway option
 			add_filter('pmpro_gateways', array('PMProGateway_paypalexpress', 'pmpro_gateways'));
 
-			//code to add at checkout
-			$gateway = pmpro_getGateway();
-			if($gateway == "paypalexpress")
-			{
-				add_filter('pmpro_include_billing_address_fields', '__return_false');
-				add_filter('pmpro_include_payment_information_fields', '__return_false');
-				add_filter('pmpro_required_billing_fields', array('PMProGateway_paypalexpress', 'pmpro_required_billing_fields'));
-				add_filter('pmpro_checkout_default_submit_button', array('PMProGateway_paypalexpress', 'pmpro_checkout_default_submit_button'));
-				add_action('http_api_curl', array('PMProGateway_paypalexpress', 'http_api_curl'), 10, 3);				
-			}
+			// Hooks not handled by static methods.
+			add_action('http_api_curl', array('PMProGateway_paypalexpress', 'http_api_curl'), 10, 3);
             add_action('pmpro_checkout_preheader', array('PMProGateway_paypalexpress', 'pmpro_checkout_preheader'));
 			add_filter( 'pmpro_process_refund_paypalexpress', array('PMProGateway_paypalexpress', 'process_refund' ), 10, 2 );
 		}
@@ -79,6 +71,84 @@
 		 */
 		public static function get_description_for_gateway_settings() {
 			return esc_html__( 'With PayPal, members can pay with their PayPal balance, credit/debit cards, linked bank accounts, or local payment methods. PayPal is accepted worldwide and offers multi-currency support for 200+ markets and 25+ currencies.', 'paid-memberships-pro' );
+		}
+
+		/**
+		 * Get the checkout label for this gateway.
+		 *
+		 * @since TBD
+		 *
+		 * @return string
+		 */
+		public static function get_checkout_label() {
+			return esc_html__( 'Check Out with PayPal', 'paid-memberships-pro' );
+		}
+
+		/**
+		 * Render checkout fields for PayPal Express.
+		 *
+		 * PayPal Express is an offsite gateway -- no payment fields needed.
+		 *
+		 * @since TBD
+		 */
+		public static function show_checkout_fields() {
+			// Offsite gateway: no checkout fields to render.
+		}
+
+		/**
+		 * PayPal Express does not require billing address fields.
+		 *
+		 * @since TBD
+		 *
+		 * @return bool
+		 */
+		public static function requires_billing_address() {
+			return false;
+		}
+
+		/**
+		 * Modify the required billing fields for PayPal Express.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $fields Associative array of field_name => value.
+		 * @return array Modified array of required fields.
+		 */
+		public static function get_required_billing_fields( $fields ) {
+			return self::pmpro_required_billing_fields( $fields );
+		}
+
+		/**
+		 * Render the submit button for PayPal Express.
+		 *
+		 * Shows the branded "Check Out With PayPal" button.
+		 *
+		 * @since TBD
+		 */
+		public static function show_submit_button() {
+			global $pmpro_requirebilling;
+
+			// If billing is not required (free level), show the standard submit button.
+			if ( ! $pmpro_requirebilling ) {
+				PMProGateway::show_submit_button();
+				return;
+			}
+
+			?>
+			<span id="pmpro_paypalexpress_checkout">
+				<input type="hidden" name="submit-checkout" value="1" />
+				<button type="submit" id="pmpro_btn-submit-paypalexpress" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout pmpro_btn-submit-checkout-paypal' ) ); ?>">
+					<?php
+						printf(
+							/* translators: %s is the PayPal logo */
+							esc_html__( 'Check Out With %s', 'paid-memberships-pro' ),
+							'<span class="pmpro_btn-submit-checkout-paypal-image"></span>'
+						);
+					?>
+					<span class="screen-reader-text"><?php esc_html_e( 'PayPal', 'paid-memberships-pro' ); ?></span>
+				</button>
+			</span>
+			<?php
 		}
 
 		/**

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -121,46 +121,29 @@ class PMProGateway_stripe extends PMProGateway {
 		global $pmpro_stripe_lite;
 		$pmpro_stripe_lite = apply_filters( "pmpro_stripe_lite", ! get_option( "pmpro_stripe_billingaddress" ) );    //default is opposite of the stripe_billingaddress setting
 
-		$gateway = pmpro_getGateway();
-		if($gateway == "stripe")
-		{
-			add_filter( 'pmpro_required_billing_fields', array( 'PMProGateway_stripe', 'pmpro_required_billing_fields' ) );
-		}
-
-		//AJAX services for creating/disabling webhooks
+		// AJAX services for creating/disabling webhooks.
 		add_action( 'wp_ajax_pmpro_stripe_create_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_create_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_delete_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_delete_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_rebuild_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_rebuild_webhook' ) );
 
-		//code to add at checkout if Stripe is the current gateway
-		$default_gateway = get_option( 'pmpro_gateway' );
-		$current_gateway = pmpro_getGateway();
-
-		// $_REQUEST['review'] here means the PayPal Express review pag
-		if ( ( $default_gateway == "stripe" || $current_gateway == "stripe" ) && empty( $_REQUEST['review'] ) ) {
-			add_filter( 'pmpro_include_billing_address_fields', array(
-				'PMProGateway_stripe',
-				'pmpro_include_billing_address_fields'
-			) );
+		// Hooks for order processing and checkout state that can't be handled by static methods
+		// (these need the $order object or checkout-specific context).
+		$enabled_gateways = pmpro_get_enabled_gateways();
+		$stripe_is_enabled = in_array( 'stripe', $enabled_gateways, true );
+		if ( $stripe_is_enabled && empty( $_REQUEST['review'] ) ) {
+			// Billing address filter for the billing update page (checkout uses requires_billing_address() instead).
+			add_filter( 'pmpro_include_billing_address_fields', array( 'PMProGateway_stripe', 'pmpro_include_billing_address_fields' ) );
 
 			if ( ! self::using_stripe_checkout() ) {
-				// On-site checkout flow.
-				add_action( 'pmpro_after_checkout_preheader', array(
-					'PMProGateway_stripe',
-					'pmpro_checkout_after_preheader'
-				) );
-
+				// Localizes paymentIntent/setupIntent for SCA and enqueues scripts for billing page.
+				add_action( 'pmpro_after_checkout_preheader', array( 'PMProGateway_stripe', 'pmpro_checkout_after_preheader' ) );
 				add_action( 'pmpro_billing_preheader', array( 'PMProGateway_stripe', 'pmpro_checkout_after_preheader' ) );
 				add_filter( 'pmpro_checkout_order', array( 'PMProGateway_stripe', 'pmpro_checkout_order' ) );
 				add_filter( 'pmpro_billing_order', array( 'PMProGateway_stripe', 'pmpro_checkout_order' ) );
-				add_filter( 'pmpro_include_payment_information_fields', array(
-					'PMProGateway_stripe',
-					'pmpro_include_payment_information_fields'
-				) );	
-				add_filter( 'pmpro_after_checkout_preheader', array( 'PMProGateway_stripe', 'clear_pmpro_review' ) );			
+				add_filter( 'pmpro_after_checkout_preheader', array( 'PMProGateway_stripe', 'clear_pmpro_review' ) );
 			} else {
-				// Checkout flow for Stripe Checkout.
-				add_filter('pmpro_include_payment_information_fields', array('PMProGateway_stripe', 'show_stripe_checkout_pending_warning'));
+				// Stripe Checkout (offsite) flow.
+				add_filter( 'pmpro_include_payment_information_fields', array( 'PMProGateway_stripe', 'show_stripe_checkout_pending_warning' ) );
 			}
 		}
 
@@ -229,6 +212,169 @@ class PMProGateway_stripe extends PMProGateway {
 	 */
 	public static function get_description_for_gateway_settings() {
 		return esc_html__( 'With Stripe, you can accept membership payment onsite or offsite. The Stripe gateway supports over 135 currencies, built-in tax collection, and multiple payment methods like credit card, Google Pay, Apple Pay, and over 40 region-specific options.', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Get the checkout label for this gateway.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_checkout_label() {
+		if ( self::using_stripe_checkout() ) {
+			return esc_html__( 'Pay with Stripe', 'paid-memberships-pro' );
+		}
+		return esc_html__( 'Pay with Credit Card', 'paid-memberships-pro' );
+	}
+
+	/**
+	 * Enqueue Stripe-specific scripts for checkout.
+	 *
+	 * @since TBD
+	 */
+	public static function enqueue_checkout_scripts() {
+		// Only enqueue for on-site checkout flow. Stripe Checkout (offsite) doesn't need these.
+		if ( self::using_stripe_checkout() ) {
+			return;
+		}
+
+		global $pmpro_level, $pmpro_requirebilling, $pmpro_currency;
+
+		// Stripe.js library.
+		wp_enqueue_script( 'stripe', 'https://js.stripe.com/v3/', array(), null );
+
+		// Skip if already registered by pmpro_checkout_after_preheader (which includes intent data for SCA).
+		if ( ! function_exists( 'pmpro_stripe_javascript' ) && ! wp_script_is( 'pmpro_stripe', 'registered' ) ) {
+			$stripe = new PMProGateway_stripe();
+			$localize_vars = array(
+				'publishableKey'               => $stripe->get_publishablekey(),
+				'user_id'                       => $stripe->get_connect_user_id(),
+				'verifyAddress'                 => apply_filters( 'pmpro_stripe_verify_address', get_option( 'pmpro_stripe_billingaddress' ) ),
+				'ajaxUrl'                       => admin_url( 'admin-ajax.php' ),
+				'msgAuthenticationValidated'    => __( 'Verification steps confirmed. Your payment is processing.', 'paid-memberships-pro' ),
+				'pmpro_require_billing'         => $pmpro_requirebilling,
+				'restUrl'                       => get_rest_url(),
+				'siteName'                      => get_bloginfo( 'name' ),
+				'updatePaymentRequestButton'    => apply_filters( 'pmpro_stripe_update_payment_request_button', true ),
+				'currency'                      => strtolower( $pmpro_currency ),
+				'accountCountry'                => $stripe->get_account_country(),
+				'style'                         => apply_filters( 'pmpro_stripe_card_element_style', array( 'base' => array( 'fontSize' => '16px' ) ) ),
+			);
+
+			wp_register_script( 'pmpro_stripe',
+				plugins_url( 'js/pmpro-stripe.js', PMPRO_BASE_FILE ),
+				array( 'jquery' ),
+				PMPRO_VERSION );
+			wp_localize_script( 'pmpro_stripe', 'pmproStripe', $localize_vars );
+			wp_enqueue_script( 'pmpro_stripe' );
+		}
+	}
+
+	/**
+	 * Render Stripe-specific checkout fields (Stripe Elements containers).
+	 *
+	 * @since TBD
+	 */
+	public static function show_checkout_fields() {
+		// If using Stripe Checkout (offsite), don't show on-site card fields.
+		if ( self::using_stripe_checkout() ) {
+			// Show pending order warning if applicable.
+			self::show_stripe_checkout_pending_warning( true );
+			return;
+		}
+
+		global $pmpro_requirebilling, $pmpro_show_discount_code, $discount_code, $CardType;
+		?>
+		<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling || apply_filters( 'pmpro_hide_payment_information_fields', false ) ) { ?>style="display: none;"<?php } ?>>
+			<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+					<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
+						<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e( 'Payment Information', 'paid-memberships-pro' ); ?></h2>
+					</legend>
+				<?php
+					if ( get_option( 'pmpro_stripe_payment_request_button' ) ) { ?>
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_payment-request-button', 'pmpro_payment-request-button' ) ); ?>">
+							<div id="payment-request-button"><!-- Alternate payment method will be inserted here. --></div>
+							<h3 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>">
+								<?php
+								echo esc_html( pmpro_is_checkout() ? __( 'Pay with Credit Card', 'paid-memberships-pro' ) : __( 'Credit Card', 'paid-memberships-pro' ) );
+								?>
+							</h3>
+						</div>
+						<?php
+					}
+				?>
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+							<input type="hidden" id="CardType" name="CardType"
+								value="<?php echo esc_attr( $CardType ); ?>"/>
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_payment-account-number', 'pmpro_payment-account-number' ) ); ?>">
+								<label for="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Card Number', 'paid-memberships-pro' ); ?></label>
+								<div id="AccountNumber"></div>
+							</div>
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ); ?>">
+								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_payment-expiration', 'pmpro_payment-expiration' ) ); ?>">
+									<label for="Expiry" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Expiration Date', 'paid-memberships-pro' ); ?></label>
+									<div id="Expiry"></div>
+								</div>
+								<?php
+								$pmpro_show_cvv = apply_filters( 'pmpro_show_cvv', true );
+								if ( $pmpro_show_cvv ) { ?>
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_payment-cvv', 'pmpro_payment-cvv' ) ); ?>">
+										<label for="CVV" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'CVC', 'paid-memberships-pro' ); ?></label>
+										<div id="CVV"></div>
+									</div>
+								<?php } ?>
+							</div> <!-- end pmpro_cols-2 -->
+							<?php if ( $pmpro_show_discount_code ) { ?>
+								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-discount-code', 'pmpro_payment-discount-code' ) ); ?>">
+										<label for="pmpro_discount_code" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e( 'Discount Code', 'paid-memberships-pro' ); ?></label>
+										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields-inline' ) ); ?>">
+											<input id="pmpro_discount_code" name="pmpro_discount_code" type="text" value="<?php echo esc_attr( $discount_code ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text pmpro_alter_price', 'pmpro_discount_code' ) ); ?>" />
+											<input aria-label="<?php esc_html_e( 'Apply discount code', 'paid-memberships-pro' ); ?>" type="button" id="discount_code_button" name="discount_code_button" value="<?php esc_attr_e( 'Apply', 'paid-memberships-pro' ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-discount-code', 'discount_code_button' ) ); ?>" />
+										</div> <!-- end pmpro_form_fields-inline -->
+										<p id="discount_code_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message' ) ); ?>" style="display: none;"></p>
+									</div>
+								</div> <!-- end pmpro_cols-2 -->
+							<?php } ?>
+						</div> <!-- end pmpro_form_fields -->
+				</div> <!-- end pmpro_card_content -->
+			</div> <!-- end pmpro_card -->
+		</fieldset> <!-- end pmpro_payment_information_fields -->
+		<?php
+	}
+
+	/**
+	 * Modify the required billing fields for Stripe.
+	 *
+	 * Stripe handles card validation via Elements, so card fields aren't
+	 * submitted directly. Billing address fields depend on the stripe_lite setting.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $fields Associative array of field_name => value.
+	 * @return array Modified array of required fields.
+	 */
+	public static function get_required_billing_fields( $fields ) {
+		return self::pmpro_required_billing_fields( $fields );
+	}
+
+	/**
+	 * Whether Stripe requires billing address fields.
+	 *
+	 * Depends on the billing address setting for on-site checkout.
+	 * Stripe Checkout (offsite) handles billing address on Stripe's side.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public static function requires_billing_address() {
+		if ( self::using_stripe_checkout() ) {
+			return false;
+		}
+		return (bool) get_option( 'pmpro_stripe_billingaddress' );
 	}
 
 	/**

--- a/includes/deprecated.php
+++ b/includes/deprecated.php
@@ -897,6 +897,11 @@ function pmpro_get_deprecated_add_ons() {
 			'file' => 'pmpro-subscription-check.php',
 			'label' => 'Subscription Check'
 		),
+		'pmpro-add-paypal-express' => array(
+			'file' => 'pmpro-add-paypal-express.php',
+			'label' => 'Add PayPal Express',
+			'message' => __( 'Offering multiple payment gateways at checkout is now a built-in feature. Enable PayPal Express as an active gateway in your Payment Settings.', 'paid-memberships-pro' ),
+		),
 	);
 	
 	$deprecated = apply_filters( 'pmpro_deprecated_add_ons_list', $deprecated );
@@ -1052,10 +1057,11 @@ function pmpro_check_for_deprecated_gateways() {
 		$undeprecated_gateways = explode( ',', $undeprecated_gateways );
 	}
 	$default_gateway = get_option( 'pmpro_gateway' );
+	$enabled_gateways = function_exists( 'pmpro_get_enabled_gateways' ) ? pmpro_get_enabled_gateways() : array( $default_gateway );
 
 	$deprecated_gateways = pmpro_get_deprecated_gateways();
 	foreach ( $deprecated_gateways as $deprecated_gateway ) {
-		if ( $default_gateway === $deprecated_gateway || in_array( $deprecated_gateway, $undeprecated_gateways ) ) {
+		if ( $default_gateway === $deprecated_gateway || in_array( $deprecated_gateway, $undeprecated_gateways ) || in_array( $deprecated_gateway, $enabled_gateways, true ) ) {
 			require_once( PMPRO_DIR . '/classes/gateways/class.pmprogateway_' . $deprecated_gateway . '.php' );
 			if ( ! in_array( $deprecated_gateway, $undeprecated_gateways ) ) {
 				$undeprecated_gateways[] = $deprecated_gateway;
@@ -1064,6 +1070,22 @@ function pmpro_check_for_deprecated_gateways() {
 		}
 	}
 }
+
+/**
+ * Disable the core gateway selector when the Pay by Check add-on is active
+ * and providing its own gateway selection UI. This prevents duplicate radio buttons.
+ *
+ * Hooked on init so that the add-on's hooks are already registered when we check.
+ *
+ * @since TBD
+ */
+function pmpro_maybe_disable_gateway_selector_for_pbc() {
+	if ( defined( 'PMPROPBC_VER' ) && has_action( 'pmpro_checkout_boxes', 'pmpropbc_checkout_boxes' ) ) {
+		add_filter( 'pmpro_show_gateway_selector', '__return_false' );
+	}
+}
+add_action( 'init', 'pmpro_maybe_disable_gateway_selector_for_pbc', 20 );
+
 
 /**
  * Disable uninstall script for duplicates

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3669,9 +3669,46 @@ function pmpro_filter_price_for_text_field( $price ) {
 }
 
 /**
+ * Get the list of enabled gateways.
+ *
+ * Returns an array of gateway slugs that have been enabled in the
+ * Payment Settings admin page.
+ *
+ * When the `pmpro_enabled_gateways` option has not been set yet (pre-multi-gateway
+ * sites or fresh upgrades), this function handles the migration automatically by
+ * falling back to the single `pmpro_gateway` option and persisting the result.
+ *
+ * @since TBD
+ *
+ * @return array Array of enabled gateway slugs.
+ */
+function pmpro_get_enabled_gateways() {
+	$enabled = get_option( 'pmpro_enabled_gateways' );
+
+	if ( is_array( $enabled ) && ! empty( $enabled ) ) {
+		return $enabled;
+	}
+
+	// First-time migration: build the enabled gateways from the legacy single gateway option.
+	$primary = get_option( 'pmpro_gateway' );
+	$enabled = array( ! empty( $primary ) ? $primary : '' );
+
+	// If the Pay by Check add-on is active and check isn't already the primary, include it.
+	if ( defined( 'PMPROPBC_VER' ) && ! in_array( 'check', $enabled, true ) ) {
+		$enabled[] = 'check';
+	}
+
+	// Persist so we only migrate once.
+	update_option( 'pmpro_enabled_gateways', $enabled );
+
+	return $enabled;
+}
+
+/**
  * What gateway should we be using?
  *
  * @since 1.8
+ * @deprecated TBD Use pmpro_get_enabled_gateways() and check $_REQUEST['gateway'] directly.
  */
 function pmpro_getGateway() {
 	// grab from param or options
@@ -3683,8 +3720,8 @@ function pmpro_getGateway() {
 		$gateway = get_option( 'pmpro_gateway' );  // get from options
 	}
 
-	// set valid gateways - the active gateway in the settings and any gateway added through the filter will be allowed
-	$valid_gateways = apply_filters( 'pmpro_valid_gateways', array( get_option( 'pmpro_gateway' ) ) );
+	// set valid gateways - all enabled gateways and any gateway added through the filter will be allowed
+	$valid_gateways = apply_filters( 'pmpro_valid_gateways', pmpro_get_enabled_gateways() );
 
 	// make sure it's valid
 	if ( ! in_array( $gateway, $valid_gateways ) ) {
@@ -4203,7 +4240,7 @@ function pmpro_insert_or_replace( $table, $data, $format, $primary_key = 'id' ) 
 /**
  * Checks if a webhook is running
  * @since 2.5
- * @since 3.7 Calling this function to read webhook status is deprecated.
+ * @since TBD Calling this function to read webhook status is deprecated.
  * @param string $gateway If passed in, requires that specific gateway.
  * @param bool $set Set to true to set the constant and fire the action hook.
  * @return bool True or false if a PMPro webhook set the constant or not.

--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -234,6 +234,39 @@ jQuery(document).ready(function(){
 			jQuery('input[name="pmpro_checkout_nonce"]').val(response);
 		});
 	}
+
+	// Gateway selector: toggle fields when switching between gateways.
+	var $gatewayRadios = jQuery( 'input[name="gateway"]' );
+	if ( $gatewayRadios.length > 1 ) {
+		$gatewayRadios.on( 'change', function() {
+			var selected = jQuery( this ).val();
+			// Use attr() instead of data() to avoid jQuery's type caching quirks.
+			var requiresBilling = jQuery( this ).attr( 'data-requires-billing' );
+
+			// Show/hide per-gateway field containers and submit buttons.
+			jQuery( '.pmpro_gateway_fields' ).hide();
+			jQuery( '.pmpro_gateway_fields_' + selected ).show();
+			jQuery( '.pmpro_gateway_submit' ).hide();
+			jQuery( '.pmpro_gateway_submit_' + selected ).show();
+
+			// Toggle billing address fields.
+			if ( requiresBilling === '1' ) {
+				jQuery( '#pmpro_billing_address_fields' ).show();
+			} else {
+				jQuery( '#pmpro_billing_address_fields' ).hide();
+			}
+
+			/**
+			 * Fire a custom event that gateway-specific JS can listen for.
+			 *
+			 * Example usage in a gateway's JS:
+			 *   jQuery( document ).on( 'pmpro_gateway_changed', function( e, gateway ) {
+			 *       if ( gateway === 'stripe' ) { // mount Stripe Elements }
+			 *   });
+			 */
+			jQuery( document ).trigger( 'pmpro_gateway_changed', [ selected ] );
+		} );
+	}
 });
 
 // Get non-sensitive checkout form data to be sent to checkout_levels endpoint.

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -179,8 +179,14 @@
 						</div>
 
 						<?php
-							$pmpro_include_billing_address_fields = apply_filters('pmpro_include_billing_address_fields', true);
-							if($pmpro_include_billing_address_fields )
+							// Use the gateway's static method to determine billing address visibility.
+							$billing_gw_class = ! empty( $gateway ) ? 'PMProGateway_' . $gateway : 'PMProGateway';
+							$pmpro_include_billing_address_fields = true;
+							if ( class_exists( $billing_gw_class ) && method_exists( $billing_gw_class, 'requires_billing_address' ) ) {
+								$pmpro_include_billing_address_fields = call_user_func( array( $billing_gw_class, 'requires_billing_address' ) );
+							}
+							$pmpro_include_billing_address_fields = apply_filters( 'pmpro_include_billing_address_fields', $pmpro_include_billing_address_fields );
+							if ( $pmpro_include_billing_address_fields )
 							{
 						?>
 						<fieldset id="pmpro_billing_address_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_billing_address_fields' ) ); ?>">
@@ -271,92 +277,11 @@
 						global $pmpro_requirebilling;
 						$pmpro_requirebilling = true;
 
-						//do we need to show the payment information (credit card) fields? gateways will override this
-						$pmpro_include_payment_information_fields = apply_filters('pmpro_include_payment_information_fields', true);
-						if($pmpro_include_payment_information_fields)
-						{
-							$pmpro_accepted_credit_cards = get_option("pmpro_accepted_credit_cards");
-							$pmpro_accepted_credit_cards = explode(",", $pmpro_accepted_credit_cards);
-							$pmpro_accepted_credit_cards_string = pmpro_implodeToEnglish($pmpro_accepted_credit_cards);
-							?>
-							<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>">
-								<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
-									<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e('Payment Information', 'paid-memberships-pro' ); ?></h2>
-								</legend>
-								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
-									<input type="hidden" id="CardType" name="CardType" value="<?php echo esc_attr($CardType);?>" />
-									<script>
-										jQuery(document).ready(function() {
-												jQuery('#AccountNumber').validateCreditCard(function(result) {
-													var cardtypenames = {
-														"amex"                      : "American Express",
-														"diners_club_carte_blanche" : "Diners Club Carte Blanche",
-														"diners_club_international" : "Diners Club International",
-														"discover"                  : "Discover",
-														"jcb"                       : "JCB",
-														"laser"                     : "Laser",
-														"maestro"                   : "Maestro",
-														"mastercard"                : "Mastercard",
-														"visa"                      : "Visa",
-														"visa_electron"             : "Visa Electron"
-													};
-
-													if(result.card_type)
-														jQuery('#CardType').val(cardtypenames[result.card_type.name]);
-													else
-														jQuery('#CardType').val('Unknown Card Type');
-												});
-										});
-									</script>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-account-number', 'pmpro_payment-account-number' ) ); ?>">
-										<label for="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Card Number', 'paid-memberships-pro' );?></label>
-										<input id="AccountNumber" name="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'AccountNumber' ) );?>" type="text" size="25" value="<?php echo esc_attr($AccountNumber)?>" autocomplete="off" />
-									</div>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-select pmpro_payment-expiration', 'pmpro_payment-expiration' ) ); ?>">
-										<label for="ExpirationMonth" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Expiration Date', 'paid-memberships-pro' );?></label>
-										<select id="ExpirationMonth" name="ExpirationMonth" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'ExpirationMonth' ) ); ?>">
-											<option value="01" <?php if($ExpirationMonth == "01") { ?>selected="selected"<?php } ?>>01</option>
-											<option value="02" <?php if($ExpirationMonth == "02") { ?>selected="selected"<?php } ?>>02</option>
-											<option value="03" <?php if($ExpirationMonth == "03") { ?>selected="selected"<?php } ?>>03</option>
-											<option value="04" <?php if($ExpirationMonth == "04") { ?>selected="selected"<?php } ?>>04</option>
-											<option value="05" <?php if($ExpirationMonth == "05") { ?>selected="selected"<?php } ?>>05</option>
-											<option value="06" <?php if($ExpirationMonth == "06") { ?>selected="selected"<?php } ?>>06</option>
-											<option value="07" <?php if($ExpirationMonth == "07") { ?>selected="selected"<?php } ?>>07</option>
-											<option value="08" <?php if($ExpirationMonth == "08") { ?>selected="selected"<?php } ?>>08</option>
-											<option value="09" <?php if($ExpirationMonth == "09") { ?>selected="selected"<?php } ?>>09</option>
-											<option value="10" <?php if($ExpirationMonth == "10") { ?>selected="selected"<?php } ?>>10</option>
-											<option value="11" <?php if($ExpirationMonth == "11") { ?>selected="selected"<?php } ?>>11</option>
-											<option value="12" <?php if($ExpirationMonth == "12") { ?>selected="selected"<?php } ?>>12</option>
-										</select>/<select id="ExpirationYear" name="ExpirationYear" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'ExpirationYear' ) ); ?>">
-										<?php
-											$num_years = apply_filters( 'pmpro_num_expiration_years', 10 );
-
-											for ( $i = date_i18n( 'Y' ); $i < intval( date_i18n( 'Y' ) ) + intval( $num_years ); $i++ )
-											{
-												?>
-												<option value="<?php echo esc_attr( $i ) ?>" <?php if($ExpirationYear == $i) { ?>selected="selected"<?php } elseif($i == date_i18n( 'Y' ) + 1) { ?>selected="selected"<?php } ?>><?php echo esc_html( $i )?></option>
-												<?php
-											}
-										?>
-										</select>
-									</div>							
-									<?php
-										$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
-										if($pmpro_show_cvv) {
-											if ( true == ini_get('allow_url_include') ) {
-												$cvv_template = pmpro_loadTemplate('popup-cvv', 'url', 'pages', 'html');
-											} else {
-												$cvv_template = plugins_url( 'paid-memberships-pro/pages/popup-cvv.html', PMPRO_DIR );
-											}
-										?>
-										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-cvv', 'pmpro_payment-cvv' ) ); ?>">
-											<label for="CVV" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('CVV', 'paid-memberships-pro' );?></label>
-											<input id="CVV" name="CVV" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr( sanitize_text_field( $_REQUEST['CVV'] ) ); }?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'CVV' ) ); ?>" />
-										</div>
-									<?php } ?>
-								</div> <!-- end pmpro_form_fields -->
-							</fieldset> <!-- end pmpro_payment_information_fields -->
-							<?php
+						// Use the gateway's static method to render payment fields.
+						if ( class_exists( $billing_gw_class ) && method_exists( $billing_gw_class, 'show_checkout_fields' ) ) {
+							call_user_func( array( $billing_gw_class, 'show_checkout_fields' ) );
+						} else {
+							PMProGateway::show_checkout_fields();
 						}
 						?>
 

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -380,9 +380,97 @@ if ( empty( $default_gateway ) ) {
 			?>
 
 			<?php
+			// Determine valid gateways and current gateway for the selector, field rendering, and submit buttons below.
+			$valid_gateways = apply_filters( 'pmpro_valid_gateways', pmpro_get_enabled_gateways() );
+			$valid_gateways = array_unique( array_values( $valid_gateways ) );
+
+			// Determine the currently selected gateway.
+			if ( ! empty( $_REQUEST['gateway'] ) ) {
+				$current_gateway = sanitize_text_field( $_REQUEST['gateway'] );
+			} else {
+				$current_gateway = ! empty( $valid_gateways ) ? $valid_gateways[0] : '';
+			}
+			if ( ! in_array( $current_gateway, $valid_gateways, true ) ) {
+				$current_gateway = ! empty( $valid_gateways ) ? $valid_gateways[0] : '';
+			}
+
+			// Check if the current gateway requires billing address (for initial page load visibility).
+			$current_gw_class = ! empty( $current_gateway ) ? 'PMProGateway_' . $current_gateway : 'PMProGateway';
+			$current_gw_requires_billing = true;
+			if ( class_exists( $current_gw_class ) && method_exists( $current_gw_class, 'requires_billing_address' ) ) {
+				$current_gw_requires_billing = call_user_func( array( $current_gw_class, 'requires_billing_address' ) );
+			}
+
+			/**
+			 * Filter to disable the core gateway selector at checkout.
+			 *
+			 * @since TBD
+			 *
+			 * @param bool   $show        Whether to show the gateway selector. Default true.
+			 * @param object $pmpro_level The level being purchased.
+			 */
+			$show_gateway_selector = apply_filters( 'pmpro_show_gateway_selector', true, $pmpro_level );
+
+			if ( $show_gateway_selector && count( $valid_gateways ) > 1 && ! pmpro_isLevelFree( $pmpro_level ) ) {
+				$all_gateways = pmpro_gateways();
+				?>
+				<fieldset id="pmpro_payment_method" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_method' ) ); ?>">
+					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
+						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+							<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
+								<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>">
+									<?php esc_html_e( 'Choose Your Payment Method', 'paid-memberships-pro' ); ?>
+								</h2>
+							</legend>
+							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-radio' ) ); ?>">
+									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-radio-items' ) ); ?>">
+										<?php foreach ( $valid_gateways as $gw_slug ) :
+											$gw_class = ! empty( $gw_slug ) ? 'PMProGateway_' . $gw_slug : 'PMProGateway';
+
+											// Get the checkout label.
+											if ( class_exists( $gw_class ) && method_exists( $gw_class, 'get_checkout_label' ) ) {
+												$label = call_user_func( array( $gw_class, 'get_checkout_label' ) );
+											} elseif ( isset( $all_gateways[ $gw_slug ] ) ) {
+												$label = $all_gateways[ $gw_slug ];
+											} else {
+												$label = ucwords( $gw_slug );
+											}
+
+											// Check if this gateway requires billing address (for JS data attribute).
+											$requires_billing = true;
+											if ( class_exists( $gw_class ) && method_exists( $gw_class, 'requires_billing_address' ) ) {
+												$requires_billing = call_user_func( array( $gw_class, 'requires_billing_address' ) );
+											}
+										?>
+											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-radio-item' ) ); ?> gateway_<?php echo esc_attr( $gw_slug ); ?>">
+												<input type="radio"
+													id="gateway_<?php echo esc_attr( $gw_slug ); ?>"
+													name="gateway"
+													class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-radio' ) ); ?>"
+													value="<?php echo esc_attr( $gw_slug ); ?>"
+													<?php checked( $current_gateway, $gw_slug ); ?>
+													data-requires-billing="<?php echo esc_attr( $requires_billing ? '1' : '0' ); ?>"
+												/>
+												<label for="gateway_<?php echo esc_attr( $gw_slug ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label pmpro_form_label-inline pmpro_clickable' ) ); ?>">
+													<?php echo esc_html( $label ); ?>
+												</label>
+											</div>
+										<?php endforeach; ?>
+									</div> <!-- end pmpro_form_field-radio-items -->
+								</div> <!-- end pmpro_form_field pmpro_form_field-radio -->
+							</div> <!-- end pmpro_form_fields -->
+						</div> <!-- end pmpro_card_content -->
+					</div> <!-- end pmpro_card -->
+				</fieldset> <!-- end pmpro_payment_method -->
+				<?php
+			}
+			?>
+
+			<?php
 				$pmpro_include_billing_address_fields = apply_filters('pmpro_include_billing_address_fields', true);
 				if ( $pmpro_include_billing_address_fields ) { ?>
-			<fieldset id="pmpro_billing_address_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_billing_address_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling || apply_filters("pmpro_hide_billing_address_fields", false) ) { ?>style="display: none;"<?php } ?>>
+			<fieldset id="pmpro_billing_address_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_billing_address_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling || ! $current_gw_requires_billing || apply_filters("pmpro_hide_billing_address_fields", false) ) { ?>style="display: none;"<?php } ?>>
 				<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
 					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 						<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
@@ -476,83 +564,45 @@ if ( empty( $default_gateway ) ) {
 
 			<?php
 				/**
-				 * Filter to set if the payment information fields should be shown.
+				 * Render per-gateway payment fields.
 				 *
-				 * @param bool $include_payment_information_fields
-				 * @return bool
+				 * When multiple gateways are enabled, each gateway's fields are
+				 * rendered inside a container div. Only the selected gateway's
+				 * container is visible; the JS toggles the others.
+				 *
+				 * When only one gateway is enabled, we still use show_checkout_fields()
+				 * but also respect the legacy pmpro_include_payment_information_fields filter.
+				 *
+				 * Uses $valid_gateways and $current_gateway set above in the gateway selector section.
 				 */
-				$pmpro_include_payment_information_fields = apply_filters( 'pmpro_include_payment_information_fields', true );
-				if ( $pmpro_include_payment_information_fields ) {
-					?>
-					<fieldset id="pmpro_payment_information_fields" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fieldset', 'pmpro_payment_information_fields' ) ); ?>" <?php if ( ! $pmpro_requirebilling || apply_filters( 'pmpro_hide_payment_information_fields', false ) ) { ?>style="display: none;"<?php } ?>>
-						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card' ) ); ?>">
-							<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
-								<legend class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_legend' ) ); ?>">
-									<h2 class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_heading pmpro_font-large' ) ); ?>"><?php esc_html_e( 'Payment Information', 'paid-memberships-pro' ); ?></h2>
-								</legend>
-								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
-									<input type="hidden" id="CardType" name="CardType" value="<?php echo esc_attr($CardType);?>" />
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-account-number', 'pmpro_payment-account-number' ) ); ?>">
-										<label for="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Card Number', 'paid-memberships-pro' );?></label>
-										<input id="AccountNumber" name="AccountNumber" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'AccountNumber' ) ); ?>" type="text" value="<?php echo esc_attr($AccountNumber); ?>" data-encrypted-name="number" autocomplete="off" />
-									</div>
-									<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ); ?>">
-										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-select pmpro_payment-expiration', 'pmpro_payment-expiration' ) ); ?>">
-											<label for="ExpirationMonth" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Expiration Date', 'paid-memberships-pro' );?></label>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields-inline' ) ); ?>">
-												<select id="ExpirationMonth" name="ExpirationMonth" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'ExpirationMonth' ) ); ?>">
-													<option value="01" <?php if($ExpirationMonth == "01") { ?>selected="selected"<?php } ?>>01</option>
-													<option value="02" <?php if($ExpirationMonth == "02") { ?>selected="selected"<?php } ?>>02</option>
-													<option value="03" <?php if($ExpirationMonth == "03") { ?>selected="selected"<?php } ?>>03</option>
-													<option value="04" <?php if($ExpirationMonth == "04") { ?>selected="selected"<?php } ?>>04</option>
-													<option value="05" <?php if($ExpirationMonth == "05") { ?>selected="selected"<?php } ?>>05</option>
-													<option value="06" <?php if($ExpirationMonth == "06") { ?>selected="selected"<?php } ?>>06</option>
-													<option value="07" <?php if($ExpirationMonth == "07") { ?>selected="selected"<?php } ?>>07</option>
-													<option value="08" <?php if($ExpirationMonth == "08") { ?>selected="selected"<?php } ?>>08</option>
-													<option value="09" <?php if($ExpirationMonth == "09") { ?>selected="selected"<?php } ?>>09</option>
-													<option value="10" <?php if($ExpirationMonth == "10") { ?>selected="selected"<?php } ?>>10</option>
-													<option value="11" <?php if($ExpirationMonth == "11") { ?>selected="selected"<?php } ?>>11</option>
-													<option value="12" <?php if($ExpirationMonth == "12") { ?>selected="selected"<?php } ?>>12</option>
-												</select>/<select id="ExpirationYear" name="ExpirationYear" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-select', 'ExpirationYear' ) ); ?>">
-												<?php
-													$num_years = apply_filters( 'pmpro_num_expiration_years', 10 );
-
-													for ( $i = date_i18n( 'Y' ); $i < intval( date_i18n( 'Y' ) ) + intval( $num_years ); $i++ )
-													{
-														?>
-														<option value="<?php echo esc_attr( $i ) ?>" <?php if($ExpirationYear == $i) { ?>selected="selected"<?php } elseif($i == date_i18n( 'Y' ) + 1) { ?>selected="selected"<?php } ?>><?php echo esc_html( $i )?></option>
-														<?php
-													}
-												?>
-												</select>
-											</div> <!-- end pmpro_form_fields-inline -->
-										</div>
-										<?php
-											$pmpro_show_cvv = apply_filters("pmpro_show_cvv", true);
-											if($pmpro_show_cvv) { ?>
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-cvv', 'pmpro_payment-cvv' ) ); ?>">
-												<label for="CVV" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Security Code (CVC)', 'paid-memberships-pro' );?></label>
-												<input id="CVV" name="CVV" type="text" size="4" value="<?php if(!empty($_REQUEST['CVV'])) { echo esc_attr( sanitize_text_field( $_REQUEST['CVV'] ) ); }?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text', 'CVV' ) ); ?>" />
-											</div>
-										<?php } ?>
-									</div> <!-- end pmpro_cols-2 -->
-									<?php if($pmpro_show_discount_code) { ?>
-										<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_cols-2' ) ); ?>">
-											<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-text pmpro_payment-discount-code', 'pmpro_payment-discount-code' ) ); ?>">
-												<label for="pmpro_discount_code" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label' ) ); ?>"><?php esc_html_e('Discount Code', 'paid-memberships-pro' );?></label>
-												<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields-inline' ) ); ?>">
-													<input class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-text pmpro_alter_price', 'discount_code' ) ); ?>" id="pmpro_discount_code" name="pmpro_discount_code" type="text" size="10" value="<?php echo esc_attr($discount_code); ?>" />
-													<input aria-label="<?php esc_html_e( 'Apply discount code', 'paid-memberships-pro' ); ?>" type="button" id="discount_code_button" name="discount_code_button" value="<?php esc_attr_e('Apply', 'paid-memberships-pro' );?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-discount-code', 'other_discount_code_button' ) ); ?>" />
-												</div> <!-- end pmpro_form_fields-inline -->
-												<div id="discount_code_message" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message', 'discount_code_message' ) ); ?>" style="display: none;"></div>
-											</div>
-										</div> <!-- end pmpro_cols-2 -->
-									<?php } ?>
-								</div> <!-- end pmpro_form_fields -->
-							</div> <!-- end pmpro_card_content -->
-						</div> <!-- end pmpro_card -->
-					</fieldset> <!-- end pmpro_payment_information_fields -->
-					<?php
+				if ( count( $valid_gateways ) > 1 ) {
+					// Multi-gateway: render each gateway's fields in a container.
+					foreach ( $valid_gateways as $gw_slug ) {
+						$gw_class = ! empty( $gw_slug ) ? 'PMProGateway_' . $gw_slug : 'PMProGateway';
+						$is_selected = ( $gw_slug === $current_gateway );
+						?>
+						<div class="pmpro_gateway_fields pmpro_gateway_fields_<?php echo esc_attr( $gw_slug ); ?>" <?php if ( ! $is_selected ) { ?>style="display: none;"<?php } ?>>
+							<?php
+							if ( class_exists( $gw_class ) && method_exists( $gw_class, 'show_checkout_fields' ) ) {
+								call_user_func( array( $gw_class, 'show_checkout_fields' ) );
+							}
+							?>
+						</div>
+						<?php
+					}
+				} else {
+					// Single gateway: use the legacy filter for backward compatibility.
+					$pmpro_include_payment_information_fields = apply_filters( 'pmpro_include_payment_information_fields', true );
+					if ( $pmpro_include_payment_information_fields ) {
+						$gw_slug = reset( $valid_gateways );
+						$gw_class = ! empty( $gw_slug ) ? 'PMProGateway_' . $gw_slug : 'PMProGateway';
+						if ( class_exists( $gw_class ) && method_exists( $gw_class, 'show_checkout_fields' ) ) {
+							call_user_func( array( $gw_class, 'show_checkout_fields' ) );
+						} else {
+							// Fall back to base class default fields.
+							PMProGateway::show_checkout_fields();
+						}
+					}
 				}
 			?>
 
@@ -599,22 +649,46 @@ if ( empty( $default_gateway ) ) {
 				<?php } else { ?>
 
 					<?php
-						/**
-						 * Filter to set the default submit button on the checkout page.
-						 *
-						 * @param bool $pmpro_checkout_default_submit_button Default is true.
-						 * @return bool
-						 */
-						$pmpro_checkout_default_submit_button = apply_filters('pmpro_checkout_default_submit_button', true);
-						if ( $pmpro_checkout_default_submit_button ) {
+					// Uses $valid_gateways and $current_gateway set above in the gateway selector section.
+					if ( count( $valid_gateways ) > 1 ) {
+						// Multi-gateway: render each gateway's submit button in a container.
+						foreach ( $valid_gateways as $gw_slug ) {
+							$gw_class = ! empty( $gw_slug ) ? 'PMProGateway_' . $gw_slug : 'PMProGateway';
+							$is_selected = ( $gw_slug === $current_gateway );
 							?>
-							<span id="pmpro_submit_span">
-								<input type="hidden" name="submit-checkout" value="1" />
-								<input type="submit" id="pmpro_btn-submit" class="<?php echo esc_attr( pmpro_get_element_class(  'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ) ); ?>" value="<?php if($pmpro_requirebilling) { esc_html_e('Submit and Check Out', 'paid-memberships-pro' ); } else { esc_html_e('Submit and Confirm', 'paid-memberships-pro' );}?>" />
-							</span>
+							<div class="pmpro_gateway_submit pmpro_gateway_submit_<?php echo esc_attr( $gw_slug ); ?>" <?php if ( ! $is_selected ) { ?>style="display: none;"<?php } ?>>
+								<?php
+								if ( class_exists( $gw_class ) && method_exists( $gw_class, 'show_submit_button' ) ) {
+									call_user_func( array( $gw_class, 'show_submit_button' ) );
+								} else {
+									PMProGateway::show_submit_button();
+								}
+								?>
+							</div>
 							<?php
-							}
-						?>
+						}
+					} else {
+						// Single gateway: use static method with legacy filter fallback.
+						$gw_slug = reset( $valid_gateways );
+						$gw_class = ! empty( $gw_slug ) ? 'PMProGateway_' . $gw_slug : 'PMProGateway';
+						if ( class_exists( $gw_class ) && method_exists( $gw_class, 'show_submit_button' ) ) {
+							call_user_func( array( $gw_class, 'show_submit_button' ) );
+						} else {
+							PMProGateway::show_submit_button();
+						}
+					}
+					?>
+
+					<?php
+					// Free-level fallback submit button, shown when a discount code makes a level free.
+					// In multi-gateway mode, the per-gateway submit buttons are inside .pmpro_gateway_submit
+					// wrappers that get hidden for free levels. This standalone button sits outside those wrappers.
+					if ( count( $valid_gateways ) > 1 ) { ?>
+						<span id="pmpro_free_submit_span" style="display: none;">
+							<input type="hidden" name="submit-checkout" value="1" />
+							<input type="submit" id="pmpro_btn-submit-free" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_btn pmpro_btn-submit-checkout', 'pmpro_btn-submit-checkout' ) ); ?>" value="<?php esc_attr_e( 'Submit and Confirm', 'paid-memberships-pro' ); ?>" />
+						</span>
+					<?php } ?>
 
 				<?php } ?>
 

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -54,8 +54,8 @@ if ( ! empty( $pmpro_review ) ) {
 	$gateway = get_option( "pmpro_gateway" );
 }
 
-//set valid gateways - the active gateway in the settings and any gateway added through the filter will be allowed
-$valid_gateways = apply_filters( "pmpro_valid_gateways", array( get_option( "pmpro_gateway" ) ) );
+//set valid gateways - all enabled gateways and any gateway added through the filter will be allowed
+$valid_gateways = apply_filters( "pmpro_valid_gateways", pmpro_get_enabled_gateways() );
 
 //let's add an error now, if an invalid gateway is set
 if ( ! in_array( $gateway, $valid_gateways ) ) {
@@ -302,6 +302,11 @@ $pmpro_required_billing_fields = array(
 	"ExpirationYear"  => $ExpirationYear,
 	"CVV"             => $CVV
 );
+// Let the selected gateway modify required billing fields via static method.
+$gw_class = ! empty( $gateway ) && $gateway !== 'free' ? 'PMProGateway_' . $gateway : 'PMProGateway';
+if ( class_exists( $gw_class ) && method_exists( $gw_class, 'get_required_billing_fields' ) ) {
+	$pmpro_required_billing_fields = call_user_func( array( $gw_class, 'get_required_billing_fields' ), $pmpro_required_billing_fields );
+}
 $pmpro_required_billing_fields = apply_filters( "pmpro_required_billing_fields", $pmpro_required_billing_fields );
 $pmpro_required_user_fields    = array(
 	"username"      => $username,
@@ -721,3 +726,14 @@ pmpro_getAllLevels();
  * @since 2.1
  */
 do_action( 'pmpro_after_checkout_preheader', $pmpro_review );
+
+// Enqueue checkout scripts for all enabled gateways.
+foreach ( $valid_gateways as $gw_slug ) {
+	if ( empty( $gw_slug ) || $gw_slug === 'free' ) {
+		continue;
+	}
+	$gw_class = 'PMProGateway_' . $gw_slug;
+	if ( class_exists( $gw_class ) && method_exists( $gw_class, 'enqueue_checkout_scripts' ) ) {
+		call_user_func( array( $gw_class, 'enqueue_checkout_scripts' ) );
+	}
+}

--- a/services/applydiscountcode.php
+++ b/services/applydiscountcode.php
@@ -176,39 +176,35 @@
 			<?php
 			}
 
-			//hide/show billing
-			if(pmpro_areLevelsFree($code_levels) || pmpro_getGateway() == "paypalexpress" || pmpro_getGateway() == "paypalstandard" || pmpro_getGateway() == 'check')
+			//hide/show billing and gateway-specific UI
+			if(pmpro_areLevelsFree($code_levels))
 			{
 				?>
 				jQuery('#pmpro_billing_address_fields').hide();
 				jQuery('#pmpro_payment_information_fields').hide();
+				jQuery('.pmpro_gateway_fields').hide();
+				jQuery('.pmpro_gateway_submit').hide();
+				jQuery('#pmpro_payment_method').hide();
+				// Show the free-level fallback button (outside gateway wrappers) or the single-gateway submit.
+				jQuery('#pmpro_free_submit_span').show();
+				jQuery('#pmpro_submit_span').show();
 				<?php
 			}
 			else
 			{
 				?>
-				jQuery('#pmpro_billing_address_fields').show();
-				jQuery('#pmpro_payment_information_fields').show();
+				jQuery('#pmpro_payment_method').show();
+				jQuery('#pmpro_free_submit_span').hide();
+				// Re-trigger the selected gateway's UI.
+				var $selectedGateway = jQuery('input[name="gateway"]:checked');
+				if ( $selectedGateway.length ) {
+					$selectedGateway.trigger('change');
+				} else {
+					jQuery('#pmpro_billing_address_fields').show();
+					jQuery('.pmpro_gateway_fields').first().show();
+					jQuery('.pmpro_gateway_submit').first().show();
+				}
 				<?php
-			}
-
-			//hide/show paypal button
-			if(pmpro_getGateway() == "paypalexpress" || pmpro_getGateway() == "paypalstandard")
-			{
-				if(pmpro_areLevelsFree($code_levels))
-				{
-					?>
-					jQuery('#pmpro_paypalexpress_checkout').hide();
-					jQuery('#pmpro_submit_span').show();
-					<?php
-				}
-				else
-				{
-					?>
-					jQuery('#pmpro_submit_span').hide();
-					jQuery('#pmpro_paypalexpress_checkout').show();
-					<?php
-				}
 			}
 
 			//filter to insert your own code. Not MMPU compatible.


### PR DESCRIPTION
## Summary

Adds the ability to enable multiple payment gateways simultaneously so members can choose their preferred payment method at checkout. This is a v4.0 breaking change — custom checkout templates will need to be updated.

### Core Infrastructure
- New `pmpro_get_enabled_gateways()` function with automatic migration from the legacy single `pmpro_gateway` option
- New static methods on `PMProGateway` base class: `get_checkout_label()`, `enqueue_checkout_scripts()`, `show_checkout_fields()`, `requires_billing_address()`, `get_required_billing_fields()`, `show_submit_button()` — with legacy hook detection for gateways that haven't been updated
- `pmpro_getGateway()` marked as deprecated

### Admin UI
- Payment Settings page redesigned with sortable Active Gateways table, collapsible Available Gateways panel, and activate/deactivate buttons
- Gateway order determines checkout display order (first = default)

### Checkout & Billing
- Gateway selector radio buttons when multiple gateways enabled
- Per-gateway payment field containers and submit buttons with JS toggling
- Billing address visibility respects each gateway's `requires_billing_address()`
- Free-level fallback submit button for discount-code-to-free scenarios
- Billing page updated to use gateway static methods

### Gateway Updates (Stripe, Check, PayPal Express)
- Each overrides the new static methods for gateway-specific behavior
- Stripe: SCA intent localization preserved, Stripe Checkout (offsite) handled
- PayPal Express: offsite redirect button with free-level fallback

### Backward Compatibility
- Base class detects legacy filter callbacks via hooked filters AND `method_exists()` (covers secondary gateways whose `init()` didn't fire)
- `pmpro_gateway` option kept in sync for legacy code
- Pay by Check add-on UI deferred via `pmpro_show_gateway_selector` filter
- Add PayPal Express add-on added to deprecated add-ons list (auto-deactivated)

## Open TODOs

- [ ] **Live price updates at checkout** — Could simplify the show/hide logic for payment fields when a discount code makes a level free/paid, replacing the current `applydiscountcode.php` JS approach
- [ ] **Per-level gateway configuration** — The Pay by Check add-on currently allows enabling/disabling gateways per level. How should core support this? Per-level gateway overrides in the level editor?
- [ ] **Address for Free Levels Add On** — How should this function with multi-gateway? Per-gateway toggle to force billing address? A sitewide checkbox? Currently `requires_billing_address()` is per-gateway but there's no admin-facing override
- [ ] **Duplicate DOM IDs** — When two onsite gateways are enabled, each gateway's `show_checkout_fields()` renders elements with the same IDs. Gateway JS that binds by ID hits the wrong element. Needs a namespacing strategy
- [ ] **Deprecated gateways as secondary** — Deprecated gateways (Braintree, etc.) render fields but not scripts when used as secondary gateways. Their `init()` only hooks checkout actions when they're the active gateway. They would need `enqueue_checkout_scripts()` overrides to work as secondary gateways
- [ ] **Discount code AJAX** — Doesn't send the selected gateway parameter, so the server response can't be gateway-aware
- [ ] Replace all `@since TBD` tags with actual version number before release

## Test Plan

- [ ] Fresh install: single gateway, no radio buttons, behavior identical to current
- [ ] Enable Stripe + Check: radio buttons appear, fields toggle, both checkout flows complete
- [ ] Enable Stripe + PayPal Express: on-site fields for Stripe, redirect button for PayPal
- [ ] Stripe Checkout (offsite) + Check: no card fields for Stripe, check shows instructions
- [ ] Stripe SCA/3D Secure: verify authentication flow completes after redirect
- [ ] Discount code makes level free: gateway selector hides, free submit button shows
- [ ] Discount code removed (level paid again): gateway selector restores, correct fields show
- [ ] Update billing: uses original subscription gateway, correct fields render
- [ ] Admin: activate/deactivate gateways, drag to reorder, verify save persists order
- [ ] Admin: deactivate all gateways, verify testing mode notice
- [ ] Pay by Check add-on active: core selector deferred, PBC radio buttons used instead
- [ ] Add PayPal Express add-on: auto-deactivated with admin notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)