### PR TITLE
Allow updating billing for subscriptions without a successful order on file

### DIFF
--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -30,7 +30,7 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 		exit;
 	}
 
-	// Get the order for this subscription.
+	// Get the most recent successful order for this subscription, if any.
 	$newest_orders = $pmpro_billing_subscription->get_orders(
 		array(
 			'status'  => 'success',
@@ -38,12 +38,19 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 			'orderby' => '`timestamp` DESC, `id` DESC',
 		)
 	);
-
-	// Get the newest successful order for this subscription, if any. The order may be null and the billing page will handle that scenario gracefully.
 	$pmpro_billing_order = ! empty( $newest_orders ) ? $newest_orders[0] : null;
+
+	// If there is no successful order yet (e.g. the subscription was linked manually in the admin),
+	// build a transient MemberOrder from the subscription so the billing page can still render and
+	// the gateway can update the payment method on the underlying subscription. This order is not
+	// saved to the database; it only carries the fields the gateway's update() method needs.
 	if ( ! is_a( $pmpro_billing_order, 'MemberOrder' ) ) {
-		wp_redirect( pmpro_url( 'account' ) );
-		exit;
+		$pmpro_billing_order                              = new MemberOrder();
+		$pmpro_billing_order->user_id                     = $pmpro_billing_subscription->get_user_id();
+		$pmpro_billing_order->membership_id               = $pmpro_billing_subscription->get_membership_level_id();
+		$pmpro_billing_order->gateway                     = $pmpro_billing_subscription->get_gateway();
+		$pmpro_billing_order->gateway_environment         = $pmpro_billing_subscription->get_gateway_environment();
+		$pmpro_billing_order->subscription_transaction_id = $pmpro_billing_subscription->get_subscription_transaction_id();
 	}
 
 	// Get the user's current membership level.


### PR DESCRIPTION
## Summary

Fixes the Membership Billing page redirecting members to `/account` when their subscription does not have a successful order on file. This happens most often when an admin links a subscription manually (Memberships → Subscriptions → Link Subscription) — the subscription record is created but no corresponding order is, so the billing page becomes unreachable for that member.

## The fix

In `preheaders/billing.php`, when no successful order exists for the subscription, build a transient `MemberOrder` from the subscription record instead of redirecting away. The transient order carries only the fields the gateway's `update()` method needs:

- `user_id`
- `membership_id`
- `gateway`
- `gateway_environment`
- `subscription_transaction_id`

The transient order is **not** saved to the database. It only carries data through the form submission so `MemberOrder::updateBilling()` can call the gateway's `update()` and the existing email/hook plumbing keeps working.

When a real successful order **is** available, behavior is unchanged — that order is used as before.

## Why this is safe

Walking the full code path the synthesized order travels through, nothing calls `saveOrder()` on it:

- `MemberOrder::updateBilling()` — single line, no save.
- Stripe `update()` — only attaches the payment method and updates the Stripe subscription; no `saveOrder()`.
- `sendBillingEmail` / `sendBillingAdminEmail` — read fields, send mail, no save.
- `pmpro_billing_order` filter (Stripe `pmpro_checkout_order` callback) — only sets transient request fields.
- `pmpro_after_update_billing` action — recaptcha/turnstile reset hooks ignore the order; in-tree spam tracking explicitly ignores it.
- `pmpro_update_billing_failed` action — spam tracking, ignores the order.

The Stripe gateway has `saveOrder()` calls elsewhere, but they're in checkout and refund paths that are not reachable from the billing update flow.

In current core PMPro, **Stripe is the only actively-shipping gateway** that uses this page's editable billing form. Braintree and Authorize.net declare support but are deprecated; PayPal Express explicitly opts out; everything else (check, cybersource, payflowpro, paypalstandard, paypalwpp, twocheckout) falls into the "log in to your gateway dashboard" branch and never touches the order.

## Test plan

- [ ] Active subscription **with** successful orders → billing page renders normally and updates billing successfully (no behavior change).
- [ ] Subscription linked manually via Memberships → Subscriptions → Link Subscription, with no order on file → billing page now renders (previously redirected to `/account`) and updates billing on the underlying gateway subscription.
- [ ] Subscription belonging to another user → still redirects to `/account` (unchanged).
- [ ] No subscription / multiple active subscriptions and no `pmpro_subscription_id` query arg → page renders the existing "no subscription" state (unchanged).
- [ ] Verify in Stripe dashboard that the subscription's default payment method is updated after submitting the billing form for a manually-linked subscription.

## Follow-up

A separate PR will update the form prefill so it prefers the most recent order's billing address fields over the legacy `pmpro_b*` user meta keys, which checkout no longer populates.
