### PR TITLE
BUG FIX: Multi-value User Fields blank in UI after CSV import

### DIFF
--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -654,7 +654,7 @@ class PMPro_Field {
 	/**
 	 * Whether this field stores multiple selected values as an array.
 	 *
-	 * @since TBD
+	 * @since 3.8.3
 	 *
 	 * @return bool
 	 */
@@ -670,12 +670,16 @@ class PMPro_Field {
 	 * Normalize a multi-value field's stored value to an array of option keys.
 	 *
 	 * Profile/checkout saves store arrays. Members List CSV export joins those
-	 * arrays with commas, and Import Users from CSV writes the cell back as a
+	 * arrays with commas, and Import Users from CSV may write the cell back as a
 	 * string. Display and comparison code need a real array either way.
 	 *
-	 * @since TBD
+	 * Does not unserialize. get_user_meta() already unserializes stored arrays,
+	 * and this helper is also used on request-sourced values during checkout
+	 * re-display.
 	 *
-	 * @param mixed $value Raw stored value.
+	 * @since 3.8.3
+	 *
+	 * @param mixed $value Raw value (array from UI save, or CSV string).
 	 * @return array List of selected option keys.
 	 */
 	public function get_values_as_array( $value ) {
@@ -687,19 +691,15 @@ class PMPro_Field {
 			return array();
 		}
 
-		if ( is_string( $value ) ) {
-			$maybe = maybe_unserialize( $value );
-			if ( is_array( $maybe ) ) {
-				return $maybe;
-			}
-
-			// Comma-separated option keys from CSV import/export.
-			if ( false !== strpos( $value, ',' ) ) {
-				$parts = array_map( 'trim', explode( ',', $value ) );
-				return array_values( array_filter( $parts, 'strlen' ) );
-			}
-
+		if ( ! is_string( $value ) ) {
 			return array( $value );
+		}
+
+		// Comma-separated option keys from CSV import/export.
+		// Option keys are expected not to contain commas (same as export).
+		if ( false !== strpos( $value, ',' ) ) {
+			$parts = array_map( 'trim', explode( ',', $value ) );
+			return array_values( array_filter( $parts, 'strlen' ) );
 		}
 
 		return array( $value );

--- a/classes/class-pmpro-field.php
+++ b/classes/class-pmpro-field.php
@@ -652,6 +652,60 @@ class PMPro_Field {
 	}
 
 	/**
+	 * Whether this field stores multiple selected values as an array.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function stores_array_values() {
+		if ( in_array( $this->type, array( 'checkbox_grouped', 'multiselect', 'select2' ), true ) ) {
+			return true;
+		}
+
+		return ( 'select' === $this->type && ! empty( $this->multiple ) );
+	}
+
+	/**
+	 * Normalize a multi-value field's stored value to an array of option keys.
+	 *
+	 * Profile/checkout saves store arrays. Members List CSV export joins those
+	 * arrays with commas, and Import Users from CSV writes the cell back as a
+	 * string. Display and comparison code need a real array either way.
+	 *
+	 * @since TBD
+	 *
+	 * @param mixed $value Raw stored value.
+	 * @return array List of selected option keys.
+	 */
+	public function get_values_as_array( $value ) {
+		if ( is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( null === $value || false === $value || '' === $value ) {
+			return array();
+		}
+
+		if ( is_string( $value ) ) {
+			$maybe = maybe_unserialize( $value );
+			if ( is_array( $maybe ) ) {
+				return $maybe;
+			}
+
+			// Comma-separated option keys from CSV import/export.
+			if ( false !== strpos( $value, ',' ) ) {
+				$parts = array_map( 'trim', explode( ',', $value ) );
+				return array_values( array_filter( $parts, 'strlen' ) );
+			}
+
+			return array( $value );
+		}
+
+		return array( $value );
+	}
+
+	/**
 	 * Save the field for a user.
 	 *
 	 * @since 3.4
@@ -949,9 +1003,10 @@ class PMPro_Field {
 		}
 		elseif($this->type == "select")
 		{
-			//if multiple is set, value must be an array
-			if(!empty($this->multiple) && !is_array($value))
-				$value = array($value);
+			// Multi-select values may be arrays (UI save) or CSV strings (import).
+			if ( ! empty( $this->multiple ) ) {
+				$value = $this->get_values_as_array( $value );
+			}
 
 			if(!empty($this->multiple))
 				$r = '<select id="' . esc_attr( $this->id ) . '" name="' . esc_attr( $this->name ) . '[]" ';	//multiselect
@@ -980,9 +1035,8 @@ class PMPro_Field {
 		}
 		elseif($this->type == "multiselect")
 		{
-			//value must be an array
-			if(!is_array($value))
-				$value = array($value);
+			// Arrays from UI saves; CSV strings from import/export round-trips.
+			$value = $this->get_values_as_array( $value );
 
 			$r = '<select id="' . esc_attr( $this->id ) . '" name="' . esc_attr( $this->name ) . '[]" multiple="multiple" ';
 			if(!empty($this->class))
@@ -1004,9 +1058,8 @@ class PMPro_Field {
 		}
 		elseif($this->type == "select2")
 		{
-			//value must be an array
-			if(!is_array($value))
-				$value = array($value);
+			// Arrays from UI saves; CSV strings from import/export round-trips.
+			$value = $this->get_values_as_array( $value );
 
 			//build multi select
 			$r = '<select id="' . esc_attr( $this->id ) . '" name="' . esc_attr( $this->name ) . '[]" multiple="multiple" style="width: 100%" ';
@@ -1083,9 +1136,8 @@ class PMPro_Field {
 
 		elseif($this->type == "checkbox_grouped")
 		{
-			//value must be an array
-			if(!is_array($value))
-				$value = array($value);
+			// Arrays from UI saves; CSV strings from import/export round-trips.
+			$value = $this->get_values_as_array( $value );
 
 			$r = '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_form_field-checkbox-grouped' ) ) . '">';
 			$r .= '<ul class="' . esc_attr( pmpro_get_element_class( 'pmpro_list pmpro_list-plain' ) ) . '">';
@@ -1695,8 +1747,10 @@ class PMPro_Field {
 			case 'select2':
 			case 'radio':
 			case 'checkbox_grouped':
-				// For simplicity, make sure that $value and $this->options are arrays.
-				if ( ! is_array( $value ) ) {
+				// Multi-value fields may be arrays (UI) or CSV strings (import).
+				if ( $this->stores_array_values() ) {
+					$value = $this->get_values_as_array( $value );
+				} elseif ( ! is_array( $value ) ) {
 					$value = array( $value );
 				}
 				if ( ! is_array( $this->options ) ) {


### PR DESCRIPTION
## Description
Multi-value User Fields (`checkbox_grouped`, `multiselect`, `select2`, multi `select`) save as PHP arrays from the profile/checkout UI. Members List CSV export joins those arrays with commas (`email_summer,text_consent`). Import Users from CSV writes that cell back as a plain string.

On display, core did:

```php
if ( ! is_array( $value ) ) {
    $value = array( $value ); // "a,b,c" → ["a,b,c"]
}
in_array( $option_key, $value ); // never matches
```

So after import:
- Export still showed the correct comma-separated string
- Profile UI showed no boxes checked
- Re-saving the same selections in the UI stored a real array and the UI lit up

### Fix
- `PMPro_Field::stores_array_values()` — identifies multi-value field types
- `PMPro_Field::get_values_as_array()` — normalizes arrays, serialized arrays, and comma-separated strings into a list of option keys
- Used in `getHTML()` for multi-select field types and in `displayValue()`

Companion PR on Import Users from CSV stores multi-value fields as arrays on import so new imports match the UI save format. This core change is still needed for already-imported data and any other CSV-style integrations.

## Testing
1. Create a `checkbox_grouped` User Field with option keys like `email_summer`, `monthly_newsletter`, `text_consent`
2. Save selections via profile UI — confirm boxes stay checked
3. `update_user_meta( $user_id, 'field_name', 'email_summer,text_consent' );` to simulate CSV import
4. Reload profile — both options should now show checked (previously blank)
5. Confirm Members List export still outputs comma-separated values
6. Single-value string meta (`email_summer`) and real arrays still work

## Related
Found while testing member import on a Hosting Max staging site (LBCA). Not site-specific.