### PR TITLE
Skip pmpro_visit cookie when WP_CACHE is active

### DIFF
--- a/adminpages/reports/logins.php
+++ b/adminpages/reports/logins.php
@@ -454,9 +454,28 @@ function pmpro_report_track_values($type, $user_id = NULL) {
 
 	//set cookie for visits
 	if( $type === 'visits' && empty( $_COOKIE['pmpro_visit'] ) ) {
-		// The secure parameter is set to is_ssl(), true if HTTPS.
-        setcookie( 'pmpro_visit', '1', 0, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
-    }
+		/**
+		 * Filter whether to set the pmpro_visit dedup cookie on the response.
+		 *
+		 * The cookie is a server-side dedup marker so we don't double-count a
+		 * single visitor's visits within a session. Setting it on the response
+		 * adds a Set-Cookie header, which causes most page caches (Surge,
+		 * Cloudflare, Varnish, WP Super Cache, etc.) to bypass the cache for
+		 * that response — defeating page caching entirely on the front end.
+		 *
+		 * Default: skip setting the cookie when WP_CACHE is true (a page cache
+		 * is installed). Set to true to force the cookie regardless.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $should_set Default !( WP_CACHE === true ).
+		 */
+		$should_set = apply_filters( 'pmpro_set_visit_cookie', ! ( defined( 'WP_CACHE' ) && WP_CACHE ) );
+		if ( $should_set ) {
+			// The secure parameter is set to is_ssl(), true if HTTPS.
+			setcookie( 'pmpro_visit', '1', 0, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+		}
+	}
 
 	//some vars for below
 	$now = current_time('timestamp');


### PR DESCRIPTION
## Summary

- The `pmpro_visit` dedup cookie is set on the response on every anonymous front-end request when the Visits Report is active.
- Any `Set-Cookie` header on a response causes page caches (Surge, Cloudflare, Varnish, WP Super Cache, etc.) to bypass the cache.
- This change skips emitting the cookie by default when `WP_CACHE` is `true` (i.e. a page cache is installed), so anon pages can actually be cached.
- New `pmpro_set_visit_cookie` filter lets sites force the previous behavior either way.

## Real-world impact

Caught on a live PMPro Hosting customer site that was sitting at **load 7+ and 30-60s TTFB** under modest traffic. Every anon request was going through full PHP because Surge couldn't cache anything with `Set-Cookie: pmpro_visit=1` on every response. Same issue with the customer's Cloudflare in front — `cf-cache-status: BYPASS` on every page.

After patching the `ignore_cookies` side at the platform level, the response-side `Set-Cookie` was *still* defeating Surge — because the cache-eligibility check happens on the response, not just the cache key. The cookie has to actually stop being sent for the cache to work.

## Why default off when WP_CACHE is true

The cookie is a server-side dedup marker for the Visits Report ("don't double-count this visitor's visits within one session"). For anonymous users it's purely informational — the actual stat increment is gated on `$user_id` being non-empty further down the same function (`pmpro_report_track_values`). Skipping the cookie on cached sites means a single visitor might count as multiple visits if they reload before the dedup window — a fair trade for the cache working at all.

For sites that genuinely need the dedup more than caching, `add_filter( 'pmpro_set_visit_cookie', '__return_true' );` restores the old behavior.

## Test plan

- [ ] Site with `WP_CACHE = true` (Surge / CF / etc.): anon GET response has no `Set-Cookie: pmpro_visit`; page cache hits on second request
- [ ] Site with `WP_CACHE = false` or unset: behavior unchanged, cookie is still set
- [ ] `add_filter( 'pmpro_set_visit_cookie', '__return_true' );` forces cookie on cached site
- [ ] `add_filter( 'pmpro_set_visit_cookie', '__return_false' );` skips cookie on uncached site
- [ ] Logged-in user flow (login -> page -> dashboard): no regressions in visits tracking for known users (cookie was irrelevant for them anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)