### PR TITLE
Fixing checkbox_grouped field input not getting the right selectors

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -1085,10 +1085,6 @@ class PMPro_Field {
 			$counter = 1;
 			foreach($this->options as $ovalue => $option)
 			{
-				if ( ! empty( $this->class ) ) {
-					$class = $this->class;
-				}
-
 				$r .= '<li class="' . esc_attr( pmpro_get_element_class( 'pmpro_list_item' ) ) . '">';
 				$r .= '<span class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field-checkbox-grouped-item' ) ) . '">';
 				$r .= sprintf(
@@ -1096,7 +1092,7 @@ class PMPro_Field {
 					esc_attr( $this->name ),
 					esc_html( $ovalue ),
 					esc_attr( "{$this->id}_{$counter}" ),
-					esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-checkbox ' . $this->id ), $this->id ),
+					esc_attr( $this->class ),
 					( in_array($ovalue, $value) ? 'checked="checked"' : null ),
 					( !empty( $this->readonly ) ? 'readonly="readonly"' : null ),
 					$this->getHTMLAttributes()


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The `checkbox_grouped` field type was building its own list of CSS selectors, different than other field types. This meant that the field level setting to add a "Field Element Class (optional)" would never reach this field type.

This PR makes sure that checkbox_grouped checkbox inputs can leverage this field setting.

### How to test the changes in this Pull Request:

1. Add a checkbox_grouped user field
2. Set the "Field Element Class (optional)" to any value
3. See that with the PR, that selector is added to the <input type="checkbox" ... /> HTML.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG: Fixed CSS selectors list issue with `checkbox_grouped` field types.
