### PR TITLE
Liquid autocomplete: Change button options to divs. The aria-selected attr dynamically changes via arrow keys

### DIFF
--- a/js/pmpro-liquid-autocomplete.js
+++ b/js/pmpro-liquid-autocomplete.js
@@ -93,6 +93,7 @@
 				if ( menu ) {
 					menu.hidden = true;
 					menu.innerHTML = '';
+					menu.removeAttribute( 'aria-activedescendant' );
 				}
 
 				items = [];
@@ -134,11 +135,11 @@
 						firstSelectable = index;
 					}
 
-					itemNode = document.createElement( 'button' );
-					itemNode.type = 'button';
+					itemNode = document.createElement( 'div' );
 					itemNode.className = 'pmpro-liquid-autocomplete__item';
 					itemNode.setAttribute( 'role', 'option' );
 					itemNode.setAttribute( 'data-index', index );
+					itemNode.setAttribute( 'id', 'pmpro-liquid-autocomplete-option-' + index );
 
 					const labelNode = document.createElement( 'span' );
 					labelNode.className = 'pmpro-liquid-autocomplete__label';
@@ -189,6 +190,11 @@
 							optionNode.scrollIntoView( { block: 'nearest' } );
 						}
 					}
+				);
+
+				ensureMenu().setAttribute(
+					'aria-activedescendant',
+					'pmpro-liquid-autocomplete-option-' + activeIndex
 				);
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Changes the options in the autocomplete `listbox` from button elements to divs. This is semantically correct.
- Adds `aria-activedescendant` to the `listbox` so it can dynamically update the `aria-selected` attribute as you navigate through the menu with arrow keys.

**Demo video of how it should look in the browser inspector:** https://www.awesomescreenshot.com/video/53498343?key=2a552ea9485df9bc2a4e271456c46b55

### How to test the changes in this Pull Request:

1. Go to **Memberships** > **Settings** > **Email Templates** > Any template you want to edit
3. Open your browser inspector. You should see the autocomplete `listbox` for liquid before the closing `</body>` tag. It might not be there on first page load. Go to the "Body" TinyMCE field and type a left curly brace to trigger it to appear. You should see it in the browser inspector. `<div class="pmpro-liquid-autocomplete" role="listbox" aria-label="Liquid autocomplete" style="left: 443.875px; top: 1476.8px;" hidden=""></div>`
4. I recommend using your keyboard/tab key to navigate the page so you can get a more authentic experience.
5. The focus/cursor should remain in the editor. Use your arrow keys to navigate the listbox and you should see the `aria-activedescendant` attribute on the listbox change dynamically between option indexes. `<div class="pmpro-liquid-autocomplete" role="listbox" aria-label="Liquid autocomplete" style="left: 450.766px; top: 1476.8px;" aria-activedescendant="pmpro-liquid-autocomplete-option-0">`

<img width="732" height="693" alt="image" src="https://github.com/user-attachments/assets/f9864899-b849-4c54-a8b8-78edc87b210e" />

If you're testing w/ Voice Over or NVDA to see how screen readers announce the listbox, that doesn't currently work. That fix will be on a separate branch/PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changed the liquid autocomplete options from `button` elements to `div` elements. Fixed the `aria-selected` attribute that wasn't changing dynamically when navigating via keyboard.
