### PR TITLE
Require Authorize.net credentials before processing Silent Post requests

### DIFF
--- a/services/authnet-silent-post.php
+++ b/services/authnet-silent-post.php
@@ -14,6 +14,13 @@
 	// Flag if this is an ARB transaction. Set to false by default.
 	$arb = false;
 
+	// Bail if Authorize.net credentials are not configured. If this site isn't set up to use
+	// Authorize.net, we should not be accepting or processing Silent Post requests at all.
+	if ( empty( get_option( 'pmpro_loginname' ) ) || empty( get_option( 'pmpro_transactionkey' ) ) ) {
+		status_header( 403 );
+		exit;
+	}
+
 	// Validate the shared-secret token if one is configured.
 	// Authorize.net sends exactly the Silent Post URL you provide, so a token appended to that URL
 	// will be present on every legitimate request and absent on forgeries.


### PR DESCRIPTION
## Summary

The Authorize.net Silent Post handler (`services/authnet-silent-post.php`) is exposed publicly via `admin-ajax.php?action=authnet_silent_post` (`wp_ajax_nopriv_`). Currently, if the optional Silent Post token is not configured, the handler will accept and process incoming requests even on sites that are not using Authorize.net at all.

This adds a basic guard: if the site has no Authorize.net credentials stored (`pmpro_loginname` / `pmpro_transactionkey`), we bail with a `403` before accepting or processing any Silent Post data.

## Change

```php
// Bail if Authorize.net credentials are not configured. If this site isn't set up to use
// Authorize.net, we should not be accepting or processing Silent Post requests at all.
if ( empty( get_option( 'pmpro_loginname' ) ) || empty( get_option( 'pmpro_transactionkey' ) ) ) {
	status_header( 403 );
	exit;
}
```

## Notes / scope

- This is a credential *presence* check only. It closes the case where a site that isn't configured for Authorize.net still exposes a live, unauthenticated Silent Post endpoint.
- It does **not** authenticate the request itself. Sites that *are* using Authorize.net should still configure the Silent Post token for true request authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
