### PR TITLE
Resolve orphaned incomplete orders superseded by a newer checkout

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -318,6 +318,54 @@ function pmpro_pull_checkout_data_from_order( $order ) {
 }
 
 /**
+ * Mark a member's older incomplete orders as error when a newer order supersedes them.
+ *
+ * Covers re-checking out for the same level, or switching to another level in a group that only
+ * allows one level at a time. Incomplete orders tied to a still-active subscription are left alone.
+ *
+ * @since TBD
+ *
+ * @param int         $user_id The ID of the user who completed checkout.
+ * @param MemberOrder $order   The newly completed order.
+ */
+function pmpro_error_orphaned_incomplete_orders( $user_id, $order ) {
+	if ( empty( $order->id ) || 'success' !== $order->status || empty( $order->membership_id ) ) {
+		return;
+	}
+
+	// Switching to a level in a one-at-a-time group deactivates sibling levels, so their orders are superseded too.
+	$superseded_level_ids = array( $order->membership_id );
+	$level_group_id       = pmpro_get_group_id_for_level( $order->membership_id );
+	$level_group          = empty( $level_group_id ) ? false : pmpro_get_level_group( $level_group_id );
+	if ( ! empty( $level_group ) && empty( $level_group->allow_multiple_selections ) ) {
+		$superseded_level_ids = pmpro_get_level_ids_for_group( $level_group->id );
+	}
+
+	$incomplete_orders = MemberOrder::get_orders( array(
+		'user_id'             => $user_id,
+		'membership_level_id' => $superseded_level_ids,
+		'status'              => array( 'token', 'pending', 'review' ),
+	) );
+
+	foreach ( $incomplete_orders as $incomplete_order ) {
+		// Only resolve orders older than the one we just completed.
+		if ( (int) $incomplete_order->id >= (int) $order->id ) {
+			continue;
+		}
+
+		$subscription = $incomplete_order->get_subscription();
+		if ( ! empty( $subscription ) && 'active' === $subscription->get_status() ) {
+			continue;
+		}
+
+		$incomplete_order->add_order_note( __( 'Order marked as error because it was superseded by a newer successful order.', 'paid-memberships-pro' ) );
+		$incomplete_order->status = 'error';
+		$incomplete_order->saveOrder();
+	}
+}
+add_action( 'pmpro_after_checkout', 'pmpro_error_orphaned_incomplete_orders', 10, 2 );
+
+/**
  * Legacy function.
  *
  * @since 2.12.3


### PR DESCRIPTION
## Problem

A member can be left with a stale `pending` order that never resolves:

1. Member checks out with **Pay by Check** on a site that filters `pmpro_check_status_after_checkout` to `pending` (withholding access until the check arrives). This creates a `pending` order.
2. Member changes their mind and checks out again with **Stripe**, which succeeds and creates a newer `success` order.
3. The original check order **stays `pending` forever** — the account page shows "Your latest payment for this membership is past due..." even though they have paid.

## Root cause

PMPro already cleans up incomplete orders: `PMPro_Subscription::save()` marks a subscription's `token`/`pending`/`review` orders as `error` when that subscription is cancelled, and a new checkout for the same level cancels the prior subscription.

**But the cleanup keys off a subscription, and the orphaned pending order has none.** A `pending` order receives a `subscription_transaction_id` at checkout, but the `PMPro_Subscription` row is only persisted when the membership is activated. While the order is `pending`, no subscription record exists — so there is nothing to cancel, and the existing cleanup never reaches the orphaned order.

## Fix

On `pmpro_after_checkout`, mark the member's older incomplete (`token`/`pending`/`review`) orders as `error` when a newer order supersedes them.

- **Same level:** re-checking out for the same level resolves the prior incomplete order.
- **Level groups:** switching to another level in a group that only allows one level at a time deactivates sibling levels, so their incomplete orders are superseded too. The fix expands the level set to the whole group in that case, mirroring the group-deactivation logic in `pmpro_changeMembershipLevel()`. Multi-selection groups and ungrouped levels stay same-level-only, so a member who can legitimately hold sibling levels keeps those pending orders.

Guards:
- Only orders **older** than the newly completed order are touched (`id` comparison).
- Orders tied to a **still-active subscription** are left alone, so legitimate past-due renewals are untouched.

An order note is added explaining the status change, mirroring the existing cleanup.

## Testing notes

- Reproduce: create a `pending` check order for a level, then complete a successful Stripe checkout for the same level (or another level in a one-at-a-time group). The older `pending` order should flip to `error` with a note.
- Confirm legitimate past-due renewals (older `success` + newer `pending`) are untouched.

## Not covered here

This resolves the orphan on the member's *next* checkout. A `pending` order that is simply abandoned (never superseded) is out of scope — a cron sweep could be added separately to catch those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)