### PR TITLE
Bulk delete: fix SQL IN() clause only checking first user when countng membership history

### DIFF
--- a/includes/cleanup.php
+++ b/includes/cleanup.php
@@ -55,9 +55,19 @@ function pmpro_delete_user_form_notice( $current_user, $userids ) {
 		}
 	}
 
-	$sqlQuery = $wpdb->prepare( "SELECT COUNT(*) as members FROM $wpdb->pmpro_memberships_users WHERE user_id IN (%s)", implode( "," , $userids ) );
+	// Build one %d placeholder per user ID so each is checked, not just the first.
+	$member_history = 0;
+	if ( ! empty( $userids ) ) {
+		$userids      = array_map( 'intval', $userids );
+		$placeholders = implode( ',', array_fill( 0, count( $userids ), '%d' ) );
 
-	$member_history = $wpdb->get_var( $sqlQuery );
+		$sqlQuery = $wpdb->prepare(
+			"SELECT COUNT(*) as members FROM $wpdb->pmpro_memberships_users WHERE user_id IN ($placeholders)",
+			$userids
+		);
+
+		$member_history = $wpdb->get_var( $sqlQuery );
+	}
 
 	// Make sure that there is actually PMPro content to delete for these users.
 	if ( empty( $userids_have_levels ) && empty( $member_history ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

The SQL query at `includes/cleanup.php:58` used `IN (%s)` with an imploded array of user IDs. The `%s` placeholder wrapped the entire list in quotes, causing MySQL to cast it to a single integer — so only the first user's membership history was ever checked.

When bulk-deleting users, if the first selected user had no membership history but others did, the "Delete any related membership history" checkbox was hidden, leaving admins with no way to clean up the remaining users' membership data.

Fixed by using individual `%d` placeholders (one per user ID) so every user is properly checked.

Resolves #3732.

### How to test the changes in this Pull Request:

1. Create 3 users: User A, User B, User C
2. Give only User B and User C a membership level (User A has no membership)
3. Go to **WP Admin > Users**, select all 3 users
4. Choose **Bulk Actions > Delete** → **Apply**
5. Verify the "Delete any related membership history" checkbox now appears
6. Check it, complete the deletion, and confirm membership history for User B and User C is removed
7. Repeat with a single user — confirm it still works as before

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fixed a bug where the "Delete any related membership history" checkbox only checked the first selected user when bulk-deleting multiple users, hiding the cleanup option if the first user had no membership history.