### PR TITLE
Fix library conflict tracker recording false positive on Windows hosts

### DIFF
--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -164,7 +164,12 @@ add_action( 'after_setup_theme', 'pmpro_compatibility_checker_themes' );
  *
  * @since 2.8
  */
-function pmpro_track_library_conflict( $name, $path, $version ) {	
+function pmpro_track_library_conflict( $name, $path, $version ) {
+	// Normalize the path so the conflict check and stored array key are stable across operating systems.
+	// On Windows, dirname() returns backslashes, which would otherwise break the substring check below
+	// and cause duplicate entries to be stored under separator-variant keys.
+	$path = wp_normalize_path( $path );
+
 	// Ignore when PMPro is trying to load.
 	if ( strpos( $path, '/plugins/paid-memberships-pro/' ) !== false ) {
 		return;


### PR DESCRIPTION
## Summary

`pmpro_track_library_conflict()` in `includes/compatibility.php` early-returns when the loaded library path contains `/plugins/paid-memberships-pro/`, so PMPro doesn't record itself as a conflict when it loads its own bundled library. That substring check uses forward slashes only, but on Windows `dirname()` returns backslash-separated paths — so the check never matches and PMPro records its own bundled Action Scheduler as a "conflict" with itself.

A second symptom of the same root cause: the stored array key is the OS-native path. If the value is manually corrected in the database, the next page load recomputes the path and writes a new entry under the original (mixed-separator) key, leaving a stale duplicate behind.

Both behaviors are fixed by normalizing `$path` with `wp_normalize_path()` at the top of the function so the substring check and the stored key are stable across operating systems.

## Notes

- The path string itself originates upstream in `ActionScheduler_SystemInformation::active_source_path()` (`trailingslashit( dirname( __DIR__ ) )`), which produces a backslash path with a trailing forward slash on Windows. Normalizing on our side neutralizes that.
- Existing stale entries in the `pmpro_library_conflicts` option won't auto-clean (the 7-day cleanup loop runs after the early-return). Sites currently affected can delete the option row to clear the slate — PMPro will only repopulate it if a real, non-PMPro conflict appears.

## Test plan

- [ ] On a Linux host with no other Action Scheduler plugin: Site Health continues to show "No library conflicts detected."
- [ ] On a Windows host with no other Action Scheduler plugin: Site Health now shows "No library conflicts detected" (previously reported a false positive).
- [ ] On any host with another plugin loading Stripe/Braintree/2Checkout/Action Scheduler before PMPro: a real conflict is still recorded, and the stored key uses forward slashes.
- [ ] Manually editing a stored key and refreshing Site Health no longer produces a duplicate entry under a separator-variant key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)