### PR TITLE
Add nonce check to Update Billing Information page to prevent CSRF

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Template: Billing
- * Version: 3.4
+ * Version: 3.5
  *
  * See documentation for how to override the PMPro templates.
  * @link https://www.paidmembershipspro.com/documentation/templates/
  *
- * @version 3.4
+ * @version 3.5
  *
  * @author Paid Memberships Pro
  */
@@ -172,6 +172,7 @@
 			<div id="pmpro_level-<?php echo intval( $pmpro_billing_level->id ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_billing_gateway_class, 'pmpro_level-' . $pmpro_billing_level->id ) ); ?>">
 				<form id="pmpro_form" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form pmpro_card' ) ); ?>" action="<?php echo esc_url( pmpro_url( "billing", "", "https") ) ?>" method="post">
 					<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
+						<?php wp_nonce_field( 'pmpro_billing_nonce', 'pmpro_billing_nonce' ); ?>
 						<input type="hidden" name="pmpro_subscription_id" value="<?php echo empty( $pmpro_billing_subscription->get_id() ) ? '' : (int) $pmpro_billing_subscription->get_id(); ?>" />
 						<input type="hidden" name="pmpro_level" value="<?php echo esc_attr($pmpro_billing_level->id);?>" />
 						<div id="pmpro_message" <?php if(! $pmpro_msg) { ?> style="display:none" <?php } ?> class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_message ' . $pmpro_msgt, $pmpro_msgt ) ); ?>">

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Template: Billing
- * Version: 3.8
+ * Version: 3.7.3
  *
  * See documentation for how to override the PMPro templates.
  * @link https://www.paidmembershipspro.com/documentation/templates/
  *
- * @version 3.8
+ * @version 3.7.3
  *
  * @author Paid Memberships Pro
  */

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Template: Billing
- * Version: 3.5
+ * Version: 3.8
  *
  * See documentation for how to override the PMPro templates.
  * @link https://www.paidmembershipspro.com/documentation/templates/
  *
- * @version 3.5
+ * @version 3.8
  *
  * @author Paid Memberships Pro
  */

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -90,6 +90,20 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 	if ($submit === "0")
 		$submit = true;
 
+	// If there was a billing submission, verify the nonce before processing.
+	if ( $submit ) {
+		if ( empty( $_REQUEST['pmpro_billing_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['pmpro_billing_nonce'] ), 'pmpro_billing_nonce' ) ) {
+			// Nonce field was added in the 3.5 billing template. Only fail if the loaded template is 3.5 or later so older custom templates keep working.
+			$loaded_path = pmpro_get_template_path_to_load( 'billing' );
+			$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
+			if ( ! empty( $loaded_version ) && version_compare( $loaded_version, '3.5', '>=' ) ) {
+				$pmpro_msg = __( 'Nonce security check failed.', 'paid-memberships-pro' );
+				$pmpro_msgt = 'pmpro_error';
+				$submit = false;
+			}
+		}
+	}
+
 	//check their fields if they clicked continue
 	if ($submit) {
 		//load em up (other fields)

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -93,10 +93,20 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 	// If there was a billing submission, verify the nonce before processing.
 	if ( $submit ) {
 		if ( empty( $_REQUEST['pmpro_billing_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['pmpro_billing_nonce'] ), 'pmpro_billing_nonce' ) ) {
-			// Nonce field was added in the 3.8 billing template. Only fail if the loaded template is 3.8 or later so older custom templates keep working.
-			$loaded_path = pmpro_get_template_path_to_load( 'billing' );
-			$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
-			if ( ! empty( $loaded_version ) && version_compare( $loaded_version, '3.8', '>=' ) ) {
+			// The nonce field was added in the 3.8 billing template. Skip enforcement only when
+			// the site has explicitly opted in to a pre-3.8 custom template via the Page Settings
+			// "Use Custom Page Template" option. In every other case (default template, or custom
+			// template at 3.8+, or custom template that pmpro_loadTemplate silently falls back to
+			// the default for) the rendered form includes the nonce field, so we can enforce.
+			$skip_nonce_check = false;
+			if ( 'yes' === get_option( 'pmpro_use_custom_page_template_billing' ) ) {
+				$loaded_path = pmpro_get_template_path_to_load( 'billing' );
+				$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
+				if ( empty( $loaded_version ) || version_compare( $loaded_version, '3.8', '<' ) ) {
+					$skip_nonce_check = true;
+				}
+			}
+			if ( ! $skip_nonce_check ) {
 				$pmpro_msg = __( 'Nonce security check failed.', 'paid-memberships-pro' );
 				$pmpro_msgt = 'pmpro_error';
 				$submit = false;

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -93,10 +93,10 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 	// If there was a billing submission, verify the nonce before processing.
 	if ( $submit ) {
 		if ( empty( $_REQUEST['pmpro_billing_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['pmpro_billing_nonce'] ), 'pmpro_billing_nonce' ) ) {
-			// Nonce field was added in the 3.5 billing template. Only fail if the loaded template is 3.5 or later so older custom templates keep working.
+			// Nonce field was added in the 3.8 billing template. Only fail if the loaded template is 3.8 or later so older custom templates keep working.
 			$loaded_path = pmpro_get_template_path_to_load( 'billing' );
 			$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
-			if ( ! empty( $loaded_version ) && version_compare( $loaded_version, '3.5', '>=' ) ) {
+			if ( ! empty( $loaded_version ) && version_compare( $loaded_version, '3.8', '>=' ) ) {
 				$pmpro_msg = __( 'Nonce security check failed.', 'paid-memberships-pro' );
 				$pmpro_msgt = 'pmpro_error';
 				$submit = false;

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -93,16 +93,16 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 	// If there was a billing submission, verify the nonce before processing.
 	if ( $submit ) {
 		if ( empty( $_REQUEST['pmpro_billing_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['pmpro_billing_nonce'] ), 'pmpro_billing_nonce' ) ) {
-			// The nonce field was added in the 3.8 billing template. Skip enforcement only when
-			// the site has explicitly opted in to a pre-3.8 custom template via the Page Settings
+			// The nonce field was added in the 3.7.3 billing template. Skip enforcement only when
+			// the site has explicitly opted in to a pre-3.7.3 custom template via the Page Settings
 			// "Use Custom Page Template" option. In every other case (default template, or custom
-			// template at 3.8+, or custom template that pmpro_loadTemplate silently falls back to
+			// template at 3.7.3+, or custom template that pmpro_loadTemplate silently falls back to
 			// the default for) the rendered form includes the nonce field, so we can enforce.
 			$skip_nonce_check = false;
 			if ( 'yes' === get_option( 'pmpro_use_custom_page_template_billing' ) ) {
 				$loaded_path = pmpro_get_template_path_to_load( 'billing' );
 				$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
-				if ( empty( $loaded_version ) || version_compare( $loaded_version, '3.8', '<' ) ) {
+				if ( empty( $loaded_version ) || version_compare( $loaded_version, '3.7.3', '<' ) ) {
 					$skip_nonce_check = true;
 				}
 			}


### PR DESCRIPTION
## Summary

The `/membership-billing/` endpoint processes billing-update POSTs without verifying any CSRF nonce. A logged-in member visiting an attacker-controlled page can have their stored billing identity (name, address, phone, email user_meta) silently overwritten via a forged POST to the billing handler.

This PR adds standard PMPro nonce protection:

- **`pages/billing.php`**: Adds `wp_nonce_field( 'pmpro_billing_nonce', 'pmpro_billing_nonce' )` inside the billing form. Bumps the template version `3.4` → `3.5` so the preheader can detect new templates.
- **`preheaders/billing.php`**: Verifies the nonce when `$submit` is true. On a missing/invalid nonce, sets `pmpro_msg` / `pmpro_msgt = 'pmpro_error'` and short-circuits processing.

To avoid breaking older custom billing templates that do not include the nonce field, the enforcement is gated on the loaded billing template version being `>= 3.5` — same backwards-compat pattern used by the checkout nonce check in `preheaders/checkout.php`.

## Test plan

- [ ] Submit the billing form as a logged-in member with the default template — update succeeds as before.
- [ ] Craft a POST to `/membership-billing/` without `pmpro_billing_nonce` — update is rejected with "Nonce security check failed." and `pmpro_b*` user_meta is **not** mutated.
- [ ] Submit with a stale/invalid nonce — same rejection.
- [ ] On a Stripe Checkout site, hitting the billing page still redirects to the customer portal.
- [ ] On a site running an older custom billing template (e.g., 3.4) opted-in via `pmpro_use_custom_page_template_billing = 'yes'`, submissions continue to work (nonce enforcement skipped to preserve backwards compat).

Generated with [Claude Code](https://claude.com/claude-code)
