### PR TITLE
BUG FIX: Clean up deleted membership level relationships

### DIFF
--- a/adminpages/levels/delete-level.php
+++ b/adminpages/levels/delete-level.php
@@ -10,15 +10,6 @@ $ml_id = intval($_REQUEST['deleteid']);
 if($ml_id > 0) {
     do_action("pmpro_delete_membership_level", $ml_id);
 
-    //remove any categories from the ml
-    $sqlQuery = $wpdb->prepare("
-        DELETE FROM $wpdb->pmpro_memberships_categories
-        WHERE membership_id = %d",
-        $ml_id
-    );
-
-    $r1 = $wpdb->query($sqlQuery);
-
     //cancel any subscriptions to the ml
     $r2 = true;
     $user_ids = $wpdb->get_col( $wpdb->prepare( "
@@ -49,8 +40,8 @@ if($ml_id > 0) {
         }
     }
 
-    // delete the level group entry.
-    $wpdb->delete( $wpdb->pmpro_membership_levels_groups, array( 'level' => $ml_id ) );
+    // Delete non-historical relationships to the membership level.
+    $r1 = pmpro_delete_membership_level_relationships( $ml_id );
 
     //delete the ml
     $sqlQuery = $wpdb->prepare( "

--- a/classes/class-pmpro-levels.php
+++ b/classes/class-pmpro-levels.php
@@ -190,7 +190,7 @@ class PMPro_Membership_Level{
         do_action( $after_action, $this );
     }
     /**
-     * Delete a membership level and categories.
+     * Delete a membership level and related non-historical records.
      * @since 2.3
      */
     function delete() {
@@ -201,14 +201,16 @@ class PMPro_Membership_Level{
 
         global $wpdb;
         $r1 = false; // Remove level.
-        $r2 = false; // Remove categories from level.
+        $r2 = false; // Remove related records from level.
         $r3 = false; // Remove users from level.
+
+        do_action( 'pmpro_delete_membership_level', $this->id );
 
         if ( $wpdb->delete( $wpdb->pmpro_membership_levels, array('id' => $this->id), array('%d') ) ) {
             $r1 = true;
         }
 
-        if ( $wpdb->delete( $wpdb->pmpro_memberships_categories, array('membership_id' => $this->id), array('%d') ) ) {
+        if ( pmpro_delete_membership_level_relationships( $this->id ) ) {
             $r2 = true;
         }
 
@@ -223,15 +225,12 @@ class PMPro_Membership_Level{
             $r3 = true;
         }
 
-        // Remove the level from the level group.
-        $wpdb->delete( $wpdb->pmpro_membership_levels_groups, array( 'level' => $this->id ) );
-            
         if ( $r1 == true && $r2 == true && $r3 == true ) {
             return true;
         } elseif ( $r1 == true && $r2 == false && $r3 == false ) {
-            return 'Only the level was deleted. Users may still be assigned to this level';
+            return 'Only the level was deleted. Users may still be assigned to this level and related records may remain.';
         } elseif ( $r1 == false && $r2 == true && $r3 == false ) {
-            return 'Only categories were deleted. Users may still be assigned to this level.';
+            return 'Only related records were deleted. Users may still be assigned to this level.';
         } elseif( $r1 == false && $r2 == false && $r3 == true ) {
             return 'Only users were removed from this level.';
         } else {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -728,6 +728,124 @@ function delete_pmpro_membership_level_meta( $level_id, $meta_key, $meta_value =
 }
 
 /**
+ * Get PMPro tables that store non-historical relationships to a membership level.
+ *
+ * This intentionally excludes orders, subscriptions, and membership history.
+ *
+ * @since 3.8
+ *
+ * @return array[] {
+ *     An array of table/column pairs.
+ *
+ *     @type string $table  The table name.
+ *     @type string $column The column containing the membership level ID.
+ * }
+ */
+function pmpro_get_membership_level_relationship_tables() {
+	global $wpdb;
+
+	return array(
+		array(
+			'table'  => $wpdb->pmpro_memberships_categories,
+			'column' => 'membership_id',
+		),
+		array(
+			'table'  => $wpdb->pmpro_memberships_pages,
+			'column' => 'membership_id',
+		),
+		array(
+			'table'  => $wpdb->pmpro_discount_codes_levels,
+			'column' => 'level_id',
+		),
+		array(
+			'table'  => $wpdb->pmpro_membership_levels_groups,
+			'column' => 'level',
+		),
+		array(
+			'table'  => $wpdb->pmpro_membership_levelmeta,
+			'column' => 'pmpro_membership_level_id',
+		),
+	);
+}
+
+/**
+ * Delete non-historical records related to a membership level.
+ *
+ * @since 3.8
+ *
+ * @param int $level_id The membership level ID.
+ * @return bool True if all related records were deleted or no related records existed; false on database error.
+ */
+function pmpro_delete_membership_level_relationships( $level_id ) {
+	global $wpdb;
+
+	$level_id = intval( $level_id );
+	if ( empty( $level_id ) ) {
+		return false;
+	}
+
+	$success = true;
+	foreach ( pmpro_get_membership_level_relationship_tables() as $relationship_table ) {
+		$deleted = $wpdb->delete(
+			$relationship_table['table'],
+			array( $relationship_table['column'] => $level_id ),
+			array( '%d' )
+		);
+
+		if ( false === $deleted ) {
+			$success = false;
+		}
+	}
+
+	wp_cache_delete( $level_id, 'pmpro_membership_level_meta' );
+
+	return $success;
+}
+
+/**
+ * Delete orphaned non-historical membership level relationship records.
+ *
+ * @since 3.8
+ *
+ * @return bool True if all orphaned records were deleted or no orphaned records existed; false on database error.
+ */
+function pmpro_delete_orphaned_membership_level_relationships() {
+	global $wpdb;
+
+	$success = true;
+	foreach ( pmpro_get_membership_level_relationship_tables() as $relationship_table ) {
+		$orphaned_level_ids = array();
+		if ( $relationship_table['table'] === $wpdb->pmpro_membership_levelmeta ) {
+			$orphaned_level_ids = (array) $wpdb->get_col(
+				"SELECT DISTINCT pmpro_level_relationship.`{$relationship_table['column']}`
+				FROM {$relationship_table['table']} AS pmpro_level_relationship
+				LEFT JOIN {$wpdb->pmpro_membership_levels} AS pmpro_membership_level
+					ON pmpro_level_relationship.`{$relationship_table['column']}` = pmpro_membership_level.id
+				WHERE pmpro_membership_level.id IS NULL"
+			);
+		}
+
+		$deleted = $wpdb->query(
+			"DELETE pmpro_level_relationship
+			FROM {$relationship_table['table']} AS pmpro_level_relationship
+			LEFT JOIN {$wpdb->pmpro_membership_levels} AS pmpro_membership_level
+				ON pmpro_level_relationship.`{$relationship_table['column']}` = pmpro_membership_level.id
+			WHERE pmpro_membership_level.id IS NULL"
+		);
+
+		if ( false === $deleted ) {
+			$success = false;
+		}
+
+		foreach ( $orphaned_level_ids as $level_id ) {
+			wp_cache_delete( intval( $level_id ), 'pmpro_membership_level_meta' );
+		}
+	}
+
+	return $success;
+}
+
+/**
  * pmpro_membership_order Meta Functions
  */
 function add_pmpro_membership_order_meta( $order_id, $meta_key, $meta_value, $unique = false ) {

--- a/includes/updates/upgrade_3_8.php
+++ b/includes/updates/upgrade_3_8.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Upgrade to version 3.8
+ *
+ * Clean up non-historical membership level relationship rows orphaned by deleted levels.
+ *
+ * @since 3.8
+ */
+function pmpro_upgrade_3_8() {
+	pmpro_delete_orphaned_membership_level_relationships();
+}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -438,6 +438,16 @@ function pmpro_checkForUpgrades() {
 		update_option( 'pmpro_db_version', '3.71' );
 	}
 
+	/**
+	 * Version 3.8
+	 * Clean up membership level relationship rows orphaned by deleted levels.
+	 */
+	if ( $pmpro_db_version < 3.8 ) {
+		require_once( PMPRO_DIR . "/includes/updates/upgrade_3_8.php" );
+		pmpro_upgrade_3_8();
+		update_option( 'pmpro_db_version', '3.8' );
+	}
+
 }
 
 function pmpro_db_delta() {


### PR DESCRIPTION
### Description

Fixes #3486.

This cleans up non-historical records related to a membership level when the level is deleted, including category links, page restrictions, discount code level links, level group links, and membership level meta. It also adds a 3.8 upgrade routine to delete orphaned rows from those relationship tables for levels that were deleted before this fix.

The `pmpro_delete_membership_level` action now also fires when deleting a level through `PMPro_Membership_Level::delete()`, including the REST API deletion path.

### How to test the changes in this Pull Request:

1. Create a membership level with categories, protected pages, a discount code, a level group, and level meta.
2. Delete the level from the Membership Levels admin page and confirm related rows are removed from `pmpro_memberships_categories`, `pmpro_memberships_pages`, `pmpro_discount_codes_levels`, `pmpro_membership_levels_groups`, and `pmpro_membership_levelmeta`.
3. Repeat deletion through the REST API / `PMPro_Membership_Level::delete()` path and confirm the same relationship cleanup happens.
4. Seed orphaned rows in those relationship tables, set `pmpro_db_version` below `3.8`, run the upgrade, and confirm the orphaned rows are removed.

### Checklist:

- [x] Runs clean with `php -l` on changed PHP files.
- [x] Runs clean with `git diff --check`.
- [ ] Have you successfully run tests with your changes locally?