### PR TITLE
Fix export download access failures in Action Scheduler export system

### DIFF
--- a/classes/class-pmpro-exports.php
+++ b/classes/class-pmpro-exports.php
@@ -155,7 +155,7 @@ class PMPro_Exports {
 	 * @return void
 	 */
 	public function handle_restricted_file_served( $file_dir, $file ) {
-		if ( 'exports' !== $file_dir || empty( $this->pending_post_serve ) ) {
+		if ( 'exports' !== $file_dir || empty( $this->pending_post_serve ) || $file !== $this->pending_post_serve['file'] ) {
 			return;
 		}
 		$ctx                    = $this->pending_post_serve;

--- a/classes/class-pmpro-exports.php
+++ b/classes/class-pmpro-exports.php
@@ -40,6 +40,14 @@ class PMPro_Exports {
 	protected $default_export_exp = 6 * HOUR_IN_SECONDS;
 
 	/**
+	 * Pending post-serve cleanup context.
+	 * Populated by export_can_access_restricted_files() and consumed by handle_restricted_file_served().
+	 *
+	 * @var array|null
+	 */
+	protected $pending_post_serve = null;
+
+	/**
 	 * Get singleton instance.
 	 *
 	 * @return PMPro_Exports
@@ -61,6 +69,8 @@ class PMPro_Exports {
 		add_action( 'pmpro_export_delete_file', array( $this, 'delete_file_task' ), 10, 1 );
 		// File access filter.
 		add_filter( 'pmpro_can_access_restricted_file', array( $this, 'export_can_access_restricted_files' ), 10, 2 );
+		// Post-serve cleanup (fires after readfile() confirms the file was delivered).
+		add_action( 'pmpro_restricted_file_served', array( $this, 'handle_restricted_file_served' ), 10, 2 );
 	}
 
 	/**
@@ -89,10 +99,14 @@ class PMPro_Exports {
 			}
 			if ( ! empty( $export_id ) && ! empty( $token ) && ! empty( $file ) ) {
 				$can_access = $this->validate_file_access( $current_user_id, $export_id, $token, $file );
-				// If access is granted, perform cleanup and schedule file deletion.
+				// If access is granted, store cleanup context for after the file is confirmed served.
+				// Actual cleanup runs in handle_restricted_file_served() once readfile() completes.
 				if ( $can_access ) {
-					$this->cleanup_after_download( $current_user_id, $export_id );
-					$this->schedule_file_deletion( $file, $this->default_export_exp, $current_user_id, $export_id );
+					$this->pending_post_serve = array(
+						'user_id'   => $current_user_id,
+						'export_id' => $export_id,
+						'file'      => $file,
+					);
 				}
 			}
 		}
@@ -128,6 +142,26 @@ class PMPro_Exports {
 		// Clear transients.
 		delete_transient( 'pmpro_export_owner_' . $export_id );
 		delete_transient( 'pmpro_export_token_' . $export_id );
+	}
+
+	/**
+	 * Perform cleanup after a restricted export file has been successfully served.
+	 * Fires on the pmpro_restricted_file_served action, which is triggered by
+	 * pmpro_restricted_files_check_request() immediately after readfile() completes.
+	 * This ensures the export record is only removed once file delivery is confirmed.
+	 *
+	 * @param string $file_dir Directory of the file that was served.
+	 * @param string $file     File name of the file that was served.
+	 * @return void
+	 */
+	public function handle_restricted_file_served( $file_dir, $file ) {
+		if ( 'exports' !== $file_dir || empty( $this->pending_post_serve ) ) {
+			return;
+		}
+		$ctx                    = $this->pending_post_serve;
+		$this->pending_post_serve = null;
+		$this->cleanup_after_download( $ctx['user_id'], $ctx['export_id'] );
+		$this->schedule_file_deletion( $ctx['file'], $this->default_export_exp, $ctx['user_id'], $ctx['export_id'] );
 	}
 
 	/**
@@ -449,6 +483,11 @@ class PMPro_Exports {
 		$chunk_size = $this->get_chunk_size_for_type( $type );
 		$threshold  = $this->get_async_threshold_for_type( $type );
 
+		// Bail early if there is nothing to export.
+		if ( 0 === $total ) {
+			return array( 'error' => __( 'No records match the selected filters. Nothing to export.', 'paid-memberships-pro' ) );
+		}
+
 		// Create export record in user meta.
 		$export = $this->create_export_record( $user_id, $type, $filters, $total, $chunk_size );
 
@@ -647,7 +686,10 @@ class PMPro_Exports {
 			'processed_count' => (int) $export['processed_count'],
 		);
 		if ( 'complete' === $export['status'] ) {
-			$resp['download_url'] = $this->get_download_url( $export );
+			$url = $this->get_download_url( $export );
+			if ( ! empty( $url ) ) {
+				$resp['download_url'] = $url;
+			}
 		}
 		if ( ! empty( $export['error'] ) ) {
 			$resp['error'] = $export['error'];
@@ -711,12 +753,17 @@ class PMPro_Exports {
 	 * Secure download URL for export file.
 	 */
 	protected function get_download_url( $export ) {
+		// Token is stored transiently; fallback to in-memory value if present (e.g. fresh sync export).
+		$token = isset( $export['token'] ) ? $export['token'] : get_transient( 'pmpro_export_token_' . $export['id'] );
+		if ( empty( $token ) ) {
+			// Token has expired; cannot build a valid download URL.
+			return null;
+		}
 		$query = array(
 			'pmpro_restricted_file_dir' => 'exports',
 			'pmpro_restricted_file'     => $export['file_name'],
 			'export_id'                 => $export['id'],
-			// Token is stored transiently; fallback to record if present.
-			'token'                     => isset( $export['token'] ) ? $export['token'] : get_transient( 'pmpro_export_token_' . $export['id'] ),
+			'token'                     => $token,
 			'_wpnonce'                  => wp_create_nonce( 'pmpro_export_download_' . $export['id'] ),
 		);
 		return add_query_arg( $query, home_url( '/' ) );
@@ -817,7 +864,7 @@ class PMPro_Exports {
 		// Mark active for this user/type.
 		update_user_meta( $user_id, $this->get_active_meta_key( $type ), $export_id );
 		// Store a transient so async Action Scheduler contexts can resolve the owner.
-		set_transient( 'pmpro_export_owner_' . $export_id, (int) $user_id, DAY_IN_SECONDS );
+		set_transient( 'pmpro_export_owner_' . $export_id, (int) $user_id, 7 * DAY_IN_SECONDS );
 		return $record;
 	}
 
@@ -833,7 +880,7 @@ class PMPro_Exports {
 		$to_store = $record;
 		if ( isset( $record['token'] ) ) {
 			// Persist token so download_url can be built after async completion.
-			set_transient( 'pmpro_export_token_' . $record['id'], $record['token'], DAY_IN_SECONDS );
+			set_transient( 'pmpro_export_token_' . $record['id'], $record['token'], 7 * DAY_IN_SECONDS );
 		}
 		unset( $to_store['token'] );
 		update_user_meta( (int) $record['user_id'], $key, wp_json_encode( $to_store ) );

--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -95,6 +95,7 @@ function pmpro_restricted_files_check_request() {
 		header( 'Content-Type: ' . $content_type );
 		header( 'Content-Disposition: ' . $content_disposition . '; filename="' . $file . '"' );
 		readfile( $file_path );
+		do_action( 'pmpro_restricted_file_served', $file_dir, $file );
 		exit;
 	} else {
 		wp_die(	esc_html__( 'File not found.', 'paid-memberships-pro' ), 404 );

--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -96,7 +96,19 @@ function pmpro_restricted_files_check_request() {
 		header( 'Content-Disposition: ' . $content_disposition . '; filename="' . $file . '"' );
 		$bytes = readfile( $file_path );
 		if ( false !== $bytes ) {
+			// Buffer the action so a misbehaving hook can't append output to the response body and corrupt the download.
+			ob_start();
+			/**
+			 * Fires after a restricted file has been successfully streamed to the client.
+			 * Handlers MUST NOT produce output; any bytes written here are discarded.
+			 *
+			 * @since 3.7
+			 *
+			 * @param string $file_dir Directory of the file that was served.
+			 * @param string $file     File name of the file that was served.
+			 */
 			do_action( 'pmpro_restricted_file_served', $file_dir, $file );
+			ob_end_clean();
 		}
 		exit;
 	} else {

--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -94,8 +94,10 @@ function pmpro_restricted_files_check_request() {
 		finfo_close( $finfo );
 		header( 'Content-Type: ' . $content_type );
 		header( 'Content-Disposition: ' . $content_disposition . '; filename="' . $file . '"' );
-		readfile( $file_path );
-		do_action( 'pmpro_restricted_file_served', $file_dir, $file );
+		$bytes = readfile( $file_path );
+		if ( false !== $bytes ) {
+			do_action( 'pmpro_restricted_file_served', $file_dir, $file );
+		}
 		exit;
 	} else {
 		wp_die(	esc_html__( 'File not found.', 'paid-memberships-pro' ), 404 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Users reported that export CSV downloads return "You do not have permission to access this file" (403) or "File not found" (404) even when the export appears to have completed. Three bugs were identified and fixed:

**Bug 1 — Export record deleted before file delivery is confirmed**

`cleanup_after_download()` was called inside the `pmpro_can_access_restricted_file` filter, which runs *before* `readfile()` in `pmpro_restricted_files_check_request()`. If the file was missing (or any error occurred after the filter), the export record was already gone — leaving the user with a 404 and no way to retry without starting over. Deferred cleanup to a new `pmpro_restricted_file_served` action that fires immediately after `readfile()` succeeds.

**Bug 2 — Token transient expiry breaks download after 24 hours**

The plaintext download token was stored in a transient with a hardcoded 1-day TTL. After expiry, `get_download_url()` silently built a URL with an empty `token=` parameter, causing a 403 for any export older than 24 hours even though the record and file still existed. Extended both the token and owner transient TTLs to 7 days. Also hardened `get_download_url()` to return `null` when no token is available, and updated `format_public_export_response()` to omit `download_url` in that case — so the UI falls back to idle/retry instead of presenting a broken link.

**Bug 3 — Zero-record exports create a ghost "complete" state with no file**

When `total_count = 0`, the export was immediately marked `complete` without ever opening or writing a CSV file. The download attempt would pass access validation, run cleanup (deleting the record), then fail with a 404. Added an early return in `start_export()` when the total count is 0, returning a descriptive error instead.

### How to test the changes in this Pull Request:

1. Export members (< 499) — confirm the CSV downloads and the button resets to idle.
2. Export members (> 499, async) — wait for background completion, confirm download works.
3. Filter members to a level with no members and attempt export — confirm an inline error message appears immediately with no ghost export record created.
4. After a successful export, manually delete the token transient (`delete_transient('pmpro_export_token_{id}')`) and poll the status endpoint — confirm `download_url` is absent from the response and the button shows idle/retry state.
5. Simulate a failed file serve (rename the export file after access is granted) — confirm the export record still exists after the 404, allowing a retry.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix export CSV download failures caused by premature record cleanup, token transient expiry after 24 hours, and zero-record exports creating an undownloadable "complete" state.