### PR TITLE
Add nonce checks to read-only admin AJAX handlers for consistency

### DIFF
--- a/adminpages/functions.php
+++ b/adminpages/functions.php
@@ -396,7 +396,8 @@ function pmpro_add_email_order_modal() {
 				// Get email address from order ID
 				data = {
 					action: 'pmpro_get_order_json',
-					order_id: order_id
+					order_id: order_id,
+					nonce: '<?php echo esc_js( wp_create_nonce( 'pmpro_get_order_json' ) ); ?>'
 				};
 				$.post(ajaxurl, data, function (response) {
 					order = JSON.parse(response);

--- a/adminpages/login-csv.php
+++ b/adminpages/login-csv.php
@@ -5,6 +5,11 @@ if ( ! function_exists( 'current_user_can' ) || ( ! current_user_can( 'manage_op
 	die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 }
 
+// Check the nonce.
+if ( empty( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'login_report_csv' ) ) {
+	die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
+}
+
 if ( ! defined( 'PMPRO_BENCHMARK' ) ) {
 	define( 'PMPRO_BENCHMARK', false );
 }

--- a/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-orders.php
@@ -78,7 +78,7 @@ class PMPro_Member_Edit_Panel_Orders extends PMPro_Member_Edit_Panel {
 										<a title="<?php esc_attr_e( 'Edit', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'id' => $order->id ), admin_url('admin.php' ) ) ); ?>"><?php esc_html_e( 'View', 'paid-memberships-pro' ); ?></a>
 									</span> |
 									<span class="print">
-										<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'id' => $order->id ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>
+										<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'id' => $order->id, 'nonce' => wp_create_nonce( 'pmpro_orders_print_view' ) ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>
 									</span>
 									<?php if ( function_exists( 'pmpro_add_email_order_modal' ) ) { ?>
 										|

--- a/adminpages/memberships-csv.php
+++ b/adminpages/memberships-csv.php
@@ -5,6 +5,11 @@ if ( ! function_exists( 'current_user_can' ) || ( ! current_user_can( 'manage_op
 	die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 }
 
+// Check the nonce.
+if ( empty( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'membership_stats_csv' ) ) {
+	die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
+}
+
 if ( ! defined( 'PMPRO_BENCHMARK' ) ) {
 	define( 'PMPRO_BENCHMARK', false );
 }

--- a/adminpages/orders-print.php
+++ b/adminpages/orders-print.php
@@ -12,6 +12,11 @@ if ( ! function_exists( "current_user_can" ) || ( ! current_user_can( "manage_op
 	die( esc_html__( "You do not have permissions to perform this action.", 'paid-memberships-pro' ) );
 }
 
+// Check the nonce.
+if ( empty( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'pmpro_orders_print_view' ) ) {
+	die( esc_html__( "You do not have permissions to perform this action.", 'paid-memberships-pro' ) );
+}
+
 // Do we have an order ID?
 if ( empty( $_REQUEST['id'] ) ) {
 	wp_redirect( admin_url( 'admin.php?page=pmpro-orders' ) );

--- a/adminpages/orders/view-order.php
+++ b/adminpages/orders/view-order.php
@@ -414,7 +414,7 @@ $subscription = $order->get_subscription();
 
 					$order_actions['print'] = array(
 						'title'   => esc_attr( sprintf( __( 'Print or save order # %s as PDF', 'paid-memberships-pro' ), esc_html( $order->code ) ) ),
-						'href'    => esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'id' => $order->id ), admin_url( 'admin-ajax.php' ) ) ),
+						'href'    => esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'id' => $order->id, 'nonce' => wp_create_nonce( 'pmpro_orders_print_view' ) ), admin_url( 'admin-ajax.php' ) ) ),
 						'target'  => '_blank',
 						'class'   => 'button button-secondary pmpro-has-icon pmpro-has-icon-printer',
 						'label'   => esc_html__( 'Print or Save as PDF', 'paid-memberships-pro' ),

--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -104,6 +104,7 @@ function pmpro_report_login_page()
 	if ( ! empty( $l ) ) {
 		$csv_export_link = add_query_arg( 'l', $l, $csv_export_link );
 	}
+	$csv_export_link = add_query_arg( 'nonce', wp_create_nonce( 'login_report_csv' ), $csv_export_link );
 ?>
 	<form id="visits-views-logins-form" method="get" action="">
 	<h1 class="wp-heading-inline">

--- a/adminpages/reports/memberships.php
+++ b/adminpages/reports/memberships.php
@@ -318,6 +318,7 @@ function pmpro_report_memberships_page() {
 			'startdate'     => $startdate,
 			'enddate'       => $enddate,
 			'level'         => $l,
+			'nonce'         => wp_create_nonce( 'membership_stats_csv' ),
 		),
 		$csv_export_link
 	);

--- a/adminpages/reports/sales.php
+++ b/adminpages/reports/sales.php
@@ -608,7 +608,8 @@ function pmpro_report_sales_page()
 		'year' => $year,
 		'month' => $month,
 		'level' => $l,
-		'discount_code' => $discount_code
+		'discount_code' => $discount_code,
+		'nonce' => wp_create_nonce( 'sales_report_csv' ),
 	);
 	$csv_export_link = add_query_arg( $args, admin_url( 'admin-ajax.php' ) );
 	?>

--- a/adminpages/sales-csv.php
+++ b/adminpages/sales-csv.php
@@ -4,6 +4,11 @@ if ( ! function_exists( "current_user_can" ) || ( ! current_user_can( "manage_op
 	die( esc_html__( "You do not have permissions to perform this action.", 'paid-memberships-pro' ) );
 }
 
+// Check the nonce.
+if ( empty( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'sales_report_csv' ) ) {
+	die( esc_html__( "You do not have permissions to perform this action.", 'paid-memberships-pro' ) );
+}
+
 //get values from form
 if(isset($_REQUEST['type']))
 	$type = sanitize_text_field($_REQUEST['type']);

--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -933,6 +933,7 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 							[
 								'action' => 'pmpro_orders_print_view',
 								'id'  => $item->id,
+								'nonce' => wp_create_nonce( 'pmpro_orders_print_view' ),
 							],
 							admin_url( 'admin-ajax.php' )
 						)

--- a/includes/profile.php
+++ b/includes/profile.php
@@ -752,7 +752,7 @@ function pmpro_membership_history_profile_fields( $user ) {
 									<a title="<?php esc_attr_e( 'Edit', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-orders', 'order' => $invoice->id ), admin_url('admin.php' ) ) ); ?>"><?php esc_html_e( 'Edit', 'paid-memberships-pro' ); ?></a>
 								</span> |
 								<span class="print">
-									<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'order' => $invoice->id ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>
+									<a target="_blank" title="<?php esc_attr_e( 'Print', 'paid-memberships-pro' ); ?>" href="<?php echo esc_url( add_query_arg( array( 'action' => 'pmpro_orders_print_view', 'order' => $invoice->id, 'nonce' => wp_create_nonce( 'pmpro_orders_print_view' ) ), admin_url('admin-ajax.php' ) ) ); ?>"><?php esc_html_e( 'Print', 'paid-memberships-pro' ); ?></a>
 								</span>
 								<?php if ( function_exists( 'pmpro_add_email_order_modal' ) ) { ?>
 									 |

--- a/includes/services.php
+++ b/includes/services.php
@@ -127,7 +127,12 @@ function pmpro_get_order_json() {
 	if ( ! function_exists( 'current_user_can' ) || ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_orders' ) ) ) {
 		die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 	}
-	
+
+	// Check the nonce.
+	if ( empty( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'pmpro_get_order_json' ) ) {
+		die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
+	}
+
 	$order_id = intval( $_REQUEST['order_id'] );
 	$order = new MemberOrder($order_id);
 	$user = get_userdata($order->user_id);


### PR DESCRIPTION
## Summary

Adds nonce verification to five capability-gated, read-only admin AJAX handlers to bring them in line with the existing nonce pattern used by `pmpro_update_level_order` and `pmpro_update_level_group_order` in the same file:

| Handler | Nonce action | File |
|---|---|---|
| `pmpro_orders_print_view` | `pmpro_orders_print_view` | `adminpages/orders-print.php` |
| `pmpro_get_order_json` | `pmpro_get_order_json` | `includes/services.php` |
| `login_report_csv` | `login_report_csv` | `adminpages/login-csv.php` |
| `sales_report_csv` | `sales_report_csv` | `adminpages/sales-csv.php` |
| `membership_stats_csv` | `membership_stats_csv` | `adminpages/memberships-csv.php` |

Each handler already enforces a `current_user_can` check (e.g. `pmpro_orders`, `pmpro_loginscsv`, `pmpro_sales_report_csv`, `pmpro_reportscsv`, `pmpro_ordersprint`), and admin-ajax cross-origin reads are blocked by the Same-Origin Policy, so this is a **hygiene / consistency change rather than a security fix**. The motivation is to stop these endpoints from showing up as "missing nonce" findings in source-review tools and to harmonize the nonce pattern across the file.

All in-tree callers are updated to mint and pass the nonce:

- `pmpro_orders_print_view` callers:
  - `adminpages/orders/view-order.php` (admin order detail)
  - `classes/class-pmpro-orders-list-table.php` (admin orders list table)
  - `includes/profile.php` (frontend membership account invoices list)
  - `adminpages/member-edit/pmpro-class-member-edit-panel-orders.php` (admin member edit)
- `pmpro_get_order_json` caller:
  - `adminpages/functions.php` (Email Order modal — inline JS, nonce printed via `esc_js( wp_create_nonce(...) )`)
- CSV export callers:
  - `adminpages/reports/logins.php`
  - `adminpages/reports/sales.php`
  - `adminpages/reports/memberships.php`

## Compatibility note

If a third-party Add On or customization is calling any of these endpoints directly (without going through PMPro's link/form generators), it will start receiving `You do not have permissions to perform this action.` and need to add a `nonce` query arg. None of these are documented as a public extensibility surface, so the blast radius should be limited.

## Test plan

- [ ] **Print order**: open an order in the admin (`Memberships → Orders → click an order`), click "Print or Save as PDF" — print view loads.
- [ ] **Print from orders list**: on the orders list table, click "Print" in row actions — print view loads.
- [ ] **Print from member edit**: on the Member Edit screen's Orders tab, click "Print" — print view loads.
- [ ] **Print from frontend account**: log in as a member with admin/`pmpro_ordersprint` cap, view `/membership-account/`, click "Print" on an invoice — print view loads. (Non-admin members hit the cap check first, as before.)
- [ ] **Email Order modal**: on the orders list, click "Email" in row actions — modal opens with the email field auto-populated from the order's user.
- [ ] **CSV exports**: from `Memberships → Reports → Sales and Revenue`, `Membership Stats`, and `Visits, Views, and Logins`, click "Export to CSV" — CSV downloads with the expected rows.
- [ ] **Negative path**: hit any of the five admin-ajax actions directly without `nonce` (or with a bad value) — handler responds with the permissions-denied message and does not execute.

Generated with [Claude Code](https://claude.com/claude-code)
