### PR TITLE
Deprecate the credit card expiring email template

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
@@ -19,11 +19,13 @@ class PMPro_Email_Template_Credit_Card_Expiring extends PMPro_Email_Template {
 	 * Constructor.
 	 *
 	 * @since 3.4
+	 * @deprecated TBD
 	 *
 	 * @param WP_User $user The user object of the user to send the email to.
 	 * @param MemberOrder $order The order object that is associated to the member.
 	 */
 	public function __construct( WP_User $user,  MemberOrder $order ) {
+		_deprecated_function( __CLASS__, 'TBD' );
 		$this->user = $user;
 		$this->order = $order;
 	}
@@ -217,12 +219,13 @@ class PMPro_Email_Template_Credit_Card_Expiring extends PMPro_Email_Template {
  * Register the email template.
  *
  * @since 3.4
+ * @deprecated TBD
  *
  * @param array $email_templates The email templates (template slug => email template class name)
  * @return array The modified email templates array.
  */
 function pmpro_email_templates_credit_card_expiring( $email_templates ) {
+	_deprecated_function( __FUNCTION__, 'TBD' );
 	$email_templates['credit_card_expiring'] = 'PMPro_Email_Template_Credit_Card_Expiring';
 	return $email_templates;
 }
-add_filter( 'pmpro_email_templates', 'pmpro_email_templates_credit_card_expiring' );


### PR DESCRIPTION
## Summary
- The `credit_card_expiring` email has been effectively dead since the `pmpro_cron_credit_card_expiring_warnings` cron was removed in 3.5 (the legacy `sendCreditCardExpiringEmail()` method was already deprecated in 3.1). Despite that, the template was still registered via the `pmpro_email_templates` filter and showed up in **Memberships → Settings → Email Templates** with an Edit screen, Send Test button, etc. — site admins could configure an email that would never fire.
- Removes the `add_filter( 'pmpro_email_templates', 'pmpro_email_templates_credit_card_expiring' )` line so the template no longer appears in the admin UI.
- Adds `_deprecated_function()` notices to the `PMPro_Email_Template_Credit_Card_Expiring` constructor and to the `pmpro_email_templates_credit_card_expiring()` filter callback (marked `TBD` until the next release), so any add-on or custom code still instantiating the class or invoking the callback gets a proper deprecation notice before the class is removed in a future major version.

## Why the deprecation approach (vs. deleting the class outright)
The class has been part of the public API since 3.4, and we cannot know what add-ons or custom code might be instantiating or subclassing it. A deprecation release gives third-party developers a notice in their error log before anything actually breaks. The class file, the `require_once`, and the existing `sendCreditCardExpiringEmail()` method are all left in place; the only behavioral change is that the template no longer appears in the admin UI.

## Test plan
- [ ] Confirm "Credit Card Expiring" no longer appears at **Memberships → Settings → Email Templates**.
- [ ] Confirm the other email templates (cancel, billing, refund, etc.) still appear and are editable.
- [ ] Confirm that directly visiting `?page=pmpro-emailtemplates&edit=credit_card_expiring` falls through to the list view rather than loading the edit screen.
- [ ] Instantiate `new PMPro_Email_Template_Credit_Card_Expiring( $user, $order )` from custom code and confirm a deprecation notice is logged (no fatal error).
- [ ] Call `pmpro_email_templates_credit_card_expiring( [] )` from custom code and confirm a deprecation notice is logged.
- [ ] Call `sendCreditCardExpiringEmail()` from custom code and confirm the existing deprecation notice still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
