### PR TITLE
Fix scope comparison in PMPro_Field_Group::save_fields()

### DIFF
--- a/classes/class-pmpro-field-group.php
+++ b/classes/class-pmpro-field-group.php
@@ -541,7 +541,7 @@ class PMPro_Field_Group {
 		$user_id = empty( $args['user_id'] ) ? get_current_user_id() : $args['user_id'];
 
 		// Make sure the current user can edit this user.
-		if ( 'scope' == 'profile' && ! current_user_can( 'edit_user', $user_id ) ) {
+		if ( 'profile' === $args['scope'] && ! current_user_can( 'edit_user', $user_id ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What

The capability guard in `PMPro_Field_Group::save_fields()` compares the literal string `'scope'` against `'profile'` instead of the value in `\$args['scope']`:

```php
if ( 'scope' == 'profile' && ! current_user_can( 'edit_user', \$user_id ) ) {
    return false;
}
```

That expression is always `false`, so the guard never runs. The companion user-facing error message ("You do not have permission to update these fields.") in `adminpages/member-edit/pmpro-class-member-edit-panel-user-fields.php` can't fire today.

This PR compares the actual arg value:

```php
if ( 'profile' === \$args['scope'] && ! current_user_can( 'edit_user', \$user_id ) ) {
    return false;
}
```

## Why

Looks like a copy/paste slip — the intent of the guard is clearly "only run the cap check for the profile scope." Upstream callers (admin member-edit, checkout hooks) have their own caps, so behavior doesn't change in normal flows, but it's nice to have the inline guard actually run so the error path is reachable.

## Test plan

- [ ] Admin saves user fields on member-edit screen → still works.
- [ ] Checkout saves user fields for the logged-in/just-created user → still works.
- [ ] Call `\$group->save_fields( array( 'user_id' => \$other_user, 'scope' => 'profile' ) )` as a user without `edit_user` on `\$other_user` → now returns `false` and surfaces the permission error.