### PR TITLE
Fix All Levels member export duplicates and missing records

### DIFF
--- a/classes/class-pmpro-exports.php
+++ b/classes/class-pmpro-exports.php
@@ -625,7 +625,11 @@ class PMPro_Exports {
 		$processed                  = (int) $written;
 		$export['processed_count'] += $processed;
 		$export['next_offset']      = $offset + count( $ids );
-		$export['status']           = ( $export['processed_count'] >= $export['total_count'] ) ? 'complete' : 'running';
+		// Use offset-based completion instead of processed_count. Row count can
+		// exceed ID count when a single user has multiple memberships (GROUP BY
+		// u.ID, mu.membership_id), causing the export to finish early and skip
+		// higher-ID users.
+		$export['status']           = ( $export['next_offset'] >= $export['total_count'] ) ? 'complete' : 'running';
 		$this->save_export_record( $export );
 
 		if ( 'complete' === $export['status'] && 'orders' === $export['type'] ) {
@@ -677,7 +681,7 @@ class PMPro_Exports {
 			return array( 'error' => __( 'You do not have permission to export this data.', 'paid-memberships-pro' ) );
 		}
 
-		// Self-heal: if export is queued/running but no chunk task is pending, enqueue it.
+		// Self-heal: if export is queued/running but no chunk task is pending or running, enqueue it.
 		if ( in_array( $export['status'], array( 'queued', 'running' ), true ) && class_exists( '\ActionScheduler' ) ) {
 			$args   = array(
 				array(
@@ -685,12 +689,28 @@ class PMPro_Exports {
 					'user_id'   => (int) $export['user_id'],
 				),
 			);
-			$exists = PMPro_Action_Scheduler::instance()->has_existing_task( 'pmpro_export_process_chunk', $args, 'pmpro_async_tasks' );
+			$exists_pending = PMPro_Action_Scheduler::instance()->has_existing_task( 'pmpro_export_process_chunk', $args, 'pmpro_async_tasks' );
+
+			// Also check for a currently-running task. has_existing_task only
+			// checks STATUS_PENDING, so a chunk actively being processed by
+			// Action Scheduler would appear as "no task exists", triggering
+			// the self-heal to process the same offset concurrently and
+			// producing duplicate rows in the CSV.
+			$running_actions = as_get_scheduled_actions(
+				array(
+					'hook'   => 'pmpro_export_process_chunk',
+					'args'   => $args,
+					'group'  => 'pmpro_async_tasks',
+					'status' => \ActionScheduler_Store::STATUS_RUNNING,
+				)
+			);
+			$exists = $exists_pending || ! empty( $running_actions );
+
 			if ( $exists && 'queued' === $export['status'] ) {
 				$export['status'] = 'running';
 				$this->save_export_record( $export );
 			}
-			// If no task exists, process a chunk inline (to surface progress) and enqueue the next chunk.
+			// If no task exists (pending or running), process a chunk inline and enqueue the next.
 			if ( ! $exists ) {
 				$result = $this->process_export_chunk_record( $export );
 				if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
## Summary

Fixes two bugs in the background member export job that cause the "All Levels" CSV export to produce **duplicate rows** and **omit members** with higher user IDs. Per-level exports are unaffected.

Reported by a user with ~1,650 members: exporting "All Levels" produced 3,279 lines with records from ~ID 1141–3736 repeated in overlapping blocks, and ~280 members with higher IDs entirely missing. Individual level exports were correct.

### Bug 1: Premature completion (missing records)

The completion check on [line 628](https://github.com/strangerstudios/paid-memberships-pro/blob/dev/classes/class-pmpro-exports.php#L628) compared `processed_count` (CSV rows written) against `total_count` (distinct user count from `COUNT(DISTINCT u.ID)`).

The problem: `members_write_rows()` uses `GROUP BY u.ID, mu.membership_id`, so a user with multiple active memberships produces multiple CSV rows. This means `processed_count` grows faster than the actual number of users processed, hitting `total_count` before all user IDs have been fetched. Users with higher IDs get silently dropped.

**Fix:** Use offset-based completion (`next_offset >= total_count`) since both the offset and total count track distinct user IDs consistently.

### Bug 2: Self-heal race condition (duplicate rows)

The status polling endpoint's [self-heal logic](https://github.com/strangerstudios/paid-memberships-pro/blob/dev/classes/class-pmpro-exports.php#L684-L709) checks for pending Action Scheduler tasks via `has_existing_task()`, which only queries `STATUS_PENDING`.

When Action Scheduler is **actively running** a chunk (`STATUS_RUNNING`), the self-heal sees "no task exists" and processes the same offset inline — writing the same rows a second time. With frequent status polling, this produces the repeated overlapping blocks seen in the report.

**Fix:** Also check for `STATUS_RUNNING` tasks before triggering the self-heal.

## Test plan

- [ ] Export members CSV with "All Levels" on a site where users have multiple active membership levels
- [ ] Verify all members appear exactly once per membership in the CSV (no duplicates, no omissions)
- [ ] Verify the total row count matches expectations
- [ ] Verify per-level exports still work correctly
- [ ] Test with both small datasets (sync path) and large datasets (async/Action Scheduler path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)