### PR TITLE
Fix broken members list CSV when an exported value contains quotes

### DIFF
--- a/adminpages/login-csv.php
+++ b/adminpages/login-csv.php
@@ -317,7 +317,7 @@ if ( empty( $_REQUEST['pmpro_no_download'] ) ) {
  * @return string
  */
 function pmpro_enclose( $s ) {
-	return '"' . str_replace( '"', '\\"', $s ) . '"';
+	return '"' . str_replace( '"', '""', $s ) . '"';
 }
 
 /**

--- a/adminpages/memberships-csv.php
+++ b/adminpages/memberships-csv.php
@@ -427,7 +427,7 @@ if ( empty( $_REQUEST['pmpro_no_download'] ) ) {
  * @return string
  */
 function pmpro_enclose( $s ) {
-	return '"' . str_replace( '"', '\\"', $s ) . '"';
+	return '"' . str_replace( '"', '""', $s ) . '"';
 }
 
 /**

--- a/adminpages/sales-csv.php
+++ b/adminpages/sales-csv.php
@@ -183,7 +183,7 @@ if ( empty( $_REQUEST['pmpro_no_download'] ) ) {
 }
 
 function pmpro_enclose( $s ) {
-	return "\"" . str_replace( "\"", "\\\"", $s ) . "\"";
+	return "\"" . str_replace( "\"", "\"\"", $s ) . "\"";
 }
 
 function pmpro_transmit_report_data( $csv_fh, $filename, $headers = array() ) {

--- a/classes/class-pmpro-exports.php
+++ b/classes/class-pmpro-exports.php
@@ -985,7 +985,7 @@ class PMPro_Exports {
 	 */
 	protected function csv_enclose( $s ) {
 		$s = (string) $s;
-		return '"' . str_replace( '"', '\\"', $s ) . '"';
+		return '"' . str_replace( '"', '""', $s ) . '"';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
- Fixes the Members List CSV export producing a malformed/corrupted file when an exported value contains a double-quote (`"`).
- `PMPro_Exports::csv_enclose()` was escaping embedded double-quotes with a backslash (`\"`), which is not valid CSV. Per RFC 4180, a double-quote inside a quoted field must be escaped by doubling it (`""`). The backslash terminated the field early, shifting and corrupting every subsequent column in the row.
- Because `csv_enclose()` wraps **every** column in the members export, this affected any value containing a quote — most commonly free-form **User Fields**.
- One-line change: `str_replace( '"', '\\"', $s )` → `str_replace( '"', '""', $s )`.

### How to test the changes in this Pull Request:
1. Edit a user (or add a User Field under **Memberships → Settings → User Fields**) and set a value that contains double-quotes, e.g. `He said "hello"`. A quick alternative: rename a membership level to something like `Premium "Plus"`.
2. Ensure that user has an active membership so they appear in the Members List.
3. Go to **Memberships → Members** and click **Export to CSV**.
4. **Before this fix:** open the downloaded CSV in a spreadsheet app (Excel/Google Sheets/LibreOffice) — the row with the quoted value has its columns shifted/misaligned, and data spills into the wrong columns from that field onward.
5. **After this fix:** the quoted value stays in a single cell (displayed as `He said "hello"`), and all other columns line up correctly.
6. Confirm rows *without* quotes are unchanged and the rest of the export is unaffected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
