### PR TITLE
Fix deprecated pmpro_changeMembershipLevel call when deleting a WP user    

### DIFF
--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -22,7 +22,9 @@ function pmpro_delete_user( $user_id ) {
 	 * @param int  $user_id                     The WordPress user ID.
 	 */
 	if ( apply_filters( 'pmpro_user_deletion_cancel_active_subscriptions', $cancel_active_subscriptions, $user_id ) ) {
-		pmpro_changeMembershipLevel( 0, $user_id );
+		foreach ( pmpro_getMembershipLevelsForUser( $user_id ) as $level ) {
+			pmpro_cancelMembershipLevel( $level->id, $user_id );
+		}
 	}
 
 	//Remove all membership history for this user from the pmpro_memberships_users table


### PR DESCRIPTION
Reported here https://github.com/strangerstudios/paid-memberships-pro/issues/3659                                                                               
 
**Summary**                                                                                                                                                                                                                                                                                                                                                              
When an admin deletes a WordPress user with active membership levels, PMPro was calling pmpro_changeMembershipLevel( 0, $user_id ) to cancel their levels. Passing 0 as the level
was deprecated in PMPro 3.0 in favor of pmpro_cancelMembershipLevel(), which generated a PHP Notice on every user deletion:                            

> Function pmpro_changeMembershipLevel was called incorrectly. The pmpro_cancelMembershipLevel() function should be used to cancel membership levels.

**Changes**

  - includes/cleanup.php — Replaced the single pmpro_changeMembershipLevel( 0, $user_id ) call in pmpro_delete_user() with a loop over pmpro_getMembershipLevelsForUser() that
  calls pmpro_cancelMembershipLevel() for each level. This matches the behavior the deprecated code path was already falling back to internally.

  Testing

  1. Create a user with one or more active membership levels.
  2. Delete the user from WP Admin → Users with "Cancel active subscriptions" checked.
  3. Confirm the membership levels are cancelled and no PHP Notice is logged.         

WordPress 6.9.4
PMPro 3.7.1               
                 
