### PR TITLE
Scope /pmpro/v1/quick_search meta lookups to custom fields

### DIFF
--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -1378,22 +1378,50 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 					$meta_key = sanitize_text_field( trim( $meta_key ) );
 					$meta_value = sanitize_text_field( trim( $meta_value ) );
 
-					$user_ids = $wpdb->get_col( $wpdb->prepare(
-						"SELECT user_id FROM {$wpdb->usermeta}
-						WHERE meta_key = %s
-						AND meta_value LIKE %s
-						LIMIT %d",
-						$meta_key,
-						$meta_value . '%',
-						$limit
+					/**
+					 * Limit the meta_key lookup to custom profile fields.
+					 *
+					 * Keys that start with an underscore are WP/plugin-internal by
+					 * convention, and a handful of well-known keys hold authentication
+					 * or capability data that the quick search isn't meant to surface.
+					 *
+					 * @since TBD
+					 *
+					 * @param array $blocklist List of meta_key names (lowercase) to skip.
+					 */
+					$meta_key_blocklist = apply_filters( 'pmpro_rest_api_quick_search_meta_key_blocklist', array(
+						'session_tokens',
+						'wp_capabilities',
+						'wp_user_level',
+						'user_activation_key',
 					) );
+
+					$meta_key_is_internal = (
+						'' === $meta_key
+						|| '_' === $meta_key[0]
+						|| in_array( strtolower( $meta_key ), $meta_key_blocklist, true )
+					);
+
+					if ( $meta_key_is_internal ) {
+						$user_ids = array();
+					} else {
+						$user_ids = $wpdb->get_col( $wpdb->prepare(
+							"SELECT user_id FROM {$wpdb->usermeta}
+							WHERE meta_key = %s
+							AND meta_value LIKE %s
+							LIMIT %d",
+							$meta_key,
+							$meta_value . '%',
+							$limit
+						) );
+					}
 					$users = array();
 					foreach( $user_ids as $user_id ) {
 						$user = get_userdata( $user_id );
 						if ( $user ) {
 							$users[] = $user;
 						}
-					}	
+					}
 				} else {
 					// Normal user search by ID, login, or email.
 					$users = $wpdb->get_results( $wpdb->prepare(


### PR DESCRIPTION
## What

The `users`-type branch of `/pmpro/v1/quick_search` supports a `key:value` syntax that runs a `LIKE` against `wp_usermeta`. Right now the `meta_key` is accepted verbatim, so a search like `_user_activation_key:abc` will run against internal WP meta that the quick search isn't meant to cover.

This PR limits the meta lookup to custom profile fields by skipping:

- `meta_key` values that begin with `_` (the WP/plugin convention for internal meta).
- A short list of well-known internal keys (`session_tokens`, `wp_capabilities`, `wp_user_level`, `user_activation_key`).

A new filter `pmpro_rest_api_quick_search_meta_key_blocklist` lets sites extend the list (e.g. a plugin that stores its own internal meta).

## Why

The quick search's meta mode is there so admins can find users by custom profile fields. Keeping the query scoped to those keeps the feature doing what it advertises and avoids surprising matches against WP internals.

## Test plan

- [ ] Search `users` with `somecustomfield:somevalue` → still matches users with `somecustomfield` meta.
- [ ] Search `users` with `_user_activation_key:anything` → returns no user results.
- [ ] Search `users` with `wp_capabilities:a:1` → returns no user results.
- [ ] Filter `pmpro_rest_api_quick_search_meta_key_blocklist` can add an extra key and it is skipped.
- [ ] Non-meta user search (no `:`) continues to work against `ID`, `user_login`, `user_email`.