### PR TITLE
Level Groups: only show selection message when group has >1 level; fixes #3664

### DIFF
--- a/pages/levels.php
+++ b/pages/levels.php
@@ -55,7 +55,7 @@ $level_groups  = pmpro_get_level_groups_in_order();
 						?>
 						<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_card_content' ) ); ?>">
 							<?php
-								if ( count( $level_groups ) > 1  ) {
+								if ( count( $level_groups ) > 1 && count( $levels_to_show_for_group ) > 1 ) {
 									if ( ! empty( $level_group->allow_multiple_selections ) ) {
 										?>
 										<p><?php esc_html_e( 'You may select multiple levels from this group.', 'paid-memberships-pro' ); ?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The "You may select multiple/only one level" message was shown for every level group whenever `count($level_groups) > 1`, even if the group contained only a single level — making the message misleading/redundant. This fix adds a `count($levels_to_show_for_group) > 1` check so the message only appears when there's an actual choice to make within the group.

Resolves #3664 

### How to test the changes in this Pull Request:

1. Go to **WP Admin > Memberships > Settings > Levels > Level Groups** and create at least 3 groups:
   - **Group A**: 1 level, allow multiple selections = off
   - **Group B**: 2+ levels, allow multiple selections = off
   - **Group C**: 2+ levels, allow multiple selections = on
2. Visit the **Membership Levels** page on the frontend.
3. Verify:
   - **Group A** (1 level) — no message shown
   - **Group B** (2+ levels, single select) — shows "You may select only one level from this group."
   - **Group C** (2+ levels, multi select) — shows "You may select multiple levels from this group."
4. Also verify that if only 1 level group exists total, no messages appear at all.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Level Groups: Only show "You may select multiple/only one level" message when the group has more than one level.