### PR TITLE
Prevent select fields from overflowing the viewport on small screens

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -273,6 +273,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--pmpro--base--spacing--medium);
+		min-width: 0;
 	}
 
 	.pmpro_form_fields-inline {
@@ -286,6 +287,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: calc( var(--pmpro--base--spacing--small) / 2 );
+		min-width: 0;
 	}
 
 	.pmpro_form_label {
@@ -328,6 +330,12 @@
 		background-repeat: no-repeat;
 		background-size: 16px 16px;
 		padding-right: calc(var(--pmpro--base--spacing--small) + 20px);
+	}
+
+	.pmpro_form_input-select,
+	.pmpro_form_input-multiselect {
+		max-width: 100%;
+		width: 100%;
 	}
 
 	.pmpro_form_input-text:focus,

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -273,6 +273,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--pmpro--base--spacing--medium);
+		min-width: 0;
 	}
 
 	.pmpro_form_fields-inline {
@@ -286,6 +287,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: calc( var(--pmpro--base--spacing--small) / 2 );
+		min-width: 0;
 	}
 
 	.pmpro_form_label {
@@ -328,6 +330,12 @@
 		background-repeat: no-repeat;
 		background-size: 16px 16px;
 		padding-right: calc(var(--pmpro--base--spacing--small) + 20px);
+	}
+
+	.pmpro_form_input-select,
+	.pmpro_form_input-multiselect {
+		max-width: 100%;
+		width: 100%;
 	}
 
 	.pmpro_form_input-text:focus,


### PR DESCRIPTION
## Problem

On small screens, `<select>` fields could break out of the viewport on the frontend checkout/forms. A `<select>` sizes itself to its widest `<option>`, so long values — most noticeably the state/province names added by the **State Dropdowns Add On** — made the select very wide. Because the form fields are laid out with flexbox (`.pmpro_form_fields` / `.pmpro_form_field` are `display: flex; flex-direction: column`), the flex default of `min-width: auto` prevented the column from shrinking below its content, pushing the whole layout past the edge of the screen.

## Fix

- Add `min-width: 0` to `.pmpro_form_fields` and `.pmpro_form_field` so the flex columns can shrink below their content's intrinsic width.
- Constrain `.pmpro_form_input-select` and `.pmpro_form_input-multiselect` to `width: 100%; max-width: 100%` so selects respect their container instead of their longest option.

Applied to both frontend style variations (`variation_1.css` and `variation_high_contrast.css`).

## Notes

- Scoped by class, so the `.pmpro_form_field-date select` carve-out in `base.css` and native `type="date"` inputs are unaffected.
- Credit card expiration dropdowns (`#ExpirationMonth` / `#ExpirationYear`) carry `pmpro_form_input-select` and already use `flex-grow: 1`; with the new `width: 100%` they still resolve to the same 50/50 split (no visual change).
- Text/email/number inputs were never affected — they already render full-width via `align-items: stretch` on the flex column.

## Testing

Verified on the checkout page at mobile widths with the State Dropdowns Add On active — the state `<select>` now stays within the card instead of overflowing the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)