### PR TITLE
Allow users with the pmpro_reports capability to view email content in the popup

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-email-log.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-email-log.php
@@ -20,10 +20,10 @@ class PMPro_Member_Edit_Panel_Email_Log extends PMPro_Member_Edit_Panel {
 	
 	/**
 	 * Check if panel should show
-	 * Only show if user has manage_options capability
+	 * Only show if user has the pmpro_reports capability, matching the Email Log report.
 	 */
 	public function should_show() {
-		return current_user_can( 'manage_options' );
+		return current_user_can( 'pmpro_reports' );
 	}
 	
 	/**

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -1821,7 +1821,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 					'capability' => 'edit_post',
 					'request_param' => 'post_id',
 				),
-				'/pmpro/v1/email_log_popup' => 'manage_options',
+				'/pmpro/v1/email_log_popup' => 'pmpro_reports',
 				'/pmpro/v1/quick_search' => true, // Permissions will be checked per result type.
 			);
 			$route_caps = apply_filters( 'pmpro_rest_api_route_capabilities', $route_caps, $request );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `/pmpro/v1/email_log_popup` route required the `manage_options` capability, which returned a 403 for non-admin roles that can otherwise view the Email Log report (gated on `pmpro_reports`), such as the Membership Manager role. This was also inconsistent with the rest of the REST route map, which uses `pmpro_*` capabilities.

Switch the required capability to `pmpro_reports` so the popup matches the report page it belongs to. Administrators are unaffected since core grants them `pmpro_reports`.

### How to test the changes in this Pull Request:
1. Have a WordPress site running Paid Memberships Pro with **Email Logging enabled** (Settings → Email → Email Logging) so the Email Log report has at least one entry.
2. Ensure a non-admin user exists who has the `pmpro_reports` capability but **not** `manage_options`. The easiest way is to install the [Membership Manager Role Add On](https://www.paidmembershipspro.com/add-ons/pmpro-membership-manager-role/) and assign a test user the **Membership Manager** role.
3. Log in as the Membership Manager (non-admin) user.
4. Go to **Memberships → Reports → Email Log**.
5. Click **View Content** on any log entry.
6. The popup fails to load. In the browser dev tools **Network** tab, the request to `/wp-json/pmpro/v1/email_log_popup` returns **403 Forbidden**.
7. Repeat steps 3–5 as the same Membership Manager user.
8. The popup opens and displays the full email content. The `/wp-json/pmpro/v1/email_log_popup` request returns **200**.

**Regression checks**
9. Log in as an **Administrator** and confirm **View Content** still works (admins have `pmpro_reports`, so no change in behavior).
10. Log in as a user with **neither** `pmpro_reports` nor `manage_options` (e.g. a Subscriber) and confirm the `email_log_popup` endpoint still returns **403** — access is not broadened beyond users who can already view the Email Log report.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fixed an issue where users with access to the email log report (such as the Membership Manager role) could not view email content.
