### PR TITLE
Register update hooks in all contexts so auto-updates run under WP-Cron

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,8 @@
 == Changelog ==
+= TBD =
+* BUG FIX: Fixed PMPro core and Add Ons never auto-updating in the background because the update hooks only registered on `admin_init`, which does not fire during WP-Cron where automatic updates run. (@dalemugford)
+* BUG FIX: Set `new_version` on `no_update` entries so up-to-date Add Ons no longer trigger an undefined-property warning in WP-CLI and other consumers of the update transient. (@dalemugford)
+
 = 3.8.2 - 2026-07-13 =
 * SECURITY: Restored sanitization of user field values on save, which had been inactive since v3.4. #3726 (@dparker1005)
 * SECURITY: The Authorize.net Silent Post handler now requires Authorize.net API credentials to be configured on the site. #3724 (@dparker1005)

--- a/classes/class-pmpro-addons.php
+++ b/classes/class-pmpro-addons.php
@@ -44,7 +44,28 @@ class PMPro_AddOns {
 		$this->addons           = get_option( 'pmpro_addons', array() );
 		$this->addons_timestamp = get_option( 'pmpro_addons_timestamp', false );
 
+		// Register update hooks in all contexts, including WP-Cron, so PMPro plugins can auto-update in the background.
+		$this->update_hooks();
+
 		add_action( 'admin_init', array( $this, 'admin_hooks' ), 0 ); // Priority 0 to run before other admin_init hooks.
+	}
+
+	/**
+	 * Hooks that must run in all contexts, including WP-Cron.
+	 *
+	 * The plugin update injection and Add On download filters previously only
+	 * registered on admin_init. WordPress runs background auto-updates under
+	 * WP-Cron, where admin_init never fires, so these filters were absent and
+	 * PMPro core and Add Ons never auto-updated even with auto-updates enabled
+	 * and a valid license. Registering them unconditionally lets the automatic
+	 * updater see and install PMPro plugin updates.
+	 *
+	 * @since TBD
+	 */
+	public function update_hooks() {
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'update_plugins_filter' ) );
+		add_filter( 'http_request_args', array( $this, 'http_request_args_for_addons' ), 10, 2 );
+		add_action( 'update_option_pmpro_license_key', array( $this, 'reset_update_plugins_cache' ), 10, 2 );
 	}
 
 	/**
@@ -91,9 +112,6 @@ class PMPro_AddOns {
 	public function admin_hooks() {
 		$this->check_when_updating_plugins();
 		add_filter( 'plugins_api', array( $this, 'plugins_api' ), 10, 3 );
-		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'update_plugins_filter' ) );
-		add_filter( 'http_request_args', array( $this, 'http_request_args_for_addons' ), 10, 2 );
-		add_action( 'update_option_pmpro_license_key', array( $this, 'reset_update_plugins_cache' ), 10, 2 );
 		// Register AJAX endpoints for add-on actions.
 		$this->register_ajax_endpoints();
 	}
@@ -362,7 +380,8 @@ class PMPro_AddOns {
 					$value->response[ $plugin_file ]->icons = array( 'default' => esc_url( $icon ) );
 				}
 			} else {
-				$value->no_update[ $plugin_file ] = $this->get_plugin_API_object_from_addon( $addon );
+				$value->no_update[ $plugin_file ]              = $this->get_plugin_API_object_from_addon( $addon );
+				$value->no_update[ $plugin_file ]->new_version = $addon['Version'];
 			}
 		}
 

--- a/classes/class-pmpro-addons.php
+++ b/classes/class-pmpro-addons.php
@@ -351,6 +351,12 @@ class PMPro_AddOns {
 			return $value;
 		}
 
+		// Ensure the get_plugin_data() function is available. This filter runs in all contexts,
+		// including WP-Cron and the front end, where wp-admin/includes/plugin.php is not always loaded.
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		// Check Add Ons
 		foreach ( $addons as $addon ) {
 			// Skip for wordpress.org plugins

--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,10 @@ Not sure? You can find out by doing a bit a research.
 4. [Ask using our contact form](https://www.paidmembershipspro.com/contact/)
 
 == Changelog ==
+= TBD =
+* BUG FIX: Fixed PMPro core and Add Ons never auto-updating in the background because the update hooks only registered on `admin_init`, which does not fire during WP-Cron where automatic updates run. (@dalemugford)
+* BUG FIX: Set `new_version` on `no_update` entries so up-to-date Add Ons no longer trigger an undefined-property warning in WP-CLI and other consumers of the update transient. (@dalemugford)
+
 = 3.8.2 - 2026-07-13 =
 * SECURITY: Restored sanitization of user field values on save, which had been inactive since v3.4. #3726 (@dparker1005)
 * SECURITY: The Authorize.net Silent Post handler now requires Authorize.net API credentials to be configured on the site. #3724 (@dparker1005)


### PR DESCRIPTION
## Problem

PMPro core and Add Ons never auto-update in the background, even with WordPress auto-updates enabled and a valid license. Reproduced on a live site stuck on 3.8.1 while 3.8.2 was available; wp.org plugins on the same site auto-updated fine.

## Root cause

Since PMPro left the wp.org repository, updates are injected into WordPress's `update_plugins` transient by `PMPro_AddOns`'s `pre_set_site_transient_update_plugins` filter. That filter (and the `http_request_args` download filter) is registered inside `admin_hooks()`, which is only hooked to `admin_init`:

```php
add_action( 'admin_init', array( $this, 'admin_hooks' ), 0 );
```

`admin_init` only fires on wp-admin requests. WordPress runs automatic background updates under **WP-Cron** (`wp_version_check` / `wp_update_plugins` / `wp_maybe_auto_update`), where `admin_init` never fires. So during the cron run the filter is not attached, the transient is rebuilt without any PMPro updates, and the automatic updater finds nothing to install. Manual updates work because loading wp-admin fires `admin_init`. Note `PMPro_AddOns::instance()` is already created on `init` (which does fire under cron) — only the hook registration was admin-gated.

Confirmed on the affected site: during a real `wp_update_plugins()` run, the callbacks on `pre_set_site_transient_update_plugins` were third-party plugins only; PMPro's was absent. Calling `update_plugins_filter()` directly injected the newer version correctly, so the logic is right, it was just never wired up under cron.

## Fix

Move the hooks that must run in all contexts into a new `update_hooks()` method called unconditionally from the constructor:

- `pre_set_site_transient_update_plugins` (inject available updates)
- `http_request_args` (SSL-verify handling for license-server package downloads during upgrade)
- `update_option_pmpro_license_key` (clear caches when the key changes)

The admin-only pieces (`plugins_api` details modal, `check_when_updating_plugins()`, AJAX endpoints) stay on `admin_init`.

Also sets `new_version` on `no_update` entries: with the filter now running in WP-CLI/cron contexts, up-to-date Add Ons land in `no_update`, and objects without `new_version` trigger undefined-property warnings from WP-CLI's plugin commands. Core sets `new_version` on `no_update` entries as well, so this matches convention.

## Companion PR

strangerstudios/pmpro-update-manager#18 applies the identical fix to `PMProUM_AddOns` (a renamed copy of this class, per its file header). This PR is the upstream source of that copy and covers sites that do not have Update Manager installed. When both are active, both filters registering is harmless — the injection is idempotent.

## Testing

- `php -l` clean.
- Verified the same change live on the affected site (via the Update Manager copy of this class): in a WP-CLI (cron-equivalent) context, `wp_update_plugins()` now attaches the filter and populates `response[paid-memberships-pro/paid-memberships-pro.php]` with the newer version, and `wp plugin list` shows `update available` with no warnings.