### PR TITLE
Fix orders list on mobile

### DIFF
--- a/classes/class-pmpro-orders-list-table.php
+++ b/classes/class-pmpro-orders-list-table.php
@@ -236,6 +236,23 @@ class PMPro_Orders_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Gets the name of the default primary column.
+	 *
+	 * @since TBD
+	 *
+	 * @return string Name of the default primary column.
+	 */
+	protected function get_default_primary_column_name() {
+		$columns = $this->get_columns();
+
+		if ( isset( $columns['order_code'] ) ) {
+			return 'order_code';
+		}
+
+		return parent::get_default_primary_column_name();
+	}
+
+	/**
 	 * Text displayed when no user data is available
 	 *
 	 * @since 2.11


### PR DESCRIPTION
The Orders list table used `order_id` as its default primary column, but that column is hidden by default. On mobile, WordPress only shows the primary column until a row is expanded, so rows could appear blank.

This sets `order_code` as the default primary column so order rows have visible content and the expand control on small screens.

Testing:
- `php -l classes/class-pmpro-orders-list-table.php`
- `git diff --check`