### PR TITLE
Honor currency decimals in pmpro_get_price_info amount_string

### DIFF
--- a/includes/currencies.php
+++ b/includes/currencies.php
@@ -162,7 +162,11 @@
 	 */
 	function pmpro_get_currency( $currency = null ) {
 		global $pmpro_currency, $pmpro_currencies;
-		
+
+		if ( empty( $currency ) ) {
+			$currency = $pmpro_currency;
+		}
+
 		// Defaults
 		$currency_array = array(
 			'name' =>__('US Dollars (&#36;)', 'paid-memberships-pro' ),
@@ -172,14 +176,14 @@
 			'symbol' => '&#36;',
 			'position' => 'left',
 		);
-		
-		if ( ! empty( $pmpro_currency ) ) {
-			if ( is_array( $pmpro_currencies[$pmpro_currency] ) ) {
-				$currency_array = array_merge( $currency_array, $pmpro_currencies[$pmpro_currency] );
+
+		if ( ! empty( $currency ) && ! empty( $pmpro_currencies[ $currency ] ) ) {
+			if ( is_array( $pmpro_currencies[ $currency ] ) ) {
+				$currency_array = array_merge( $currency_array, $pmpro_currencies[ $currency ] );
 			} else {
-				$currency_array['name'] = $pmpro_currencies[$pmpro_currency];
+				$currency_array['name'] = $pmpro_currencies[ $currency ];
 			}
 		}
-		
+
 		return $currency_array;
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3619,11 +3619,15 @@ function pmpro_get_price_info( $amount, $currency = null ) {
 		)
 	);
 
-	// Get the zero-padded decimal amount.
-	$price_info['parts']['decimal_string'] = sprintf( '%02d', $price_info['parts']['decimal'] );
+	// Get the zero-padded decimal amount, sized to the currency's decimal count.
+	$price_info['parts']['decimal_string'] = $currency_info['decimals'] > 0
+		? sprintf( '%0' . $currency_info['decimals'] . 'd', $price_info['parts']['decimal'] )
+		: '';
 
-	// Get the amount as a string.
-	$price_info['amount_string'] = sprintf( '%s.%s', $price_info['parts']['number'], $price_info['parts']['decimal_string'] );
+	// Get the amount as a string. Zero-decimal currencies have no fractional part.
+	$price_info['amount_string'] = $currency_info['decimals'] > 0
+		? sprintf( '%s.%s', $price_info['parts']['number'], $price_info['parts']['decimal_string'] )
+		: (string) $price_info['parts']['number'];
 
 	return $price_info;
 }


### PR DESCRIPTION
## Summary
- `pmpro_get_price_info()` was hardcoded to build `amount_string` as `"<int>.<2 digits>"` regardless of the currency. For zero-decimal currencies (JPY, KRW, VND, UAH, ALL) it produced strings like `"25.00"`, which payment gateways such as the PayPal billing API reject with a `DECIMAL_PRECISION` error. The `decimal_string` is now sized to the currency decimal count, and the fractional portion is dropped entirely when decimals is 0.
- `pmpro_get_currency()` advertised a `$currency` parameter but never read it — the body always indexed `$pmpro_currencies` with the global `$pmpro_currency`. So `pmpro_get_price_info( $amount, $currency )` silently returned info for the site currency rather than the requested one. Now honors the parameter and falls back to the global, with an `isset` guard so an unknown code degrades to the USD defaults instead of emitting an undefined-index warning.

Stripe is unaffected — it consumes `amount_flat` (cents), not `amount_string`. The only behavioral change in `amount_string` is that JPY/KRW/VND/UAH/ALL now return e.g. `"25"` instead of `"25.00"`, which is the correct ISO-4217 representation.

This is paired with a small fix on the new PMPro PayPal add-on (`pmpro-paypal#TBD`) but the bug is in core and surfaces wherever `pmpro_round_price_as_string()` is used with a zero-decimal currency.

## Test plan
- [ ] On a USD site, confirm `pmpro_round_price_as_string( 25 )` still returns `"25.00"` and level pages render prices unchanged.
- [ ] On a JPY site, confirm `pmpro_round_price_as_string( 25 )` returns `"25"` and `pmpro_formatPrice( 25 )` still renders the expected display string.
- [ ] Run a JPY checkout end-to-end on the new PayPal add-on and confirm the plan/order is accepted.
- [ ] Spot-check Stripe checkout with USD and a zero-decimal currency to confirm `amount_flat` is unchanged.
- [ ] Run unit/integration tests if present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
