### PR TITLE
Tighten ownership check in /pmpro/v1/order permission callback

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -971,6 +971,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 			// Check if the user does not have access but is trying to get an order.
 			if ( ! $permission && 'GET' === $method && '/pmpro/v1/order' === $route ) {
+				// Only a logged-in user can own an order, so bail early for anonymous requests.
+				if ( ! is_user_logged_in() ) {
+					return $permission;
+				}
+
 				// Check if the order belongs to the user.
 				$params = $request->get_params();
 				$code   = isset( $params['code'] ) ? sanitize_text_field( $params['code'] ) : null;
@@ -978,7 +983,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				if ( ! empty( $code ) ) {
 					$order = new MemberOrder( $code );
 
-					if ( $order->user_id == get_current_user_id() ) {
+					if ( ! empty( $order->id ) && (int) $order->user_id === get_current_user_id() ) {
 						return true;
 					}
 				}


### PR DESCRIPTION
## What

Small cleanup to the `pmpro_rest_api_permissions_get_order` filter:

- Bail early for anonymous requests (an anonymous user cannot own an order, so there's no work to do).
- Require `! empty( $order->id )` before granting access, so a non-existent `code` doesn't fall through to the ownership comparison on an empty `MemberOrder`.
- Switch the ownership match to a strict integer comparison (`(int) $order->user_id === get_current_user_id()`), which matches the rest of the REST code and is a touch more defensive around the `MemberOrder` class defaults.

## Why

Incrementally tidies up the permission callback so each check stands on its own — no reliance on `MemberOrder`'s default property values happening to not match. Behavior for a legitimate logged-in user fetching their own order is unchanged.

## Test plan

- [ ] Logged-out request to `/pmpro/v1/order?code=<real code>` → `401/403` (unchanged from before in practice).
- [ ] Logged-in user requests their own order → 200 with order data.
- [ ] Logged-in user requests someone else's order → 401/403.
- [ ] Admin with `pmpro_orders` cap → 200 regardless (default cap path, unaffected).