### PR TITLE
Remove unused pmpro_userfields_get_group and pmpro_userfields_get_field AJAX handlers

### DIFF
--- a/includes/services.php
+++ b/includes/services.php
@@ -202,21 +202,3 @@ function pmpro_update_level_group_order() {
 }
 add_action('wp_ajax_pmpro_update_level_group_order', 'pmpro_update_level_group_order');
 
-// User fields AJAX.
-/**
- * Callback to draw a field group.
- */
-function pmpro_userfields_get_group_ajax() {	
-	pmpro_get_field_group_html();
-    exit;
-}
-add_action( 'wp_ajax_pmpro_userfields_get_group', 'pmpro_userfields_get_group_ajax' );
- 
-/**
- * Callback to draw a field.
- */
-function pmpro_userfields_get_field_ajax() {
- 	pmpro_get_field_html();
-	exit;
-}
-add_action( 'wp_ajax_pmpro_userfields_get_field', 'pmpro_userfields_get_field_ajax' );


### PR DESCRIPTION
## Summary

Removes two `wp_ajax_` handlers in `includes/services.php` that have no callers anywhere in the codebase:

- `pmpro_userfields_get_group_ajax` (action: `pmpro_userfields_get_group`)
- `pmpro_userfields_get_field_ajax` (action: `pmpro_userfields_get_field`)

The User Fields admin UI builds blank groups/fields client-side from data passed via `wp_localize_script` — see `includes/scripts.php:160-161` and the `pmpro.user_fields_blank_group` / `pmpro.user_fields_blank_field` references in `js/pmpro-admin.js`. The two AJAX endpoints are vestigial.

Both handlers also had no `current_user_can` check and no nonce check, so any logged-in user (including subscribers) could trigger them and get the admin field-settings template rendered with default/empty values. There is no PII or state change in the response, so this is not a security advisory — but it's strictly better to delete dead code than to leave unauthenticated endpoints reachable.

## Test plan

- [ ] Open the User Fields admin page (`Settings → User Fields`). Add a new field group via the "Add Group" button — UI still works (no AJAX dependency).
- [ ] Add and remove fields within a group via the "Add Field" / delete buttons — UI still works.
- [ ] Save the User Fields settings — values persist correctly.
- [ ] Confirm `wp-admin/admin-ajax.php?action=pmpro_userfields_get_group` and `?action=pmpro_userfields_get_field` now return `0` (WordPress's "no handler registered" response) instead of admin HTML.

Generated with [Claude Code](https://claude.com/claude-code)
