### PR TITLE
Use wp_editor for email template Liquid autocomplete

### DIFF
--- a/adminpages/emailtemplates-edit.php
+++ b/adminpages/emailtemplates-edit.php
@@ -74,6 +74,29 @@
 			esc_html__( 'Global Variables', 'paid-memberships-pro' ) => PMPro_Email_Template::get_base_email_template_variables_with_description(),
 		);
 	}
+
+	// Enable Liquid autocomplete when the variable reference uses Liquid syntax.
+	$pmpro_liquid_autocomplete_enabled = (bool) $email_template_class || in_array( $edit, array( 'header', 'footer' ), true );
+
+	$pmpro_tinymce_settings = array(
+		'readonly' => filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ),
+	);
+
+	if ( $pmpro_liquid_autocomplete_enabled ) {
+		$pmpro_tinymce_settings['pmpro_liquid_autocomplete'] = wp_json_encode( pmpro_get_liquid_autocomplete_settings( $email_variables ) );
+	}
+
+	$pmpro_email_template_editor_settings = array(
+		'textarea_name'    => 'pmpro_email_template_body',
+		'textarea_rows'    => 15,
+		'editor_height'    => 500,
+		'media_buttons'    => true,
+		'default_editor'   => 'tinymce',
+		'drag_drop_upload' => true,
+		'wpautop'          => false,
+		'tinymce'          => $pmpro_tinymce_settings,
+		'quicktags'        => true,
+	);
 ?>
 <hr class="wp-header-end">
 <div id="message" class="status_message_wrapper">
@@ -188,7 +211,16 @@
 							<th scope="row" valign="top"><label for="pmpro_email_template_body"><?php esc_html_e( 'Body', 'paid-memberships-pro' ); ?></label></th>
 							<td>
 								<div id="template_editor_container">
-									<textarea rows="15" name="pmpro_email_template_body" id="pmpro_email_template_body" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?>><?php echo esc_textarea( stripslashes( $template_data['body'] ) ); ?></textarea>
+									<?php
+										if ( $pmpro_liquid_autocomplete_enabled ) {
+											pmpro_register_liquid_autocomplete_editor( 'pmpro_email_template_body' );
+										}
+										wp_editor(
+											stripslashes( $template_data['body'] ),
+											'pmpro_email_template_body',
+											$pmpro_email_template_editor_settings
+										);
+									?>
 								</div>
 							</td>
 						</tr>

--- a/classes/class-pmpro-liquid-renderer.php
+++ b/classes/class-pmpro-liquid-renderer.php
@@ -374,21 +374,13 @@ class PMPro_Liquid_Renderer {
 				continue;
 			}
 
-			$operator        = null;
-			$operator_length = 0;
+			$operator_match = self::parse_comparison_operator_at_position( $condition_string, $i );
 
-			$two_char_operator = substr( $condition_string, $i, 2 );
-			if ( in_array( $two_char_operator, array( '==', '!=', '>=', '<=' ), true ) ) {
-				$operator        = $two_char_operator;
-				$operator_length = 2;
-			} elseif ( $char === '>' || $char === '<' ) {
-				$operator        = $char;
-				$operator_length = 1;
-			}
-
-			if ( $operator !== null ) {
-				$left_token  = trim( substr( $condition_string, 0, $i ) );
-				$right_token = trim( substr( $condition_string, $i + $operator_length ) );
+			if ( ! empty( $operator_match ) ) {
+				$operator        = $operator_match['operator'];
+				$operator_length = $operator_match['length'];
+				$left_token      = trim( substr( $condition_string, 0, $i ) );
+				$right_token     = trim( substr( $condition_string, $i + $operator_length ) );
 
 				if ( $left_token === '' || $right_token === '' ) {
 					return null;
@@ -400,6 +392,58 @@ class PMPro_Liquid_Renderer {
 					'right'    => $right_token,
 				);
 			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse a comparison operator at a specific position in a condition string.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $condition_string The condition expression to parse.
+	 * @param int    $position         The position to check for a comparison operator.
+	 * @return array|null {
+	 *     Parsed comparison operator.
+	 *
+	 *     @type string $operator Canonical comparison operator.
+	 *     @type int    $length   Length of the matched operator string.
+	 * }
+	 */
+	private static function parse_comparison_operator_at_position( $condition_string, $position ) {
+		$operators = array(
+			'=='      => '==',
+			'!='      => '!=',
+			'>='      => '>=',
+			'<='      => '<=',
+			'&gt;='   => '>=',
+			'&#62;='  => '>=',
+			'&#x3e;=' => '>=',
+			'&lt;='   => '<=',
+			'&#60;='  => '<=',
+			'&#x3c;=' => '<=',
+			'>'       => '>',
+			'<'       => '<',
+			'&gt;'    => '>',
+			'&#62;'   => '>',
+			'&#x3e;'  => '>',
+			'&lt;'    => '<',
+			'&#60;'   => '<',
+			'&#x3c;'  => '<',
+		);
+
+		foreach ( $operators as $operator_string => $canonical_operator ) {
+			$operator_length = strlen( $operator_string );
+
+			if ( strtolower( substr( $condition_string, $position, $operator_length ) ) !== $operator_string ) {
+				continue;
+			}
+
+			return array(
+				'operator' => $canonical_operator,
+				'length'   => $operator_length,
+			);
 		}
 
 		return null;

--- a/css/admin.css
+++ b/css/admin.css
@@ -2576,6 +2576,8 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 }
 
 .pmpro-liquid-autocomplete__item:hover,
+.pmpro-liquid-autocomplete__item:focus,
+.pmpro-liquid-autocomplete__item:focus-visible,
 .pmpro-liquid-autocomplete__item.is-active {
 	background: #2271b1;
 	color: #fff;

--- a/css/admin.css
+++ b/css/admin.css
@@ -2544,6 +2544,77 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	max-width: 900px;
 }
 
+.pmpro-liquid-autocomplete {
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+	box-sizing: border-box;
+	max-height: 280px;
+	overflow-y: auto;
+	position: absolute;
+	max-width: calc(100vw - 24px);
+	width: 380px;
+	z-index: 100100;
+}
+
+.pmpro-liquid-autocomplete[hidden] {
+	display: none;
+}
+
+.pmpro-liquid-autocomplete__item {
+	background: transparent;
+	border: 0;
+	box-sizing: border-box;
+	color: #1d2327;
+	cursor: pointer;
+	display: block;
+	margin: 0;
+	padding: 8px 10px;
+	text-align: left;
+	width: 100%;
+}
+
+.pmpro-liquid-autocomplete__item:hover,
+.pmpro-liquid-autocomplete__item.is-active {
+	background: #2271b1;
+	color: #fff;
+}
+
+.pmpro-liquid-autocomplete__label,
+.pmpro-liquid-autocomplete__description {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pmpro-liquid-autocomplete__label {
+	font-family: Consolas, Monaco, monospace;
+	font-size: 13px;
+	font-weight: 600;
+	line-height: 1.4;
+}
+
+.pmpro-liquid-autocomplete__description {
+	font-size: 12px;
+	line-height: 1.35;
+	margin-top: 2px;
+	opacity: 0.78;
+}
+
+.pmpro-liquid-autocomplete__separator {
+	background: #f6f7f7;
+	border-bottom: 1px solid #dcdcde;
+	border-top: 1px solid #dcdcde;
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0;
+	padding: 6px 10px;
+	text-transform: uppercase;
+}
+
 /**
  * User Fields Settings
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4348,6 +4348,7 @@ function pmpro_get_liquid_autocomplete_settings( $variables = array() ) {
 		'filters'   => pmpro_get_liquid_autocomplete_filter_suggestions(),
 		'tags'      => pmpro_get_liquid_autocomplete_tag_suggestions(),
 		'strings'   => array(
+			'autocompleteLabel' => __( 'Liquid autocomplete', 'paid-memberships-pro' ),
 			'liquidTagsHeader' => __( 'Liquid Tags', 'paid-memberships-pro' ),
 		),
 	);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4335,6 +4335,141 @@ function pmpro_kses( $original_string, $context = 'email' ) {
 }
 
 /**
+ * Get TinyMCE autocomplete settings for Liquid syntax.
+ *
+ * @since TBD
+ *
+ * @param array $variables Variables to include in autocomplete. Supports a flat variable => description map or grouped maps.
+ * @return array Liquid autocomplete settings.
+ */
+function pmpro_get_liquid_autocomplete_settings( $variables = array() ) {
+	$settings = array(
+		'variables' => pmpro_get_liquid_autocomplete_variable_suggestions( $variables ),
+		'filters'   => pmpro_get_liquid_autocomplete_filter_suggestions(),
+		'tags'      => pmpro_get_liquid_autocomplete_tag_suggestions(),
+		'strings'   => array(
+			'liquidTagsHeader' => __( 'Liquid Tags', 'paid-memberships-pro' ),
+		),
+	);
+
+	return $settings;
+}
+
+/**
+ * Convert a list of Liquid variables into autocomplete suggestions.
+ *
+ * @since TBD
+ *
+ * @param array $variables Variables to include in autocomplete. Supports a flat variable => description map or grouped maps.
+ * @return array Variable autocomplete suggestions.
+ */
+function pmpro_get_liquid_autocomplete_variable_suggestions( $variables ) {
+	$suggestions = array();
+
+	foreach ( (array) $variables as $key => $description ) {
+		if ( is_array( $description ) ) {
+			foreach ( $description as $group_key => $group_description ) {
+				$suggestions[] = pmpro_get_liquid_autocomplete_variable_suggestion( $group_key, $group_description );
+			}
+
+			continue;
+		}
+
+		$suggestions[] = pmpro_get_liquid_autocomplete_variable_suggestion( $key, $description );
+	}
+
+	return $suggestions;
+}
+
+/**
+ * Convert a single Liquid variable into an autocomplete suggestion.
+ *
+ * @since TBD
+ *
+ * @param string $variable    The variable token.
+ * @param string $description The variable description.
+ * @return array Variable autocomplete suggestion.
+ */
+function pmpro_get_liquid_autocomplete_variable_suggestion( $variable, $description = '' ) {
+	$name = $variable;
+
+	if ( preg_match( '/^\{\{\s*([^}|\s]+)/', $variable, $match ) ) {
+		$name = $match[1];
+	}
+
+	return array(
+		'name'        => $name,
+		'label'       => $variable,
+		'description' => $description,
+		'insert'      => $variable,
+	);
+}
+
+/**
+ * Get Liquid filter autocomplete suggestions.
+ *
+ * @since TBD
+ *
+ * @return array Liquid filter autocomplete suggestions.
+ */
+function pmpro_get_liquid_autocomplete_filter_suggestions() {
+	$suggestions = array();
+
+	if ( ! class_exists( 'PMPro_Liquid_Renderer' ) ) {
+		return $suggestions;
+	}
+
+	foreach ( PMPro_Liquid_Renderer::get_filters() as $filter_name => $filter ) {
+		$suggestions[] = array(
+			'name'        => $filter_name,
+			'label'       => $filter_name,
+			'description' => isset( $filter['description'] ) ? $filter['description'] : '',
+			'insert'      => ( 'default' === $filter_name ) ? ' | default: "__pmpro_cursor__"' : ' | ' . $filter_name,
+		);
+	}
+
+	return $suggestions;
+}
+
+/**
+ * Get Liquid tag autocomplete suggestions.
+ *
+ * @since TBD
+ *
+ * @return array Liquid tag autocomplete suggestions.
+ */
+function pmpro_get_liquid_autocomplete_tag_suggestions() {
+	$suggestions = array(
+		array(
+			'name'        => 'if',
+			'label'       => '{% if ... %} ... {% endif %}',
+			'description' => __( 'Show content when a condition is true', 'paid-memberships-pro' ),
+			'insert'      => '{% if __pmpro_cursor__ %}{% endif %}',
+		),
+		array(
+			'name'        => 'elsif',
+			'label'       => '{% elsif ... %}',
+			'description' => __( 'Add another condition inside an if block', 'paid-memberships-pro' ),
+			'insert'      => '{% elsif __pmpro_cursor__ %}',
+		),
+		array(
+			'name'        => 'else',
+			'label'       => '{% else %}',
+			'description' => __( 'Add fallback content inside an if block', 'paid-memberships-pro' ),
+			'insert'      => '{% else %}',
+		),
+		array(
+			'name'        => 'endif',
+			'label'       => '{% endif %}',
+			'description' => __( 'Close an if block', 'paid-memberships-pro' ),
+			'insert'      => '{% endif %}',
+		),
+	);
+
+	return $suggestions;
+}
+
+/**
  * Replace last occurrence of a string.
  * From: http://stackoverflow.com/a/3835653/1154321
  * @since 2.6

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -196,3 +196,54 @@ function pmpro_admin_enqueue_scripts() {
 	}
 }
 add_action( 'admin_enqueue_scripts', 'pmpro_admin_enqueue_scripts' );
+
+/**
+ * Register a wp_editor() instance for PMPro Liquid autocomplete support.
+ *
+ * @since TBD
+ *
+ * @param string $editor_id TinyMCE editor ID.
+ */
+function pmpro_register_liquid_autocomplete_editor( $editor_id ) {
+	if ( empty( $editor_id ) ) {
+		return;
+	}
+
+	if ( empty( $GLOBALS['pmpro_liquid_autocomplete_editor_ids'] ) || ! is_array( $GLOBALS['pmpro_liquid_autocomplete_editor_ids'] ) ) {
+		$GLOBALS['pmpro_liquid_autocomplete_editor_ids'] = array();
+	}
+
+	$GLOBALS['pmpro_liquid_autocomplete_editor_ids'][ $editor_id ] = true;
+}
+
+/**
+ * Load PMPro's TinyMCE plugin for registered Liquid autocomplete editors.
+ *
+ * @since TBD
+ *
+ * @param array  $external_plugins External TinyMCE plugins.
+ * @param string $editor_id        TinyMCE editor ID. Empty on WordPress versions before 5.3.
+ * @return array External TinyMCE plugins.
+ */
+function pmpro_liquid_autocomplete_tinymce_external_plugins( $external_plugins, $editor_id = '' ) {
+	$registered_editor_ids = empty( $GLOBALS['pmpro_liquid_autocomplete_editor_ids'] ) || ! is_array( $GLOBALS['pmpro_liquid_autocomplete_editor_ids'] )
+		? array()
+		: $GLOBALS['pmpro_liquid_autocomplete_editor_ids'];
+
+	if ( ! empty( $editor_id ) && empty( $registered_editor_ids[ $editor_id ] ) ) {
+		return $external_plugins;
+	}
+
+	if ( empty( $editor_id ) && empty( $registered_editor_ids ) ) {
+		return $external_plugins;
+	}
+
+	$external_plugins['pmpro_liquid_autocomplete'] = add_query_arg(
+		'ver',
+		PMPRO_VERSION,
+		plugins_url( 'js/pmpro-liquid-autocomplete.js', __DIR__ )
+	);
+
+	return $external_plugins;
+}
+add_filter( 'mce_external_plugins', 'pmpro_liquid_autocomplete_tinymce_external_plugins', 10, 2 );

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -838,8 +838,13 @@ jQuery(document).ready(function ($) {
 		$("#pmpro_email_template_cc").val( cc_val );
 		$("#pmpro_email_template_bcc").val( bcc_val );
 
-		if ( typeof tinymce !== 'undefined' ) {
-			tinymce.triggerSave();
+		// Sync the visual editor to the textarea before reading its value, but
+		// only when TinyMCE is the active mode. When the user is in Text mode,
+		// the textarea already holds the live edits and calling editor.save()
+		// would overwrite them with the iframe's stale content.
+		var editor = pmpro_email_template_body_editor();
+		if ( editor && ! editor.isHidden() ) {
+			editor.save();
 		}
 
 		$data = {

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -743,9 +743,16 @@ jQuery(document).ready(function ($) {
 
 	/* Variables */
 	$template = $('#edit').val();
+	var $emailTemplateForm = $("#pmpro_submit_template_data").closest('form');
 
-	$("#pmpro_submit_template_data").click(function () {
-		pmpro_save_template()
+	$emailTemplateForm.submit(function (e) {
+		e.preventDefault();
+		pmpro_save_template();
+	});
+
+	$("#pmpro_submit_template_data").click(function (e) {
+		e.preventDefault();
+		pmpro_save_template();
 	});
 
 	$("#pmpro_reset_template_data").click(function () {
@@ -757,7 +764,12 @@ jQuery(document).ready(function ($) {
 	});
 
 	$("#send_test_email").click(function (e) {
-		pmpro_save_template().done(setTimeout(function () { pmpro_send_test_email(); }, '1000'));
+		e.preventDefault();
+		pmpro_save_template().done(function () {
+			setTimeout(function () {
+				pmpro_send_test_email();
+			}, 1000);
+		});
 	});
 
 	/**
@@ -774,6 +786,46 @@ jQuery(document).ready(function ($) {
 		return value.split( ',' ).map( function( s ) { return s.trim(); } ).filter( Boolean ).join( ', ' );
 	}
 
+	function pmpro_email_template_body_editor() {
+		if ( typeof tinymce === 'undefined' ) {
+			return null;
+		}
+
+		return tinymce.get( 'pmpro_email_template_body' ) || null;
+	}
+
+	function pmpro_set_email_template_body_disabled( disabled ) {
+		var isDisabled = disabled === true || disabled === 'true';
+		var editor = pmpro_email_template_body_editor();
+		var $editorWrap = $('#wp-pmpro_email_template_body-wrap');
+
+		if ( isDisabled ) {
+			$("#pmpro_email_template_body").attr('readonly', 'readonly').attr('disabled', 'disabled');
+			$editorWrap.find('.quicktags-toolbar input, .wp-switch-editor').prop('disabled', true);
+		} else {
+			$("#pmpro_email_template_body").removeAttr('readonly').removeAttr('disabled');
+			$editorWrap.find('.quicktags-toolbar input, .wp-switch-editor').prop('disabled', false);
+		}
+
+		if ( editor && typeof editor.setMode === 'function' ) {
+			editor.setMode( isDisabled ? 'readonly' : 'design' );
+		}
+	}
+
+	if ( typeof tinymce !== 'undefined' && typeof tinymce.on === 'function' ) {
+		tinymce.on( 'AddEditor', function( event ) {
+			if ( event.editor.id === 'pmpro_email_template_body' ) {
+				event.editor.on( 'init', function() {
+					pmpro_set_email_template_body_disabled( $("#pmpro_email_template_disable").is(":checked") );
+				} );
+			}
+		} );
+	}
+
+	if ( $("#pmpro_email_template_disable").is(":checked") ) {
+		pmpro_set_email_template_body_disabled( true );
+	}
+
 	function pmpro_save_template() {
 
 		$("#pmpro_submit_template_data").attr("disabled", true);
@@ -786,6 +838,10 @@ jQuery(document).ready(function ($) {
 		$("#pmpro_email_template_cc").val( cc_val );
 		$("#pmpro_email_template_bcc").val( bcc_val );
 
+		if ( typeof tinymce !== 'undefined' ) {
+			tinymce.triggerSave();
+		}
+
 		$data = {
 			template: $template,
 			subject: $("#pmpro_email_template_subject").val(),
@@ -796,7 +852,7 @@ jQuery(document).ready(function ($) {
 			action: 'pmpro_email_templates_save_template_data',
 			security: $('input[name=security]').val()
 		};
-		$.post(ajaxurl, $data, function (response) {
+		return $.post(ajaxurl, $data, function (response) {
 			if (response != 0) {
 				$(".status_message_wrapper").addClass('updated');
 			}
@@ -808,8 +864,6 @@ jQuery(document).ready(function ($) {
 			$(".status_message").show();
 			$('html, body').animate({ scrollTop : 0 }, 'fast');
 		});
-
-		return $.Deferred().resolve();
 	}
 
 	function pmpro_reset_template() {
@@ -827,6 +881,10 @@ jQuery(document).ready(function ($) {
 			var template_data = $.parseJSON(response);
 			$('#pmpro_email_template_subject').val(template_data['subject']);
 			$('#pmpro_email_template_body').val(template_data['body']);
+			var editor = pmpro_email_template_body_editor();
+			if ( editor ) {
+				editor.setContent( template_data['body'] );
+			}
 			$('#pmpro_email_template_to').val(template_data['to']);
 			$('#pmpro_email_template_cc').val(template_data['cc']);
 			$('#pmpro_email_template_bcc').val(template_data['bcc']);
@@ -907,9 +965,10 @@ jQuery(document).ready(function ($) {
 	}
 
 	function pmpro_toggle_form_disabled(disabled) {
+		pmpro_set_email_template_body_disabled( disabled );
+
 		if (disabled == 'true') {
 			$("#pmpro_email_template_disable").prop('checked', true);
-			$("#pmpro_email_template_body").attr('readonly', 'readonly').attr('disabled', 'disabled');
 			$("#pmpro_email_template_subject").attr('readonly', 'readonly').attr('disabled', 'disabled');
 			$("#pmpro_email_template_to").attr('readonly', 'readonly').attr('disabled', 'disabled');
 			$("#pmpro_email_template_cc").attr('readonly', 'readonly').attr('disabled', 'disabled');
@@ -917,7 +976,6 @@ jQuery(document).ready(function ($) {
 		}
 		else {
 			$("#pmpro_email_template_disable").prop('checked', false);
-			$("#pmpro_email_template_body").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
 			$("#pmpro_email_template_subject").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
 			$("#pmpro_email_template_to").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
 			$("#pmpro_email_template_cc").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');

--- a/js/pmpro-liquid-autocomplete.js
+++ b/js/pmpro-liquid-autocomplete.js
@@ -1,0 +1,573 @@
+( function ( tinymce, document, window ) {
+	'use strict';
+
+	if ( ! tinymce ) {
+		return;
+	}
+
+	const CURSOR_MARKER = '__pmpro_cursor__';
+	const MENU_CLASS = 'pmpro-liquid-autocomplete';
+
+	tinymce.PluginManager.add(
+		'pmpro_liquid_autocomplete',
+		function ( editor ) {
+			const settings = normalizeSettings(
+				editor.getParam( 'pmpro_liquid_autocomplete', null )
+			);
+
+			if ( ! settings ) {
+				return;
+			}
+
+			let menu = null;
+			let items = [];
+			let activeIndex = -1;
+			let activeContext = null;
+			let markerIndex = 0;
+			const strings = settings.strings || {};
+
+			function handleResize() {
+				closeMenu();
+			}
+
+			function normalizeSettings( value ) {
+				if ( typeof value === 'string' ) {
+					try {
+						value = JSON.parse( value );
+					} catch ( error ) {
+						value = {};
+					}
+				}
+
+				return value && typeof value === 'object' ? value : null;
+			}
+
+			function ensureMenu() {
+				if ( menu ) {
+					return menu;
+				}
+
+				menu = document.createElement( 'div' );
+				menu.className = MENU_CLASS;
+				menu.setAttribute( 'role', 'listbox' );
+				menu.setAttribute( 'aria-label', 'Liquid autocomplete' );
+				menu.hidden = true;
+				document.body.appendChild( menu );
+
+				menu.addEventListener( 'mousedown', function ( event ) {
+					const itemNode = closest(
+						event.target,
+						'.pmpro-liquid-autocomplete__item'
+					);
+
+					if ( ! itemNode ) {
+						return;
+					}
+
+					event.preventDefault();
+					setActive(
+						parseInt( itemNode.getAttribute( 'data-index' ), 10 )
+					);
+					chooseActive();
+				} );
+
+				return menu;
+			}
+
+			function closest( node, selector ) {
+				while ( node && node !== document ) {
+					if ( node.matches && node.matches( selector ) ) {
+						return node;
+					}
+
+					node = node.parentNode;
+				}
+
+				return null;
+			}
+
+			function closeMenu() {
+				if ( menu ) {
+					menu.hidden = true;
+					menu.innerHTML = '';
+				}
+
+				items = [];
+				activeIndex = -1;
+				activeContext = null;
+			}
+
+			function isMenuOpen() {
+				return menu && ! menu.hidden;
+			}
+
+			function renderMenu( nextItems, context ) {
+				let firstSelectable = -1;
+				const container = ensureMenu();
+
+				items = nextItems;
+				activeContext = context;
+				container.innerHTML = '';
+
+				if ( ! items.length ) {
+					closeMenu();
+					return;
+				}
+
+				items.forEach( function ( item, index ) {
+					let itemNode;
+					let descriptionNode;
+
+					if ( item.type === 'separator' ) {
+						itemNode = document.createElement( 'div' );
+						itemNode.className =
+							'pmpro-liquid-autocomplete__separator';
+						itemNode.textContent = item.label;
+						container.appendChild( itemNode );
+						return;
+					}
+
+					if ( firstSelectable === -1 ) {
+						firstSelectable = index;
+					}
+
+					itemNode = document.createElement( 'button' );
+					itemNode.type = 'button';
+					itemNode.className = 'pmpro-liquid-autocomplete__item';
+					itemNode.setAttribute( 'role', 'option' );
+					itemNode.setAttribute( 'data-index', index );
+
+					const labelNode = document.createElement( 'span' );
+					labelNode.className = 'pmpro-liquid-autocomplete__label';
+					labelNode.textContent = item.label;
+					itemNode.appendChild( labelNode );
+
+					if ( item.description ) {
+						descriptionNode = document.createElement( 'span' );
+						descriptionNode.className =
+							'pmpro-liquid-autocomplete__description';
+						descriptionNode.textContent = item.description;
+						itemNode.appendChild( descriptionNode );
+					}
+
+					container.appendChild( itemNode );
+				} );
+
+				container.hidden = false;
+				positionMenu( context );
+				setActive( firstSelectable );
+			}
+
+			function setActive( index ) {
+				if ( ! items[ index ] || items[ index ].type === 'separator' ) {
+					return;
+				}
+
+				activeIndex = index;
+				const optionNodes = ensureMenu().querySelectorAll(
+					'.pmpro-liquid-autocomplete__item'
+				);
+
+				Array.prototype.forEach.call(
+					optionNodes,
+					function ( optionNode ) {
+						const isActive =
+							parseInt(
+								optionNode.getAttribute( 'data-index' ),
+								10
+							) === activeIndex;
+						optionNode.classList.toggle( 'is-active', isActive );
+						optionNode.setAttribute(
+							'aria-selected',
+							isActive ? 'true' : 'false'
+						);
+
+						if ( isActive ) {
+							optionNode.scrollIntoView( { block: 'nearest' } );
+						}
+					}
+				);
+			}
+
+			function moveActive( direction ) {
+				let nextIndex = activeIndex;
+				let checked = 0;
+
+				if ( ! items.length ) {
+					return;
+				}
+
+				do {
+					nextIndex += direction;
+
+					if ( nextIndex < 0 ) {
+						nextIndex = items.length - 1;
+					} else if ( nextIndex >= items.length ) {
+						nextIndex = 0;
+					}
+
+					checked++;
+				} while (
+					items[ nextIndex ].type === 'separator' &&
+					checked <= items.length
+				);
+
+				setActive( nextIndex );
+			}
+
+			function positionMenu() {
+				const caretRect = getCaretRect();
+				const iframe = editor.iframeElement;
+				const iframeRect = iframe
+					? iframe.getBoundingClientRect()
+					: { left: 0, top: 0 };
+				const viewportWidth =
+					window.innerWidth || document.documentElement.clientWidth;
+				const viewportHeight =
+					window.innerHeight || document.documentElement.clientHeight;
+				let left;
+				let top;
+
+				if ( ! caretRect ) {
+					return;
+				}
+
+				left = window.pageXOffset + iframeRect.left + caretRect.left;
+				top =
+					window.pageYOffset + iframeRect.top + caretRect.bottom + 6;
+
+				menu.style.left = left + 'px';
+				menu.style.top = top + 'px';
+
+				const rect = menu.getBoundingClientRect();
+
+				if ( rect.right > viewportWidth - 12 ) {
+					left = Math.max(
+						12,
+						window.pageXOffset + viewportWidth - rect.width - 12
+					);
+					menu.style.left = left + 'px';
+				}
+
+				if ( rect.bottom > viewportHeight - 12 ) {
+					top =
+						window.pageYOffset +
+						iframeRect.top +
+						caretRect.top -
+						rect.height -
+						6;
+					menu.style.top =
+						Math.max( window.pageYOffset + 12, top ) + 'px';
+				}
+			}
+
+			function getCaretRect() {
+				const range = editor.selection.getRng();
+				let rect = null;
+
+				if ( ! range ) {
+					return null;
+				}
+
+				if ( range.getClientRects ) {
+					rect =
+						range.getClientRects()[ 0 ] ||
+						range.getBoundingClientRect();
+				}
+
+				if (
+					rect &&
+					( rect.left || rect.top || rect.width || rect.height )
+				) {
+					return rect;
+				}
+
+				const clone = range.cloneRange();
+				const marker = editor.getDoc().createElement( 'span' );
+				marker.appendChild(
+					editor.getDoc().createTextNode( '\uFEFF' )
+				);
+				clone.insertNode( marker );
+				rect = marker.getBoundingClientRect();
+
+				if ( marker.parentNode ) {
+					marker.parentNode.removeChild( marker );
+				}
+
+				editor.selection.setRng( range );
+
+				return rect;
+			}
+
+			function getContext() {
+				const range = editor.selection.getRng();
+				let raw;
+				let pipeOffset;
+
+				if (
+					! range ||
+					! range.collapsed ||
+					! range.startContainer ||
+					range.startContainer.nodeType !== 3
+				) {
+					return null;
+				}
+
+				const node = range.startContainer;
+				const offset = range.startOffset;
+				const before = node.data.slice( 0, offset );
+				const lastVariableOpen = before.lastIndexOf( '{{' );
+				const lastTagOpen = before.lastIndexOf( '{%' );
+				const lastTagClose = before.lastIndexOf( '%}' );
+
+				if (
+					lastTagOpen > lastTagClose &&
+					lastTagOpen >= lastVariableOpen
+				) {
+					raw = before.slice( lastTagOpen + 2 );
+
+					if ( raw.indexOf( '%}' ) !== -1 ) {
+						return null;
+					}
+
+					return {
+						type: 'tag',
+						query: cleanQuery( raw ),
+						node,
+						start: lastTagOpen,
+						end: offset,
+					};
+				}
+
+				const lastVariableClose = before.lastIndexOf( '}}' );
+
+				if (
+					lastVariableOpen > lastVariableClose &&
+					lastVariableOpen >= lastTagOpen
+				) {
+					raw = before.slice( lastVariableOpen + 2 );
+					pipeOffset = raw.lastIndexOf( '|' );
+
+					if ( raw.indexOf( '}}' ) !== -1 ) {
+						return null;
+					}
+
+					if ( pipeOffset !== -1 ) {
+						return {
+							type: 'filter',
+							query: cleanQuery( raw.slice( pipeOffset + 1 ) ),
+							node,
+							start: lastVariableOpen + 2 + pipeOffset,
+							end: offset,
+						};
+					}
+
+					return {
+						type: 'variable',
+						query: cleanQuery( raw ),
+						node,
+						start: lastVariableOpen,
+						end: offset,
+					};
+				}
+
+				if (
+					before.charAt( before.length - 1 ) === '{' &&
+					before.charAt( before.length - 2 ) !== '{'
+				) {
+					return {
+						type: 'initial',
+						query: '',
+						node,
+						start: offset - 1,
+						end: offset,
+					};
+				}
+
+				return null;
+			}
+
+			function cleanQuery( value ) {
+				return value.replace( /^\s+/, '' ).toLowerCase();
+			}
+
+			function getSuggestions( context ) {
+				if ( context.type === 'initial' ) {
+					return suggestVariables( '' )
+						.concat( [
+							{
+								type: 'separator',
+								label:
+									strings.liquidTagsHeader || 'Liquid Tags',
+							},
+						] )
+						.concat( suggestTags( '' ) );
+				}
+
+				if ( context.type === 'variable' ) {
+					return suggestVariables( context.query );
+				}
+
+				if ( context.type === 'tag' ) {
+					return suggestTags( context.query );
+				}
+
+				if ( context.type === 'filter' ) {
+					return suggestFilters( context.query );
+				}
+
+				return [];
+			}
+
+			function suggestVariables( query ) {
+				return filterItems( settings.variables || [], query );
+			}
+
+			function suggestTags( query ) {
+				return filterItems( settings.tags || [], query );
+			}
+
+			function suggestFilters( query ) {
+				return filterItems( settings.filters || [], query );
+			}
+
+			function filterItems( sourceItems, query ) {
+				return sourceItems
+					.filter( function ( item ) {
+						return (
+							! query ||
+							item.name.toLowerCase().indexOf( query ) !== -1
+						);
+					} )
+					.slice( 0, 100 )
+					.map( function ( item ) {
+						return {
+							type: 'item',
+							label: item.label || item.name,
+							description: item.description || '',
+							insert: item.insert || item.label || item.name,
+						};
+					} );
+			}
+
+			function updateMenu() {
+				const context = getContext();
+
+				if ( ! context ) {
+					closeMenu();
+					return;
+				}
+
+				const nextItems = getSuggestions( context );
+				renderMenu( nextItems, context );
+			}
+
+			function chooseActive() {
+				const item = items[ activeIndex ];
+
+				if ( ! item || item.type === 'separator' || ! activeContext ) {
+					return;
+				}
+
+				editor.focus();
+				editor.undoManager.transact( function () {
+					replaceContextWith( activeContext, item.insert );
+				} );
+				closeMenu();
+			}
+
+			function replaceContextWith( context, insert ) {
+				const range = editor.getDoc().createRange();
+				const markerId =
+					'pmpro-liquid-autocomplete-cursor-' + ++markerIndex;
+				const markerHtml =
+					'<span id="' +
+					markerId +
+					'" data-mce-type="bookmark"></span>';
+				let markerNode;
+
+				range.setStart( context.node, context.start );
+				range.setEnd( context.node, context.end );
+				editor.selection.setRng( range );
+
+				if ( insert.indexOf( CURSOR_MARKER ) !== -1 ) {
+					editor.insertContent(
+						insert.replace( CURSOR_MARKER, markerHtml )
+					);
+					markerNode = editor.dom.get( markerId );
+
+					if ( markerNode ) {
+						editor.selection.select( markerNode );
+						editor.selection.collapse( true );
+						editor.dom.remove( markerNode );
+					}
+				} else {
+					editor.insertContent( insert );
+				}
+			}
+
+			function shouldIgnoreKeyup( event ) {
+				return (
+					event.keyCode === 13 ||
+					event.keyCode === 27 ||
+					event.keyCode === 38 ||
+					event.keyCode === 40 ||
+					event.keyCode === 9
+				);
+			}
+
+			editor.on( 'keyup', function ( event ) {
+				if ( shouldIgnoreKeyup( event ) ) {
+					return;
+				}
+
+				updateMenu();
+			} );
+
+			editor.on(
+				'keydown',
+				function ( event ) {
+					if ( ! isMenuOpen() ) {
+						return;
+					}
+
+					if ( event.keyCode === 27 ) {
+						event.preventDefault();
+						event.stopPropagation();
+						closeMenu();
+					} else if ( event.keyCode === 38 ) {
+						event.preventDefault();
+						event.stopPropagation();
+						moveActive( -1 );
+					} else if ( event.keyCode === 40 ) {
+						event.preventDefault();
+						event.stopPropagation();
+						moveActive( 1 );
+					} else if ( event.keyCode === 13 || event.keyCode === 9 ) {
+						event.preventDefault();
+						event.stopPropagation();
+						chooseActive();
+					}
+				},
+				true
+			);
+
+			editor.on( 'click blur hide', closeMenu );
+			editor.on( 'ScrollContent ResizeEditor', function () {
+				if ( isMenuOpen() && activeContext ) {
+					positionMenu( activeContext );
+				}
+			} );
+			editor.on( 'remove', function () {
+				closeMenu();
+				window.removeEventListener( 'resize', handleResize );
+
+				if ( menu && menu.parentNode ) {
+					menu.parentNode.removeChild( menu );
+				}
+			} );
+
+			window.addEventListener( 'resize', handleResize );
+		}
+	);
+} )( window.tinymce, document, window );

--- a/js/pmpro-liquid-autocomplete.js
+++ b/js/pmpro-liquid-autocomplete.js
@@ -50,7 +50,10 @@
 				menu = document.createElement( 'div' );
 				menu.className = MENU_CLASS;
 				menu.setAttribute( 'role', 'listbox' );
-				menu.setAttribute( 'aria-label', 'Liquid autocomplete' );
+				menu.setAttribute(
+					'aria-label',
+					strings.autocompleteLabel || 'Liquid autocomplete'
+				);
 				menu.hidden = true;
 				document.body.appendChild( menu );
 
@@ -353,11 +356,20 @@
 					}
 
 					if ( pipeOffset !== -1 ) {
+						let start = lastVariableOpen + 2 + pipeOffset;
+
+						while (
+							start > lastVariableOpen + 2 &&
+							/\s/.test( before.charAt( start - 1 ) )
+						) {
+							start--;
+						}
+
 						return {
 							type: 'filter',
 							query: cleanQuery( raw.slice( pipeOffset + 1 ) ),
 							node,
-							start: lastVariableOpen + 2 + pipeOffset,
+							start,
 							end: offset,
 						};
 					}


### PR DESCRIPTION
## Summary
- Replaces #3663 with a `wp_editor()`-based email template editor instead of adding TinyMCE 8.
- Adds a reusable Liquid autocomplete TinyMCE plugin for PMPro email templates.
- Adds Liquid autocomplete settings helpers and scoped TinyMCE plugin registration.
- Keeps the email template disable/read-only behavior working with Visual/Text editor modes.
- Updates the Liquid renderer to recognize HTML-entity comparison operators from HTML-serialized editor content.

## Notes
This keeps PMPro on WordPress' built-in editor stack while preserving the Liquid variable/tag/filter autocomplete behavior that was needed from #3663.

## Testing
- `php -l adminpages/emailtemplates-edit.php`
- `php -l classes/class-pmpro-liquid-renderer.php`
- `php -l includes/functions.php`
- `php -l includes/scripts.php`
- `node --check js/pmpro-admin.js`
- `node --check js/pmpro-liquid-autocomplete.js`
- `npx wp-scripts lint-js js/pmpro-liquid-autocomplete.js`
- Direct renderer checks for literal and encoded `<`, `>`, `<=`, `>=` comparison operators.
- Manual/Playwright retest confirmed autocomplete, save/reload, disable/re-enable, and rendered comparison behavior.
