### PR TITLE
Detect PMPro SMTP Add On as an approved email sending service

### DIFF
--- a/includes/email.php
+++ b/includes/email.php
@@ -546,10 +546,11 @@ add_filter( 'pmpro_email_data', 'pmpro_sanitize_email_data' );
  * Detect how outbound email is being sent from this site.
  *
  * Runs these checks in order and returns on the first hit:
- *   1. An active SMTP/transactional-email plugin we recognize.
- *   2. wp-config.php SMTP constants (manual SMTP setup).
- *   3. PMPro Max hosting (handles transactional email at the server level).
- *   4. Fallback: unknown / WordPress default (PHP `mail()`).
+ *   1. The PMPro SMTP Add On with a connector configured.
+ *   2. An active SMTP/transactional-email plugin we recognize.
+ *   3. wp-config.php SMTP constants (manual SMTP setup).
+ *   4. PMPro Max hosting (handles transactional email at the server level).
+ *   5. Fallback: unknown / WordPress default (PHP `mail()`).
  *
  * Plugin checks run first so that a plugin overriding the default on Max is
  * reported accurately.
@@ -564,6 +565,23 @@ add_filter( 'pmpro_email_data', 'pmpro_sanitize_email_data' );
  * }
  */
 function pmpro_detect_email_method() {
+	// The PMPro SMTP Add On only handles mail when a connector is configured,
+	// so check its actual state instead of treating activation as a signal.
+	// If it is active without a connector, mail passes through untouched and
+	// the checks below describe the site more accurately.
+	if ( function_exists( 'pmpro_smtp_get_active_connector' ) ) {
+		$connector = pmpro_smtp_get_active_connector();
+		if ( null !== $connector ) {
+			return apply_filters( 'pmpro_detect_email_method', array(
+				'method' => 'pmpro-smtp',
+				// translators: %s: The name of the connector configured in the PMPro SMTP Add On.
+				'label'  => sprintf( __( 'PMPro SMTP (%s)', 'paid-memberships-pro' ), $connector->get_title() ),
+				'relay'  => 'generic' === $connector->get_name() ? $connector->get_setting( 'host' ) : null,
+				'source' => 'plugin',
+			) );
+		}
+	}
+
 	// Known SMTP/transactional-email plugins, roughly by popularity.
 	// `class`, `function`, and `constant` may each be a string or array of strings.
 	$plugin_signatures = array(


### PR DESCRIPTION
## What this does

Adds the PMPro SMTP Add On to the sending-method detection in `pmpro_detect_email_method()` (`includes/email.php`), so sites using it get the green "active" Sending Method tag on the Email Settings page and accurate info in Site Health.

## Implementation notes

Instead of adding a blind class/constant entry to the third-party `$plugin_signatures` array (those checks fire whenever a plugin is merely active), this adds a dedicated first-party check before the signatures loop that inspects the Add On's actual state:

- If `pmpro_smtp_get_active_connector()` returns a connector, it is reported as the sending method with the connector name in the label (e.g. **PMPro SMTP (Mailgun)**), `method => 'pmpro-smtp'`, `source => 'plugin'`.
- For the Generic SMTP connector, the `relay` field is populated with the configured SMTP host, matching how the wp-config `SMTP_HOST` branch reports it.
- If the Add On is active but no connector is configured, mail passes through it untouched, so detection falls through to the existing checks (other plugins → wp-config constants → PMPro Max → default) rather than showing an "active" tag while the site is really on PHP `mail()`.

The function docblock's check-order list is updated to match. No changes needed in `adminpages/emailsettings.php` or Site Health — they render whatever the detector returns.

## Testing

- `php -l` passes.
- Verified on a dev site with PMPro SMTP's Mailgun connector configured: Memberships → Settings → Email shows the **PMPro SMTP (Mailgun)** tag with the "We detected … active on this site" description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)