### PR TITLE
Link Stripe Radar rules in billing address field description

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -553,7 +553,7 @@ class PMProGateway_stripe extends PMProGateway {
 					<option value="1"
 							<?php if ( ! empty( $values['stripe_billingaddress'] ) ) { ?>selected="selected"<?php } ?>><?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></option>
 				</select>
-				<p class="description"><?php echo wp_kses_post( __( "Stripe doesn't require billing address fields. Choose 'No' to hide them on the checkout page.<br /><strong>If No, make sure you disable address verification in the Stripe dashboard settings.</strong>", 'paid-memberships-pro' ) ); ?></p>
+				<p class="description"><?php echo sprintf( wp_kses( __( 'Stripe doesn\'t require billing address fields. Choose \'No\' to hide them on the checkout page.<br /><strong>If No, make sure you disable address verification in your <a target="_blank" href="%s">Stripe Radar rules</a>.</strong>', 'paid-memberships-pro' ), array( 'br' => array(), 'strong' => array(), 'a' => array( 'href' => array(), 'target' => array() ) ) ), 'https://dashboard.stripe.com/settings/radar/rules' ); ?></p>
 			</td>
 		</tr>
 		<tr class="gateway gateway_stripe" <?php if ( $gateway != "stripe" ) { ?>style="display: none;"<?php } ?>>
@@ -970,7 +970,7 @@ class PMProGateway_stripe extends PMProGateway {
 									<option value="1"
 											<?php if ( ! empty( $billing_address ) ) { ?>selected="selected"<?php } ?>><?php esc_html_e( 'Yes', 'paid-memberships-pro' ); ?></option>
 								</select>
-								<p class="description"><?php echo wp_kses_post( __( "Stripe doesn't require billing address fields. Choose 'No' to hide them on the checkout page.<br /><strong>If No, make sure you disable address verification in the Stripe dashboard settings.</strong>", 'paid-memberships-pro' ) ); ?></p>
+								<p class="description"><?php echo sprintf( wp_kses( __( 'Stripe doesn\'t require billing address fields. Choose \'No\' to hide them on the checkout page.<br /><strong>If No, make sure you disable address verification in your <a target="_blank" href="%s">Stripe Radar rules</a>.</strong>', 'paid-memberships-pro' ), array( 'br' => array(), 'strong' => array(), 'a' => array( 'href' => array(), 'target' => array() ) ) ), 'https://dashboard.stripe.com/settings/radar/rules' ); ?></p>
 							</td>
 						</tr>
 						<tr class="gateway_stripe_checkout_fields">


### PR DESCRIPTION
## Summary

- Links the "Stripe dashboard settings" reference in the Stripe gateway "Show Billing Address Fields" setting description directly to the **Stripe Radar rules** page (`https://dashboard.stripe.com/settings/radar/rules`).
- Renames the link text to "Stripe Radar rules" since the AVS block rules that conflict with hiding billing address fields live in Radar, not general dashboard settings — the previous wording sent admins hunting through the wrong area.
- Switches the description from `wp_kses_post( __( ... ) )` to the `sprintf( wp_kses( __( ... ), $allowed ), $url )` pattern already used a few lines down for the Stripe Tax description, so the URL stays out of the translatable string.

Applies to both occurrences of the setting (standalone Stripe settings page at `classes/gateways/class.pmprogateway_stripe.php:556` and the gateway-settings inline form at `:973`).

## Test plan

- [ ] Visit **Memberships → Settings → Payment Gateway & SSL** with Stripe selected as the gateway. Confirm the "Show Billing Address Fields" description renders correctly with **Stripe Radar rules** as a link.
- [ ] Click the link and verify it opens `https://dashboard.stripe.com/settings/radar/rules` in a new tab.
- [ ] Switch to a different gateway and back to Stripe; confirm the description still renders correctly in both Stripe settings UI locations.
- [ ] Confirm no PHP notices/warnings appear (the new `wp_kses` allowed-tags array covers `<br>`, `<strong>`, and `<a href target>`).
