### PR TITLE
Fix warnings on Stripe delayed checkout processing

### DIFF
--- a/services/class-pmpro-stripe-webhook-handler.php
+++ b/services/class-pmpro-stripe-webhook-handler.php
@@ -633,6 +633,26 @@ class PMPro_Stripe_Webhook_Handler {
 			return;
 		}
 
+		// For one-time payments, the Charge didn't exist at checkout.session.completed time, so fill in the transaction ID now.
+		if ( 'payment' === $checkout_session->mode
+			&& empty( $order->payment_transaction_id )
+			&& ! empty( $checkout_session->payment_intent )
+		) {
+			try {
+				$payment_intent = \Stripe\PaymentIntent::retrieve(
+					array(
+						'id'     => $checkout_session->payment_intent,
+						'expand' => array( 'latest_charge' ),
+					)
+				);
+				if ( ! empty( $payment_intent->latest_charge ) ) {
+					$order->payment_transaction_id = $payment_intent->latest_charge->id;
+				}
+			} catch ( \Stripe\Error\Base $e ) {
+				// Could not get payment intent. We just won't set a payment transaction ID.
+			}
+		}
+
 		// No we have not processed this order. Let's process it now.
 		if ( self::change_membership_level( $order ) ) {
 			$logstr .= 'Order #' . $order->id . ' for Checkout Session ' . $checkout_session->id . ' was processed successfully.';

--- a/services/class-pmpro-stripe-webhook-handler.php
+++ b/services/class-pmpro-stripe-webhook-handler.php
@@ -514,7 +514,11 @@ class PMPro_Stripe_Webhook_Handler {
 					),
 				);
 				$payment_intent = \Stripe\PaymentIntent::retrieve( $payment_intent_args );
-				$order->payment_transaction_id = empty( $checkout_session->invoice ) ? $payment_intent->latest_charge->id : $checkout_session->invoice;
+				if ( ! empty( $checkout_session->invoice ) ) {
+					$order->payment_transaction_id = $checkout_session->invoice;
+				} elseif ( ! empty( $payment_intent->latest_charge ) ) {
+					$order->payment_transaction_id = $payment_intent->latest_charge->id;
+				}
 				if ( ! empty( $payment_intent->payment_method ) ) {
 					$payment_method = $payment_intent->payment_method;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes a PHP warning and a missing transaction ID when one-time checkouts are paid with a delayed-notification method (e.g. Stripe Bank Transfer).

When checkout.session.completed fires for a payment-mode session using an async payment method, the PaymentIntent has no latest_charge yet (funds haven't settled). The existing `$payment_intent->latest_charge->id` check in `handle_checkout_session_completed` generates a warning: `Attempt to read property "id" on null`

This PR:
1. Guards `latest_charge` access in `handle_checkout_session_completed` so the warning is no longer emitted when the Charge doesn't exist yet. If there's no invoice and no `latest_charge`, `payment_transaction_id` is left unset and will be filled in later.
2. Populates the transaction ID in `handle_checkout_session_async_payment_succeeded` for one-time payments. When the async payment clears, we retrieve the PaymentIntent (with latest_charge expanded) and assign `$order->payment_transaction_id = $payment_intent->latest_charge->id`

Resolves #3638

### How to test the changes in this Pull Request:
1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
