### PR TITLE
Fix email log details modal error on Plain permalinks

### DIFF
--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -1743,8 +1743,11 @@ jQuery(document).ready(function($) {
 
 		// Use WordPress REST API
 		$.ajax({
-			url: pmpro.rest_url + 'pmpro/v1/email_log_popup?log_id=' + logId,
+			url: pmpro.rest_url + 'pmpro/v1/email_log_popup',
 			type: 'GET',
+			data: {
+				log_id: logId
+			},
 			beforeSend: function(xhr) {
 				xhr.setRequestHeader('X-WP-Nonce', pmpro.nonce);
 			},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The email log modal hard-coded the REST query string with "?log_id=", which produced a double "?" on sites using Plain permalinks (where pmpro.rest_url ends in "?rest_route=/"). WordPress then folded log_id into the rest_route value, matching no route and returning a 404.

Pass log_id via jQuery's data object instead so the separator is chosen correctly under both pretty and plain permalink structures, matching the existing quick_search handler.

### How to test the changes in this Pull Request:

1. Set **Settings → Permalinks** to **Plain** and save.
2. Ensure email logging is enabled and at least one email has been logged.
3. Go to the email log report.
4. Click the **View Content** link on a log entry.
5. **Before the fix:** the modal shows "Error loading email log details." and the `email_log_popup` REST request returns a 404.
    **After the fix:** the modal opens and displays the email details, and the REST request returns a 200.
6. **Regression check:** switch **Settings → Permalinks** to **Post name**, save, and repeat steps 3–4. The modal should still open correctly (request returns 200).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed the View Email Log details modal returning an error on sites using Plain permalinks.
