### PR TITLE
ENHANCEMENT: Add support for Cloudflare Turnstile invisible widget mode

### DIFF
--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -22,9 +22,18 @@ function pmpro_cloudflare_turnstile_get_html() {
 	if ( $cf_theme !== 'light' ) {
 		$cf_theme = 'dark';
 	}
+
+	// Get the widget mode setting.
+	$cf_mode = get_option( 'pmpro_cloudflare_turnstile_mode', 'managed' );
+
+	// Set the appearance attribute based on mode.
+	$appearance_attr = '';
+	if ( $cf_mode === 'invisible' ) {
+		$appearance_attr = ' data-appearance="interaction-only"';
+	}
 	?>
 	<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-	<div class="cf-turnstile" data-sitekey="<?php echo esc_attr( get_option( 'pmpro_cloudflare_turnstile_site_key' ) ); ?>" data-theme="<?php echo esc_attr( $cf_theme ); ?>"></div>
+	<div class="cf-turnstile" data-sitekey="<?php echo esc_attr( get_option( 'pmpro_cloudflare_turnstile_site_key' ) ); ?>" data-theme="<?php echo esc_attr( $cf_theme ); ?>"<?php echo $appearance_attr; ?>></div>
 	<?php
 
 }
@@ -93,6 +102,7 @@ add_action( 'pmpro_billing_update_checks', 'pmpro_cloudflare_turnstile_validatio
 function pmpro_cloudflare_turnstile_settings() {
 	// Get the options
 	$cloudflare_turnstile  = get_option( 'pmpro_cloudflare_turnstile', '0' );
+	$cloudflare_mode = get_option( 'pmpro_cloudflare_turnstile_mode', 'managed' );
 	$cloudflare_site_key = get_option( 'pmpro_cloudflare_turnstile_site_key', '' );
 	$cloudflare_secret_key = get_option( 'pmpro_cloudflare_turnstile_secret_key', '' );
 
@@ -111,6 +121,16 @@ function pmpro_cloudflare_turnstile_settings() {
 				<option value="1" <?php selected( $cloudflare_turnstile, 1 ); ?>><?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></option>
 			</select>
 			<p class="description"><?php esc_html_e( 'A free CloudFlare Turnstile key is required.', 'paid-memberships-pro' ); ?> <a href="https://www.cloudflare.com/products/turnstile/" target="_blank" rel="nofollow noopener"><?php esc_html_e( 'Click here to signup for CloudFlare Turnstile', 'paid-memberships-pro' ); ?></a>.</p>
+		</td>
+	</tr>
+	<tr class="pmpro_cloudflare_turnstile_settings" style="<?php echo esc_attr( $tr_style ); ?>">
+		<th scope="row" valign="top"><label for="cloudflare_turnstile_mode"><?php esc_html_e( 'Widget Mode', 'paid-memberships-pro' ); ?></label></th>
+		<td>
+			<select id="cloudflare_turnstile_mode" name="cloudflare_turnstile_mode">
+				<option value="managed" <?php selected( 'managed', $cloudflare_mode ); ?>><?php esc_html_e( 'Managed (Recommended)', 'paid-memberships-pro' ); ?></option>
+				<option value="invisible" <?php selected( 'invisible', $cloudflare_mode ); ?>><?php esc_html_e( 'Invisible (Non-interactive)', 'paid-memberships-pro' ); ?></option>
+			</select>
+			<p class="description"><?php esc_html_e( 'Managed mode lets Cloudflare decide when to show a challenge. Invisible mode always attempts invisible verification first, showing a challenge only when needed.', 'paid-memberships-pro' ); ?></p>
 		</td>
 	</tr>
    <tr class="pmpro_cloudflare_turnstile_settings" style="<?php echo esc_attr( $tr_style ); ?>">
@@ -147,6 +167,7 @@ add_action( 'pmpro_security_spam_fields', 'pmpro_cloudflare_turnstile_settings' 
  */
 function pmpro_cloudflare_turnstile_settings_save() {
 	pmpro_setOption( 'cloudflare_turnstile', intval( $_POST['cloudflare_turnstile'] ) );
+	pmpro_setOption( 'cloudflare_turnstile_mode', sanitize_text_field( $_POST['cloudflare_turnstile_mode'] ) );
 	pmpro_setOption( 'cloudflare_turnstile_site_key', sanitize_text_field( $_POST['cloudflare_turnstile_site_key'] ) );
 	pmpro_setOption( 'cloudflare_turnstile_secret_key', sanitize_text_field( $_POST['cloudflare_turnstile_secret_key'] ) );
 }


### PR DESCRIPTION
## Summary

Adds support for Cloudflare Turnstile's invisible (non-interactive) widget mode, following the same pattern as the existing reCAPTCHA integration.

## Problem

When using Cloudflare Turnstile in Managed mode, Cloudflare may decide to use invisible verification. If that invisible verification fails, no visible challenge is shown and checkout cannot proceed — users just see "Please complete the security check" with no way to actually complete it.

You can replicate this by:
1. Setting widget mode to Managed (Recommended) in Cloudflare dashboard
2. Using the test site key `2x00000000000000000000BB` which always fails verification
3. Attempting checkout — the form won't submit and no challenge appears

## Solution

This PR adds a **Widget Mode** dropdown to the Cloudflare Turnstile settings with two options:

- **Managed (Recommended)** — default behavior, Cloudflare decides when to show a challenge
- **Invisible (Non-interactive)** — explicitly uses `data-appearance="interaction-only"`, which ensures a visible challenge is shown when invisible verification fails

When Invisible mode is selected, the widget renders with the `data-appearance="interaction-only"` attribute, which tells Cloudflare Turnstile to show a visible challenge if invisible verification fails, preventing checkout from being blocked.

This follows the same pattern as PMPro's reCAPTCHA implementation, which offers v2 (checkbox) and v3 (invisible) modes via a dropdown.

## Testing

1. Enable Cloudflare Turnstile in Memberships → Settings → Security and Spam Prevention
2. Select **Invisible (Non-interactive)** from the Widget Mode dropdown
3. Use the test site key `2x00000000000000000000BB` (always fails)
4. Attempt checkout — a visible challenge should appear when invisible verification fails
5. With **Managed** mode, the same test should show no challenge and block submission

## Technical Details

**Files changed:** `includes/cloudflare-turnstile.php`

**Changes:**
- Added `pmpro_cloudflare_turnstile_mode` option (default: `managed`)
- Modified `pmpro_cloudflare_turnstile_get_html()` to conditionally add `data-appearance="interaction-only"` attribute
- Added Widget Mode dropdown in settings UI
- Updated `pmpro_cloudflare_turnstile_settings_save()` to save the new option

Closes #3661

🤖 Generated with [Claude Code](https://claude.com/claude-code)