### PR TITLE
Cancel duplicate recurring action chains in maybe_add_recurring_task

### DIFF
--- a/classes/class-pmpro-action-scheduler.php
+++ b/classes/class-pmpro-action-scheduler.php
@@ -313,19 +313,25 @@ class PMPro_Action_Scheduler {
 		// The $unique flag below only guards new scheduling. Duplicate chains that already
 		// exist (e.g. inherited from a cloned or migrated database) self-perpetuate because
 		// Action Scheduler reschedules each chain's next occurrence without a uniqueness check.
-		$pending_action_ids = as_get_scheduled_actions(
+		$pending_action_ids = (array) as_get_scheduled_actions(
 			array(
 				'hook'     => $hook,
+				'args'     => array(),
 				'group'    => $group,
 				'status'   => ActionScheduler_Store::STATUS_PENDING,
-				'per_page' => -1,
+				'claimed'  => false,
+				'per_page' => 20,
 				'orderby'  => 'date',
 				'order'    => 'ASC',
 			),
 			'ids'
 		);
 		foreach ( array_slice( $pending_action_ids, 1 ) as $duplicate_action_id ) {
-			ActionScheduler::store()->cancel_action( $duplicate_action_id );
+			try {
+				ActionScheduler::store()->cancel_action( $duplicate_action_id );
+			} catch ( Exception $e ) {
+				// The action may have been deleted or claimed by another process.
+			}
 		}
 
 		if ( ! as_next_scheduled_action( $hook, array(), $group ) ) {

--- a/classes/class-pmpro-action-scheduler.php
+++ b/classes/class-pmpro-action-scheduler.php
@@ -298,6 +298,8 @@ class PMPro_Action_Scheduler {
 	/**
 	 * Maybe add a recurring task (if not exists)
 	 *
+	 * Also cancels duplicate pending actions for the hook, keeping the earliest scheduled one.
+	 *
 	 * @access public
 	 * @since 3.5
 	 * @param string   $hook The hook for the task.
@@ -307,6 +309,25 @@ class PMPro_Action_Scheduler {
 	 * @return void
 	 */
 	public function maybe_add_recurring_task( $hook, $interval_in_seconds = null, $first_run_datetime = null, $group = 'pmpro_recurring_tasks' ) {
+		// Cancel duplicate pending actions for this hook, keeping the earliest scheduled one.
+		// The $unique flag below only guards new scheduling. Duplicate chains that already
+		// exist (e.g. inherited from a cloned or migrated database) self-perpetuate because
+		// Action Scheduler reschedules each chain's next occurrence without a uniqueness check.
+		$pending_action_ids = as_get_scheduled_actions(
+			array(
+				'hook'     => $hook,
+				'group'    => $group,
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => -1,
+				'orderby'  => 'date',
+				'order'    => 'ASC',
+			),
+			'ids'
+		);
+		foreach ( array_slice( $pending_action_ids, 1 ) as $duplicate_action_id ) {
+			ActionScheduler::store()->cancel_action( $duplicate_action_id );
+		}
+
 		if ( ! as_next_scheduled_action( $hook, array(), $group ) ) {
 			// Make sure first run datetime has been set.
 			$first_run_datetime = $first_run_datetime ?: self::as_strtotime( 'now +5 minutes' );


### PR DESCRIPTION
## Summary
Duplicate `pmpro_schedule_*` recurring actions cause tasks to run two or more times simultaneously (observed in production as concurrent restic backup runs destroying each other's DB dump). The `$unique` flag added in 3.5.3 (8ff0b4f9c) prevents *new* duplicates at registration, but duplicate chains that already exist self-perpetuate forever: after each run, Action Scheduler's `ActionScheduler_ActionFactory::repeat()` stores the next occurrence with a plain (non-unique) `store()`. This is still the case upstream as of Action Scheduler 4.1.0, so duplicates inherited from a cloned or migrated database (or minted before 3.5.3) never heal on their own.

This PR makes `maybe_add_recurring_task()` self-healing: on every registration pass it cancels duplicate pending actions for the hook, keeping the earliest scheduled one.

## Key Features / Changes
- `PMPro_Action_Scheduler::maybe_add_recurring_task()` now queries pending actions for the hook/group (ordered by scheduled date ascending) and cancels all but the first via `ActionScheduler::store()->cancel_action()`.
- The existing `as_next_scheduled_action()` guard and `$unique = true` scheduling are unchanged; one indexed query is added per recurring hook on registration.

## How to Test
1. On a test site, create a duplicate chain: `wp eval 'as_schedule_recurring_action( time() + 60, DAY_IN_SECONDS, "pmpro_schedule_daily", array(), "pmpro_recurring_tasks" );'` (bypasses the unique guard by scheduling directly).
2. Confirm two pending `pmpro_schedule_daily` actions exist (Tools > Scheduled Actions, or `wp action-scheduler action list`).
3. Load any page (or run `wp cron event run action_scheduler_run_queue`) so PMPro's recurring-task registration fires.
4. Confirm only one pending `pmpro_schedule_daily` action remains, and it is the earlier-scheduled of the two; the extra shows as cancelled.
5. Confirm the surviving chain still reschedules normally after its next run.