### PR TITLE
Skip content visibility controls for unsupported blocks in widget editors

### DIFF
--- a/blocks/src/component-content-visibility/index.js
+++ b/blocks/src/component-content-visibility/index.js
@@ -2,6 +2,13 @@ import { __ } from '@wordpress/i18n';
 
 import ContentVisibilityControls from './content-visibility-controls';
 
+// Content Visibility Controls will not be added to these blocks in the widget context.
+const WIDGET_EXCLUDED_BLOCKS = [ 'core/html', 'core/legacy-widget' ];
+
+// WordPress sets window.pagenow to 'widgets' on the block-based Widgets screen
+// and 'customize' in the Customizer, so we can detect both without touching the data stores.
+const IS_WIDGETS_CONTEXT = window.pagenow === 'widgets' || window.pagenow === 'customize';
+
 /**
  * Add the visibility attributes to the block settings.
  *
@@ -11,6 +18,12 @@ import ContentVisibilityControls from './content-visibility-controls';
 function addContentVisibilityAttribute(settings, name) {
 	if (typeof settings.attributes !== 'undefined') {
 		if (name.startsWith('core/')) {
+
+			// Skip unsupported blocks when in widget editors.
+			if (IS_WIDGETS_CONTEXT && WIDGET_EXCLUDED_BLOCKS.includes(name)) {
+				return settings;
+			}
+
 			settings.attributes = Object.assign(settings.attributes, {
 				"visibilityBlockEnabled": {
 					"type": 'boolean',
@@ -54,11 +67,12 @@ const contentVisibilityComponent = wp.compose.createHigherOrderComponent((BlockE
 	 return (props) => {
 
 		const { Fragment } = wp.element;
-		const {  isSelected } = props;
-		 return (	
+		const { isSelected } = props;
+		const isExcludedInWidgetContext = IS_WIDGETS_CONTEXT && WIDGET_EXCLUDED_BLOCKS.includes(props.name);
+		return (
 			<Fragment>
 				<BlockEdit {...props} />
-				{ isSelected && (props.name.startsWith('core/')) &&	ContentVisibilityControls(props) }
+				{ isSelected && props.name.startsWith('core/') && !isExcludedInWidgetContext && ContentVisibilityControls(props) }
 			</Fragment>
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The PMPro Content Visibility controls are injected into every core/* block.

In the block-based Widgets screen and the Customizer, the visibility settings on certain blocks (notably core/html and core/legacy-widget) cannot be saved reliably, so users were being offered a UI that silently didn't work.

This PR hides the Content Visibility panel and skips registering the related block attributes for core/html and core/legacy-widget when the editor context is the Widgets screen or the Customizer. The post/site editor behavior is unchanged.

An excluded-blocks list (WIDGET_EXCLUDED_BLOCKS) is used so more blocks can be added later if needed.

Affects the editor UI only. No render-side / frontend logic is changed.

Resolves #3577, confirmed "View As" feature works as expected with blocks in widget areas.

### How to test the changes in this Pull Request:
1. npm run build
2. On a site with PMPro active, go to _Appearance > Widgets_ (block-based Widgets screen). 
3. Insert a Custom HTML block and a Legacy Widget block, plus a Paragraph block for contrast. Confirm the Paragraph block shows the Content Visibility panel in the inspector, while the Custom HTML and Legacy Widget blocks do not.
4. Open _Appearance > Customize > Widgets_ and repeat step 1 inside the Customizer. Expected behavior is the same.
5. Edit a post or page in the block editor. Insert a Custom HTML block and confirm the Content Visibility panel still appears (post-editor behavior is unchanged).
6. If you have a Custom HTML block in a widget area from before this change that already had content visibility applied, confirm it still renders on the frontend as it did before (no regression in existing saved content).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Hiding the PMPro Content Visibility controls from unsupported blocks in the Widgets editor and the Customizer.
