### PR TITLE
Fix #3722 - Don't let Stripe Checkout overwrite an existing Customer

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2131,6 +2131,16 @@ class PMProGateway_stripe extends PMProGateway {
 			'enabled' => false,
 		);
 		$billing_address_collection = get_option( 'pmpro_stripe_checkout_billing_address' ) ?: 'auto';
+		
+		/*
+		 * Only let Stripe Checkout overwrite the Customer's address if we are
+		 * actually requiring address collection in this session ('required').
+		 * Otherwise, if billing_address_collection is 'auto', Stripe may sync
+		 * an empty or incomplete address back onto the Customer object,
+		 * wiping out an address that was already set (e.g. via the API,
+		 * update_customer_at_checkout(), or a previous order).
+		 */
+		$customer_update_address = ( 'required' === $billing_address_collection ) ? 'auto' : 'never';
 
 		// And let's send 'em to Stripe!
 		$checkout_session_params = array(
@@ -2142,7 +2152,7 @@ class PMProGateway_stripe extends PMProGateway {
 			'tax_id_collection' => $tax_id_collection,
 			'billing_address_collection' => $billing_address_collection,
 			'customer_update' => array(
-				'address' => 'auto',
+				'address' => $customer_update_address,
 				'name' => 'auto'
 			),
 			'success_url' => apply_filters( 'pmpro_confirmation_url', add_query_arg( 'pmpro_level', $morder->membership_level->id, pmpro_url("confirmation" ) ), $user_id, $pmpro_level ),

--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,9 @@ Not sure? You can find out by doing a bit a research.
 4. [Ask using our contact form](https://www.paidmembershipspro.com/contact/)
 
 == Changelog ==
+= Upcoming Version =
+* BUG FIX: Fixed an issue where Stripe Checkout could overwrite an existing Stripe Customer's billing address with empty data when the "Collect Billing Address in Stripe Checkout" setting was not set to "Always". #3722 (@fadlyknight)
+
 = 3.8.1 - 2026-06-29 =
 * ENHANCEMENT: Added a new `style` attribute to the `[pmpro_checkout_button]` shortcode to render it as a link or a button, and improved its styling. #3708 (@kimcoleman)
 * ENHANCEMENT: Improved the HTML validity and accessibility of frontend forms and pages, including fixing duplicate `id` attributes and invalid fieldset/legend markup. #3707 (@kimcoleman)


### PR DESCRIPTION
# Fix: Stripe Checkout overwrites Customer billing address with empty data

## Description

When using **Stripe Checkout** (Stripe-hosted payment page) as the payment
flow, the `customer_update.address` parameter sent to Stripe when creating
the Checkout Session is hardcoded to `'auto'`, regardless of the
**"Collect Billing Address in Stripe Checkout"** setting
(`pmpro_stripe_checkout_billing_address`).

When that setting is left at its default value (`auto` / "Only when
necessary"), Stripe Checkout does not always require the customer to enter
a billing address. However, because `customer_update.address` is still
`'auto'`, Stripe will sync whatever (possibly empty/incomplete) address was
present in that Checkout Session back onto the Stripe Customer object —
silently overwriting a complete billing address that may have already been
set on the Customer (e.g. via the REST API, `update_customer_at_checkout()`,
or a previous order).

This means a Customer's billing address that was correct immediately after
checkout starts can end up wiped out by the time the checkout session is
confirmed, with no error or warning shown anywhere.

## Steps to Reproduce

1. Set Stripe as the gateway, Payment Flow = "Accept payments in Stripe
   (Stripe Checkout)".
2. Set "Collect Billing Address in Stripe Checkout" to **"Only when
   necessary"** (the default).
3. Create/have a Stripe Customer with a complete `address` set (e.g. via
   `POST /v1/customers`).
4. Have that same Customer complete a PMPro checkout using Stripe Checkout.
5. Open the Customer in the Stripe Dashboard after checkout completes.

**Expected:** The Customer's previously-set address is preserved.
**Actual:** The Customer's `address` field is empty/wiped.

## Root Cause

In `pmpro_checkout_before_change_membership_level()`
(`includes/gateways/class.pmprogateway_stripe.php`), the Checkout Session
params send:

```php
'customer_update' => array(
    'address' => 'auto',
    'name' => 'auto'
),
```

`'auto'` is not conditioned on whether address collection was actually
`'required'` for that session, so an empty/partial address collected (or
not collected at all) at Checkout time can override a Customer's existing
address.

## Fix

Tie `customer_update.address` to the same
`pmpro_stripe_checkout_billing_address` setting already used for
`billing_address_collection`. Only allow Stripe to sync the address back
onto the Customer when address collection was actually `'required'` for
that session; otherwise, use `'never'` so the existing Customer address is
left untouched.

This is a minimal, backwards-compatible change:

- If "Collect Billing Address in Stripe Checkout" is set to **Always**
  (`required`), behavior is unchanged — Stripe still syncs the address.
- If it's set to **"Only when necessary"** (`auto`, the default), Stripe
  will no longer silently overwrite an existing Customer address with
  empty data.

## Testing Done

- Reproduced the issue in Stripe test mode with a Customer created via the
  API with a full address, then completed a PMPro Stripe Checkout session
  with billing address collection set to "auto" — confirmed the address
  was wiped on the Customer object before the fix, and preserved after.
- Verified that with "Collect Billing Address in Stripe Checkout" set to
  **Always**, address sync continues to work as before (no regression).
- Confirmed the `pmpro_stripe_checkout_session_parameters` filter can still
  be used to override this behavior for anyone who wants a different
  policy.

## Checklist

- [x] Branched off `dev` per CONTRIBUTING.md.
- [x] Followed WordPress Coding Standards / existing file's style (tabs,
      indent size 4).
- [x] No unrelated style/formatting changes (beautifier disabled).
- [x] phpDoc / inline comment added explaining the reasoning.
- [x] Changelog entry added to `readme.txt` (optional per CONTRIBUTING.md —
      core team may also add this).