### PR TITLE
Show new PayPal Gateway Add On as enabled on the Payment Gateway settings page

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -215,7 +215,8 @@
 											// Special Cases for Add Ons that add secondary gateways. These will be removed when core natively supports multiple gateways.
 											if (
 												( function_exists( 'pmproappe_pmpro_valid_gateways' ) && $gateway_slug === 'paypalexpress' ) || // Add PayPal Express Add On.
-												( defined( 'PMPROPBC_VER' ) && $gateway_slug === 'check' ) // Pay by Check Add On.
+												( defined( 'PMPROPBC_VER' ) && $gateway_slug === 'check' ) || // Pay by Check Add On.
+												( $gateway_slug === 'paypal' && function_exists( 'pmpro_paypal_is_secondary' ) && pmpro_paypal_is_secondary() ) // PayPal Gateway Add On (only when configured to act as a secondary).
 											) {
 												// The Add On is active for the gateway being shown.
 												if ( pmpro_getOption( 'gateway' ) === $gateway_slug ) {


### PR DESCRIPTION
## Summary

The new [pmpro-paypal](https://github.com/strangerstudios/pmpro-paypal) Add On (released as 1.1) registers `paypal` as a secondary gateway at checkout when the site's primary gateway is something else and PayPal credentials are configured. Without this change, the `paypal` row on the Payment Gateway settings page renders a plain `&#8212;` (em dash) in the Status column even when the gateway is actively offered to members at checkout.

This adds a third entry to the existing "Add Ons that add secondary gateways" special-case block at [adminpages/paymentsettings.php:215](adminpages/paymentsettings.php#L215), so the row reads `Enabled (via Add On)` (or `Enabled (Primary Gateway & via Add On)` when paypal is also primary), matching how the page already treats the `paypalexpress` slug under the Add PayPal Express Add On and `check` under Pay by Check.

Rather than a plain `function_exists()` "is the Add On loaded" check, this calls the Add On's own [`pmpro_paypal_is_secondary()`](https://github.com/strangerstudios/pmpro-paypal/blob/dev/includes/checkout.php) helper. That helper already encodes the same "will this be shown at checkout?" decision the label is trying to describe, and any future filter or condition baked into the helper flows through automatically without another core change.

## Test plan

- [ ] Activate Paid Memberships Pro and the pmpro-paypal Add On (>= 1.1).
- [ ] With Stripe (or any non-PayPal gateway) as the primary gateway and PayPal credentials saved, the `PayPal` row on Memberships → Settings → Payment Gateway shows `Enabled (via Add On)`.
- [ ] Switch the primary gateway to PayPal — the row shows `Enabled (Primary Gateway & via Add On)`.
- [ ] With pmpro-paypal Add On *not* active, the `PayPal` row no longer appears (because the gateway is unregistered) and no PHP notices fire.
- [ ] Existing rows for `paypalexpress` (with Add PayPal Express) and `check` (with Pay by Check) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
