### PR TITLE
Add automatic cleanup for abandoned checkout users

### DIFF
--- a/includes/abandoned-signups.php
+++ b/includes/abandoned-signups.php
@@ -134,6 +134,10 @@ function pmpro_add_abandoned_signup_advanced_setting( $settings ) {
 		),
 	);
 
+	if ( is_multisite() ) {
+		$settings['auto_delete_abandoned_signups']['description'] .= ' ' . __( 'On multisite, users are removed from this site only.', 'paid-memberships-pro' );
+	}
+
 	return $settings;
 }
 add_filter( 'pmpro_custom_advanced_settings', 'pmpro_add_abandoned_signup_advanced_setting' );
@@ -191,11 +195,8 @@ function pmpro_delete_abandoned_signups() {
 		return;
 	}
 
-	// wp_delete_user() and wpmu_delete_user() are not loaded automatically during scheduled actions.
+	// wp_delete_user() is not loaded automatically during scheduled actions.
 	require_once ABSPATH . 'wp-admin/includes/user.php';
-	if ( is_multisite() ) {
-		require_once ABSPATH . 'wp-admin/includes/ms.php';
-	}
 
 	foreach ( $user_ids as $user_id ) {
 		$user_id = (int) $user_id;
@@ -205,13 +206,9 @@ function pmpro_delete_abandoned_signups() {
 			continue;
 		}
 
-		// On multisite, wp_delete_user() only removes the user from the current site. Delete the account
-		// from the network instead, unless the user also belongs to another site.
-		if ( is_multisite() && count( get_blogs_of_user( $user_id, true ) ) <= 1 ) {
-			wpmu_delete_user( $user_id );
-		} else {
-			wp_delete_user( $user_id, null );
-		}
+		// On multisite, this only removes the user from the current site. The user may be active on
+		// another site in the network, so network-wide deletion is left to the network admin.
+		wp_delete_user( $user_id, null );
 	}
 }
 add_action( 'pmpro_schedule_daily', 'pmpro_delete_abandoned_signups' );

--- a/includes/abandoned-signups.php
+++ b/includes/abandoned-signups.php
@@ -90,6 +90,115 @@ function pmpro_remove_abandoned_signup_taxonomy_on_page_load() {
 add_action( 'wp', 'pmpro_remove_abandoned_signup_taxonomy_on_page_load' );
 
 /**
+ * Get the number of days that an abandoned signup should be kept before deletion.
+ *
+ * @since 3.9
+ *
+ * @return int The number of days to keep abandoned signups.
+ */
+function pmpro_get_abandoned_signup_deletion_days() {
+	/**
+	 * Filter the number of days that an abandoned signup should be kept before deletion.
+	 *
+	 * @since 3.9
+	 *
+	 * @param int $days The number of days to keep abandoned signups. Default 30.
+	 */
+	$days = apply_filters( 'pmpro_abandoned_signup_deletion_days', 30 );
+
+	return max( 1, absint( $days ) );
+}
+
+/**
+ * Add the automatic abandoned signup deletion setting to the Advanced Settings page.
+ *
+ * @since 3.9
+ *
+ * @param array $settings The custom Advanced Settings fields.
+ * @return array The custom Advanced Settings fields.
+ */
+function pmpro_add_abandoned_signup_advanced_setting( $settings ) {
+	$settings['auto_delete_abandoned_signups'] = array(
+		'field_name'    => 'auto_delete_abandoned_signups',
+		'field_type'    => 'select',
+		'options'       => array(
+			0 => __( 'No', 'paid-memberships-pro' ),
+			1 => __( 'Yes', 'paid-memberships-pro' ),
+		),
+		'is_associative' => true,
+		'label'         => __( 'Automatically Delete Abandoned Checkout Users', 'paid-memberships-pro' ),
+		'description'   => sprintf(
+			/* translators: %d: Number of days before an abandoned checkout user is deleted. */
+			__( 'Permanently delete user accounts that were created during checkout and remain marked as abandoned for more than %d days. This cannot be undone.', 'paid-memberships-pro' ),
+			pmpro_get_abandoned_signup_deletion_days()
+		),
+	);
+
+	return $settings;
+}
+add_filter( 'pmpro_custom_advanced_settings', 'pmpro_add_abandoned_signup_advanced_setting' );
+
+/**
+ * Delete a batch of old abandoned signup users.
+ *
+ * @since 3.9
+ *
+ * @return void
+ */
+function pmpro_delete_abandoned_signups() {
+	global $wpdb;
+
+	// This destructive cleanup must be explicitly enabled by the site administrator.
+	if ( ! get_option( 'pmpro_auto_delete_abandoned_signups', 0 ) ) {
+		return;
+	}
+
+	$abandoned_signup_term = get_term_by( 'slug', 'abandoned-signup', 'pmpro_abandoned_signup' );
+	if ( empty( $abandoned_signup_term ) || is_wp_error( $abandoned_signup_term ) ) {
+		return;
+	}
+
+	$deletion_days = pmpro_get_abandoned_signup_deletion_days();
+	$cutoff_date   = gmdate( 'Y-m-d H:i:s', time() - ( $deletion_days * DAY_IN_SECONDS ) );
+	$batch_size    = defined( 'PMPRO_CRON_LIMIT' ) ? absint( PMPRO_CRON_LIMIT ) : 250;
+
+	if ( empty( $batch_size ) ) {
+		return;
+	}
+
+	// Query only one batch so a large bot-driven spike cannot exhaust the scheduled action.
+	$user_ids = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT DISTINCT users.ID
+			FROM {$wpdb->users} AS users
+			INNER JOIN {$wpdb->term_relationships} AS relationships ON users.ID = relationships.object_id
+			INNER JOIN {$wpdb->term_taxonomy} AS taxonomy ON relationships.term_taxonomy_id = taxonomy.term_taxonomy_id
+			WHERE taxonomy.taxonomy = %s
+				AND taxonomy.term_id = %d
+				AND users.user_registered < %s
+			ORDER BY users.ID ASC
+			LIMIT %d",
+			'pmpro_abandoned_signup',
+			$abandoned_signup_term->term_id,
+			$cutoff_date,
+			$batch_size
+		)
+	);
+
+	if ( empty( $user_ids ) ) {
+		return;
+	}
+
+	// wp_delete_user() is not loaded automatically during scheduled actions.
+	require_once ABSPATH . 'wp-admin/includes/user.php';
+
+	foreach ( $user_ids as $user_id ) {
+		wp_delete_user( (int) $user_id, null );
+	}
+}
+add_action( 'pmpro_schedule_daily', 'pmpro_delete_abandoned_signups' );
+
+/**
  * Filter the views on the Users page to include a view for abandoned signups.
  *
  * @since 2.11

--- a/includes/abandoned-signups.php
+++ b/includes/abandoned-signups.php
@@ -92,7 +92,7 @@ add_action( 'wp', 'pmpro_remove_abandoned_signup_taxonomy_on_page_load' );
 /**
  * Get the number of days that an abandoned signup should be kept before deletion.
  *
- * @since 3.9
+ * @since TBD
  *
  * @return int The number of days to keep abandoned signups.
  */
@@ -100,7 +100,7 @@ function pmpro_get_abandoned_signup_deletion_days() {
 	/**
 	 * Filter the number of days that an abandoned signup should be kept before deletion.
 	 *
-	 * @since 3.9
+	 * @since TBD
 	 *
 	 * @param int $days The number of days to keep abandoned signups. Default 30.
 	 */
@@ -112,7 +112,7 @@ function pmpro_get_abandoned_signup_deletion_days() {
 /**
  * Add the automatic abandoned signup deletion setting to the Advanced Settings page.
  *
- * @since 3.9
+ * @since TBD
  *
  * @param array $settings The custom Advanced Settings fields.
  * @return array The custom Advanced Settings fields.
@@ -141,7 +141,7 @@ add_filter( 'pmpro_custom_advanced_settings', 'pmpro_add_abandoned_signup_advanc
 /**
  * Delete a batch of old abandoned signup users.
  *
- * @since 3.9
+ * @since TBD
  *
  * @return void
  */
@@ -167,6 +167,7 @@ function pmpro_delete_abandoned_signups() {
 	}
 
 	// Query only one batch so a large bot-driven spike cannot exhaust the scheduled action.
+	// Users with any membership history are skipped as a safeguard, since this deletion cannot be undone.
 	$user_ids = $wpdb->get_col(
 		$wpdb->prepare(
 			"SELECT DISTINCT users.ID
@@ -176,6 +177,7 @@ function pmpro_delete_abandoned_signups() {
 			WHERE taxonomy.taxonomy = %s
 				AND taxonomy.term_id = %d
 				AND users.user_registered < %s
+				AND NOT EXISTS ( SELECT 1 FROM {$wpdb->pmpro_memberships_users} AS memberships WHERE memberships.user_id = users.ID )
 			ORDER BY users.ID ASC
 			LIMIT %d",
 			'pmpro_abandoned_signup',
@@ -189,11 +191,27 @@ function pmpro_delete_abandoned_signups() {
 		return;
 	}
 
-	// wp_delete_user() is not loaded automatically during scheduled actions.
+	// wp_delete_user() and wpmu_delete_user() are not loaded automatically during scheduled actions.
 	require_once ABSPATH . 'wp-admin/includes/user.php';
+	if ( is_multisite() ) {
+		require_once ABSPATH . 'wp-admin/includes/ms.php';
+	}
 
 	foreach ( $user_ids as $user_id ) {
-		wp_delete_user( (int) $user_id, null );
+		$user_id = (int) $user_id;
+
+		// Re-check right before deleting in case the user completed checkout after the query ran.
+		if ( ! is_object_in_term( $user_id, 'pmpro_abandoned_signup', 'abandoned-signup' ) ) {
+			continue;
+		}
+
+		// On multisite, wp_delete_user() only removes the user from the current site. Delete the account
+		// from the network instead, unless the user also belongs to another site.
+		if ( is_multisite() && count( get_blogs_of_user( $user_id, true ) ) <= 1 ) {
+			wpmu_delete_user( $user_id );
+		} else {
+			wp_delete_user( $user_id, null );
+		}
 	}
 }
 add_action( 'pmpro_schedule_daily', 'pmpro_delete_abandoned_signups' );


### PR DESCRIPTION
## Summary

- add an opt-in Advanced Setting to automatically delete abandoned checkout users
- delete users still carrying the existing `pmpro_abandoned_signup` term after 30 days
- allow the retention period to be customized with `pmpro_abandoned_signup_deletion_days`
- process one bounded batch during the existing `pmpro_schedule_daily` Action Scheduler task
- use `wp_delete_user()` and load its admin dependency in the scheduled callback

## Testing

- `git diff --check`
- PHP syntax check for `includes/abandoned-signups.php`
- stubbed assertions for the Advanced Settings field, UTC cutoff, taxonomy query, and batch size

## Scope

This uses the existing abandoned-signup taxonomy as the source of truth. It does not add new spam-detection heuristics, historical rescanning, or deletion logging.