### PR TITLE
Respect group checkout visibility when a field overrides profile visibility

### DIFF
--- a/includes/fields.php
+++ b/includes/fields.php
@@ -1099,18 +1099,27 @@ function pmpro_load_user_fields_from_settings() {
         
         foreach ( $group->fields as $settings_field ) {
             // Figure out field profile from settings and group profile.
+            // The field setting only overrides profile visibility. Checkout visibility is always set at the group level.
             if ( empty( $settings_field->profile ) || $settings_field->profile === '[Inherit Group Setting]' ) {
                 $profile = $group_profile;
-            } else {
+            } elseif ( $group->checkout === 'yes' ) {
                 if ( $settings_field->profile === 'yes' ) {
                     $profile = true;
-                } elseif ( $settings_field->profile === 'no' ) {
-                    $profile = false;
                 } elseif ( $settings_field->profile === 'admins' ) {
                     $profile = 'admin';
                 } else {
                     // default to no
                     $profile = false;
+                }
+            } else {
+                // The group is hidden from checkout, so use an "only" value to keep the field off the checkout page.
+                if ( $settings_field->profile === 'yes' ) {
+                    $profile = 'only';
+                } elseif ( $settings_field->profile === 'admins' ) {
+                    $profile = 'only_admin';
+                } else {
+                    // Hide from checkout AND profile? Okay, skip this field.
+                    continue;
                 }
             }
             


### PR DESCRIPTION
## Problem

Reported: a field group has **Show Fields At Checkout = No** and **Show fields on user profile = Yes (only admins)**. If a field inside that group sets its own **Show field on user profile = Yes (only admins)**, the field renders on the checkout page anyway. Setting the field to `[Inherit Group Setting]` behaves correctly.

The scope is wider than reported. With the group's checkout setting at No, *every* explicit field-level profile value leaked the field onto the public checkout form:

| Field's profile setting | Resolved `$field->profile` | Shown at checkout? |
|---|---|---|
| `[Inherit Group Setting]` | `only_admin` | No — correct |
| Yes | `true` | **Yes — bug** |
| Yes (only admins) | `admin` | **Yes — bug** (the reported case) |
| No | `false` | **Yes — bug** |

## Cause

The settings UI keeps checkout visibility on the group and profile visibility on both the group and the field. `pmpro_load_user_fields_from_settings()` collapses both axes into the single `$field->profile` value, where `only` / `only_admin` encode "profile only, never at checkout". `PMPro_Field_Group::get_fields_to_display()` skips a field at checkout only when its profile is one of those two values.

When a field supplied its own profile setting, the old code mapped just the profile axis (`admins` → `admin`) and silently dropped the group's checkout setting, so the resulting value was never in the skip list. `[Inherit Group Setting]` was unaffected because it passes `$group_profile` straight through.

## Fix

Branch on the group's checkout setting before mapping the field-level value:

- Group shows at checkout → unchanged behaviour.
- Group hidden from checkout → `yes` becomes `only`, `admins` becomes `only_admin`.
- Group hidden from checkout **and** field hidden from profile → skip the field entirely, since there is nowhere left to show it. This mirrors the existing handling one block above, where a group hidden from both checkout and profile is skipped.

Checkout display, required-field validation, saving, and the admin confirmation email all read through `get_fields_to_display()`, so the single change covers every path.

## Testing

Test matrix installed via the real settings option — group `bugtest` (checkout=No, profile=admins) and control `ctrltest` (checkout=Yes, profile=admins), each with four fields covering every field-level profile value.

Before:

```
SCOPE checkout:  bugtest  -> bt_yes, bt_admins, bt_no
                 ctrltest -> ct_inherit, ct_yes, ct_admins, ct_no
```

After:

```
SCOPE checkout:  bugtest  -> (none)
                 ctrltest -> ct_inherit, ct_yes, ct_admins, ct_no
```

- Confirmed in a browser on `/membership-checkout/?pmpro_level=1`: no `bt_*` inputs render and the group heading/description are gone, while all four `ct_*` inputs still render.
- The control group's output is identical before and after, so groups that show at checkout are untouched.
- Profile scope verified for both an administrator and a subscriber; unchanged in both groups before and after.

## Note for reviewers

One deliberate behaviour change beyond the reported bug: a field set to profile **No** inside a group hidden from checkout is now unregistered rather than registered-and-leaked. `pmpro_get_user_fields_for_csv()` reads raw `get_fields()` instead of the display filter, so such a field also disappears from the Members List CSV export.

There is no representable "registered but hidden everywhere" state in the current encoding — `only` still shows on the profile and `only_admin` still shows to admins — so skipping is the only way to express it without adding a new state to `get_fields_to_display()`. It also matches how a fully-hidden group is already treated. Flagging it in case a different trade-off is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
