### PR TITLE
Fix: restricted-files dir self-test reports "Unable to determine" on sites with no member uploads

### DIFF
--- a/includes/restricted-files.php
+++ b/includes/restricted-files.php
@@ -29,6 +29,20 @@ function pmpro_set_up_restricted_files_directory() {
 		'  </IfModule>' . "\n" .
 		'</FilesMatch>';
 	file_put_contents( trailingslashit( $restricted_file_directory ) . '.htaccess', $htaccess );
+
+	// Write a non-dotfile marker so pmpro_is_restricted_directory_protected()
+	// has something to HEAD-test against. Without this, sites that have not
+	// yet stored any member-uploaded files report "Unable to determine"
+	// because pmpro_find_testable_file() deliberately skips dotfiles (and
+	// .htaccess is the only file present on a fresh install).
+	$marker_path = trailingslashit( $restricted_file_directory ) . 'pmpro-protection-test.txt';
+	if ( ! file_exists( $marker_path ) ) {
+		$marker_content  = "PMPro restricted-files protection test marker.\n";
+		$marker_content .= "This file is intentional. PMPro uses it to verify the directory is\n";
+		$marker_content .= "correctly protected from public access. It is safe to delete; PMPro\n";
+		$marker_content .= "will recreate it on the next daily run.\n";
+		file_put_contents( $marker_path, $marker_content );
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

The Restricted Files protection check on Memberships > Settings > Security reports `Unable to determine` on any site that hasn't yet stored a member-uploaded file. The directory IS protected — Apache is correctly denying access via the generated `.htaccess` — but the self-test can't prove it because there's no file to HEAD-test against.

## Root cause

`pmpro_is_restricted_directory_protected()` (introduced in 3.7) verifies protection by calling `pmpro_find_testable_file()`, then `wp_remote_head()`-ing that file's URL. `pmpro_find_testable_file()` deliberately skips dotfiles (line 274 of `includes/restricted-files.php`), so on installs where the only file in the restricted dir is the generated `.htaccess`, the iterator returns `null` and the protection check returns `null` → status displays as `Unable to determine`.

## Key Changes

- `pmpro_set_up_restricted_files_directory()` now also writes `pmpro-protection-test.txt` alongside the `.htaccess`. This is the file the protection self-test will pick up.
- File content explains the file's purpose so admins don't delete it accidentally (and notes that PMPro will recreate it on the next daily run if they do).
- Idempotent: skips the write if the marker is already present.

## How to Test

1. On a fresh PMPro install (or any site that has never stored member files), visit Memberships > Settings > Security.
2. Confirm the Restricted Files status shows `Unable to determine`.
3. Apply this branch.
4. Trigger the daily action (`wp action-scheduler run` or wait for the daily schedule), or run `pmpro_set_up_restricted_files_directory()` directly via `wp eval`.
5. Confirm `wp-content/uploads/pmpro-<hash>/pmpro-protection-test.txt` is now present.
6. Reload the Security Settings page; status should now be `Protected`.
7. Direct browser access to the marker URL should return 403.

## Notes

The setup function runs daily via Action Scheduler, so existing 3.7+ installs that have hit this status will self-heal within 24h once this lands. No upgrade routine is necessary.