### PR TITLE
Add Elementor v4 (atomic widgets) support to content restriction

### DIFF
--- a/includes/compatibility/elementor.php
+++ b/includes/compatibility/elementor.php
@@ -80,17 +80,47 @@ function pmpro_elementor_is_dynamic_content( $is_dynamic_content, $element_raw_d
 	}
 
 	// If we detect that PMPro enabled option is set, let's make it dynamic content.
-	if ( isset( $element_raw_data['settings']['pmpro_enable'] ) && $element_raw_data['settings']['pmpro_enable'] ) {
-		return true;
+	if ( isset( $element_raw_data['settings']['pmpro_enable'] ) ) {
+		$pmpro_enable = $element_raw_data['settings']['pmpro_enable'];
+		if ( is_array( $pmpro_enable ) && isset( $pmpro_enable['$$type'] ) && array_key_exists( 'value', $pmpro_enable ) ) {
+			$pmpro_enable = $pmpro_enable['value'];
+		}
+
+		if ( ! empty( $pmpro_enable ) && 'no' !== $pmpro_enable ) {
+			return true;
+		}
+	}
+
+	if ( ! empty( $element_raw_data['settings'] ) ) {
+		$settings_to_check = array_values( $element_raw_data['settings'] );
+		while ( ! empty( $settings_to_check ) ) {
+			$setting = array_pop( $settings_to_check );
+			if ( is_array( $setting ) && isset( $setting['$$type'] ) && array_key_exists( 'value', $setting ) ) {
+				$setting = $setting['value'];
+			}
+
+			// Look for an embedded PMPro shortcode (e.g. [pmpro_member], [pmpro_account]) so the element
+			// isn't statically cached. We match the shortcode opener specifically rather than any "pmpro"
+			// substring, so that an unrelated CSS class or URL containing "pmpro" doesn't needlessly
+			// disable caching. Restriction settings themselves are already handled by the pmpro_enable
+			// check above.
+			if ( is_string( $setting ) && str_contains( $setting, '[pmpro' ) ) {
+				return true;
+			}
+
+			if ( is_array( $setting ) ) {
+				$settings_to_check = array_merge( $settings_to_check, array_values( $setting ) );
+			}
+		}
 	}
 
 	// Check Elementor text editor for 'pmpro' string.
-	if ( ! empty( $element_raw_data['settings']['editor'] ) && str_contains( $element_raw_data['settings']['editor'], 'pmpro' ) ) {
+	if ( ! empty( $element_raw_data['settings']['editor'] ) && is_string( $element_raw_data['settings']['editor'] ) && str_contains( $element_raw_data['settings']['editor'], 'pmpro' ) ) {
 		return true;
 	}
 
 	// Check if Elementor shortcode widget has a PMPro shortcode.
-	if ( ! empty( $element_raw_data['settings']['shortcode'] ) && str_contains( $element_raw_data['settings']['shortcode'], 'pmpro' ) ) {
+	if ( ! empty( $element_raw_data['settings']['shortcode'] ) && is_string( $element_raw_data['settings']['shortcode'] ) && str_contains( $element_raw_data['settings']['shortcode'], 'pmpro' ) ) {
 		return true;
 	}
 

--- a/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
@@ -164,6 +164,12 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 			return $schema;
 		}
 
+		// Elementor v4 dependency semantics: a control with an `effect => 'hide'` dependency is HIDDEN
+		// when its where-condition is NOT met, and shown when it IS met. In other words, each `where`
+		// below describes the condition under which the dependent field should be VISIBLE. (Verified
+		// against Elementor's editor logic; its own widgets use the same pattern, e.g. a video's
+		// "playsinline" is shown only when "autoplay" is true.) Do not invert these — reading them as
+		// "hide when the condition is true" is backwards.
 		$enabled_dependency = Atomic_Dependency_Manager::make()
 			->where(
 				array(
@@ -301,7 +307,7 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 					)
 				),
 			Chips_Control::bind_to( 'pmpro_levels' )
-				->set_label( __( 'Membership Levels', 'paid-memberships-pro' ) )
+				->set_label( esc_html__( 'Membership Levels', 'paid-memberships-pro' ) )
 				->set_options( $level_options ),
 		);
 
@@ -309,7 +315,7 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 			->set_label( esc_html__( 'Show no access message', 'paid-memberships-pro' ) );
 
 		$controls[] = Section::make()
-			->set_label( __( 'Paid Memberships Pro', 'paid-memberships-pro' ) )
+			->set_label( esc_html__( 'Paid Memberships Pro', 'paid-memberships-pro' ) )
 			->set_id( $this->section_name )
 			->set_items( $items );
 
@@ -405,7 +411,18 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 	 * @param object $element The Elementor element being rendered.
 	 */
 	public function pmpro_elementor_before_render( $element ) {
-		if ( \Elementor\Plugin::$instance->editor->is_edit_mode() || 'widget' === $element->get_type() ) {
+		if ( \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
+			return;
+		}
+
+		// Scope this no-access-message swap to the element types that can actually carry a PMPro
+		// restriction: classic sections/containers and the supported atomic container types. Everything
+		// else — widgets (handled via pmpro_elementor_render_content()), columns, atomic structural
+		// sub-elements, etc. — is skipped here so we don't resolve settings for every element on the page.
+		// Note classic sections/containers are included, which is what lets a classic container with a
+		// "no access message" enabled show that message via this buffer swap.
+		$element_type = method_exists( $element, 'get_type' ) ? $element->get_type() : '';
+		if ( ! in_array( $element_type, array_merge( array( 'section', 'container' ), $this->get_atomic_container_types() ), true ) ) {
 			return;
 		}
 
@@ -472,8 +489,13 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 		// If something else has already decided not to render this element — another should_render
 		// filter (e.g. a display-condition plugin) or Elementor's own empty-content check — respect that.
 		// Discard any no-access message we buffered in pmpro_elementor_before_render() so it is not echoed
-		// in place of an element that is supposed to be gone, and let the buffer close balanced. We run
-		// late (priority 9999) so other plugins' decisions are visible here; note this is a strong
+		// in place of an element that is supposed to be gone, and let the buffer close balanced.
+		//
+		// This is reachable, not dead code: Elementor fires the `elementor/frontend/before_render` action
+		// (where we buffer the message) BEFORE the `{type}/should_render` filter we are in now — see
+		// Element_Base::print_element() (before_render at line ~492, should_render at line ~531). So when
+		// this runs, $this->no_access_messages may already hold a message for this element. We register
+		// late (priority 9999) so other plugins' decisions are visible here; that makes this a strong
 		// mitigation rather than a guarantee, since a filter hooked even later could still win.
 		if ( false === $should_render ) {
 			$element_id = $element->get_id();

--- a/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
+++ b/includes/compatibility/elementor/class-pmpro-elementor-content-restriction.php
@@ -3,16 +3,51 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 use Elementor\Controls_Manager;
+use Elementor\Modules\AtomicWidgets\Controls\Section;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Chips_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Select_Control;
+use Elementor\Modules\AtomicWidgets\Controls\Types\Switch_Control;
+use Elementor\Modules\AtomicWidgets\PropDependencies\Manager as Atomic_Dependency_Manager;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\Boolean_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Array_Prop_Type;
+use Elementor\Modules\AtomicWidgets\PropTypes\Primitives\String_Prop_Type;
 
 class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
+	private $no_access_messages = array();
+
+	/**
+	 * Cached list of supported atomic container element types, resolved once per request.
+	 *
+	 * @var array|null
+	 */
+	private $atomic_container_types = null;
+
 	protected function content_restriction() {
 		// Setup controls
 		$this->register_controls();
+		add_filter( 'elementor/atomic-widgets/props-schema', array( $this, 'add_atomic_props_schema' ) );
+		add_filter( 'elementor/atomic-widgets/controls', array( $this, 'add_atomic_controls' ), 10, 2 );
 
 		// Filter elementor render_content hook
 		add_action( 'elementor/widget/render_content', array( $this, 'pmpro_elementor_render_content' ), 10, 2 );
-		add_action( 'elementor/frontend/section/should_render', array( $this, 'pmpro_elementor_should_render' ), 10, 2 );
-		add_action( 'elementor/frontend/container/should_render', array( $this, 'pmpro_elementor_should_render' ), 10, 2 );
+		// Run our should_render checks late (priority 9999) so they can see decisions made by other
+		// should_render filters (e.g. display-condition plugins). This lets pmpro_elementor_should_render()
+		// stand down — and discard any buffered no-access message — when something else has already
+		// hidden the element.
+		add_action( 'elementor/frontend/section/should_render', array( $this, 'pmpro_elementor_should_render' ), 9999, 2 );
+		add_action( 'elementor/frontend/container/should_render', array( $this, 'pmpro_elementor_should_render' ), 9999, 2 );
+		add_action( 'elementor/frontend/before_render', array( $this, 'pmpro_elementor_before_render' ), 0 );
+		add_action( 'elementor/frontend/after_render', array( $this, 'pmpro_elementor_after_render' ), PHP_INT_MAX );
+
+		// Register the should_render filter for each supported Elementor v4 (atomic) container type.
+		// The same list gates which elements display the restriction controls (see add_atomic_controls()),
+		// keeping the editor UI and the frontend enforcement in sync. Note this list is read once here at
+		// setup time, so the pmpro_elementor_atomic_element_types filter must be added early (by the time
+		// this runs on plugins_loaded) for a custom type to get both its controls and its enforcement.
+		// Atomic widgets are handled separately via the render_content filter above, so they are not listed here.
+		foreach ( $this->get_atomic_container_types() as $element_type ) {
+			add_filter( 'elementor/frontend/' . $element_type . '/should_render', array( $this, 'pmpro_elementor_should_render' ), 9999, 2 );
+		}
 
 		// Migrate settings from old restriction method (pmpro_require_membership) to new method (pmpro_enable).
 		add_action( 'wp', array( $this, 'migrate_settings' ) ); // Migrate on frontend (also runs when editing but too late).
@@ -25,6 +60,260 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 		foreach( $this->locations as $where ) {
             add_action('elementor/element/'.$where['element'].'/'.$this->section_name.'/before_section_end', array( $this, 'add_controls' ), 10, 2 );
 		}
+	}
+
+	/**
+	 * Get the Elementor v4 (atomic) container element types that support PMPro content restriction.
+	 *
+	 * This single list drives both the frontend should_render enforcement (see content_restriction())
+	 * and the editor restriction controls (see add_atomic_controls()), keeping the two in sync so we
+	 * never display a restriction toggle for a container that wouldn't actually be enforced.
+	 *
+	 * Structural sub-elements (individual tabs, tab menus, tab content areas, form success/error
+	 * messages, etc.) are intentionally excluded: hiding them in isolation breaks their parent widget.
+	 * Atomic widgets are handled via the render_content filter and are not included here.
+	 *
+	 * @since TBD
+	 *
+	 * @return array Array of atomic container element type names.
+	 */
+	private function get_atomic_container_types() {
+		// Resolve once and cache for the rest of the request. The first call happens at setup time in
+		// content_restriction() (where the should_render hooks are registered), and add_atomic_controls()
+		// reuses that same snapshot. This guarantees the editor UI and the frontend enforcement always
+		// use an identical list, even if the pmpro_elementor_atomic_element_types filter is changed later.
+		if ( null === $this->atomic_container_types ) {
+			$this->atomic_container_types = apply_filters(
+				'pmpro_elementor_atomic_element_types',
+				array( 'e-div-block', 'e-flexbox', 'e-tabs', 'e-form' )
+			);
+		}
+
+		return $this->atomic_container_types;
+	}
+
+	/**
+	 * Whether the Elementor v4 (atomic widgets) APIs this integration relies on are available.
+	 *
+	 * Both add_atomic_props_schema() (which registers the settings) and add_atomic_controls() (which
+	 * renders the editor UI for those settings) are gated on this single check so that the prop-type
+	 * classes and the control classes are always verified together. If only one set were present we
+	 * could end up binding controls to props that were never registered.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True if all required Elementor v4 classes exist.
+	 */
+	private function atomic_widgets_available() {
+		return class_exists( Boolean_Prop_Type::class )
+			&& class_exists( String_Prop_Type::class )
+			&& class_exists( String_Array_Prop_Type::class )
+			&& class_exists( Atomic_Dependency_Manager::class )
+			&& class_exists( Section::class )
+			&& class_exists( Switch_Control::class )
+			&& class_exists( Select_Control::class )
+			&& class_exists( Chips_Control::class );
+	}
+
+	/**
+	 * Build the pmpro_apply_block_visibility() parameters from an element's resolved settings.
+	 *
+	 * Centralizes the normalization so the should_render, before_render, and render_content paths
+	 * always agree (they previously each built this array by hand and could drift). Two intentional
+	 * rules live here:
+	 *
+	 * - Membership levels are only forwarded for the "specific" audience. This prevents a stale
+	 *   pmpro_levels value (e.g. chosen under "Specific Membership Levels" and then left behind after
+	 *   switching the audience back to "All Members", where the field is hidden but the value is kept)
+	 *   from being treated as a legacy specific-level restriction by pmpro_apply_block_visibility().
+	 * - The "no access" message only applies when showing content to members, never when hiding
+	 *   content from them, so show_noaccess is forced off whenever the rule is inverted.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $settings The element's resolved settings (atomic get_atomic_settings() or classic get_active_settings()).
+	 * @return array Parameters for pmpro_apply_block_visibility().
+	 */
+	private function build_visibility_params( $settings ) {
+		$segment = ! empty( $settings['pmpro_segment'] ) ? $settings['pmpro_segment'] : 'all';
+		$invert_restrictions = ! empty( $settings['pmpro_invert_restrictions'] ) ? filter_var( $settings['pmpro_invert_restrictions'], FILTER_VALIDATE_BOOLEAN ) : false;
+		$show_noaccess = ! empty( $settings['pmpro_show_noaccess'] ) ? filter_var( $settings['pmpro_show_noaccess'], FILTER_VALIDATE_BOOLEAN ) : false;
+
+		return array(
+			'segment'             => $segment,
+			'levels'              => ( 'specific' === $segment && ! empty( $settings['pmpro_levels'] ) ) ? array_map( 'strval', (array) $settings['pmpro_levels'] ) : array(),
+			'invert_restrictions' => $invert_restrictions,
+			'show_noaccess'       => $show_noaccess && ! $invert_restrictions,
+		);
+	}
+
+	/**
+	 * Add PMPro props to Elementor v4 atomic element schemas.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $schema The atomic element props schema.
+	 * @return array
+	 */
+	public function add_atomic_props_schema( $schema ) {
+		if ( ! $this->atomic_widgets_available() ) {
+			return $schema;
+		}
+
+		if ( isset( $schema['pmpro_enable'] ) ) {
+			return $schema;
+		}
+
+		$enabled_dependency = Atomic_Dependency_Manager::make()
+			->where(
+				array(
+					'operator' => 'eq',
+					'path'     => array( 'pmpro_enable' ),
+					'value'    => true,
+					'effect'   => 'hide',
+				)
+			)
+			->get();
+
+		$specific_levels_dependency = Atomic_Dependency_Manager::make( Atomic_Dependency_Manager::RELATION_AND )
+			->where(
+				array(
+					'operator' => 'eq',
+					'path'     => array( 'pmpro_enable' ),
+					'value'    => true,
+					'effect'   => 'hide',
+				)
+			)
+			->where(
+				array(
+					'operator' => 'eq',
+					'path'     => array( 'pmpro_segment' ),
+					'value'    => 'specific',
+					'effect'   => 'hide',
+				)
+			)
+			->get();
+
+		$no_access_dependency = Atomic_Dependency_Manager::make( Atomic_Dependency_Manager::RELATION_AND )
+			->where(
+				array(
+					'operator' => 'eq',
+					'path'     => array( 'pmpro_enable' ),
+					'value'    => true,
+					'effect'   => 'hide',
+				)
+			)
+			->where(
+				array(
+					'operator' => 'eq',
+					'path'     => array( 'pmpro_invert_restrictions' ),
+					'value'    => '0',
+					'effect'   => 'hide',
+				)
+			)
+			->get();
+
+		$schema['pmpro_enable'] = Boolean_Prop_Type::make()
+			->default( false );
+		$schema['pmpro_invert_restrictions'] = String_Prop_Type::make()
+			->enum( array( '0', '1' ) )
+			->default( '0' )
+			->set_dependencies( $enabled_dependency );
+		$schema['pmpro_segment'] = String_Prop_Type::make()
+			->enum( array( 'all', 'specific', 'logged_in' ) )
+			->default( 'all' )
+			->set_dependencies( $enabled_dependency );
+		$schema['pmpro_levels'] = String_Array_Prop_Type::make()
+			->default( array() )
+			->set_dependencies( $specific_levels_dependency );
+		$schema['pmpro_show_noaccess'] = Boolean_Prop_Type::make()
+			->default( false )
+			->set_dependencies( $no_access_dependency );
+
+		return $schema;
+	}
+
+	/**
+	 * Add PMPro controls to Elementor v4 atomic elements.
+	 *
+	 * @since TBD
+	 *
+	 * @param array  $controls The atomic controls.
+	 * @param object $element  The atomic element.
+	 * @return array
+	 */
+	public function add_atomic_controls( $controls, $element ) {
+		if ( ! $this->atomic_widgets_available() ) {
+			return $controls;
+		}
+
+		// Only offer the restriction controls on elements we can actually enforce: atomic widgets
+		// (handled via the render_content filter) and the supported atomic container types (handled
+		// via the should_render filters registered in content_restriction()). This prevents showing a
+		// restriction toggle on structural sub-elements where it wouldn't be enforced or would break
+		// the parent widget.
+		$element_type = method_exists( $element, 'get_type' ) ? $element->get_type() : '';
+		if ( 'widget' !== $element_type && ! in_array( $element_type, $this->get_atomic_container_types(), true ) ) {
+			return $controls;
+		}
+
+		$level_options = array();
+		foreach ( pmpro_elementor_get_all_levels() as $level_id => $level_name ) {
+			$level_options[] = array(
+				'value' => (string) $level_id,
+				'label' => $level_name,
+			);
+		}
+
+		$items = array(
+			Switch_Control::bind_to( 'pmpro_enable' )
+				->set_label( esc_html__( 'Enable Paid Memberships Pro module visibility?', 'paid-memberships-pro' ) ),
+			Select_Control::bind_to( 'pmpro_invert_restrictions' )
+				->set_label( esc_html__( 'Visibility rule', 'paid-memberships-pro' ) )
+				->set_options(
+					array(
+						array(
+							'value' => '0',
+							'label' => esc_html__( 'Show content to...', 'paid-memberships-pro' ),
+						),
+						array(
+							'value' => '1',
+							'label' => esc_html__( 'Hide content from...', 'paid-memberships-pro' ),
+						),
+					)
+				),
+			Select_Control::bind_to( 'pmpro_segment' )
+				->set_label( esc_html__( 'Audience', 'paid-memberships-pro' ) )
+				->set_options(
+					array(
+						array(
+							'value' => 'all',
+							'label' => esc_html__( 'All Members', 'paid-memberships-pro' ),
+						),
+						array(
+							'value' => 'specific',
+							'label' => esc_html__( 'Specific Membership Levels', 'paid-memberships-pro' ),
+						),
+						array(
+							'value' => 'logged_in',
+							'label' => esc_html__( 'Logged-In Users', 'paid-memberships-pro' ),
+						),
+					)
+				),
+			Chips_Control::bind_to( 'pmpro_levels' )
+				->set_label( __( 'Membership Levels', 'paid-memberships-pro' ) )
+				->set_options( $level_options ),
+		);
+
+		$items[] = Switch_Control::bind_to( 'pmpro_show_noaccess' )
+			->set_label( esc_html__( 'Show no access message', 'paid-memberships-pro' ) );
+
+		$controls[] = Section::make()
+			->set_label( __( 'Paid Memberships Pro', 'paid-memberships-pro' ) )
+			->set_id( $this->section_name )
+			->set_items( $items );
+
+		return $controls;
 	}
 
 	// Define controls
@@ -100,6 +389,74 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 	}
 
 	/**
+	 * Replace a restricted atomic container's output with its "no access" message.
+	 *
+	 * Atomic container elements (div blocks, flexbox, tabs, forms) cannot have their rendered content
+	 * filtered the way widgets can, so we buffer the container's output here and swap it for the no
+	 * access message in pmpro_elementor_after_render(). Note that Elementor renders the element (and
+	 * its children) before this output is discarded, so the restricted content is built on the server
+	 * and then thrown away rather than skipped entirely; it is never sent to the browser, but the work
+	 * (and any assets the inner widgets enqueue) still happens.
+	 *
+	 * Widgets are handled separately via pmpro_elementor_render_content(), so they are skipped here.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $element The Elementor element being rendered.
+	 */
+	public function pmpro_elementor_before_render( $element ) {
+		if ( \Elementor\Plugin::$instance->editor->is_edit_mode() || 'widget' === $element->get_type() ) {
+			return;
+		}
+
+		$element_settings = method_exists( $element, 'get_atomic_settings' ) ? $element->get_atomic_settings() : $element->get_active_settings();
+
+		// If the block is not being restricted, there is nothing to replace.
+		if ( empty( $element_settings['pmpro_enable'] ) || 'no' === $element_settings['pmpro_enable'] ) {
+			return;
+		}
+
+		$apply_block_visibility_params = $this->build_visibility_params( $element_settings );
+
+		// This path only renders the "no access" message. When the message is off (or the rule is
+		// inverted, in which case build_visibility_params() forces it off) there is nothing to do here;
+		// hiding is handled by pmpro_elementor_should_render().
+		if ( empty( $apply_block_visibility_params['show_noaccess'] ) ) {
+			return;
+		}
+
+		$placeholder = 'pmpro-elementor-access-probe';
+		$result = pmpro_apply_block_visibility( $apply_block_visibility_params, $placeholder );
+		if ( ! empty( $result ) && $result !== $placeholder ) {
+			$this->no_access_messages[ $element->get_id() ] = $result;
+			ob_start();
+		}
+	}
+
+	/**
+	 * Output the buffered "no access" message in place of a restricted atomic container's content.
+	 *
+	 * @since TBD
+	 *
+	 * @param object $element The Elementor element being rendered.
+	 */
+	public function pmpro_elementor_after_render( $element ) {
+		if ( empty( $this->no_access_messages[ $element->get_id() ] ) ) {
+			return;
+		}
+
+		// Discard the element's real (restricted) output that was buffered in pmpro_elementor_before_render().
+		ob_get_clean();
+
+		// The no access message comes from pmpro_get_no_access_message() and is intentionally output
+		// as-is: it is admin-controlled HTML (links and markup), not user input, and escaping it would
+		// strip that markup. This matches how PMPro outputs the no access message elsewhere (e.g. the
+		// core blocks integration in includes/blocks.php).
+		echo $this->no_access_messages[ $element->get_id() ]; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		unset( $this->no_access_messages[ $element->get_id() ] );
+	}
+
+	/**
 	 * Filter sections to render content or not.
 	 * If user doesn't have access, hide the section.
 	 * @return boolean whether to show or hide section.
@@ -112,24 +469,29 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
 			return $should_render;
 		}        
         
-		// Bypass if it's already hidden.
-		if ( $should_render === false ) {
+		// If something else has already decided not to render this element — another should_render
+		// filter (e.g. a display-condition plugin) or Elementor's own empty-content check — respect that.
+		// Discard any no-access message we buffered in pmpro_elementor_before_render() so it is not echoed
+		// in place of an element that is supposed to be gone, and let the buffer close balanced. We run
+		// late (priority 9999) so other plugins' decisions are visible here; note this is a strong
+		// mitigation rather than a guarantee, since a filter hooked even later could still win.
+		if ( false === $should_render ) {
+			$element_id = $element->get_id();
+			if ( isset( $this->no_access_messages[ $element_id ] ) ) {
+				ob_get_clean();
+				unset( $this->no_access_messages[ $element_id ] );
+			}
 			return $should_render;
 		}
 
-        $element_settings = $element->get_active_settings();
+        $element_settings = method_exists( $element, 'get_atomic_settings' ) ? $element->get_atomic_settings() : $element->get_active_settings();
 
         // If the block is not being restricted, then the user should be able to view it.
         if ( empty( $element_settings['pmpro_enable'] ) || 'no' === $element_settings['pmpro_enable'] ) {
             return true;
         }
 
-        $apply_block_visibility_params = array(
-            'segment' => $element_settings['pmpro_segment'],
-            'levels' => $element_settings['pmpro_levels'],
-            'invert_restrictions' => filter_var( $element_settings['pmpro_invert_restrictions'], FILTER_VALIDATE_BOOLEAN ),
-            'show_noaccess' => ! empty( $element_settings['pmpro_show_noaccess'] ) ? filter_var( $element_settings['pmpro_show_noaccess'], FILTER_VALIDATE_BOOLEAN ) : false,
-        );
+        $apply_block_visibility_params = $this->build_visibility_params( $element_settings );
         $should_render = ! empty( pmpro_apply_block_visibility( $apply_block_visibility_params, 'sample content' ) );
 		
 		return apply_filters_deprecated( 'pmpro_elementor_section_access', array( $should_render, $element ), '3.5' );
@@ -152,7 +514,7 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
             return $content;
         }
         
-        $widget_settings = $widget->get_active_settings();
+        $widget_settings = method_exists( $widget, 'get_atomic_settings' ) ? $widget->get_atomic_settings() : $widget->get_active_settings();
 
         // If the block is not being restricted, bail.
         if ( empty( $widget_settings['pmpro_enable'] ) || 'no' === $widget_settings['pmpro_enable'] ) {
@@ -160,12 +522,7 @@ class PMPro_Elementor_Content_Restriction extends PMPro_Elementor {
         }
 
         // Use the pmpro_apply_block_visibility() method to generate output.
-        $apply_block_visibility_params = array(
-            'segment' => $widget_settings['pmpro_segment'],
-            'levels' => $widget_settings['pmpro_levels'],
-            'invert_restrictions' => filter_var( $widget_settings['pmpro_invert_restrictions'], FILTER_VALIDATE_BOOLEAN ),
-            'show_noaccess' => filter_var( $widget_settings['pmpro_show_noaccess'], FILTER_VALIDATE_BOOLEAN ),
-        );
+        $apply_block_visibility_params = $this->build_visibility_params( $widget_settings );
         return pmpro_apply_block_visibility( $apply_block_visibility_params, $content );
 
 	}


### PR DESCRIPTION
## Summary

Extends PMPro's existing Elementor content-restriction integration to **Elementor v4 "atomic" elements** (Div Block, Flexbox, Tabs, Form, and atomic widgets), so the "Paid Memberships Pro" visibility controls work in the new v4 editor and are enforced on the front end.

The classic (v3) behavior is unchanged — the same code paths now fall back to `get_atomic_settings()` when an element is atomic and `get_active_settings()` otherwise.

## What's included

- **Editor UI** — registers the PMPro props/controls on atomic elements via the `elementor/atomic-widgets/props-schema` and `elementor/atomic-widgets/controls` filters (Switch / Select / Chips controls), with dependency rules so the sub-fields show only when relevant.
- **Frontend enforcement**
  - Atomic **containers**: `should_render` + a `before_render`/`after_render` output-buffer swap to show the no-access message.
  - Atomic **widgets**: the existing `elementor/widget/render_content` filter.
- **Caching safety** — restricted atomic elements are flagged in the `is_dynamic_content` filter so Elementor's element cache renders them live (via its shortcode-placeholder mechanism) rather than baking a member view into a cached page.
- **Single source of truth** — one cached, filterable list (`pmpro_elementor_atomic_element_types`) drives both which container types show the controls and which get frontend enforcement, so the two can't drift. Structural sub-elements (individual tabs, tab menus, form messages) are intentionally excluded.
- **Visibility params centralized** in `build_visibility_params()`:
  - membership levels are only forwarded for the **specific** audience, preventing a stale `pmpro_levels` value (chosen under "Specific", then switched back to "All Members") from silently mis-restricting an element;
  - the no-access message is forced off when the rule is inverted.
- **Good-citizen `should_render`** — runs late and stands down (discarding any buffered message) when another `should_render` filter has already hidden the element.

## Known caveats (documented in code, not bugs in this PR)

- Restricted content is rendered server-side then discarded on the no-access-message path, so inner-widget assets/inline data may still enqueue. Pre-existing for v3 too.
- Setting an element's Elementor **Cache Settings → Active** (`_element_cache='no'`) bypasses the dynamic-content check and would statically cache it; this is checked by Elementor before our filter, so it can't be overridden from PMPro. Worth a docs note.
- A hidden simple widget can leave an empty `.elementor-widget-container`, same as classic-widget behavior today.

## Testing

- `php -l` clean on both files.
- Standalone harness covering the control-gating (widgets + 4 container types get controls; structural sub-elements/`stack` do not), the cached type list, and `build_visibility_params()` (stale-levels gating, invert → no message) — all pass.
- Manual browser test on a mixed v3/v4 page: v4 atomic container restriction enforced for a logged-out visitor (content replaced by the no-access message), editor controls + dependency chain behave, classic v3 widgets still enforced, no PHP errors.

## Notes for reviewers

Requesting review from @flintfromthebasement and Copilot. **Please do not merge** — this is up for review/feedback first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
