### PR TITLE
Fix fatal error when checkout data is missing from order meta

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -159,23 +159,53 @@ function pmpro_get_sensitive_checkout_request_vars() {
  */
 function pmpro_pull_checkout_data_from_order( $order ) {
 	global $pmpro_level, $discount_code;
+
+	// Keep track of any checkout data that we expected to find but could not.
+	$missing_data = array();
+
 	// We need to pull the checkout level and fields data from the order.
 	$checkout_level_arr = get_pmpro_membership_order_meta( $order->id, 'checkout_level', true );
+	if ( ! is_array( $checkout_level_arr ) ) {
+		$missing_data[] = 'checkout_level';
+		$checkout_level_arr = array();
+	}
 	$pmpro_level = (object) $checkout_level_arr;
 	$order->membership_level = $pmpro_level;
 
 	// Set $discount_code_id.
 	// @TODO: Remove this in v4.0. Discount codes should be set on the level object.
 	$discount_code = get_pmpro_membership_order_meta( $order->id, 'checkout_discount_code', true );
-	
+
 	// Set $_REQUEST.
 	$checkout_request_vars = get_pmpro_membership_order_meta( $order->id, 'checkout_request_vars', true );
-	$_REQUEST = array_merge( $_REQUEST, $checkout_request_vars );
+	if ( is_array( $checkout_request_vars ) ) {
+		$_REQUEST = array_merge( $_REQUEST, $checkout_request_vars );
+	} else {
+		$missing_data[] = 'checkout_request_vars';
+	}
 
 	// Set $_FILES.
 	$checkout_files = get_pmpro_membership_order_meta( $order->id, 'checkout_files', true );
-	if ( ! empty( $checkout_files ) ) {
+	if ( is_array( $checkout_files ) ) {
 		$_FILES = array_merge( $_FILES, $checkout_files );
+	}
+	// Note: We do not track missing 'checkout_files' meta since it is only saved when files were uploaded.
+
+	// If any of the checkout data that we expected is missing, note it on the order. Membership will still be
+	// assigned, but data submitted during checkout may not be saved, so admins should know to follow up.
+	if ( ! empty( $missing_data ) && ! empty( $order->id ) ) {
+		$missing_data_note = sprintf(
+			// translators: %s is a comma-separated list of order meta keys.
+			__( 'Warning: Could not load the checkout data for this order (%s). Information submitted during checkout may not have been saved.', 'paid-memberships-pro' ),
+			implode( ', ', $missing_data )
+		);
+
+		// Only add the note if we haven't already added it. This function may run more than once for
+		// an order, such as when an admin rechecks the payment status for a token order.
+		if ( false === strpos( (string) $order->notes, $missing_data_note ) ) {
+			$order->add_order_note( $missing_data_note );
+			$order->saveOrder();
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

A site reported this fatal error when customers returned from Stripe Checkout, and again when an admin used the "Recheck" link on the Orders page:

```
PHP Fatal error: Uncaught TypeError: array_merge(): Argument #2 must be of type array, string given
in .../includes/checkout.php:173
#0 .../includes/checkout.php(173): array_merge(Array, '')
#1 .../classes/gateways/class.pmprogateway_stripe.php: pmpro_pull_checkout_data_from_order(Object(MemberOrder))
#2 .../includes/functions.php: PMProGateway_stripe->check_token_order(Object(MemberOrder))
#3 .../adminpages/orders.php: pmpro_check_token_order_for_completion(360)
```

The affected orders were left in `token` status with no membership assigned, and the error recurred on every recheck attempt.

`pmpro_pull_checkout_data_from_order()` passed the return value of `get_pmpro_membership_order_meta( ..., true )` directly into `array_merge()`. That returns an **empty string** when the meta row does not exist, which is a fatal on PHP 8. The three reads were also inconsistent about this:

- `checkout_level` — unguarded, but `(object) ''` fails silently, so the error surfaced later.
- `checkout_request_vars` — unguarded, and the actual crash site.
- `checkout_files` — guarded with `! empty()`, which covers the empty-string case but would still fatal on a non-empty non-array.

## Root cause note

In every supported flow this meta should exist: all callers of `pmpro_pull_checkout_data_from_order()` operate on orders PMPro created via `pmpro_save_checkout_data_to_order()`. For Stripe Checkout the ordering is conclusive — `check_token_order()` returns early unless `stripe_checkout_session_id` exists, and that meta is written *after* `checkout_request_vars`. So reaching the crash proves the save function ran and its later writes landed while the first one did not.

So this PR fixes the fatal but does not fix whatever caused the write to fail. That is deliberate: a fatal is never the right response to missing meta, and the crash currently blocks membership assignment entirely. To keep the guard from silently masking the underlying issue, the missing data is recorded on the order. On the reporting site only `checkout_request_vars` was missing, which suggests something specific to that value (size, or bytes rejected for the ordermeta column charset) rather than a control-flow problem. We have asked the reporter for `LENGTH(meta_value)` per meta key on an affected order, plus the column type and collation, to narrow that down.

## Changes

`includes/checkout.php`, in `pmpro_pull_checkout_data_from_order()`:

- Type check all three meta reads before use. Missing `checkout_level` now falls back to an empty array instead of `(object) ''`.
- Add an order note listing which expected keys could not be loaded, deduplicated so repeated rechecks do not append it over and over, and guarded on `! empty( $order->id )` so `saveOrder()` cannot insert a stray order row.

## Notes / caveats

- Affected orders will now complete and assign membership, but the user field values submitted at checkout are gone — they were never persisted. The guard cannot recover them; the order note is what makes that visible.
- If `checkout_level` is missing, checkout still will not complete (no level to assign). That matches the previous effective behavior, minus the fatal and the undefined-property warnings.

## Testing

Static review only, not yet exercised in a browser.

Suggested manual test:
1. Set up a level with user fields, including a file field, and check out through Stripe Checkout.
2. Before returning from Stripe, delete the `checkout_request_vars` row from `wp_pmpro_membership_ordermeta` for that order.
3. Complete the return, or use "Recheck Payment Status" on the order.
4. Expected: no fatal, order moves to `success`, membership assigned, and the order shows the "Could not load the checkout data" note.
5. Repeat the recheck to confirm the note is not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
