### PR TITLE
Fix old members CSV export including active members

### DIFF
--- a/classes/class-pmpro-exports.php
+++ b/classes/class-pmpro-exports.php
@@ -1287,6 +1287,7 @@ class PMPro_Exports {
 		$filter = '';
 		if ( 'oldmembers' === $l ) {
 			$filter = " AND mu.status <> 'active' ";
+			$filter .= " AND NOT EXISTS ( SELECT 1 FROM {$wpdb->pmpro_memberships_users} mu2 WHERE mu2.user_id = u.ID AND mu2.status = 'active' ) ";
 		}
 		if ( 'expired' === $l || 'cancelled' === $l ) {
 			$statuses = ( 'expired' === $l ) ? array( 'expired' ) : array( 'cancelled', 'admin_cancelled' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Users with a prior expired/cancelled membership row AND a current active membership were incorrectly included in the Old Members export. Add a NOT EXISTS guard to exclude users with any active membership, matching the same logic already used by the expired and cancelled filters.

### How to test the changes in this Pull Request:
1. Create a test user and assign them a membership level, then cancel it.                                                                                                                                         
2. Re-assign that same user an active membership level (so they now have both an old and an active row in pmpro_memberships_users).
3. In WP Admin, go to _Memberships > Members_ and filter by _Old Members_. Confirm the re-activated user does not appear in the list.
4. Click Export to CSV with the Old Members filter active. Open the downloaded CSV and confirm the re-activated user is not in it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed the Old Members CSV export incorrectly including users who had a prior expired or cancelled membership but currently hold an active membership.
