### PR TITLE
Fix fatal on billing page for logged-out requests

### DIFF
--- a/pages/billing.php
+++ b/pages/billing.php
@@ -1,12 +1,12 @@
 <?php
 /**
  * Template: Billing
- * Version: 3.7.3
+ * Version: TBD
  *
  * See documentation for how to override the PMPro templates.
  * @link https://www.paidmembershipspro.com/documentation/templates/
  *
- * @version 3.7.3
+ * @version TBD
  *
  * @author Paid Memberships Pro
  */

--- a/pages/billing.php
+++ b/pages/billing.php
@@ -525,6 +525,11 @@
 	// Get all previous memberships, this includes cancelled and 'active' memberships.
 	$previous_memberships = pmpro_getMembershipLevelsForUser( $current_user->ID, true );
 
+	// pmpro_getMembershipLevelsForUser() returns false when there is no user (e.g. a logged-out visitor), so normalize to an array before filtering.
+	if ( ! is_array( $previous_memberships ) ) {
+		$previous_memberships = array();
+	}
+
 	// Let's remove active ones from the list before looping through.
 	$previous_memberships = array_filter( $previous_memberships, function( $membership ) {
 		return ! ( $membership->status === 'active' || pmpro_hasMembershipLevel( $membership->id ) );


### PR DESCRIPTION
## Problem

`pages/billing.php` fatals with an uncaught `TypeError` for any request where the current user is logged out:

```
PHP Fatal error: Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, false given in .../pages/billing.php:529
```

`pmpro_getMembershipLevelsForUser()` returns `false` when there is no user (`$current_user->ID` is `0`). billing.php passes that return value straight into `array_filter()`, which throws.

Because the billing page is rendered via a block, this is hit by logged-out visitors and crawlers (in the wild it was triggered repeatedly by SEO/sitemap bots), white-screening the page each time.

## Fix

Normalize the return value to an array before filtering:

```php
$previous_memberships = pmpro_getMembershipLevelsForUser( $current_user->ID, true );

if ( ! is_array( $previous_memberships ) ) {
	$previous_memberships = array();
}

$previous_memberships = array_filter( $previous_memberships, ... );
```

## How to reproduce

Render the billing page / billing block while logged out (or hit it with a crawler). Before the fix: fatal `TypeError`. After: the page renders normally (falls through to the "no active membership" path).

## Notes

- Found while diagnosing high CPU / error-log flooding on a production site; the billing fatal was a recurring entry in the Apache error log driven by bot traffic.
- Current as of `dev` (3.7.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)