### PR TITLE
Tighten checkout nonce gate to only skip on opted-in pre-3.0 custom templates

### DIFF
--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -319,10 +319,20 @@ $pmpro_confirmed = false;
 if ( $submit && $pmpro_msgt != "pmpro_error" ) {
 	// Check the nonce.
 	if ( empty( $_REQUEST['pmpro_checkout_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_REQUEST['pmpro_checkout_nonce'] ), 'pmpro_checkout_nonce' ) ) {
-		// Nonce is not valid, but a nonce was only added in the 3.0 checkout template. We only want to show an error if the checkout template is 3.0 or later.
-		$loaded_path = pmpro_get_template_path_to_load( 'checkout' );
-		$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
-		if ( ! empty( $loaded_version ) && version_compare( $loaded_version, '3.0', '>=' ) ) {
+		// The nonce field was added in the 3.0 checkout template. Skip enforcement only when
+		// the site has explicitly opted in to a pre-3.0 custom template via the Page Settings
+		// "Use Custom Page Template" option. In every other case (default template, or custom
+		// template at 3.0+, or custom template that pmpro_loadTemplate silently falls back to
+		// the default for) the rendered form includes the nonce field, so we can enforce.
+		$skip_nonce_check = false;
+		if ( 'yes' === get_option( 'pmpro_use_custom_page_template_checkout' ) ) {
+			$loaded_path = pmpro_get_template_path_to_load( 'checkout' );
+			$loaded_version = pmpro_get_version_for_page_template_at_path( $loaded_path );
+			if ( empty( $loaded_version ) || version_compare( $loaded_version, '3.0', '<' ) ) {
+				$skip_nonce_check = true;
+			}
+		}
+		if ( ! $skip_nonce_check ) {
 			// Nonce is not valid. Show an error.
 			pmpro_setMessage( __( "Nonce security check failed.", 'paid-memberships-pro' ), 'pmpro_error' );
 		}


### PR DESCRIPTION
## Summary

Tightens the checkout nonce gate at `preheaders/checkout.php:321–329` so that nonce enforcement is only skipped when the site has **explicitly opted in** to a pre-3.0 custom checkout template, rather than skipped any time the loaded template's `Version:` header is missing or `< 3.0`.

The previous gate was:

```php
if ( ! empty( $loaded_version ) && version_compare( $loaded_version, '3.0', '>=' ) ) {
    pmpro_setMessage( __( "Nonce security check failed.", 'paid-memberships-pro' ), 'pmpro_error' );
}
```

That silently skipped enforcement in a non-obvious case: a site that ships a pre-3.0 custom `checkout.php` in their theme but **has not** set `pmpro_use_custom_page_template_checkout = 'yes'`. In that scenario `pmpro_loadTemplate()` falls back to rendering the default template (which **does** contain the nonce field — see `includes/page-templates.php:78–94`), but `pmpro_get_template_path_to_load()` still returns the custom path, so the preheader reads the old version and skips enforcement. The rendered form has the nonce, the server isn't checking it.

The new gate only skips when both:

- `pmpro_use_custom_page_template_checkout` is `'yes'` (the user explicitly opted in to keep their custom template), **and**
- that custom template's version is `< 3.0` or has no `Version:` header

In every other case — default template, custom template at 3.0+, or pre-3.0 custom template silently overridden by `pmpro_loadTemplate` — enforcement runs.

## Context

This pattern was the original PMPro 3.0-era backwards-compat gate. The same shape exists in the billing nonce check from #3671, which is being tightened in parallel on that PR's branch.

## Test plan

- [ ] Default checkout template (no custom): submit checkout normally — succeeds. POST without `pmpro_checkout_nonce` — fails with "Nonce security check failed."
- [ ] Site with custom `checkout.php` at 3.0+ in theme, opt-in to it via Settings → Pages: same behavior as default — submit succeeds, nonce-less POST fails.
- [ ] Site with pre-3.0 custom `checkout.php` in theme, **opt-in** to it: legitimate submissions continue to work (nonce enforcement skipped, as before), nonce-less POST is also accepted (matching the explicit opt-in trade-off).
- [ ] Site with pre-3.0 custom `checkout.php` in theme, **no opt-in** (default `pmpro_use_custom_page_template_checkout` option absent or not `'yes'`): rendered template is the default 3.x (with nonce field). Legitimate submission succeeds. Nonce-less POST now correctly fails — this is the gap that this PR closes.
- [ ] Free-level checkout, paid checkout (Stripe), and renewal flows all still work end-to-end on a default install.

Generated with [Claude Code](https://claude.com/claude-code)
