### PR TITLE
Hooks added to subscriptions panel of edit member and single subscription view

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-subscriptions.php
@@ -105,6 +105,14 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 					<th><?php esc_html_e( 'Gateway', 'paid-memberships-pro' ); ?></th>
 					<th><?php echo esc_html( $showing_active_subscriptions ? __( 'Next Payment', 'paid-memberships-pro' ) : __( 'Ended', 'paid-memberships-pro' ) ); ?></th>
 					<th><?php esc_html_e( 'Orders', 'paid-memberships-pro' ); ?></th>
+					<?php
+						/**
+						 * Allow adding extra columns to the subscriptions table.
+						 *
+						 * @since TBD
+						 */
+						do_action('pmpro_edit_member_subscriptions_extra_cols_header');
+					?>
 				</tr>
 			</thead>
 			<tbody>
@@ -247,6 +255,16 @@ class PMPro_Member_Edit_Panel_Subscriptions extends PMPro_Member_Edit_Panel {
 							?>
 							<a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 's' => $subscription->get_subscription_transaction_id() ), admin_url( 'admin.php' ) ) ); ?>" title="<?php esc_attr_e( 'View all orders for this subscription', 'paid-memberships-pro' ); ?>"><?php echo esc_html( number_format_i18n( $orders_count ) ); ?></a>
 						</td>
+						<?php
+							/**
+							 * Allow adding extra columns to the subscriptions table.
+							 *
+							 * @since TBD
+							 *
+							 * @param PMPro_Subscription $subscription The subscription for the current row in the table.
+							 */
+							do_action('pmpro_edit_member_subscriptions_extra_cols_body', $subscription );
+						?>
 					</tr>
 					<?php
 				}

--- a/adminpages/subscriptions/view-subscription.php
+++ b/adminpages/subscriptions/view-subscription.php
@@ -154,6 +154,16 @@ $sub_membership_level_id = $subscription->get_membership_level_id();
 				</ul>
 			</div> <!-- end pmpro_section_inside -->
 		</div> <!-- end pmpro_section -->
+		<?php
+			/**
+			 * Allow adding additional content to the subscription view page.
+			 *
+			 * @since TBD
+			 *
+			 * @param PMPro_Subscription $subscription The subscription object.
+			 */
+			do_action( 'pmpro_after_subscription_view_main', $subscription );
+		?>
 	</div> <!-- end pmpro_main -->
 
 	<div class="pmpro_sidebar">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adding hooks to the Edit Member "Subscriptions" panel and the single subscription "View" screen in the admin.

The current use case for this is to show Payment Plan details on these screens.