### PR TITLE
Skip archived/inactive Stripe prices in get_price_for_product()

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3519,6 +3519,7 @@ class PMProGateway_stripe extends PMProGateway {
 			'type'     => $is_recurring ? 'recurring' : 'one_time',
 			'currency' => strtolower( $pmpro_currency ),
 			'limit' => 100,
+			'active'   => true,
 		);
 		if ( $is_recurring ) {
 			$price_search_args['recurring'] = array( 'interval' => $cycle_period );
@@ -3534,6 +3535,10 @@ class PMProGateway_stripe extends PMProGateway {
 			return $e->getMessage();
 		}
 		foreach ( $prices as $price ) {
+			// Skip archived/inactive prices. Create a new one instead.
+			if ( empty( $price->active ) ) {
+				continue;
+			}
 			// Check whether price is the same. If not, continue.
 			if ( intval( $price->unit_amount ) !== intval( $unit_amount ) ) {
 				continue;


### PR DESCRIPTION
## Problem

When a Stripe Price is archived (`active: false`), checkout fails with the error:

> Could not create checkout session. The price specified is inactive. This fields only accepts active prices.

This commonly happens when discount codes change the checkout amount — PMPro searches for an existing Price matching the discounted amount, finds an archived one, and tries to reuse it. Stripe rejects it.

## Solution

Two changes in `get_price_for_product()`:

1. **Add `active => true` to the price search args** — Stripe filters server-side, only returning active prices.
2. **Add an in-loop check for `empty( $price->active )`** — belt-and-suspenders safety net that skips any inactive price and falls through to create a new one.

## Behavior

- Archived prices are **not** unarchived — respecting the intent of whoever archived them
- A new active Price is created for the checkout amount instead
- Old archived prices stay archived; reporting on the new price starts fresh

## Testing

1. Archive a Stripe Price that matches a level/discount code combination
2. Attempt checkout with that level + discount code
3. Before fix: "The price specified is inactive" error
4. After fix: checkout succeeds, a new active Price is created in Stripe