### PR TITLE
Add pmpro_is_ssl() helper for proxy-fronted sites in pmpro_https_filter

### DIFF
--- a/includes/https.php
+++ b/includes/https.php
@@ -18,50 +18,58 @@ function pmpro_status_filter( $s ) {
 add_filter('status_header', 'pmpro_status_filter');
 
 /**
- * Detect HTTPS context, including when SSL is terminated by an upstream proxy
- * (Cloudflare, NGINX, AWS ELB, etc.) and the origin only sees plain HTTP.
+ * Detect HTTPS context for PMPro's own URL rewriting.
  *
- * WordPress's is_ssl() checks $_SERVER['HTTPS'] and SERVER_PORT == 443. Behind
- * a proxy that terminates TLS, both can be empty, so is_ssl() returns false
- * even though the visitor's request was HTTPS end-to-end. That makes
- * pmpro_https_filter() flip URLs to http:// inside cached HTML, which then
- * forces another redirect or breaks mixed-content on a properly secured site.
+ * Mirrors WordPress's is_ssl() by default and exposes a `pmpro_is_ssl` filter
+ * so sites behind a TLS-terminating reverse proxy (Cloudflare Flexible, NGINX
+ * with TLS upstream, AWS ELB, etc.) can opt into HTTPS detection based on
+ * their proxy's signaling. Why a filter and not a default fallback to common
+ * forwarded headers:
  *
- * This helper falls back to the conventional reverse-proxy headers when
- * is_ssl() is false. Wrapped in an apply_filters() call so site owners with
- * non-standard proxy headers (e.g. CF-Visitor) can plug in their own check.
+ * - Trusting `X-Forwarded-Proto` is only safe when the origin is not directly
+ *   reachable by clients. Whether that's true depends on the site's network,
+ *   not the plugin. WordPress core itself keeps `is_ssl()` conservative for
+ *   this reason.
+ * - Multi-proxy setups send comma-separated values like `https, http` that
+ *   need site-specific parsing; the safe default is to do nothing.
  *
- * Note: trusting X-Forwarded-Proto only widens trust for URL rewriting inside
- * this filter — it does not change WordPress's own cookie-secure or redirect
- * logic. Sites that need the rest of WP to recognize HTTPS from a proxy header
- * should set $_SERVER['HTTPS'] = 'on' early (e.g. via wp-config.php).
+ * Example: enable trust of `X-Forwarded-Proto` on a site that's always
+ * fronted by a proxy. Apply once in a mu-plugin or theme functions.php:
+ *
+ *     add_filter( 'pmpro_is_ssl', function( $is_ssl ) {
+ *         if ( $is_ssl ) {
+ *             return true;
+ *         }
+ *         if ( ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
+ *             $first = trim( strtok( $_SERVER['HTTP_X_FORWARDED_PROTO'], ',' ) );
+ *             if ( 'https' === strtolower( $first ) ) {
+ *                 return true;
+ *             }
+ *         }
+ *         return $is_ssl;
+ *     } );
+ *
+ * Sites that need the rest of WordPress (cookies, redirects, etc.) to also
+ * recognize HTTPS from a proxy header should normalize at the WP level by
+ * setting $_SERVER['HTTPS'] = 'on' early in wp-config.php.
  *
  * @since TBD
  *
- * @return bool True if the current request is HTTPS or appears proxied from HTTPS.
+ * @return bool True if the current request should be treated as HTTPS for
+ *              PMPro URL rewriting purposes.
  */
 function pmpro_is_ssl() {
-	if ( is_ssl() ) {
-		$is_ssl = true;
-	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && 'https' === strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
-		$is_ssl = true;
-	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_SSL'] ) && 'on' === strtolower( $_SERVER['HTTP_X_FORWARDED_SSL'] ) ) {
-		$is_ssl = true;
-	} else {
-		$is_ssl = false;
-	}
-
 	/**
 	 * Filter PMPro's HTTPS detection.
 	 *
-	 * Use this to add support for proxy headers other than X-Forwarded-Proto /
-	 * X-Forwarded-SSL (for example, Cloudflare's CF-Visitor JSON header).
+	 * Default mirrors WordPress's is_ssl(). Hook this to extend detection
+	 * for proxy-fronted sites — see pmpro_is_ssl() docblock for an example.
 	 *
 	 * @since TBD
 	 *
-	 * @param bool $is_ssl Whether the current request is HTTPS or proxied from HTTPS.
+	 * @param bool $is_ssl Whether the current request is HTTPS.
 	 */
-	return (bool) apply_filters( 'pmpro_is_ssl', $is_ssl );
+	return (bool) apply_filters( 'pmpro_is_ssl', is_ssl() );
 }
 
 /**

--- a/includes/https.php
+++ b/includes/https.php
@@ -18,13 +18,60 @@ function pmpro_status_filter( $s ) {
 add_filter('status_header', 'pmpro_status_filter');
 
 /**
+ * Detect HTTPS context, including when SSL is terminated by an upstream proxy
+ * (Cloudflare, NGINX, AWS ELB, etc.) and the origin only sees plain HTTP.
+ *
+ * WordPress's is_ssl() checks $_SERVER['HTTPS'] and SERVER_PORT == 443. Behind
+ * a proxy that terminates TLS, both can be empty, so is_ssl() returns false
+ * even though the visitor's request was HTTPS end-to-end. That makes
+ * pmpro_https_filter() flip URLs to http:// inside cached HTML, which then
+ * forces another redirect or breaks mixed-content on a properly secured site.
+ *
+ * This helper falls back to the conventional reverse-proxy headers when
+ * is_ssl() is false. Wrapped in an apply_filters() call so site owners with
+ * non-standard proxy headers (e.g. CF-Visitor) can plug in their own check.
+ *
+ * Note: trusting X-Forwarded-Proto only widens trust for URL rewriting inside
+ * this filter — it does not change WordPress's own cookie-secure or redirect
+ * logic. Sites that need the rest of WP to recognize HTTPS from a proxy header
+ * should set $_SERVER['HTTPS'] = 'on' early (e.g. via wp-config.php).
+ *
+ * @since TBD
+ *
+ * @return bool True if the current request is HTTPS or appears proxied from HTTPS.
+ */
+function pmpro_is_ssl() {
+	if ( is_ssl() ) {
+		$is_ssl = true;
+	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && 'https' === strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
+		$is_ssl = true;
+	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_SSL'] ) && 'on' === strtolower( $_SERVER['HTTP_X_FORWARDED_SSL'] ) ) {
+		$is_ssl = true;
+	} else {
+		$is_ssl = false;
+	}
+
+	/**
+	 * Filter PMPro's HTTPS detection.
+	 *
+	 * Use this to add support for proxy headers other than X-Forwarded-Proto /
+	 * X-Forwarded-SSL (for example, Cloudflare's CF-Visitor JSON header).
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $is_ssl Whether the current request is HTTPS or proxied from HTTPS.
+	 */
+	return (bool) apply_filters( 'pmpro_is_ssl', $is_ssl );
+}
+
+/**
  * Filters links/etc to add HTTPS to URL if needed.
  */
 function pmpro_https_filter( $s ) {
 	global $besecure;
 	$besecure = apply_filters( 'pmpro_besecure', $besecure );
-		
-	if( $besecure || is_ssl() )
+
+	if( $besecure || pmpro_is_ssl() )
 		return str_replace( 'http:', 'https:', $s );
 	else
 		return str_replace( 'https:', 'http:', $s );

--- a/includes/https.php
+++ b/includes/https.php
@@ -34,7 +34,13 @@ add_filter('status_header', 'pmpro_status_filter');
  *   need site-specific parsing; the safe default is to do nothing.
  *
  * Example: enable trust of `X-Forwarded-Proto` on a site that's always
- * fronted by a proxy. Apply once in a mu-plugin or theme functions.php:
+ * fronted by a proxy. Apply once in a mu-plugin or theme functions.php.
+ *
+ * WARNING: Only use this example if (1) your proxy strips or overwrites any
+ * inbound `X-Forwarded-Proto` header from clients, and (2) the origin server
+ * is not directly reachable on the public internet. If either is false a
+ * client can forge the header and influence PMPro's URL output for their own
+ * responses. Verify those conditions for your setup before adding the filter.
  *
  *     add_filter( 'pmpro_is_ssl', function( $is_ssl ) {
  *         if ( $is_ssl ) {


### PR DESCRIPTION
## Summary

`pmpro_https_filter()` runs on `home_url`, `option_siteurl`, `login_url`, `logout_url`, `option_home`, `bloginfo_url`, and `wp_list_pages` — nearly every page render. It branches on `is_ssl()`, which checks `$_SERVER['HTTPS']` and `SERVER_PORT == 443`. Behind a reverse proxy that terminates TLS (Cloudflare Flexible mode, NGINX/Caddy in front of Apache, AWS ELB, etc.) both are empty on the origin, so `is_ssl()` returns `false` even when the visitor's request was HTTPS end-to-end.

When that happens, `pmpro_https_filter()` falls into its `else` branch and rewrites `https://` URLs back to `http://` in the page output. On a Force-HTTPS site that's a redirect loop, and on any properly secured site it sneaks mixed-content URLs into cached HTML.

This PR adds a `pmpro_is_ssl()` helper that:

- **Mirrors `is_ssl()` by default** — zero behavior change on every install that doesn't opt in.
- **Exposes a `pmpro_is_ssl` filter** so sites that know their origin sits behind a trusted proxy can extend HTTPS detection to their proxy's signaling (X-Forwarded-Proto, CF-Visitor, custom headers, etc.) without overriding `is_ssl()` globally.

Then swaps the bare `is_ssl()` call inside `pmpro_https_filter()` for `pmpro_is_ssl()`.

The docblock on `pmpro_is_ssl()` includes a copy-pasteable example for the most common case (CF Flexible / standard reverse proxy with `X-Forwarded-Proto`) that handles comma-separated multi-proxy values and surrounding whitespace correctly.

## Why a filter instead of a default header fallback

An earlier revision of this PR trusted `X-Forwarded-Proto` / `X-Forwarded-SSL` by default. Codex reviewed and (correctly) flagged that as too loose: an attacker who reaches the origin directly can forge those headers, and multi-proxy setups send values like `https, http` that need site-specific parsing. The trust boundary depends on the site's network, not the plugin. So the safe default is to do nothing, and let site owners opt in.

## Scope (intentionally narrow)

This helper widens HTTPS detection only for URL rewriting inside `pmpro_https_filter()`. It does **not** change:

- WordPress's own cookie-`secure` logic
- `force_ssl_admin()` or `pmpro_besecure()` redirect logic
- Anything else in core or PMPro that calls `is_ssl()` directly

Sites that need the rest of WordPress to recognize HTTPS from a proxy header should normalize at the WP layer by setting `$_SERVER['HTTPS'] = 'on'` early in wp-config.php — called out in the docblock.

## Test plan

- [ ] Native HTTPS site, no filter hooked: `pmpro_https_filter()` still rewrites `http://` → `https://` for `besecure`/`is_ssl()` requests. No behavior change.
- [ ] Native HTTP site, no filter hooked: no rewrites. No behavior change.
- [ ] Site behind CF Flexible with the docblock-example filter added: URL rewriting produces `https://` consistently even when origin sees HTTP. Without the filter callback: matches dev behavior (no change from this PR).
- [ ] Filter receives `false` from `is_ssl()` and can override to `true`; receives `true` and can pass through.
- [ ] PHPCS clean for `includes/https.php`.

## Related follow-up — not in this PR

While reviewing `includes/https.php` we noticed two other rough edges that probably warrant their own follow-up before deprecating anything. Pasting here so they don't get lost; happy to file as separate issues if useful.

1. **Admin notice for redundant Force-SSL settings.** When `siteurl` already starts with `https://`, both `pmpro_use_ssl == 1` (server-side redirect) and `pmpro_nuclear_HTTPS` (the output-buffer URL rewrite) are doing nothing useful and only add risk. On a proxy-fronted site in Flexible mode they can introduce redirect loops. A dismissable admin notice on the PMPro settings page in that situation ("Your site URL is already HTTPS — this setting is redundant and can cause issues on proxy-fronted sites") would prevent self-inflicted login loops.

2. **Soft-deprecate `pmpro_NuclearHTTPS`.** The function registers an `ob_start( 'pmpro_replaceURLsInBuffer' )` callback that buffers the entire response and regex-replaces `http://` → `https://` for the site's domain. That's the same anti-pattern as SSL Insecure Content Fixer's `capture_all` mode — it can collide with page caches that also want to own the outermost buffer (Surge, WP Rocket, W3TC), and on a modern stack with correct `siteurl` + `FORCE_SSL_ADMIN` + a properly-configured proxy it's solving a problem that's already solved one layer down. Suggest: hide the checkbox from new installs while leaving the runtime behavior intact for legacy sites that have it on.

## Story behind this

A PMPro Hosting customer with Cloudflare in front hit a login loop. Investigation surfaced two unrelated issues: their site's third-party SSL Insecure Content Fixer plugin in `capture_all` mode (separate fix), and this latent fragility in PMPro's own `pmpro_https_filter()` for the next customer who's behind a TLS-terminating proxy.

## Review history

- **First commit**: Defaulted to trusting `X-Forwarded-Proto` / `X-Forwarded-SSL`.
- **Second commit**: After Codex flagged the spoofable-header concern and multi-proxy value handling, reverted to a safe-default helper that only wraps `is_ssl()` and exposes the filter as the extension point. The example in the docblock is what an opting-in site would add to their wp-config or a mu-plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)