### PR TITLE
Stripe: Clear stale card info when a recovered payment uses a non-card payment method

### DIFF
--- a/services/class-pmpro-stripe-webhook-handler.php
+++ b/services/class-pmpro-stripe-webhook-handler.php
@@ -1066,9 +1066,19 @@ class PMPro_Stripe_Webhook_Handler {
 				$order_data['accountnumber'] = hideCardNumber( $payment_method->card->last4 );
 				$order_data['expirationmonth'] = $payment_method->card->exp_month;
 				$order_data['expirationyear'] = $payment_method->card->exp_year;
+			} else {
+				// Not a card. Clear card fields in case the order being updated has card info from a previous payment attempt.
+				$order_data['cardtype'] = '';
+				$order_data['accountnumber'] = '';
+				$order_data['expirationmonth'] = '';
+				$order_data['expirationyear'] = '';
 			}
 		} else {
 			$order_data['payment_type'] = 'Stripe';
+			$order_data['cardtype'] = '';
+			$order_data['accountnumber'] = '';
+			$order_data['expirationmonth'] = '';
+			$order_data['expirationyear'] = '';
 		}
 
 		// Set the billing address.


### PR DESCRIPTION
## Issue

When a `charge.failed` webhook is received, we create a pending order using the failed payment method's card info (intentional — the billing failure email tells the member which card failed).

However, when the member then pays the invoice with a payment method that has no card details — Link, bank debit, Cash App, etc. — the `invoice.payment_succeeded` webhook never set the card fields in `get_order_data_from_invoice()`. Since the gateway request handlers only update order properties for keys present in `$order_data`, the declined card's brand, last 4, and expiration survived onto the now-successful order. The result was an order with `payment_type = "Stripe - link"` showing the declined card's details in the admin order view, orders list, frontend invoice page, and invoice email.

Note that for PaymentMethods of type `link`, Stripe exposes no card details at all, so any last 4 shown for a Link payment was guaranteed to be stale data from an earlier card attempt.

## Fix

`get_order_data_from_invoice()` now always sets `cardtype`, `accountnumber`, `expirationmonth`, and `expirationyear`:
- Populated from the card when the payment method has one (unchanged).
- Cleared to `''` when the payment method has no card details, or when no payment method can be found.

This matches the existing behavior of `populate_order_from_payment()`, which already clears these fields for checkout session events.

All display locations (admin order view, orders list table, invoice page, email templates) are gated on `accountnumber` being non-empty, so clearing the field cleans up the displays with no template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)