### PR TITLE
Add REST API bulk collection endpoints for members, orders, and subscriptions

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -494,6 +494,13 @@ class PMPro_Subscription {
 		if ( $limit ) {
 			$sql_query .= ' LIMIT %d';
 			$prepared[] = $limit;
+
+			// Maybe offset the data for pagination.
+			$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
+			if ( $offset > 0 ) {
+				$sql_query .= ' OFFSET %d';
+				$prepared[] = $offset;
+			}
 		}
 
 		// Maybe prepare the query.

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -725,6 +725,13 @@
 				if ( $limit ) {
 					$sql_query .= ' LIMIT %d';
 					$prepared[] = $limit;
+
+					// Maybe offset the data for pagination.
+					$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
+					if ( $offset > 0 ) {
+						$sql_query .= ' OFFSET %d';
+						$prepared[] = $offset;
+					}
 				}
 			}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5520,3 +5520,135 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
 		do_action( 'pmpro_after_updating_post_level_restrictions', $post_id );
 	}
 }
+
+/**
+ * Query PMPro members (WordPress users who hold a membership) with filtering and pagination.
+ *
+ * Provides a single reusable member query for the REST API collection endpoint
+ * ( /pmpro/v1/members ) and the `wp pmpro member list` CLI command, so both share
+ * the same filtering, pagination, and output shape.
+ *
+ * @since TBD
+ *
+ * @param array $args {
+ *     Optional. Query arguments.
+ *
+ *     @type int|int[]       $membership_id Only return members holding these level IDs. Default null (any level).
+ *     @type string|string[] $status        Membership status(es) to match, or 'all' for any status. Default 'active'.
+ *     @type string          $search        Match users by login, email, or display name. Default ''.
+ *     @type int             $limit         Maximum rows to return. 0 for no limit. Default 100.
+ *     @type int             $offset        Rows to skip, for pagination. Default 0.
+ *     @type string          $orderby       One of id, user_login, user_email, display_name, membership_id, startdate, enddate, joindate. Default 'id'.
+ *     @type string          $order         'ASC' or 'DESC'. Default 'DESC'.
+ *     @type bool            $return_count  Return the total matching count instead of rows. Default false.
+ * }
+ * @return array|int Array of member row arrays, or an integer count when $return_count is true.
+ */
+function pmpro_get_members( $args = array() ) {
+	global $wpdb;
+
+	$defaults = array(
+		'membership_id' => null,
+		'status'        => 'active',
+		'search'        => '',
+		'limit'         => 100,
+		'offset'        => 0,
+		'orderby'       => 'id',
+		'order'         => 'DESC',
+		'return_count'  => false,
+	);
+	$args = wp_parse_args( $args, $defaults );
+
+	$return_count = ! empty( $args['return_count'] );
+	$where        = array();
+	$prepared     = array();
+
+	if ( $return_count ) {
+		$sql = "SELECT COUNT( DISTINCT u.ID, mu.membership_id )";
+	} else {
+		$sql = "SELECT u.ID AS user_id, u.user_login, u.user_email, u.display_name, mu.membership_id, mu.status,
+			u.user_registered AS joindate, mu.startdate, mu.enddate, m.name AS membership_name";
+	}
+
+	$sql .= " FROM {$wpdb->users} u
+		INNER JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id
+		LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id";
+
+	// Only include rows tied to a real membership level.
+	$where[] = 'mu.membership_id > 0';
+
+	// Filter by membership level ID(s).
+	if ( ! empty( $args['membership_id'] ) ) {
+		$ids      = array_map( 'intval', (array) $args['membership_id'] );
+		$where[]  = 'mu.membership_id IN ( ' . implode( ', ', array_fill( 0, count( $ids ), '%d' ) ) . ' )';
+		$prepared = array_merge( $prepared, $ids );
+	}
+
+	// Filter by membership status(es). Pass 'all' to include every status.
+	if ( ! empty( $args['status'] ) && 'all' !== $args['status'] ) {
+		$statuses = array_map( 'strval', (array) $args['status'] );
+		$where[]  = 'mu.status IN ( ' . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ' )';
+		$prepared = array_merge( $prepared, $statuses );
+	}
+
+	// Search by login, email, or display name.
+	if ( ! empty( $args['search'] ) ) {
+		$like       = '%' . $wpdb->esc_like( $args['search'] ) . '%';
+		$where[]    = '( u.user_login LIKE %s OR u.user_email LIKE %s OR u.display_name LIKE %s )';
+		$prepared[] = $like;
+		$prepared[] = $like;
+		$prepared[] = $like;
+	}
+
+	$sql .= ' WHERE ' . implode( ' AND ', $where );
+
+	if ( $return_count ) {
+		if ( $prepared ) {
+			$sql = $wpdb->prepare( $sql, $prepared );
+		}
+		return (int) $wpdb->get_var( $sql );
+	}
+
+	// One row per user/level pair.
+	$sql .= ' GROUP BY u.ID, mu.membership_id';
+
+	// Sanitize orderby against an allowlist of safe columns.
+	$orderby_map = array(
+		'id'            => 'u.ID',
+		'user_login'    => 'u.user_login',
+		'user_email'    => 'u.user_email',
+		'display_name'  => 'u.display_name',
+		'membership_id' => 'mu.membership_id',
+		'startdate'     => 'mu.startdate',
+		'enddate'       => 'mu.enddate',
+		'joindate'      => 'u.user_registered',
+	);
+	$orderby_col = isset( $orderby_map[ $args['orderby'] ] ) ? $orderby_map[ $args['orderby'] ] : 'u.ID';
+	$order       = ( 'ASC' === strtoupper( (string) $args['order'] ) ) ? 'ASC' : 'DESC';
+	$sql        .= " ORDER BY {$orderby_col} {$order}";
+
+	// Pagination.
+	$limit  = max( 0, (int) $args['limit'] );
+	$offset = max( 0, (int) $args['offset'] );
+	if ( $limit ) {
+		$sql       .= ' LIMIT %d OFFSET %d';
+		$prepared[] = $limit;
+		$prepared[] = $offset;
+	}
+
+	if ( $prepared ) {
+		$sql = $wpdb->prepare( $sql, $prepared );
+	}
+
+	/**
+	 * Filter the SQL used by pmpro_get_members().
+	 *
+	 * @since TBD
+	 *
+	 * @param string $sql  The prepared SQL query.
+	 * @param array  $args The parsed query arguments.
+	 */
+	$sql = apply_filters( 'pmpro_get_members_sql', $sql, $args );
+
+	return $wpdb->get_results( $sql, ARRAY_A );
+}

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -257,6 +257,83 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		);
 
 		/**
+		 * Get a paginated, filterable collection of members.
+		 * @since TBD
+		 * Example: https://example.com/wp-json/pmpro/v1/members?level=1&status=active&page=1&per_page=20
+		 */
+		register_rest_route( $pmpro_namespace, '/members',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'pmpro_rest_api_get_members' ),
+					'args'     => array(
+						'page'     => array( 'sanitize_callback' => 'absint' ),
+						'per_page' => array( 'sanitize_callback' => 'absint' ),
+						'level'    => array(),
+						'status'   => array(),
+						'search'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'  => array( 'sanitize_callback' => 'sanitize_key' ),
+						'order'    => array( 'sanitize_callback' => 'sanitize_key' ),
+						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+					),
+					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+				)
+			)
+		);
+
+		/**
+		 * Get a paginated, filterable collection of orders.
+		 * @since TBD
+		 * Example: https://example.com/wp-json/pmpro/v1/orders?status=success&per_page=20
+		 */
+		register_rest_route( $pmpro_namespace, '/orders',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'pmpro_rest_api_get_orders' ),
+					'args'     => array(
+						'page'       => array( 'sanitize_callback' => 'absint' ),
+						'per_page'   => array( 'sanitize_callback' => 'absint' ),
+						'user_id'    => array( 'sanitize_callback' => 'absint' ),
+						'level'      => array(),
+						'status'     => array(),
+						'gateway'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'start_date' => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'end_date'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'     => array( 'sanitize_callback' => 'sanitize_text_field' ),
+					),
+					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+				)
+			)
+		);
+
+		/**
+		 * Get a paginated, filterable collection of subscriptions.
+		 * @since TBD
+		 * Example: https://example.com/wp-json/pmpro/v1/subscriptions?status=active&per_page=20
+		 */
+		register_rest_route( $pmpro_namespace, '/subscriptions',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'pmpro_rest_api_get_subscriptions' ),
+					'args'     => array(
+						'page'     => array( 'sanitize_callback' => 'absint' ),
+						'per_page' => array( 'sanitize_callback' => 'absint' ),
+						'user_id'  => array( 'sanitize_callback' => 'absint' ),
+						'level'    => array(),
+						'status'   => array(),
+						'gateway'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+					),
+					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+				)
+			)
+		);
+
+		/**
 		 * Get the IDs that a post has been restricted to.
 		 * @since 3.0
 		 * Example: https://example.com/wp-json/pmpro/v1/post_restrictions
@@ -1254,6 +1331,289 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		}
 
 		/**
+		 * Get a paginated, filterable collection of members.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return WP_REST_Response The REST response.
+		 */
+		public function pmpro_rest_api_get_members( $request ) {
+			$params   = $request->get_params();
+			$per_page = $this->pmpro_rest_api_get_per_page( $params );
+			$page     = $this->pmpro_rest_api_get_page( $params );
+
+			$query_args = array(
+				'limit'  => $per_page,
+				'offset' => ( $page - 1 ) * $per_page,
+			);
+			if ( isset( $params['level'] ) && '' !== $params['level'] ) {
+				$query_args['membership_id'] = array_map( 'intval', explode( ',', (string) $params['level'] ) );
+			}
+			if ( isset( $params['status'] ) && '' !== $params['status'] ) {
+				$query_args['status'] = array_map( 'sanitize_text_field', explode( ',', (string) $params['status'] ) );
+			}
+			if ( ! empty( $params['search'] ) ) {
+				$query_args['search'] = sanitize_text_field( $params['search'] );
+			}
+			if ( ! empty( $params['orderby'] ) ) {
+				$query_args['orderby'] = sanitize_key( $params['orderby'] );
+			}
+			if ( ! empty( $params['order'] ) ) {
+				$query_args['order'] = ( 'asc' === strtolower( (string) $params['order'] ) ) ? 'ASC' : 'DESC';
+			}
+
+			$total   = (int) pmpro_get_members( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$members = pmpro_get_members( $query_args );
+
+			$fields = $this->pmpro_rest_api_get_fields( $params );
+			$items  = array();
+			foreach ( (array) $members as $member ) {
+				$item = array(
+					'user_id'         => (int) $member['user_id'],
+					'user_login'      => $member['user_login'],
+					'user_email'      => $member['user_email'],
+					'display_name'    => $member['display_name'],
+					'membership_id'   => (int) $member['membership_id'],
+					'membership_name' => $member['membership_name'],
+					'status'          => $member['status'],
+					'joindate'        => $this->pmpro_rest_api_maybe_iso8601( $member['joindate'] ),
+					'startdate'       => $this->pmpro_rest_api_maybe_iso8601( $member['startdate'] ),
+					'enddate'         => $this->pmpro_rest_api_maybe_iso8601( $member['enddate'] ),
+				);
+				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
+			}
+
+			return $this->pmpro_rest_api_collection_response( $items, $total, $page, $per_page );
+		}
+
+		/**
+		 * Get a paginated, filterable collection of orders.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return WP_REST_Response The REST response.
+		 */
+		public function pmpro_rest_api_get_orders( $request ) {
+			$params   = $request->get_params();
+			$per_page = $this->pmpro_rest_api_get_per_page( $params );
+			$page     = $this->pmpro_rest_api_get_page( $params );
+
+			$query_args = array(
+				'limit'  => $per_page,
+				'offset' => ( $page - 1 ) * $per_page,
+			);
+			if ( ! empty( $params['user_id'] ) ) {
+				$query_args['user_id'] = (int) $params['user_id'];
+			}
+			if ( isset( $params['level'] ) && '' !== $params['level'] ) {
+				$query_args['membership_level_id'] = array_map( 'intval', explode( ',', (string) $params['level'] ) );
+			}
+			if ( isset( $params['status'] ) && '' !== $params['status'] ) {
+				$query_args['status'] = array_map( 'sanitize_text_field', explode( ',', (string) $params['status'] ) );
+			}
+			if ( ! empty( $params['gateway'] ) ) {
+				$query_args['gateway'] = sanitize_text_field( $params['gateway'] );
+			}
+			if ( ! empty( $params['start_date'] ) ) {
+				$query_args['start_date'] = sanitize_text_field( $params['start_date'] );
+			}
+			if ( ! empty( $params['end_date'] ) ) {
+				$query_args['end_date'] = sanitize_text_field( $params['end_date'] );
+			}
+
+			$total  = (int) MemberOrder::get_orders( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$orders = MemberOrder::get_orders( $query_args );
+
+			$fields = $this->pmpro_rest_api_get_fields( $params );
+			$items  = array();
+			foreach ( (array) $orders as $order ) {
+				$item = array(
+					'id'                           => (int) $order->id,
+					'code'                         => $order->code,
+					'user_id'                      => (int) $order->user_id,
+					'membership_id'                => (int) $order->membership_id,
+					'status'                       => $order->status,
+					'gateway'                      => $order->gateway,
+					'gateway_environment'          => $order->gateway_environment,
+					'subtotal'                     => $order->subtotal,
+					'tax'                          => $order->tax,
+					'total'                        => $order->total,
+					'payment_transaction_id'       => $order->payment_transaction_id,
+					'subscription_transaction_id'  => $order->subscription_transaction_id,
+					'timestamp'                    => ! empty( $order->timestamp ) ? gmdate( DateTime::ATOM, (int) $order->timestamp ) : null,
+				);
+				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
+			}
+
+			return $this->pmpro_rest_api_collection_response( $items, $total, $page, $per_page );
+		}
+
+		/**
+		 * Get a paginated, filterable collection of subscriptions.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return WP_REST_Response The REST response.
+		 */
+		public function pmpro_rest_api_get_subscriptions( $request ) {
+			$params   = $request->get_params();
+			$per_page = $this->pmpro_rest_api_get_per_page( $params );
+			$page     = $this->pmpro_rest_api_get_page( $params );
+
+			$query_args = array(
+				'limit'  => $per_page,
+				'offset' => ( $page - 1 ) * $per_page,
+			);
+			if ( ! empty( $params['user_id'] ) ) {
+				$query_args['user_id'] = (int) $params['user_id'];
+			}
+			if ( isset( $params['level'] ) && '' !== $params['level'] ) {
+				$query_args['membership_level_id'] = array_map( 'intval', explode( ',', (string) $params['level'] ) );
+			}
+			if ( isset( $params['status'] ) && '' !== $params['status'] ) {
+				$query_args['status'] = array_map( 'sanitize_text_field', explode( ',', (string) $params['status'] ) );
+			}
+			if ( ! empty( $params['gateway'] ) ) {
+				$query_args['gateway'] = sanitize_text_field( $params['gateway'] );
+			}
+
+			$total         = (int) PMPro_Subscription::get_subscriptions( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$subscriptions = PMPro_Subscription::get_subscriptions( $query_args );
+
+			$fields = $this->pmpro_rest_api_get_fields( $params );
+			$items  = array();
+			foreach ( (array) $subscriptions as $subscription ) {
+				$item = array(
+					'id'                          => (int) $subscription->get_id(),
+					'user_id'                     => (int) $subscription->get_user_id(),
+					'membership_level_id'         => (int) $subscription->get_membership_level_id(),
+					'status'                      => (string) $subscription->get_status(),
+					'gateway'                     => (string) $subscription->get_gateway(),
+					'gateway_environment'         => (string) $subscription->get_gateway_environment(),
+					'subscription_transaction_id' => (string) $subscription->get_subscription_transaction_id(),
+					'billing_amount'              => (float) $subscription->get_billing_amount(),
+					'cycle_number'                => (int) $subscription->get_cycle_number(),
+					'cycle_period'                => (string) $subscription->get_cycle_period(),
+					'startdate'                   => $subscription->get_startdate( 'c' ),
+					'enddate'                     => $subscription->get_enddate( 'c' ),
+					'next_payment_date'           => $subscription->get_next_payment_date( 'c' ),
+				);
+				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
+			}
+
+			return $this->pmpro_rest_api_collection_response( $items, $total, $page, $per_page );
+		}
+
+		/**
+		 * Get the requested page number for a collection request. Minimum 1.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $params The request parameters.
+		 * @return int
+		 */
+		private function pmpro_rest_api_get_page( $params ) {
+			return isset( $params['page'] ) ? max( 1, (int) $params['page'] ) : 1;
+		}
+
+		/**
+		 * Get the requested per_page value for a collection request, clamped to a hard maximum.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $params The request parameters.
+		 * @return int
+		 */
+		private function pmpro_rest_api_get_per_page( $params ) {
+			$per_page = isset( $params['per_page'] ) ? (int) $params['per_page'] : 20;
+
+			/**
+			 * Filter the maximum number of items a PMPro REST collection endpoint will return per page.
+			 *
+			 * @since TBD
+			 *
+			 * @param int $max The maximum per_page value. Default 100.
+			 */
+			$max = (int) apply_filters( 'pmpro_rest_api_max_per_page', 100 );
+
+			if ( $per_page < 1 ) {
+				$per_page = 20;
+			}
+
+			return min( $per_page, $max );
+		}
+
+		/**
+		 * Parse the requested field list for a collection request.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $params The request parameters.
+		 * @return array Array of requested field names, or empty array for all fields.
+		 */
+		private function pmpro_rest_api_get_fields( $params ) {
+			if ( empty( $params['fields'] ) ) {
+				return array();
+			}
+			return array_filter( array_map( 'trim', explode( ',', (string) $params['fields'] ) ) );
+		}
+
+		/**
+		 * Reduce an item array to only the requested fields.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $item   The full item array.
+		 * @param array $fields The requested field names. Empty means all fields.
+		 * @return array
+		 */
+		private function pmpro_rest_api_apply_fields( $item, $fields ) {
+			if ( empty( $fields ) ) {
+				return $item;
+			}
+			return array_intersect_key( $item, array_flip( $fields ) );
+		}
+
+		/**
+		 * Format a stored datetime string as ISO 8601, returning null for empty or zero dates.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $date The datetime string.
+		 * @return string|null
+		 */
+		private function pmpro_rest_api_maybe_iso8601( $date ) {
+			if ( empty( $date ) || 0 === strpos( (string) $date, '0000-00-00' ) ) {
+				return null;
+			}
+			return pmpro_format_date_iso8601( $date );
+		}
+
+		/**
+		 * Build a collection response with pagination headers.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $items    The response items.
+		 * @param int   $total    The total number of matching records.
+		 * @param int   $page     The current page.
+		 * @param int   $per_page The page size.
+		 * @return WP_REST_Response
+		 */
+		private function pmpro_rest_api_collection_response( $items, $total, $page, $per_page ) {
+			$response    = new WP_REST_Response( $items, 200 );
+			$total_pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 0;
+
+			$response->header( 'X-WP-Total', (string) $total );
+			$response->header( 'X-WP-TotalPages', (string) $total_pages );
+
+			return $response;
+		}
+
+		/**
 		 * Get the membership level IDs restricting a given post.
 		 *
 		 * @since 3.0
@@ -1817,6 +2177,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				'/pmpro/v1/me' => true,
 				'/pmpro/v1/recent_memberships' => 'pmpro_edit_members',
 				'/pmpro/v1/recent_orders' => 'pmpro_orders',
+				'/pmpro/v1/members' => 'pmpro_edit_members',
+				'/pmpro/v1/orders' => 'pmpro_orders',
+				'/pmpro/v1/subscriptions' => 'pmpro_edit_members',
 				'/pmpro/v1/post_restrictions' => array(
 					'capability' => 'edit_post',
 					'request_param' => 'post_id',

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -274,7 +274,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'search'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'orderby'  => array( 'sanitize_callback' => 'sanitize_key' ),
 						'order'    => array( 'sanitize_callback' => 'sanitize_key' ),
-						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'   => array(
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => function( $value ) {
+								return $this->pmpro_rest_api_validate_fields( $value, 'members' );
+							},
+						),
 					),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				)
@@ -301,7 +306,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'start_date' => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'end_date'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'orderby'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
-						'fields'     => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'     => array(
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => function( $value ) {
+								return $this->pmpro_rest_api_validate_fields( $value, 'orders' );
+							},
+						),
 					),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				)
@@ -326,7 +336,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'status'   => array(),
 						'gateway'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'orderby'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
-						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'   => array(
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => function( $value ) {
+								return $this->pmpro_rest_api_validate_fields( $value, 'subscriptions' );
+							},
+						),
 					),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				)
@@ -1431,17 +1446,17 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			foreach ( (array) $orders as $order ) {
 				$item = array(
 					'id'                           => (int) $order->id,
-					'code'                         => $order->code,
+					'code'                         => (string) $order->code,
 					'user_id'                      => (int) $order->user_id,
 					'membership_id'                => (int) $order->membership_id,
-					'status'                       => $order->status,
-					'gateway'                      => $order->gateway,
-					'gateway_environment'          => $order->gateway_environment,
-					'subtotal'                     => $order->subtotal,
-					'tax'                          => $order->tax,
-					'total'                        => $order->total,
-					'payment_transaction_id'       => $order->payment_transaction_id,
-					'subscription_transaction_id'  => $order->subscription_transaction_id,
+					'status'                       => (string) $order->status,
+					'gateway'                      => (string) $order->gateway,
+					'gateway_environment'          => (string) $order->gateway_environment,
+					'subtotal'                     => (float) $order->subtotal,
+					'tax'                          => (float) $order->tax,
+					'total'                        => (float) $order->total,
+					'payment_transaction_id'       => (string) $order->payment_transaction_id,
+					'subscription_transaction_id'  => (string) $order->subscription_transaction_id,
 					'timestamp'                    => ! empty( $order->timestamp ) ? gmdate( DateTime::ATOM, (int) $order->timestamp ) : null,
 				);
 				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
@@ -1559,6 +1574,99 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				return array();
 			}
 			return array_filter( array_map( 'trim', explode( ',', (string) $params['fields'] ) ) );
+		}
+
+		/**
+		 * Get the field names a collection endpoint can return.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $collection One of 'members', 'orders' or 'subscriptions'.
+		 * @return array Array of valid field names.
+		 */
+		private function pmpro_rest_api_get_collection_fields( $collection ) {
+			$fields = array(
+				'members'       => array(
+					'user_id',
+					'user_login',
+					'user_email',
+					'display_name',
+					'membership_id',
+					'membership_name',
+					'status',
+					'joindate',
+					'startdate',
+					'enddate',
+				),
+				'orders'        => array(
+					'id',
+					'code',
+					'user_id',
+					'membership_id',
+					'status',
+					'gateway',
+					'gateway_environment',
+					'subtotal',
+					'tax',
+					'total',
+					'payment_transaction_id',
+					'subscription_transaction_id',
+					'timestamp',
+				),
+				'subscriptions' => array(
+					'id',
+					'user_id',
+					'membership_level_id',
+					'status',
+					'gateway',
+					'gateway_environment',
+					'subscription_transaction_id',
+					'billing_amount',
+					'cycle_number',
+					'cycle_period',
+					'startdate',
+					'enddate',
+					'next_payment_date',
+				),
+			);
+
+			return isset( $fields[ $collection ] ) ? $fields[ $collection ] : array();
+		}
+
+		/**
+		 * Validate a requested `fields` list against a collection's known fields.
+		 *
+		 * Unknown names are rejected rather than silently dropped so that callers
+		 * get told which fields actually exist.
+		 *
+		 * @since TBD
+		 *
+		 * @param mixed  $value      The `fields` parameter value.
+		 * @param string $collection One of 'members', 'orders' or 'subscriptions'.
+		 * @return true|WP_Error True when valid, WP_Error otherwise.
+		 */
+		private function pmpro_rest_api_validate_fields( $value, $collection ) {
+			if ( empty( $value ) ) {
+				return true;
+			}
+
+			$known   = $this->pmpro_rest_api_get_collection_fields( $collection );
+			$unknown = array_diff( array_filter( array_map( 'trim', explode( ',', (string) $value ) ) ), $known );
+
+			if ( ! empty( $unknown ) ) {
+				return new WP_Error(
+					'rest_invalid_param',
+					sprintf(
+						/* translators: 1: comma-separated list of unrecognized field names. 2: comma-separated list of valid field names. */
+						__( 'Unknown field(s): %1$s. Valid fields are: %2$s.', 'paid-memberships-pro' ),
+						implode( ', ', $unknown ),
+						implode( ', ', $known )
+					),
+					array( 'status' => 400 )
+				);
+			}
+
+			return true;
 		}
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds REST API **bulk collection endpoints** so AI agents and integrations can query PMPro data at scale instead of making N single-record calls. Part of the "PMPro CLI and WP MCP/Abilities" pitch (companion PRs: pmpro-cli, and @mircobabini's abilities PR #3736).

New read-only endpoints under `pmpro/v1`:

- `GET /pmpro/v1/members` — filter by `level`, `status`, `search`; paginate; select fields.
- `GET /pmpro/v1/orders` — filter by `user_id`, `level`, `status`, `gateway`, `start_date`, `end_date`.
- `GET /pmpro/v1/subscriptions` — filter by `user_id`, `level`, `status`, `gateway`.

All three support:
- **Pagination** — `page` + `per_page`, with `X-WP-Total` and `X-WP-TotalPages` response headers. Hard-capped (default max 100) via the new `pmpro_rest_api_max_per_page` filter, so no unbounded queries.
- **Field selection** — `fields=id,status,total` to trim the payload.
- The **existing permission model** (`pmpro_rest_api_get_permissions_check`) — `pmpro_edit_members` for members/subscriptions, `pmpro_orders` for orders. No new auth scheme.

Supporting changes:
- New reusable `pmpro_get_members( $args )` query helper (with a `pmpro_get_members_sql` filter) in `includes/functions.php`, shared by this endpoint and the forthcoming `pmpro-cli`. There was no core function to query members with filters + pagination; this fills that gap.
- Backward-compatible `offset` support added to `MemberOrder::get_orders()` and `PMPro_Subscription::get_subscriptions()` (both already supported `limit`) to enable pagination.

### How to test the changes in this Pull Request:

1. With PMPro active and some members/orders/subscriptions present, authenticate as a user with `pmpro_edit_members` / `pmpro_orders`.
2. `GET /wp-json/pmpro/v1/members?status=active&per_page=5&page=1` — confirm 5 members, correct `X-WP-Total` header, and page 2 returns the next set.
3. `GET /wp-json/pmpro/v1/orders?status=success&fields=id,total,status` — confirm only those fields return.
4. `GET /wp-json/pmpro/v1/subscriptions?status=active` — confirm the collection and pagination headers.
5. Confirm a user without the relevant capability gets a 401/403.

### Changelog entry

> FEATURE: Added REST API bulk collection endpoints (`/members`, `/orders`, `/subscriptions`) with filtering, pagination, and field selection.

---
*`@since TBD` tags are placeholders — set to the target milestone at merge.*
🤖 Generated with [Claude Code](https://claude.com/claude-code)
