### PR TITLE
Filters for avatar upload location/render location to support multisite

### DIFF
--- a/includes/avatars.php
+++ b/includes/avatars.php
@@ -218,7 +218,17 @@ function pmpro_avatar_get_bucketed_size( $size ) {
  */
 function pmpro_avatar_get_upload_dir( $user_id = 0, $file = '' ) {
 	$upload_dir = wp_upload_dir();
-	$avatar_dir = trailingslashit( $upload_dir['basedir'] ) . 'pmpro-avatars/';
+
+	/**
+	 * Filter the base directory used for PMPro avatar storage.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $basedir The base upload directory path.
+	 * @param int    $user_id The user ID (0 if not user-specific).
+	 */
+	$basedir    = apply_filters( 'pmpro_avatar_basedir', $upload_dir['basedir'], $user_id );
+	$avatar_dir = trailingslashit( $basedir ) . 'pmpro-avatars/';
 
 	if ( $user_id ) {
 		$avatar_dir .= $user_id . '/';
@@ -242,7 +252,17 @@ function pmpro_avatar_get_upload_dir( $user_id = 0, $file = '' ) {
  */
 function pmpro_avatar_get_upload_url( $user_id = 0, $file = '' ) {
 	$upload_dir = wp_upload_dir();
-	$avatar_url = trailingslashit( $upload_dir['baseurl'] ) . 'pmpro-avatars/';
+
+	/**
+	 * Filter the base URL used for PMPro avatar storage.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $baseurl The base upload URL.
+	 * @param int    $user_id The user ID (0 if not user-specific).
+	 */
+	$baseurl    = apply_filters( 'pmpro_avatar_baseurl', $upload_dir['baseurl'], $user_id );
+	$avatar_url = trailingslashit( $baseurl ) . 'pmpro-avatars/';
 
 	if ( $user_id ) {
 		$avatar_url .= $user_id . '/';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Sites using the `pmpro-network-subsite` Add On to control membership access from the main network site have no way to carry the main site's "user avatar" through to the subsites.

This PR introduces two new filters that allow developers OR our Add Ons to customize the base directory and URL used for PMPro avatar storage. Previously, avatars were always stored in the default WordPress uploads directory with no way to override the location.

`pmpro_avatar_basedir` Filters the base directory path used for avatar storage.

`pmpro_avatar_baseurl` Filters the base URL used for avatar storage.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* ENHANCEMENT: Added filters `pmpro_avatar_basedir` and `pmpro_avatar_baseurl` to support handling user avatars across a multisite network.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
