### PR TITLE
Remove misleading Advanced Settings hints from no access message controls

### DIFF
--- a/blocks/src/component-content-visibility/content-visibility-controls.js
+++ b/blocks/src/component-content-visibility/content-visibility-controls.js
@@ -124,7 +124,6 @@ export default function ContentVisibilityControls (props) {
 								__nextHasNoMarginBottom
 								value={show_noaccess}
 								label={ __( 'Show No Access Message?', 'paid-memberships-pro' ) }
-								help={ __ ( "Modify the 'no access' message on the Memberships > Advanced Settings page.", "paid-memberships-pro" ) }
 								options={[
 									{ label: __( 'No - Hide this block if the user does not have access', 'paid-memberships-pro' ), value: '0' },
 									{ label: __( "Yes - Show the 'no access' message if the user does not have access", 'paid-memberships-pro' ), value: '1' },

--- a/js/pmpro-divi-5.js
+++ b/js/pmpro-divi-5.js
@@ -313,20 +313,11 @@
 			// No access message only applies to positive access requirements.
 			currentRule === 'hasMembership' ? wrapField(
 				__( 'No Access Message', 'paid-memberships-pro' ),
-				createElement(
-					Fragment,
-					null,
-					renderSelect(
-						'pmpro-show-no-access',
-						settings.showNoAccessMessage || 'off',
-						yesNoOptions,
-						function ( val ) { update( { showNoAccessMessage: val } ); }
-					),
-					createElement(
-						'p',
-						{ className: 'et-vb-field-description', style: { marginTop: '4px' } },
-						__( "Modify the 'no access' message on the Memberships > Advanced Settings page.", 'paid-memberships-pro' )
-					)
+				renderSelect(
+					'pmpro-show-no-access',
+					settings.showNoAccessMessage || 'off',
+					yesNoOptions,
+					function ( val ) { update( { showNoAccessMessage: val } ); }
 				)
 			) : null
 		);


### PR DESCRIPTION
## Summary

- Removes the description text under the **No Access Message** dropdown in the Divi 5 Visual Builder PMPro condition settings panel.
- Removes the same misleading helper text from the block editor **Content Visibility** controls.
- The hint read: _"Modify the 'no access' message on the Memberships > Advanced Settings page."_ — but that's only true for sites with a saved legacy `pmpro_nonmembertext` option. For everyone else, the Advanced Settings page has no such field to point them to.
- The custom message field on Advanced Settings is also explicitly labeled "Legacy" and described as slated for removal in a future version, so directing new users there is doubly misleading.

## Notes

- Block build artifacts are generated during the release process and are not updated in this PR.

## Test plan

- [ ] In the Divi 5 Visual Builder, open a module's Display Conditions and add a PMPro **Membership Access** condition.
- [ ] Set Condition = "User has required access" — confirm the **No Access Message** dropdown still renders with its two options ("Hide restricted content" / "Replace restricted content with the no access message").
- [ ] Confirm the helper text under the Divi 5 dropdown is gone.
- [ ] Confirm the inverse Divi 5 rule ("User does not have required access") still hides the No Access Message field as before.
- [ ] In the block editor, select a block and enable **Content Visibility**.
- [ ] With the visibility mode set to **Show**, confirm **Show No Access Message?** still renders with its two options and the helper text is gone.
- [ ] Switch the visibility mode to **Hide** and confirm the **Show No Access Message?** field remains hidden as before.