### PR TITLE
Standalone levels and guest checkout

### DIFF
--- a/adminpages/membershiplevels.php
+++ b/adminpages/membershiplevels.php
@@ -486,11 +486,7 @@
 											</div>
 										</td>
 										<td>
-											<?php if(pmpro_isLevelFree($level)) { ?>
-												<?php esc_html_e( 'Free', 'paid-memberships-pro' ); ?>
-											<?php } else { ?>
-												<?php echo wp_kses_post( str_replace( 'The price for membership is', '', pmpro_getLevelCost($level) ) ); ?>
-											<?php } ?>
+											<?php echo wp_kses_post( pmpro_getLevelCost( $level, true, true ) ); ?>
 										</td>
 										<td>
 											<?php if(!pmpro_isLevelExpiring($level)) {

--- a/adminpages/orders/view-order.php
+++ b/adminpages/orders/view-order.php
@@ -359,6 +359,16 @@ $subscription = $order->get_subscription();
 				<?php } else { ?>
 					<p><?php esc_html_e( 'The user ID associated with this order is not a valid user.', 'paid-memberships-pro' ); ?></p>
 				<?php } ?>
+				<?php
+				/**
+				 * Fires after the member information content in the order view sidebar.
+				 *
+				 * @since TBD
+				 *
+				 * @param MemberOrder $order The order being viewed.
+				 */
+				do_action( 'pmpro_order_view_after_member_info', $order );
+				?>
 			</div><!-- .pmpro_section_inside -->
 		</div><!-- .pmpro_section -->
 

--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -1066,6 +1066,15 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 		} else {
 			echo '['. esc_html__( 'none', 'paid-memberships-pro' ) . ']';
 		}
+
+		/**
+		 * Fires after the user column content in the orders list table.
+		 *
+		 * @since TBD
+		 *
+		 * @param MemberOrder $item The order being displayed.
+		 */
+		do_action( 'pmpro_orders_column_after_user', $item );
 	}
 
 	/**

--- a/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check-admin.php
@@ -140,10 +140,7 @@ class PMPro_Email_Template_Checkout_Check_Admin extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
-		if ( empty( $membership_level ) ) {
-			$membership_level = pmpro_getLevel( $order->membership_id );
-		}
+		$membership_level = $order->getMembershipLevelAtCheckout();
 
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
 		if ( ! empty( $confirmation_in_email ) ) {

--- a/classes/email-templates/class-pmpro-email-template-checkout-check.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-check.php
@@ -179,10 +179,7 @@ class PMPro_Email_Template_Checkout_Check extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
-		if ( empty( $membership_level ) ) {
-			$membership_level = pmpro_getLevel( $order->membership_id );
-		}
+		$membership_level = $order->getMembershipLevelAtCheckout();
 
 		$discount_code = "";
 		$discount_code_name = '';

--- a/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free-admin.php
@@ -160,10 +160,7 @@ class PMPro_Email_Template_Checkout_Free_Admin extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
-		if ( empty( $membership_level ) ) {
-			$membership_level = pmpro_getLevel( $order->membership_id );
-		}
+		$membership_level = $order->getMembershipLevelAtCheckout();
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-checkout-free.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-free.php
@@ -158,10 +158,7 @@ class PMPro_Email_Template_Checkout_Free extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
-		if ( empty( $membership_level ) ) {
-			$membership_level = pmpro_getLevel( $order->membership_id );
-		}
+		$membership_level = $order->getMembershipLevelAtCheckout();
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid-admin.php
@@ -146,10 +146,7 @@ class PMPro_Email_Template_Checkout_Paid_Admin extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
-		if ( empty( $membership_level ) ) {
-			$membership_level = pmpro_getLevel( $order->membership_id );
-		}
+		$membership_level = $order->getMembershipLevelAtCheckout();
 
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );
 			if ( ! empty( $confirmation_in_email ) ) {

--- a/classes/email-templates/class-pmpro-email-template-checkout-paid.php
+++ b/classes/email-templates/class-pmpro-email-template-checkout-paid.php
@@ -151,10 +151,7 @@ class PMPro_Email_Template_Checkout_Paid extends PMPro_Email_Template {
 	public function get_email_template_variables() {
 		$order = $this->order;
 		$user = $this->user;
-		$membership_level = pmpro_getSpecificMembershipLevelForUser( $user->ID, $order->membership_id );
-		if ( empty( $membership_level ) ) {
-			$membership_level = pmpro_getLevel( $order->membership_id );
-		}
+		$membership_level = $order->getMembershipLevelAtCheckout();
 
 		$confirmation_message = '';
 		$confirmation_in_email = get_pmpro_membership_level_meta( $membership_level->id, 'confirmation_in_email', true );

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2466,11 +2466,23 @@ class PMProGateway_stripe extends PMProGateway {
 		$user = empty( $user_id ) ? null : get_userdata( $user_id );
 		$customer = empty( $user_id ) ? null : $this->get_customer_for_user( $user_id );
 
-		// Get customer name.
-		$name = empty( $order->billing->name ) ? $user->user_login : $order->billing->name;
+		// Get customer name. Fall back to billing info for guest checkouts.
+		if ( ! empty( $order->billing->name ) ) {
+			$name = $order->billing->name;
+		} elseif ( ! empty( $user->user_login ) ) {
+			$name = $user->user_login;
+		} else {
+			$name = '';
+		}
 
-		// Get user's email.
-		$email = empty( $user->user_email ) ? "No Email" : $user->user_email;
+		// Get user's email. Fall back to the email submitted at checkout.
+		if ( ! empty( $user->user_email ) ) {
+			$email = $user->user_email;
+		} elseif ( ! empty( $_REQUEST['bemail'] ) ) {
+			$email = sanitize_email( $_REQUEST['bemail'] );
+		} else {
+			$email = '';
+		}
 
 		// Build data to update customer with.
 		$customer_args = array(

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -233,8 +233,19 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 		'enddate'         => $enddate
 	);
 
-	//change level and continue "checkout"
-	if ( pmpro_changeMembershipLevel( $custom_level, $order->user_id, 'changed' ) !== false ) {
+	/**
+	 * Filter whether to skip the membership level change during checkout.
+	 *
+	 * When true, the checkout will proceed as successful without calling
+	 * pmpro_changeMembershipLevel(). Used by standalone levels.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool        $skip_level_change Whether to skip the level change. Default false.
+	 * @param MemberOrder $order             The order being processed.
+	 * @param array       $custom_level      The level data that would be assigned.
+	 */
+	if ( apply_filters( 'pmpro_checkout_skip_level_change', false, $order, $custom_level ) || pmpro_changeMembershipLevel( $custom_level, $order->user_id, 'changed' ) !== false ) {
 		// Mark the order as successful.
 		$order->status = "success";
 		if ( ! empty( $discount_code_id ) ) {
@@ -277,17 +288,33 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 
 		// Check if we should send emails.
 		if ( apply_filters( 'pmpro_send_checkout_emails', true, $order ) ) {
-			// Set up some values for the emails.
-			$user                   = get_userdata( $order->user_id );
-			$user->membership_level = $pmpro_level;        // Make sure that they have the right level info.
+			// Set up the user for the emails.
+			$user = get_userdata( $order->user_id );
 
-			// Send email to member.
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendCheckoutEmail( $user, $order );
+			/**
+			 * Filter the user object used for checkout emails.
+			 *
+			 * Allows overriding the user for cases where no WordPress user
+			 * exists, such as guest checkouts.
+			 *
+			 * @since TBD
+			 *
+			 * @param WP_User|false $user  The user object, or false if not found.
+			 * @param MemberOrder   $order The order being processed.
+			 */
+			$user = apply_filters( 'pmpro_checkout_email_user', $user, $order );
 
-			// Send email to admin.
-			$pmproemail = new PMProEmail();
-			$pmproemail->sendCheckoutAdminEmail( $user, $order );
+			if ( ! empty( $user ) ) {
+				$user->membership_level = $pmpro_level;
+
+				// Send email to member.
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendCheckoutEmail( $user, $order );
+
+				// Send email to admin.
+				$pmproemail = new PMProEmail();
+				$pmproemail->sendCheckoutAdminEmail( $user, $order );
+			}
 		}
 
 		return true;

--- a/includes/standalone-levels.php
+++ b/includes/standalone-levels.php
@@ -1,0 +1,529 @@
+<?php
+/**
+ * Standalone Levels and Guest Checkout functionality for PMPro.
+ *
+ * Standalone levels allow one-time purchases that don't assign a membership.
+ * Guest checkout allows completing a standalone checkout without an account.
+ * Both are enabled per-level via level meta flags on the edit level page.
+ *
+ * @since TBD
+ */
+
+/*
+ * ----------------------------------------
+ * Standalone Level Hooks
+ * ----------------------------------------
+ */
+
+/**
+ * Skip the membership level change for standalone levels.
+ *
+ * @since TBD
+ *
+ * @param bool        $skip         Whether to skip the level change.
+ * @param MemberOrder $order        The order being processed.
+ * @param array       $custom_level The level data that would be assigned.
+ * @return bool
+ */
+function pmpro_standalone_skip_level_change( $skip, $order, $custom_level ) {
+	if ( ! empty( $custom_level['membership_id'] ) && get_pmpro_membership_level_meta( $custom_level['membership_id'], 'is_standalone', true ) ) {
+		return true;
+	}
+	return $skip;
+}
+add_filter( 'pmpro_checkout_skip_level_change', 'pmpro_standalone_skip_level_change', 10, 3 );
+
+/**
+ * Validate standalone level checkout restrictions.
+ *
+ * Standalone levels only support one-time payments — no recurring
+ * billing and no expirations.
+ *
+ * @since TBD
+ *
+ * @param bool $checks Whether the checkout should continue.
+ * @return bool
+ */
+function pmpro_standalone_checkout_checks( $checks ) {
+	global $pmpro_level;
+
+	if ( empty( $pmpro_level ) || empty( $pmpro_level->id ) ) {
+		return $checks;
+	}
+
+	if ( ! get_pmpro_membership_level_meta( $pmpro_level->id, 'is_standalone', true ) ) {
+		return $checks;
+	}
+
+	if ( pmpro_isLevelRecurring( $pmpro_level ) ) {
+		pmpro_setMessage( __( 'Recurring payments are not supported for standalone levels.', 'paid-memberships-pro' ), 'pmpro_error' );
+		return false;
+	}
+
+	if ( pmpro_isLevelExpiring( $pmpro_level ) ) {
+		pmpro_setMessage( __( 'Expirations are not supported for standalone levels.', 'paid-memberships-pro' ), 'pmpro_error' );
+		return false;
+	}
+
+	return $checks;
+}
+add_filter( 'pmpro_checkout_checks', 'pmpro_standalone_checkout_checks' );
+
+/**
+ * Add standalone note to level cost text in the admin levels list.
+ *
+ * @since TBD
+ *
+ * @param string $cost  The level cost text.
+ * @param object $level The level object.
+ * @return string
+ */
+function pmpro_standalone_level_cost_text( $cost, $level ) {
+	if ( empty( $level->id ) || ! is_admin() || empty( $_REQUEST['page'] ) || $_REQUEST['page'] !== 'pmpro-membershiplevels' ) {
+		return $cost;
+	}
+	if ( get_pmpro_membership_level_meta( $level->id, 'is_standalone', true ) ) {
+		$cost .= '<br /><em>' . esc_html__( 'Standalone level. No membership assigned.', 'paid-memberships-pro' ) . '</em>';
+	}
+	return $cost;
+}
+add_filter( 'pmpro_level_cost_text', 'pmpro_standalone_level_cost_text', 20, 2 );
+
+/**
+ * Replace the checkout level name text for standalone levels.
+ *
+ * Replaces "You have selected the X membership level" and any level
+ * replacement warnings with a standalone-appropriate message.
+ *
+ * @since TBD
+ *
+ * @param string $text  The level name and change text.
+ * @param object $level The level being purchased.
+ * @return string
+ */
+function pmpro_standalone_checkout_level_name_text( $text, $level ) {
+	if ( empty( $level->id ) || ! get_pmpro_membership_level_meta( $level->id, 'is_standalone', true ) ) {
+		return $text;
+	}
+
+	return sprintf(
+		esc_html__( 'You are purchasing %s. This is a one-time purchase and will not affect your membership.', 'paid-memberships-pro' ),
+		'<strong>' . esc_html( $level->name ) . '</strong>'
+	);
+}
+add_filter( 'pmpro_checkout_level_name_text', 'pmpro_standalone_checkout_level_name_text', 10, 2 );
+
+
+/*
+ * ----------------------------------------
+ * Admin: Edit Level Settings
+ * ----------------------------------------
+ */
+
+/**
+ * Add standalone level settings to the edit level page.
+ *
+ * @since TBD
+ *
+ * @param object $level The membership level object.
+ */
+function pmpro_standalone_level_settings( $level ) {
+	$is_standalone = get_pmpro_membership_level_meta( $level->id, 'is_standalone', true );
+	$allow_guest_checkout = get_pmpro_membership_level_meta( $level->id, 'allow_guest_checkout', true );
+	?>
+	<table class="form-table">
+		<tbody>
+			<tr>
+				<th scope="row" valign="top"><label for="is_standalone"><?php esc_html_e( 'Standalone Level', 'paid-memberships-pro' ); ?></label></th>
+				<td>
+					<input id="is_standalone" name="is_standalone" type="checkbox" value="1" <?php checked( $is_standalone, 1 ); ?> />
+					<label for="is_standalone"><?php esc_html_e( 'Make this a standalone level. No membership will be assigned after purchase, existing memberships will not be cancelled, and this level can always be repurchased.', 'paid-memberships-pro' ); ?></label>
+				</td>
+			</tr>
+			<tr id="allow_guest_checkout_tr" <?php if ( empty( $is_standalone ) ) { ?>style="display: none;"<?php } ?>>
+				<th scope="row" valign="top"><label for="allow_guest_checkout"><?php esc_html_e( 'Allow Guest Checkout', 'paid-memberships-pro' ); ?></label></th>
+				<td>
+					<input id="allow_guest_checkout" name="allow_guest_checkout" type="checkbox" value="1" <?php checked( $allow_guest_checkout, 1 ); ?> />
+					<label for="allow_guest_checkout"><?php esc_html_e( 'Allow users to check out without creating an account.', 'paid-memberships-pro' ); ?></label>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<script>
+		jQuery(document).ready(function($) {
+			$('#is_standalone').on('change', function() {
+				if ($(this).is(':checked')) {
+					$('#allow_guest_checkout_tr').show();
+				} else {
+					$('#allow_guest_checkout_tr').hide();
+					$('#allow_guest_checkout').prop('checked', false);
+				}
+			});
+		});
+	</script>
+	<?php
+}
+add_action( 'pmpro_membership_level_after_other_settings', 'pmpro_standalone_level_settings' );
+
+/**
+ * Save standalone level settings when a level is saved.
+ *
+ * @since TBD
+ *
+ * @param int $level_id The level ID being saved.
+ */
+function pmpro_standalone_save_level_settings( $level_id ) {
+	update_pmpro_membership_level_meta( $level_id, 'is_standalone', ! empty( $_REQUEST['is_standalone'] ) ? 1 : 0 );
+	update_pmpro_membership_level_meta( $level_id, 'allow_guest_checkout', ! empty( $_REQUEST['allow_guest_checkout'] ) ? 1 : 0 );
+}
+add_action( 'pmpro_save_membership_level', 'pmpro_standalone_save_level_settings' );
+
+/*
+ * ----------------------------------------
+ * Guest Checkout Helpers
+ * ----------------------------------------
+ */
+
+/**
+ * Check if the current checkout is a guest checkout.
+ *
+ * Requires: the guest checkout checkbox is checked, the user is not
+ * logged in, and the level allows guest checkout.
+ *
+ * @since TBD
+ *
+ * @return bool Whether the current checkout is a guest checkout.
+ */
+function pmpro_is_guest_checkout() {
+	if ( empty( $_REQUEST['pmpro_guest_checkout'] ) ) {
+		return false;
+	}
+
+	if ( is_user_logged_in() ) {
+		return false;
+	}
+
+	$level = pmpro_getLevelAtCheckout();
+	if ( empty( $level ) || empty( $level->id ) ) {
+		return false;
+	}
+
+	if ( ! get_pmpro_membership_level_meta( $level->id, 'allow_guest_checkout', true ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Check if an order was a guest checkout.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order to check.
+ * @return bool Whether the order was a guest checkout.
+ */
+function pmpro_order_is_guest_checkout( $order ) {
+	if ( empty( $order->id ) ) {
+		return false;
+	}
+	return ! empty( get_pmpro_membership_order_meta( $order->id, 'guest_email', true ) );
+}
+
+/*
+ * ----------------------------------------
+ * Guest Checkout Flow Hooks
+ * ----------------------------------------
+ */
+
+/**
+ * Skip user creation (and validation) for guest checkouts.
+ *
+ * @since TBD
+ *
+ * @param bool   $skip  Whether to skip user creation.
+ * @param object $level The level being purchased.
+ * @return bool
+ */
+function pmpro_guest_checkout_skip_user_creation( $skip, $level ) {
+	if ( pmpro_is_guest_checkout() ) {
+		return true;
+	}
+	return $skip;
+}
+add_filter( 'pmpro_skip_user_creation', 'pmpro_guest_checkout_skip_user_creation', 10, 2 );
+
+/**
+ * Save guest checkout data to order meta after checkout.
+ *
+ * @since TBD
+ *
+ * @param int         $user_id The user ID (0 for guests).
+ * @param MemberOrder $order   The order that was created.
+ */
+function pmpro_guest_checkout_after_checkout( $user_id, $order ) {
+	if ( ! pmpro_is_guest_checkout() ) {
+		return;
+	}
+
+	$guest_email = ! empty( $_REQUEST['bemail'] ) ? sanitize_email( $_REQUEST['bemail'] ) : '';
+	update_pmpro_membership_order_meta( $order->id, 'guest_email', $guest_email );
+}
+add_action( 'pmpro_after_checkout', 'pmpro_guest_checkout_after_checkout', 5, 2 );
+
+/**
+ * Provide a WP_User object for guest checkout emails.
+ *
+ * When there's no WordPress user (user_id=0), build a WP_User
+ * from the checkout form data so the standard email flow works.
+ *
+ * @since TBD
+ *
+ * @param WP_User|false $user  The user object, or false if not found.
+ * @param MemberOrder   $order The order being processed.
+ * @return WP_User|false
+ */
+function pmpro_guest_checkout_email_user( $user, $order ) {
+	if ( ! empty( $user ) ) {
+		return $user;
+	}
+
+	if ( ! pmpro_is_guest_checkout() ) {
+		return $user;
+	}
+
+	$user               = new WP_User();
+	$user->user_email   = ! empty( $_REQUEST['bemail'] ) ? sanitize_email( $_REQUEST['bemail'] ) : '';
+	$user->display_name = ! empty( $order->billing->name ) ? $order->billing->name : '';
+	$user->user_login   = '';
+
+	return $user;
+}
+add_filter( 'pmpro_checkout_email_user', 'pmpro_guest_checkout_email_user', 10, 2 );
+
+/**
+ * Redirect standalone checkouts to the invoice page instead of the confirmation page.
+ *
+ * The confirmation page expects the user to have the purchased level active.
+ * Standalone levels skip level assignment, so we redirect to the invoice page.
+ * For guests, the email is included in the URL for access.
+ *
+ * @since TBD
+ *
+ * @param string $url     The confirmation URL.
+ * @param int    $user_id The user ID (0 for guests).
+ * @param object $level   The membership level.
+ * @return string The redirect URL.
+ */
+function pmpro_standalone_confirmation_url( $url, $user_id, $level ) {
+	if ( empty( $level->id ) || ! get_pmpro_membership_level_meta( $level->id, 'is_standalone', true ) ) {
+		return $url;
+	}
+
+	global $pmpro_review;
+	if ( empty( $pmpro_review ) || empty( $pmpro_review->code ) ) {
+		return $url;
+	}
+
+	$args = array( 'invoice' => $pmpro_review->code );
+
+	// For guest checkouts, include the email for invoice access.
+	if ( empty( $user_id ) ) {
+		$guest_email = ! empty( $_REQUEST['bemail'] ) ? sanitize_email( $_REQUEST['bemail'] ) : '';
+		$args['email'] = rawurlencode( $guest_email );
+	}
+
+	return add_query_arg( $args, pmpro_url( 'invoice' ) );
+}
+add_filter( 'pmpro_confirmation_url', 'pmpro_standalone_confirmation_url', 10, 3 );
+
+/**
+ * Allow guests to view their own guest orders on the invoice page.
+ *
+ * Validates both the order code and the guest email to prevent enumeration.
+ *
+ * @since TBD
+ *
+ * @param bool             $can_view Whether the visitor can view the order.
+ * @param MemberOrder|null $order    The order being viewed.
+ * @return bool
+ */
+function pmpro_guest_checkout_allow_viewing_order( $can_view, $order ) {
+	if ( $can_view ) {
+		return $can_view;
+	}
+
+	if ( empty( $order ) || ! pmpro_order_is_guest_checkout( $order ) ) {
+		return $can_view;
+	}
+
+	$provided_email = ! empty( $_REQUEST['email'] ) ? sanitize_email( $_REQUEST['email'] ) : '';
+	$guest_email    = get_pmpro_membership_order_meta( $order->id, 'guest_email', true );
+
+	if ( empty( $provided_email ) || empty( $guest_email ) ) {
+		return false;
+	}
+
+	if ( strtolower( $provided_email ) !== strtolower( $guest_email ) ) {
+		return false;
+	}
+
+	// Set a guest user stub on the order so the invoice template can render.
+	$order->user                  = new stdClass();
+	$order->user->ID              = 0;
+	$order->user->display_name    = ! empty( $order->billing->name ) ? $order->billing->name : __( 'Guest', 'paid-memberships-pro' );
+	$order->user->user_email      = $guest_email;
+	$order->user->user_login      = '';
+	$order->user->user_registered = '';
+
+	return true;
+}
+add_filter( 'pmpro_allow_viewing_order', 'pmpro_guest_checkout_allow_viewing_order', 10, 2 );
+
+/*
+ * ----------------------------------------
+ * Admin Display
+ * ----------------------------------------
+ */
+
+/**
+ * Show guest checkout info after the user column in the orders list.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $item The order being displayed.
+ */
+function pmpro_guest_checkout_orders_column_after_user( $item ) {
+	if ( ! pmpro_order_is_guest_checkout( $item ) ) {
+		return;
+	}
+
+	$guest_email = get_pmpro_membership_order_meta( $item->id, 'guest_email', true );
+	if ( empty( $guest_email ) ) {
+		return;
+	}
+
+	echo '<br /><em>' . esc_html__( 'Guest Checkout', 'paid-memberships-pro' ) . '</em>';
+	echo '<br />' . esc_html( $guest_email );
+}
+add_action( 'pmpro_orders_column_after_user', 'pmpro_guest_checkout_orders_column_after_user' );
+
+/**
+ * Show guest checkout info after the member info in the order view sidebar.
+ *
+ * @since TBD
+ *
+ * @param MemberOrder $order The order being viewed.
+ */
+function pmpro_guest_checkout_order_view_after_member_info( $order ) {
+	if ( ! pmpro_order_is_guest_checkout( $order ) ) {
+		return;
+	}
+
+	$guest_email = get_pmpro_membership_order_meta( $order->id, 'guest_email', true );
+	if ( empty( $guest_email ) ) {
+		return;
+	}
+	?>
+	<p>
+		<strong><?php esc_html_e( 'Guest Checkout', 'paid-memberships-pro' ); ?></strong><br />
+		<?php echo esc_html( $guest_email ); ?>
+	</p>
+	<?php
+}
+add_action( 'pmpro_order_view_after_member_info', 'pmpro_guest_checkout_order_view_after_member_info' );
+
+/*
+ * ----------------------------------------
+ * Checkout Page UI
+ * ----------------------------------------
+ */
+
+/**
+ * Add guest checkout checkbox to the checkout page.
+ *
+ * Shows a "Check out as a guest" checkbox when the level allows
+ * guest checkout and the user is not logged in.
+ *
+ * @since TBD
+ */
+function pmpro_guest_checkout_add_checkout_toggle() {
+	global $pmpro_level;
+
+	// Only show for logged-out users on levels that allow guest checkout.
+	if ( is_user_logged_in() || empty( $pmpro_level ) || empty( $pmpro_level->id ) ) {
+		return;
+	}
+
+	if ( ! get_pmpro_membership_level_meta( $pmpro_level->id, 'allow_guest_checkout', true ) ) {
+		return;
+	}
+	?>
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-checkbox' ) ); ?>">
+		<label class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label pmpro_form_label-inline pmpro_clickable' ) ); ?>">
+			<input type="checkbox" id="pmpro_guest_checkout" name="pmpro_guest_checkout" value="1" <?php checked( ! empty( $_REQUEST['pmpro_guest_checkout'] ) ); ?> />
+			<?php esc_html_e( 'Check out as a guest', 'paid-memberships-pro' ); ?>
+		</label>
+	</div>
+	<script>
+		jQuery(document).ready(function($) {
+			var $checkbox = $('#pmpro_guest_checkout');
+			var $userFieldset = $('#pmpro_user_fields');
+			var $formFields = $userFieldset.find('.pmpro_form_fields');
+			var $loginLink = $userFieldset.find('.pmpro_card_actions');
+
+			// Fields to hide in guest mode.
+			var $usernameField = $formFields.find('.pmpro_form_field-username');
+			var $passwordFields = $formFields.find('.pmpro_form_field-password');
+			var $passwordCols = $passwordFields.first().closest('.pmpro_cols-2');
+			var $confirmEmailField = $formFields.find('.pmpro_form_field-bconfirmemail');
+			var $emailField = $formFields.find('.pmpro_form_field-bemail');
+
+			// The email and confirm email may share a pmpro_cols-2 wrapper.
+			var $emailCols = $emailField.closest('.pmpro_cols-2');
+			var isGuest = false;
+
+			function setGuestMode(guest) {
+				isGuest = guest;
+				$checkbox.prop('checked', isGuest);
+
+				if (isGuest) {
+					$usernameField.hide();
+					$passwordFields.hide();
+					$passwordCols.hide();
+					$confirmEmailField.hide();
+					$loginLink.hide();
+
+					// Move email field out of the cols-2 wrapper so hiding confirm doesn't hide email too.
+					if ($emailCols.length) {
+						$emailField.insertBefore($emailCols);
+						$emailCols.hide();
+					}
+				} else {
+					// Move email field back into the cols-2 wrapper.
+					if ($emailCols.length) {
+						$emailCols.prepend($emailField);
+						$emailCols.show();
+					}
+
+					$usernameField.show();
+					$passwordFields.show();
+					$passwordCols.show();
+					$confirmEmailField.show();
+					$loginLink.show();
+				}
+			}
+
+			$checkbox.on('change', function() {
+				setGuestMode($(this).is(':checked'));
+			});
+
+			// If reloading with guest checkout already checked.
+			if ($checkbox.is(':checked')) {
+				setGuestMode(true);
+			}
+		});
+	</script>
+	<?php
+}
+add_action( 'pmpro_checkout_before_account_fields', 'pmpro_guest_checkout_add_checkout_toggle' );

--- a/pages/checkout.php
+++ b/pages/checkout.php
@@ -97,39 +97,44 @@ if ( empty( $default_gateway ) ) {
 
 					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 
-						<p class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_name_text' ) );?>">
-							<?php
-							// Tell the user which level they are signing up for.
-							printf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level->name ) . '</strong>' );
+						<?php
+							// Build the level name and membership change text.
+							$level_name_text = sprintf( esc_html__('You have selected the %s membership level.', 'paid-memberships-pro' ), '<strong>' . esc_html( $pmpro_level->name ) . '</strong>' );
 
 							// If a level will be removed with this purchase, let them know that too.
-							// First off, get the group for this level and check if it allows a user to have multiple levels.
 							$group_id = pmpro_get_group_id_for_level( $pmpro_level->id );
 							$group    = pmpro_get_level_group( $group_id );
 							if ( ! empty( $group ) && empty( $group->allow_multiple_selections ) ) {
-								// Get all of the user's current membership levels.
 								$levels = pmpro_getMembershipLevelsForUser( $current_user->ID );
-
-								// Loop through the levels and see if any are in the same group as the level being purchased.
 								if ( ! empty( $levels ) ) {
 									foreach ( $levels as $level ) {
-										// If this is the level that the user is purchasing, continue.
 										if ( $level->id == $pmpro_level->id ) {
 											continue;
 										}
-
-										// If this level is not in the same group, continue.
 										if ( pmpro_get_group_id_for_level( $level->id ) != $group_id ) {
 											continue;
 										}
-
-										// If we made it this far, the user is going to lose this level after checkout.
-										printf( ' ' . esc_html__( 'Your current membership level of %s will be removed when you complete your purchase.', 'paid-memberships-pro' ), '<strong>' . esc_html( $level->name ) . '</strong>' );
+										$level_name_text .= ' ' . sprintf( esc_html__( 'Your current membership level of %s will be removed when you complete your purchase.', 'paid-memberships-pro' ), '<strong>' . esc_html( $level->name ) . '</strong>' );
 									}
 								}
 							}
-							?>
+
+							/**
+							 * Filter the level name and membership change text at checkout.
+							 *
+							 * @since TBD
+							 *
+							 * @param string $level_name_text The text to display.
+							 * @param object $pmpro_level     The level being purchased.
+							 */
+							$level_name_text = apply_filters( 'pmpro_checkout_level_name_text', $level_name_text, $pmpro_level );
+
+							if ( ! empty( $level_name_text ) ) {
+						?>
+						<p class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_level_name_text' ) );?>">
+							<?php echo wp_kses_post( $level_name_text ); ?>
 						</p> <!-- end pmpro_level_name_text -->
+						<?php } ?>
 
 						<?php
 							/**
@@ -246,6 +251,7 @@ if ( empty( $default_gateway ) ) {
 							</legend>
 							<?php if ( ! $skip_account_fields ) { ?>
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_fields' ) ); ?>">
+									<?php do_action( 'pmpro_checkout_before_account_fields' ); ?>
 									<?php
 										// Get discount code from URL parameter, so if the user logs in it will keep it applied.
 										$discount_code_link = ! empty( $discount_code) ? '&pmpro_discount_code=' . $discount_code : '';

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -144,6 +144,7 @@ require_once( PMPRO_DIR . '/includes/site-types.php' );             // site type
 require_once( PMPRO_DIR . '/includes/spam.php' );					// code to combat spam of various kinds
 require_once( PMPRO_DIR . '/includes/abandoned-signups.php' );		// track users who were created at checkout but did not complete checkout.
 require_once( PMPRO_DIR . '/includes/checkout.php' );		        // Common functions used at checkout.
+require_once( PMPRO_DIR . '/includes/standalone-levels.php' );       // Standalone levels and guest checkout functionality.
 require_once( PMPRO_DIR . '/includes/level-groups.php' );		    // Common functions for level groups.
 require_once( PMPRO_DIR . '/includes/avatars.php' );				// Common functions for avatars.
 require_once( PMPRO_DIR . '/includes/restricted-files.php' );		// Restrict access to files.

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -367,8 +367,21 @@ if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
 		}
 	}
 
-	// If we don't have a user yet, check the user fields.
-	if ( empty( $current_user->ID ) ) {
+	/**
+	 * Filter whether to skip user creation during checkout.
+	 *
+	 * When true, the checkout will proceed without creating a WordPress user
+	 * and will skip user field validation. Used by guest checkouts.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool   $skip_user_creation Whether to skip user creation. Default false.
+	 * @param object $pmpro_level        The level being purchased.
+	 */
+	$pmpro_skip_user_creation = apply_filters( 'pmpro_skip_user_creation', false, $pmpro_level );
+
+	// If we don't have a user yet and we're not skipping user creation, check the user fields.
+	if ( empty( $current_user->ID ) && ! $pmpro_skip_user_creation ) {
 		foreach ( $pmpro_required_user_fields as $key => $field ) {
 			if ( ! $field ) {
 				$pmpro_error_fields[] = $key;
@@ -451,8 +464,8 @@ if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
 		}
 	}
 
-	// If there is still a vaild checkout submission but we don't have a user yet, create one.
-	if ( $pmpro_msgt != "pmpro_error" && empty( $current_user->ID ) ) {
+	// If there is still a valid checkout submission but we don't have a user yet, create one.
+	if ( $pmpro_msgt != "pmpro_error" && empty( $current_user->ID ) && ! $pmpro_skip_user_creation ) {
 		//first name
 		if ( ! empty( $_REQUEST['first_name'] ) ) {
 			$first_name = sanitize_text_field( $_REQUEST['first_name'] );

--- a/preheaders/invoice.php
+++ b/preheaders/invoice.php
@@ -9,29 +9,44 @@ if ( ! empty( $_REQUEST['invoice'] ) ) {
 	$invoice_code = NULL;
 }
 
-// Redirect non-user to the login page; pass the Invoice page as the redirect_to query arg.
-if ( ! is_user_logged_in() ) {
-	if ( ! empty( $invoice_code ) ) {
-		$invoice_url = add_query_arg( 'invoice', $invoice_code, pmpro_url( 'invoice' ) );
-	} else {
-		$invoice_url = pmpro_url( 'invoice' );
-	}
-	wp_redirect( add_query_arg( 'redirect_to', urlencode( $invoice_url ), wp_login_url() ) );
-	exit;
-}
-
+// Load the order by code if we have one.
 if ( ! empty( $invoice_code ) ) {
 	$pmpro_invoice = new MemberOrder( $invoice_code );
 
 	if ( ! $pmpro_invoice->id ) {
-		// Redirect user to the account page if no invoice found.
-		wp_redirect( pmpro_url( 'account' ) );
-		exit;
+		$pmpro_invoice = null;
 	}
+}
 
-	// Make sure they have permission to view this.
-	if ( ! current_user_can( 'pmpro_orders' ) && $current_user->ID != $pmpro_invoice->user_id ) {
-		wp_redirect( pmpro_url( 'account' ) ); //no permission
-		exit;
+// Determine if the current visitor can view this order.
+if ( ! empty( $pmpro_invoice ) ) {
+	$can_view_order = is_user_logged_in() && ( current_user_can( 'pmpro_orders' ) || $current_user->ID == $pmpro_invoice->user_id );
+} else {
+	$can_view_order = is_user_logged_in();
+}
+
+/**
+ * Filter whether the current visitor can view the requested order.
+ *
+ * @since TBD
+ *
+ * @param bool             $can_view_order Whether the visitor can view the order.
+ * @param MemberOrder|null $pmpro_invoice  The order being viewed, or null if no order was requested.
+ */
+$can_view_order = apply_filters( 'pmpro_allow_viewing_order', $can_view_order, $pmpro_invoice );
+
+if ( ! $can_view_order ) {
+	if ( ! is_user_logged_in() ) {
+		// Redirect non-user to the login page; pass the Invoice page as the redirect_to query arg.
+		if ( ! empty( $invoice_code ) ) {
+			$invoice_url = add_query_arg( 'invoice', $invoice_code, pmpro_url( 'invoice' ) );
+		} else {
+			$invoice_url = pmpro_url( 'invoice' );
+		}
+		wp_redirect( add_query_arg( 'redirect_to', urlencode( $invoice_url ), wp_login_url() ) );
+	} else {
+		// Logged-in user without permission; redirect to account page.
+		wp_redirect( pmpro_url( 'account' ) );
 	}
+	exit;
 }


### PR DESCRIPTION
## Summary
- Adds **Standalone Level** setting: one-time purchases that don't assign a membership, don't cancel existing memberships, and can always be repurchased. Ideal for donations, gifts, event tickets, etc.
- Adds **Allow Guest Checkout** setting (on standalone levels): lets users check out without creating a WordPress account.
- All standalone and guest checkout logic lives in a single new file `includes/standalone-levels.php`, hooked into core via filters and actions.
- Adds general-purpose hooks and filters that are useful beyond standalone/guest checkout.

## Still TODO
- [ ] Wording and UX during standalone checkout (email templates still reference "membership")
- [ ] Wording and UX when a purchase has been completed as a guest
- [ ] Ensure Add Ons handle orders and checkouts without user IDs gracefully
- [ ] Consider hiding billing/expiration/recurring fields on the edit level page when standalone is checked
- [ ] Consider dedicated email templates for standalone/guest checkouts
- [ ] Test with all payment gateways
- [ ] Test with key Add Ons (Donations, Gift Levels, Sponsored Members)

## Test plan
- Create a membership level, check "Standalone Level" under Other Settings
- Verify the levels list shows "Standalone level. No membership assigned." in the cost column
- Check out for the standalone level while logged in — verify no membership assigned, redirected to invoice page
- Check "Allow Guest Checkout", check out while logged out with the guest checkbox — verify no user created, order saved with guest_email in meta, redirected to invoice page with email access
- Verify guest order shows guest email in admin orders list and order view sidebar
- Verify recurring billing is blocked on standalone levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)