### PR TITLE
Add wp pmpro subscription sync CLI command

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -494,6 +494,13 @@ class PMPro_Subscription {
 		if ( $limit ) {
 			$sql_query .= ' LIMIT %d';
 			$prepared[] = $limit;
+
+			// Maybe offset the data for pagination.
+			$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
+			if ( $offset > 0 ) {
+				$sql_query .= ' OFFSET %d';
+				$prepared[] = $offset;
+			}
 		}
 
 		// Maybe prepare the query.

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -725,6 +725,13 @@
 				if ( $limit ) {
 					$sql_query .= ' LIMIT %d';
 					$prepared[] = $limit;
+
+					// Maybe offset the data for pagination.
+					$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
+					if ( $offset > 0 ) {
+						$sql_query .= ' OFFSET %d';
+						$prepared[] = $offset;
+					}
 				}
 			}
 

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Register PMPro WP-CLI commands.
+ *
+ * Provides `wp pmpro <noun> <verb>` commands (member, level, order, subscription)
+ * that wrap the same PMPro functions used by the REST API, so PMPro data is
+ * scriptable by default on any install.
+ *
+ * @since TBD
+ * @package PaidMembershipsPro\CLI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+	return;
+}
+
+require_once PMPRO_DIR . '/includes/cli/class-pmpro-cli-command.php';
+require_once PMPRO_DIR . '/includes/cli/class-pmpro-cli-member.php';
+require_once PMPRO_DIR . '/includes/cli/class-pmpro-cli-level.php';
+require_once PMPRO_DIR . '/includes/cli/class-pmpro-cli-order.php';
+require_once PMPRO_DIR . '/includes/cli/class-pmpro-cli-subscription.php';
+
+WP_CLI::add_command( 'pmpro member', 'PMPro_CLI_Member' );
+WP_CLI::add_command( 'pmpro level', 'PMPro_CLI_Level' );
+WP_CLI::add_command( 'pmpro order', 'PMPro_CLI_Order' );
+WP_CLI::add_command( 'pmpro subscription', 'PMPro_CLI_Subscription' );
+
+/**
+ * Fires after PMPro registers its core WP-CLI commands, so Add Ons can register their own.
+ *
+ * @since TBD
+ */
+do_action( 'pmpro_cli_init' );

--- a/includes/cli/class-pmpro-cli-command.php
+++ b/includes/cli/class-pmpro-cli-command.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Base class for PMPro WP-CLI commands.
+ *
+ * @since TBD
+ * @package PaidMembershipsPro\CLI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared helpers for PMPro WP-CLI commands.
+ *
+ * @since TBD
+ */
+abstract class PMPro_CLI_Command {
+
+	/**
+	 * Output a set of associative-array items using the requested WP-CLI format.
+	 *
+	 * Honors --format ( table, csv, json, yaml, ids, count ) and --fields.
+	 *
+	 * @param array $items  The items to output (array of associative arrays).
+	 * @param array $fields The default columns to display.
+	 * @param array $assoc_args The command's associative arguments.
+	 */
+	protected function output_items( $items, $fields, $assoc_args ) {
+		$format = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';
+
+		if ( 'count' === $format ) {
+			WP_CLI::line( (string) count( $items ) );
+			return;
+		}
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_items( $items );
+	}
+
+	/**
+	 * Read an integer flag from the associative arguments.
+	 *
+	 * @param array  $assoc_args The associative arguments.
+	 * @param string $key        The flag name.
+	 * @param int    $default    The default value.
+	 * @return int
+	 */
+	protected function int_arg( $assoc_args, $key, $default = 0 ) {
+		return isset( $assoc_args[ $key ] ) ? (int) $assoc_args[ $key ] : $default;
+	}
+
+	/**
+	 * Split a comma-separated flag into an array of trimmed values.
+	 *
+	 * @param array  $assoc_args The associative arguments.
+	 * @param string $key        The flag name.
+	 * @return array
+	 */
+	protected function list_arg( $assoc_args, $key ) {
+		if ( empty( $assoc_args[ $key ] ) ) {
+			return array();
+		}
+		return array_filter( array_map( 'trim', explode( ',', (string) $assoc_args[ $key ] ) ) );
+	}
+}

--- a/includes/cli/class-pmpro-cli-level.php
+++ b/includes/cli/class-pmpro-cli-level.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * `wp pmpro level` commands.
+ *
+ * @since TBD
+ * @package PaidMembershipsPro\CLI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage PMPro membership levels.
+ *
+ * @since TBD
+ */
+class PMPro_CLI_Level extends PMPro_CLI_Command {
+
+	/**
+	 * Default columns shown for a level.
+	 *
+	 * @var array
+	 */
+	private $default_fields = array( 'id', 'name', 'initial_payment', 'billing_amount', 'cycle_number', 'cycle_period', 'billing_limit', 'expiration_number', 'expiration_period', 'allow_signups' );
+
+	/**
+	 * List membership levels.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--include-hidden]
+	 * : Include levels that are not shown on the levels page.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - ids
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro level list
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$include_hidden = ! empty( $assoc_args['include-hidden'] );
+		$levels         = pmpro_getAllLevels( $include_hidden, true );
+
+		$items = array();
+		foreach ( (array) $levels as $level ) {
+			$items[] = $this->normalize_level( $level );
+		}
+
+		$this->output_items( $items, $this->default_fields, $assoc_args );
+	}
+
+	/**
+	 * Get a single membership level.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The membership level ID.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro level get 2
+	 *
+	 * @subcommand get
+	 */
+	public function get( $args, $assoc_args ) {
+		$level = pmpro_getLevel( (int) $args[0] );
+		if ( empty( $level ) ) {
+			WP_CLI::error( sprintf( 'Membership level %d not found.', (int) $args[0] ) );
+		}
+
+		$item   = $this->normalize_level( $level );
+		$fields = ! empty( $assoc_args['fields'] ) ? $this->list_arg( $assoc_args, 'fields' ) : array_keys( $item );
+		$format = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';
+
+		$assoc_args['format'] = $format;
+		$formatter            = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_item( $item );
+	}
+
+	/**
+	 * Normalize a level object to an associative array.
+	 *
+	 * @param object $level The level object.
+	 * @return array
+	 */
+	private function normalize_level( $level ) {
+		return array(
+			'id'                => (int) $level->id,
+			'name'              => $level->name,
+			'description'       => isset( $level->description ) ? wp_strip_all_tags( $level->description ) : '',
+			'initial_payment'   => $level->initial_payment,
+			'billing_amount'    => $level->billing_amount,
+			'cycle_number'      => (int) $level->cycle_number,
+			'cycle_period'      => $level->cycle_period,
+			'billing_limit'     => (int) $level->billing_limit,
+			'trial_amount'      => $level->trial_amount,
+			'trial_limit'       => (int) $level->trial_limit,
+			'expiration_number' => (int) $level->expiration_number,
+			'expiration_period' => $level->expiration_period,
+			'allow_signups'     => (int) $level->allow_signups,
+		);
+	}
+}

--- a/includes/cli/class-pmpro-cli-member.php
+++ b/includes/cli/class-pmpro-cli-member.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * `wp pmpro member` commands.
+ *
+ * @since TBD
+ * @package PaidMembershipsPro\CLI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage PMPro members.
+ *
+ * @since TBD
+ */
+class PMPro_CLI_Member extends PMPro_CLI_Command {
+
+	/**
+	 * List members (users who hold a membership).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--level=<ids>]
+	 * : Only list members with these membership level IDs. Comma-separated.
+	 *
+	 * [--status=<statuses>]
+	 * : Membership status(es) to match, or 'all' for any status. Comma-separated. Default: active.
+	 *
+	 * [--search=<term>]
+	 * : Match users by login, email, or display name.
+	 *
+	 * [--number=<n>]
+	 * : Maximum number of members to return. Default: 100.
+	 *
+	 * [--page=<n>]
+	 * : Page of results to return. Default: 1.
+	 *
+	 * [--orderby=<column>]
+	 * : Column to order by (id, user_login, user_email, display_name, membership_id, startdate, enddate, joindate). Default: id.
+	 *
+	 * [--order=<order>]
+	 * : ASC or DESC. Default: DESC.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - ids
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro member list --level=2 --status=active
+	 *     wp pmpro member list --search=jane --format=json
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$number = $this->int_arg( $assoc_args, 'number', 100 );
+		$page   = max( 1, $this->int_arg( $assoc_args, 'page', 1 ) );
+
+		$query = array(
+			'limit'  => $number,
+			'offset' => ( $page - 1 ) * $number,
+		);
+
+		$levels = $this->list_arg( $assoc_args, 'level' );
+		if ( $levels ) {
+			$query['membership_id'] = array_map( 'intval', $levels );
+		}
+
+		$statuses = $this->list_arg( $assoc_args, 'status' );
+		if ( $statuses ) {
+			$query['status'] = ( array( 'all' ) === $statuses ) ? 'all' : $statuses;
+		}
+
+		if ( ! empty( $assoc_args['search'] ) ) {
+			$query['search'] = (string) $assoc_args['search'];
+		}
+		if ( ! empty( $assoc_args['orderby'] ) ) {
+			$query['orderby'] = (string) $assoc_args['orderby'];
+		}
+		if ( ! empty( $assoc_args['order'] ) ) {
+			$query['order'] = (string) $assoc_args['order'];
+		}
+
+		$members = pmpro_get_members( $query );
+
+		$items = array();
+		foreach ( (array) $members as $member ) {
+			$items[] = array(
+				'user_id'         => (int) $member['user_id'],
+				'user_login'      => $member['user_login'],
+				'user_email'      => $member['user_email'],
+				'display_name'    => $member['display_name'],
+				'membership_id'   => (int) $member['membership_id'],
+				'membership_name' => $member['membership_name'],
+				'status'          => $member['status'],
+				'startdate'       => $member['startdate'],
+				'enddate'         => $member['enddate'],
+			);
+		}
+
+		$this->output_items(
+			$items,
+			array( 'user_id', 'user_login', 'user_email', 'display_name', 'membership_id', 'membership_name', 'status', 'startdate', 'enddate' ),
+			$assoc_args
+		);
+	}
+
+	/**
+	 * Get the memberships held by a single member.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <user_id>
+	 * : The user ID.
+	 *
+	 * [--include-inactive]
+	 * : Include inactive/cancelled/expired memberships.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro member get 42
+	 *
+	 * @subcommand get
+	 */
+	public function get( $args, $assoc_args ) {
+		$user_id = (int) $args[0];
+		$user    = get_userdata( $user_id );
+		if ( ! $user ) {
+			WP_CLI::error( sprintf( 'User %d not found.', $user_id ) );
+		}
+
+		$include_inactive = ! empty( $assoc_args['include-inactive'] );
+		$levels           = pmpro_getMembershipLevelsForUser( $user_id, $include_inactive );
+
+		$items = array();
+		foreach ( (array) $levels as $level ) {
+			$items[] = array(
+				'membership_id' => (int) $level->id,
+				'name'          => $level->name,
+				'status'        => isset( $level->status ) ? $level->status : '',
+				'startdate'     => ! empty( $level->startdate ) ? gmdate( 'Y-m-d H:i:s', (int) $level->startdate ) : '',
+				'enddate'       => ! empty( $level->enddate ) ? gmdate( 'Y-m-d H:i:s', (int) $level->enddate ) : '',
+			);
+		}
+
+		if ( empty( $items ) ) {
+			WP_CLI::log( sprintf( 'No memberships found for user %d.', $user_id ) );
+			return;
+		}
+
+		$this->output_items( $items, array( 'membership_id', 'name', 'status', 'startdate', 'enddate' ), $assoc_args );
+	}
+
+	/**
+	 * Change (or grant) a member's membership level.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --user=<id>
+	 * : The user ID.
+	 *
+	 * --level=<id>
+	 * : The membership level ID to set. Use 0 to cancel all of the member's levels.
+	 *
+	 * [--dry-run]
+	 * : Preview the change without applying it.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro member change-level --user=42 --level=2
+	 *     wp pmpro member change-level --user=42 --level=0 --yes
+	 *
+	 * @subcommand change-level
+	 */
+	public function change_level( $args, $assoc_args ) {
+		$user_id = $this->int_arg( $assoc_args, 'user', 0 );
+		if ( empty( $user_id ) ) {
+			WP_CLI::error( 'The --user=<id> argument is required.' );
+		}
+		if ( ! isset( $assoc_args['level'] ) ) {
+			WP_CLI::error( 'The --level=<id> argument is required.' );
+		}
+
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			WP_CLI::error( sprintf( 'User %d not found.', $user_id ) );
+		}
+
+		$level_id = (int) $assoc_args['level'];
+		if ( $level_id > 0 ) {
+			$level = pmpro_getLevel( $level_id );
+			if ( empty( $level ) ) {
+				WP_CLI::error( sprintf( 'Membership level %d not found.', $level_id ) );
+			}
+			$description = sprintf( 'Change %s (#%d) to level "%s" (#%d)?', $user->user_login, $user_id, $level->name, $level_id );
+		} else {
+			$description = sprintf( 'Cancel ALL memberships for %s (#%d)?', $user->user_login, $user_id );
+		}
+
+		if ( ! empty( $assoc_args['dry-run'] ) ) {
+			WP_CLI::log( '[dry-run] Would ' . lcfirst( $description ) );
+			return;
+		}
+
+		WP_CLI::confirm( $description, $assoc_args );
+
+		$result = pmpro_changeMembershipLevel( $level_id, $user_id );
+		if ( $result ) {
+			WP_CLI::success( sprintf( 'Updated membership for user %d.', $user_id ) );
+		} else {
+			WP_CLI::error( sprintf( 'Failed to change membership level for user %d.', $user_id ) );
+		}
+	}
+
+	/**
+	 * Cancel a member's membership.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --user=<id>
+	 * : The user ID.
+	 *
+	 * [--level=<id>]
+	 * : A specific membership level ID to cancel. Omit to cancel all of the member's levels.
+	 *
+	 * [--dry-run]
+	 * : Preview the cancellation without applying it.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro member cancel --user=42
+	 *     wp pmpro member cancel --user=42 --level=2
+	 *
+	 * @subcommand cancel
+	 */
+	public function cancel( $args, $assoc_args ) {
+		$user_id = $this->int_arg( $assoc_args, 'user', 0 );
+		if ( empty( $user_id ) ) {
+			WP_CLI::error( 'The --user=<id> argument is required.' );
+		}
+
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			WP_CLI::error( sprintf( 'User %d not found.', $user_id ) );
+		}
+
+		$level_id = isset( $assoc_args['level'] ) ? (int) $assoc_args['level'] : 0;
+		if ( $level_id > 0 ) {
+			$description = sprintf( 'Cancel level #%d for %s (#%d)?', $level_id, $user->user_login, $user_id );
+		} else {
+			$description = sprintf( 'Cancel ALL memberships for %s (#%d)?', $user->user_login, $user_id );
+		}
+
+		if ( ! empty( $assoc_args['dry-run'] ) ) {
+			WP_CLI::log( '[dry-run] Would ' . lcfirst( $description ) );
+			return;
+		}
+
+		WP_CLI::confirm( $description, $assoc_args );
+
+		if ( $level_id > 0 ) {
+			$result = pmpro_cancelMembershipLevel( $level_id, $user_id );
+		} else {
+			$result = pmpro_changeMembershipLevel( 0, $user_id );
+		}
+
+		if ( $result ) {
+			WP_CLI::success( sprintf( 'Cancelled membership(s) for user %d.', $user_id ) );
+		} else {
+			WP_CLI::error( sprintf( 'Failed to cancel membership for user %d.', $user_id ) );
+		}
+	}
+}

--- a/includes/cli/class-pmpro-cli-order.php
+++ b/includes/cli/class-pmpro-cli-order.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * `wp pmpro order` commands.
+ *
+ * @since TBD
+ * @package PaidMembershipsPro\CLI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage PMPro orders.
+ *
+ * @since TBD
+ */
+class PMPro_CLI_Order extends PMPro_CLI_Command {
+
+	/**
+	 * Default columns shown for an order.
+	 *
+	 * @var array
+	 */
+	private $default_fields = array( 'id', 'code', 'user_id', 'membership_id', 'status', 'gateway', 'total', 'timestamp' );
+
+	/**
+	 * List orders.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--user=<id>]
+	 * : Only list orders for this user ID.
+	 *
+	 * [--level=<ids>]
+	 * : Only list orders for these membership level IDs. Comma-separated.
+	 *
+	 * [--status=<statuses>]
+	 * : Only list orders with these statuses. Comma-separated.
+	 *
+	 * [--gateway=<gateway>]
+	 * : Only list orders for this gateway.
+	 *
+	 * [--number=<n>]
+	 * : Maximum number of orders to return. Default: 100.
+	 *
+	 * [--page=<n>]
+	 * : Page of results to return. Default: 1.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - ids
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro order list --status=success --number=20
+	 *     wp pmpro order list --user=42
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$number = $this->int_arg( $assoc_args, 'number', 100 );
+		$page   = max( 1, $this->int_arg( $assoc_args, 'page', 1 ) );
+
+		$query = array(
+			'limit'  => $number,
+			'offset' => ( $page - 1 ) * $number,
+		);
+
+		if ( ! empty( $assoc_args['user'] ) ) {
+			$query['user_id'] = (int) $assoc_args['user'];
+		}
+		$levels = $this->list_arg( $assoc_args, 'level' );
+		if ( $levels ) {
+			$query['membership_level_id'] = array_map( 'intval', $levels );
+		}
+		$statuses = $this->list_arg( $assoc_args, 'status' );
+		if ( $statuses ) {
+			$query['status'] = $statuses;
+		}
+		if ( ! empty( $assoc_args['gateway'] ) ) {
+			$query['gateway'] = (string) $assoc_args['gateway'];
+		}
+
+		$orders = MemberOrder::get_orders( $query );
+
+		$items = array();
+		foreach ( (array) $orders as $order ) {
+			$items[] = $this->normalize_order( $order );
+		}
+
+		$this->output_items( $items, $this->default_fields, $assoc_args );
+	}
+
+	/**
+	 * Get a single order by ID or code.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id-or-code>
+	 * : The order ID (numeric) or order code.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro order get 123
+	 *     wp pmpro order get abc123def
+	 *
+	 * @subcommand get
+	 */
+	public function get( $args, $assoc_args ) {
+		$identifier = $args[0];
+		$order      = is_numeric( $identifier ) ? MemberOrder::get_order( (int) $identifier ) : MemberOrder::get_order( (string) $identifier );
+
+		if ( empty( $order ) || empty( $order->id ) ) {
+			WP_CLI::error( sprintf( 'Order "%s" not found.', $identifier ) );
+		}
+
+		$item   = $this->normalize_order( $order );
+		$fields = ! empty( $assoc_args['fields'] ) ? $this->list_arg( $assoc_args, 'fields' ) : array_keys( $item );
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_item( $item );
+	}
+
+	/**
+	 * Normalize a MemberOrder object to an associative array.
+	 *
+	 * @param MemberOrder $order The order object.
+	 * @return array
+	 */
+	private function normalize_order( $order ) {
+		return array(
+			'id'                          => (int) $order->id,
+			'code'                        => $order->code,
+			'user_id'                     => (int) $order->user_id,
+			'membership_id'               => (int) $order->membership_id,
+			'status'                      => $order->status,
+			'gateway'                     => $order->gateway,
+			'gateway_environment'         => $order->gateway_environment,
+			'subtotal'                    => $order->subtotal,
+			'tax'                         => $order->tax,
+			'total'                       => $order->total,
+			'payment_transaction_id'      => $order->payment_transaction_id,
+			'subscription_transaction_id' => $order->subscription_transaction_id,
+			'timestamp'                   => ! empty( $order->timestamp ) ? gmdate( 'Y-m-d H:i:s', (int) $order->timestamp ) : '',
+		);
+	}
+}

--- a/includes/cli/class-pmpro-cli-subscription.php
+++ b/includes/cli/class-pmpro-cli-subscription.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * `wp pmpro subscription` commands.
+ *
+ * @since TBD
+ * @package PaidMembershipsPro\CLI
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manage PMPro subscriptions.
+ *
+ * @since TBD
+ */
+class PMPro_CLI_Subscription extends PMPro_CLI_Command {
+
+	/**
+	 * Default columns shown for a subscription.
+	 *
+	 * @var array
+	 */
+	private $default_fields = array( 'id', 'user_id', 'membership_level_id', 'status', 'gateway', 'billing_amount', 'cycle_number', 'cycle_period', 'startdate', 'next_payment_date' );
+
+	/**
+	 * List subscriptions.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--user=<id>]
+	 * : Only list subscriptions for this user ID.
+	 *
+	 * [--level=<ids>]
+	 * : Only list subscriptions for these membership level IDs. Comma-separated.
+	 *
+	 * [--status=<statuses>]
+	 * : Only list subscriptions with these statuses. Comma-separated.
+	 *
+	 * [--gateway=<gateway>]
+	 * : Only list subscriptions for this gateway.
+	 *
+	 * [--number=<n>]
+	 * : Maximum number of subscriptions to return. Default: 100.
+	 *
+	 * [--page=<n>]
+	 * : Page of results to return. Default: 1.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 *   - ids
+	 *   - count
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro subscription list --status=active
+	 *     wp pmpro subscription list --user=42
+	 *
+	 * @subcommand list
+	 */
+	public function list_( $args, $assoc_args ) {
+		$number = $this->int_arg( $assoc_args, 'number', 100 );
+		$page   = max( 1, $this->int_arg( $assoc_args, 'page', 1 ) );
+
+		$query = array(
+			'limit'  => $number,
+			'offset' => ( $page - 1 ) * $number,
+		);
+
+		if ( ! empty( $assoc_args['user'] ) ) {
+			$query['user_id'] = (int) $assoc_args['user'];
+		}
+		$levels = $this->list_arg( $assoc_args, 'level' );
+		if ( $levels ) {
+			$query['membership_level_id'] = array_map( 'intval', $levels );
+		}
+		$statuses = $this->list_arg( $assoc_args, 'status' );
+		if ( $statuses ) {
+			$query['status'] = $statuses;
+		}
+		if ( ! empty( $assoc_args['gateway'] ) ) {
+			$query['gateway'] = (string) $assoc_args['gateway'];
+		}
+
+		$subscriptions = PMPro_Subscription::get_subscriptions( $query );
+
+		$items = array();
+		foreach ( (array) $subscriptions as $subscription ) {
+			$items[] = $this->normalize_subscription( $subscription );
+		}
+
+		$this->output_items( $items, $this->default_fields, $assoc_args );
+	}
+
+	/**
+	 * Get a single subscription by ID.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>
+	 * : The subscription ID.
+	 *
+	 * [--fields=<fields>]
+	 * : Comma-separated list of fields to display.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - csv
+	 *   - json
+	 *   - yaml
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro subscription get 55
+	 *
+	 * @subcommand get
+	 */
+	public function get( $args, $assoc_args ) {
+		$subscription = PMPro_Subscription::get_subscription( (int) $args[0] );
+		if ( empty( $subscription ) ) {
+			WP_CLI::error( sprintf( 'Subscription %d not found.', (int) $args[0] ) );
+		}
+
+		$item   = $this->normalize_subscription( $subscription );
+		$fields = ! empty( $assoc_args['fields'] ) ? $this->list_arg( $assoc_args, 'fields' ) : array_keys( $item );
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );
+		$formatter->display_item( $item );
+	}
+
+	/**
+	 * Normalize a PMPro_Subscription object to an associative array.
+	 *
+	 * @param PMPro_Subscription $subscription The subscription object.
+	 * @return array
+	 */
+	private function normalize_subscription( $subscription ) {
+		return array(
+			'id'                          => (int) $subscription->get_id(),
+			'user_id'                     => (int) $subscription->get_user_id(),
+			'membership_level_id'         => (int) $subscription->get_membership_level_id(),
+			'status'                      => (string) $subscription->get_status(),
+			'gateway'                     => (string) $subscription->get_gateway(),
+			'subscription_transaction_id' => (string) $subscription->get_subscription_transaction_id(),
+			'billing_amount'              => (float) $subscription->get_billing_amount(),
+			'cycle_number'                => (int) $subscription->get_cycle_number(),
+			'cycle_period'                => (string) $subscription->get_cycle_period(),
+			'startdate'                   => $subscription->get_startdate( 'Y-m-d H:i:s' ),
+			'enddate'                     => $subscription->get_enddate( 'Y-m-d H:i:s' ),
+			'next_payment_date'           => $subscription->get_next_payment_date( 'Y-m-d H:i:s' ),
+		);
+	}
+}

--- a/includes/cli/class-pmpro-cli-subscription.php
+++ b/includes/cli/class-pmpro-cli-subscription.php
@@ -144,6 +144,75 @@ class PMPro_CLI_Subscription extends PMPro_CLI_Command {
 	}
 
 	/**
+	 * Sync one or more subscriptions with their gateway.
+	 *
+	 * Pulls the latest subscription info from the gateway and saves it locally.
+	 * Sync errors are stored in subscription meta ( sync_error ).
+	 *
+	 * ## OPTIONS
+	 *
+	 * <id>...
+	 * : One or more subscription IDs or gateway transaction IDs ( e.g. sub_XXXX ).
+	 *
+	 * [--dry-run]
+	 * : Preview which subscriptions would be synced without making changes.
+	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp pmpro subscription sync 55
+	 *     wp pmpro subscription sync sub_1RXa2b3C4d
+	 *     wp pmpro subscription sync 55 56 57 --yes
+	 *
+	 * @subcommand sync
+	 */
+	public function sync( $args, $assoc_args ) {
+		$subscriptions = array();
+		foreach ( $args as $arg ) {
+			if ( is_numeric( $arg ) ) {
+				$subscription = PMPro_Subscription::get_subscription( (int) $arg );
+			} else {
+				// Assume a gateway transaction ID, e.g. "sub_XXXX".
+				$subscription = PMPro_Subscription::get_subscription( array( 'subscription_transaction_id' => (string) $arg ) );
+			}
+			if ( empty( $subscription ) ) {
+				WP_CLI::error( sprintf( 'Subscription %s not found.', $arg ) );
+			}
+			$subscriptions[ $subscription->get_id() ] = $subscription;
+		}
+
+		if ( ! empty( $assoc_args['dry-run'] ) ) {
+			WP_CLI::log( sprintf( '[dry-run] Would sync %d subscription(s) with their gateway: %s', count( $subscriptions ), implode( ', ', array_keys( $subscriptions ) ) ) );
+			return;
+		}
+
+		WP_CLI::confirm( sprintf( 'Sync %d subscription(s) with their gateway?', count( $subscriptions ) ), $assoc_args );
+
+		$failed = 0;
+		foreach ( $subscriptions as $id => $subscription ) {
+			if ( $subscription->update() ) {
+				$sync_error = get_pmpro_subscription_meta( $id, 'sync_error', true );
+				if ( empty( $sync_error ) ) {
+					WP_CLI::log( sprintf( 'Synced subscription %d ( status: %s, next payment: %s ).', $id, $subscription->get_status(), $subscription->get_next_payment_date( 'Y-m-d H:i:s' ) ) );
+				} else {
+					$failed++;
+					WP_CLI::warning( sprintf( 'Subscription %d saved, but the gateway sync reported an error: %s', $id, $sync_error ) );
+				}
+			} else {
+				$failed++;
+				WP_CLI::warning( sprintf( 'Failed to sync subscription %d.', $id ) );
+			}
+		}
+
+		if ( $failed ) {
+			WP_CLI::error( sprintf( '%d of %d subscription(s) failed to sync.', $failed, count( $subscriptions ) ) );
+		}
+		WP_CLI::success( sprintf( 'Synced %d subscription(s).', count( $subscriptions ) ) );
+	}
+
+	/**
 	 * Normalize a PMPro_Subscription object to an associative array.
 	 *
 	 * @param PMPro_Subscription $subscription The subscription object.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5520,3 +5520,135 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
 		do_action( 'pmpro_after_updating_post_level_restrictions', $post_id );
 	}
 }
+
+/**
+ * Query PMPro members (WordPress users who hold a membership) with filtering and pagination.
+ *
+ * Provides a single reusable member query for the REST API collection endpoint
+ * ( /pmpro/v1/members ) and the `wp pmpro member list` CLI command, so both share
+ * the same filtering, pagination, and output shape.
+ *
+ * @since TBD
+ *
+ * @param array $args {
+ *     Optional. Query arguments.
+ *
+ *     @type int|int[]       $membership_id Only return members holding these level IDs. Default null (any level).
+ *     @type string|string[] $status        Membership status(es) to match, or 'all' for any status. Default 'active'.
+ *     @type string          $search        Match users by login, email, or display name. Default ''.
+ *     @type int             $limit         Maximum rows to return. 0 for no limit. Default 100.
+ *     @type int             $offset        Rows to skip, for pagination. Default 0.
+ *     @type string          $orderby       One of id, user_login, user_email, display_name, membership_id, startdate, enddate, joindate. Default 'id'.
+ *     @type string          $order         'ASC' or 'DESC'. Default 'DESC'.
+ *     @type bool            $return_count  Return the total matching count instead of rows. Default false.
+ * }
+ * @return array|int Array of member row arrays, or an integer count when $return_count is true.
+ */
+function pmpro_get_members( $args = array() ) {
+	global $wpdb;
+
+	$defaults = array(
+		'membership_id' => null,
+		'status'        => 'active',
+		'search'        => '',
+		'limit'         => 100,
+		'offset'        => 0,
+		'orderby'       => 'id',
+		'order'         => 'DESC',
+		'return_count'  => false,
+	);
+	$args = wp_parse_args( $args, $defaults );
+
+	$return_count = ! empty( $args['return_count'] );
+	$where        = array();
+	$prepared     = array();
+
+	if ( $return_count ) {
+		$sql = "SELECT COUNT( DISTINCT u.ID, mu.membership_id )";
+	} else {
+		$sql = "SELECT u.ID AS user_id, u.user_login, u.user_email, u.display_name, mu.membership_id, mu.status,
+			u.user_registered AS joindate, mu.startdate, mu.enddate, m.name AS membership_name";
+	}
+
+	$sql .= " FROM {$wpdb->users} u
+		INNER JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id
+		LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id";
+
+	// Only include rows tied to a real membership level.
+	$where[] = 'mu.membership_id > 0';
+
+	// Filter by membership level ID(s).
+	if ( ! empty( $args['membership_id'] ) ) {
+		$ids      = array_map( 'intval', (array) $args['membership_id'] );
+		$where[]  = 'mu.membership_id IN ( ' . implode( ', ', array_fill( 0, count( $ids ), '%d' ) ) . ' )';
+		$prepared = array_merge( $prepared, $ids );
+	}
+
+	// Filter by membership status(es). Pass 'all' to include every status.
+	if ( ! empty( $args['status'] ) && 'all' !== $args['status'] ) {
+		$statuses = array_map( 'strval', (array) $args['status'] );
+		$where[]  = 'mu.status IN ( ' . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ' )';
+		$prepared = array_merge( $prepared, $statuses );
+	}
+
+	// Search by login, email, or display name.
+	if ( ! empty( $args['search'] ) ) {
+		$like       = '%' . $wpdb->esc_like( $args['search'] ) . '%';
+		$where[]    = '( u.user_login LIKE %s OR u.user_email LIKE %s OR u.display_name LIKE %s )';
+		$prepared[] = $like;
+		$prepared[] = $like;
+		$prepared[] = $like;
+	}
+
+	$sql .= ' WHERE ' . implode( ' AND ', $where );
+
+	if ( $return_count ) {
+		if ( $prepared ) {
+			$sql = $wpdb->prepare( $sql, $prepared );
+		}
+		return (int) $wpdb->get_var( $sql );
+	}
+
+	// One row per user/level pair.
+	$sql .= ' GROUP BY u.ID, mu.membership_id';
+
+	// Sanitize orderby against an allowlist of safe columns.
+	$orderby_map = array(
+		'id'            => 'u.ID',
+		'user_login'    => 'u.user_login',
+		'user_email'    => 'u.user_email',
+		'display_name'  => 'u.display_name',
+		'membership_id' => 'mu.membership_id',
+		'startdate'     => 'mu.startdate',
+		'enddate'       => 'mu.enddate',
+		'joindate'      => 'u.user_registered',
+	);
+	$orderby_col = isset( $orderby_map[ $args['orderby'] ] ) ? $orderby_map[ $args['orderby'] ] : 'u.ID';
+	$order       = ( 'ASC' === strtoupper( (string) $args['order'] ) ) ? 'ASC' : 'DESC';
+	$sql        .= " ORDER BY {$orderby_col} {$order}";
+
+	// Pagination.
+	$limit  = max( 0, (int) $args['limit'] );
+	$offset = max( 0, (int) $args['offset'] );
+	if ( $limit ) {
+		$sql       .= ' LIMIT %d OFFSET %d';
+		$prepared[] = $limit;
+		$prepared[] = $offset;
+	}
+
+	if ( $prepared ) {
+		$sql = $wpdb->prepare( $sql, $prepared );
+	}
+
+	/**
+	 * Filter the SQL used by pmpro_get_members().
+	 *
+	 * @since TBD
+	 *
+	 * @param string $sql  The prepared SQL query.
+	 * @param array  $args The parsed query arguments.
+	 */
+	$sql = apply_filters( 'pmpro_get_members_sql', $sql, $args );
+
+	return $wpdb->get_results( $sql, ARRAY_A );
+}

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -257,6 +257,83 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		);
 
 		/**
+		 * Get a paginated, filterable collection of members.
+		 * @since TBD
+		 * Example: https://example.com/wp-json/pmpro/v1/members?level=1&status=active&page=1&per_page=20
+		 */
+		register_rest_route( $pmpro_namespace, '/members',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'pmpro_rest_api_get_members' ),
+					'args'     => array(
+						'page'     => array( 'sanitize_callback' => 'absint' ),
+						'per_page' => array( 'sanitize_callback' => 'absint' ),
+						'level'    => array(),
+						'status'   => array(),
+						'search'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'  => array( 'sanitize_callback' => 'sanitize_key' ),
+						'order'    => array( 'sanitize_callback' => 'sanitize_key' ),
+						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+					),
+					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+				)
+			)
+		);
+
+		/**
+		 * Get a paginated, filterable collection of orders.
+		 * @since TBD
+		 * Example: https://example.com/wp-json/pmpro/v1/orders?status=success&per_page=20
+		 */
+		register_rest_route( $pmpro_namespace, '/orders',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'pmpro_rest_api_get_orders' ),
+					'args'     => array(
+						'page'       => array( 'sanitize_callback' => 'absint' ),
+						'per_page'   => array( 'sanitize_callback' => 'absint' ),
+						'user_id'    => array( 'sanitize_callback' => 'absint' ),
+						'level'      => array(),
+						'status'     => array(),
+						'gateway'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'start_date' => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'end_date'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'     => array( 'sanitize_callback' => 'sanitize_text_field' ),
+					),
+					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+				)
+			)
+		);
+
+		/**
+		 * Get a paginated, filterable collection of subscriptions.
+		 * @since TBD
+		 * Example: https://example.com/wp-json/pmpro/v1/subscriptions?status=active&per_page=20
+		 */
+		register_rest_route( $pmpro_namespace, '/subscriptions',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'pmpro_rest_api_get_subscriptions' ),
+					'args'     => array(
+						'page'     => array( 'sanitize_callback' => 'absint' ),
+						'per_page' => array( 'sanitize_callback' => 'absint' ),
+						'user_id'  => array( 'sanitize_callback' => 'absint' ),
+						'level'    => array(),
+						'status'   => array(),
+						'gateway'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+					),
+					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
+				)
+			)
+		);
+
+		/**
 		 * Get the IDs that a post has been restricted to.
 		 * @since 3.0
 		 * Example: https://example.com/wp-json/pmpro/v1/post_restrictions
@@ -1254,6 +1331,289 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		}
 
 		/**
+		 * Get a paginated, filterable collection of members.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return WP_REST_Response The REST response.
+		 */
+		public function pmpro_rest_api_get_members( $request ) {
+			$params   = $request->get_params();
+			$per_page = $this->pmpro_rest_api_get_per_page( $params );
+			$page     = $this->pmpro_rest_api_get_page( $params );
+
+			$query_args = array(
+				'limit'  => $per_page,
+				'offset' => ( $page - 1 ) * $per_page,
+			);
+			if ( isset( $params['level'] ) && '' !== $params['level'] ) {
+				$query_args['membership_id'] = array_map( 'intval', explode( ',', (string) $params['level'] ) );
+			}
+			if ( isset( $params['status'] ) && '' !== $params['status'] ) {
+				$query_args['status'] = array_map( 'sanitize_text_field', explode( ',', (string) $params['status'] ) );
+			}
+			if ( ! empty( $params['search'] ) ) {
+				$query_args['search'] = sanitize_text_field( $params['search'] );
+			}
+			if ( ! empty( $params['orderby'] ) ) {
+				$query_args['orderby'] = sanitize_key( $params['orderby'] );
+			}
+			if ( ! empty( $params['order'] ) ) {
+				$query_args['order'] = ( 'asc' === strtolower( (string) $params['order'] ) ) ? 'ASC' : 'DESC';
+			}
+
+			$total   = (int) pmpro_get_members( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$members = pmpro_get_members( $query_args );
+
+			$fields = $this->pmpro_rest_api_get_fields( $params );
+			$items  = array();
+			foreach ( (array) $members as $member ) {
+				$item = array(
+					'user_id'         => (int) $member['user_id'],
+					'user_login'      => $member['user_login'],
+					'user_email'      => $member['user_email'],
+					'display_name'    => $member['display_name'],
+					'membership_id'   => (int) $member['membership_id'],
+					'membership_name' => $member['membership_name'],
+					'status'          => $member['status'],
+					'joindate'        => $this->pmpro_rest_api_maybe_iso8601( $member['joindate'] ),
+					'startdate'       => $this->pmpro_rest_api_maybe_iso8601( $member['startdate'] ),
+					'enddate'         => $this->pmpro_rest_api_maybe_iso8601( $member['enddate'] ),
+				);
+				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
+			}
+
+			return $this->pmpro_rest_api_collection_response( $items, $total, $page, $per_page );
+		}
+
+		/**
+		 * Get a paginated, filterable collection of orders.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return WP_REST_Response The REST response.
+		 */
+		public function pmpro_rest_api_get_orders( $request ) {
+			$params   = $request->get_params();
+			$per_page = $this->pmpro_rest_api_get_per_page( $params );
+			$page     = $this->pmpro_rest_api_get_page( $params );
+
+			$query_args = array(
+				'limit'  => $per_page,
+				'offset' => ( $page - 1 ) * $per_page,
+			);
+			if ( ! empty( $params['user_id'] ) ) {
+				$query_args['user_id'] = (int) $params['user_id'];
+			}
+			if ( isset( $params['level'] ) && '' !== $params['level'] ) {
+				$query_args['membership_level_id'] = array_map( 'intval', explode( ',', (string) $params['level'] ) );
+			}
+			if ( isset( $params['status'] ) && '' !== $params['status'] ) {
+				$query_args['status'] = array_map( 'sanitize_text_field', explode( ',', (string) $params['status'] ) );
+			}
+			if ( ! empty( $params['gateway'] ) ) {
+				$query_args['gateway'] = sanitize_text_field( $params['gateway'] );
+			}
+			if ( ! empty( $params['start_date'] ) ) {
+				$query_args['start_date'] = sanitize_text_field( $params['start_date'] );
+			}
+			if ( ! empty( $params['end_date'] ) ) {
+				$query_args['end_date'] = sanitize_text_field( $params['end_date'] );
+			}
+
+			$total  = (int) MemberOrder::get_orders( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$orders = MemberOrder::get_orders( $query_args );
+
+			$fields = $this->pmpro_rest_api_get_fields( $params );
+			$items  = array();
+			foreach ( (array) $orders as $order ) {
+				$item = array(
+					'id'                           => (int) $order->id,
+					'code'                         => $order->code,
+					'user_id'                      => (int) $order->user_id,
+					'membership_id'                => (int) $order->membership_id,
+					'status'                       => $order->status,
+					'gateway'                      => $order->gateway,
+					'gateway_environment'          => $order->gateway_environment,
+					'subtotal'                     => $order->subtotal,
+					'tax'                          => $order->tax,
+					'total'                        => $order->total,
+					'payment_transaction_id'       => $order->payment_transaction_id,
+					'subscription_transaction_id'  => $order->subscription_transaction_id,
+					'timestamp'                    => ! empty( $order->timestamp ) ? gmdate( DateTime::ATOM, (int) $order->timestamp ) : null,
+				);
+				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
+			}
+
+			return $this->pmpro_rest_api_collection_response( $items, $total, $page, $per_page );
+		}
+
+		/**
+		 * Get a paginated, filterable collection of subscriptions.
+		 *
+		 * @since TBD
+		 *
+		 * @param WP_REST_Request $request The REST request.
+		 * @return WP_REST_Response The REST response.
+		 */
+		public function pmpro_rest_api_get_subscriptions( $request ) {
+			$params   = $request->get_params();
+			$per_page = $this->pmpro_rest_api_get_per_page( $params );
+			$page     = $this->pmpro_rest_api_get_page( $params );
+
+			$query_args = array(
+				'limit'  => $per_page,
+				'offset' => ( $page - 1 ) * $per_page,
+			);
+			if ( ! empty( $params['user_id'] ) ) {
+				$query_args['user_id'] = (int) $params['user_id'];
+			}
+			if ( isset( $params['level'] ) && '' !== $params['level'] ) {
+				$query_args['membership_level_id'] = array_map( 'intval', explode( ',', (string) $params['level'] ) );
+			}
+			if ( isset( $params['status'] ) && '' !== $params['status'] ) {
+				$query_args['status'] = array_map( 'sanitize_text_field', explode( ',', (string) $params['status'] ) );
+			}
+			if ( ! empty( $params['gateway'] ) ) {
+				$query_args['gateway'] = sanitize_text_field( $params['gateway'] );
+			}
+
+			$total         = (int) PMPro_Subscription::get_subscriptions( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$subscriptions = PMPro_Subscription::get_subscriptions( $query_args );
+
+			$fields = $this->pmpro_rest_api_get_fields( $params );
+			$items  = array();
+			foreach ( (array) $subscriptions as $subscription ) {
+				$item = array(
+					'id'                          => (int) $subscription->get_id(),
+					'user_id'                     => (int) $subscription->get_user_id(),
+					'membership_level_id'         => (int) $subscription->get_membership_level_id(),
+					'status'                      => (string) $subscription->get_status(),
+					'gateway'                     => (string) $subscription->get_gateway(),
+					'gateway_environment'         => (string) $subscription->get_gateway_environment(),
+					'subscription_transaction_id' => (string) $subscription->get_subscription_transaction_id(),
+					'billing_amount'              => (float) $subscription->get_billing_amount(),
+					'cycle_number'                => (int) $subscription->get_cycle_number(),
+					'cycle_period'                => (string) $subscription->get_cycle_period(),
+					'startdate'                   => $subscription->get_startdate( 'c' ),
+					'enddate'                     => $subscription->get_enddate( 'c' ),
+					'next_payment_date'           => $subscription->get_next_payment_date( 'c' ),
+				);
+				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
+			}
+
+			return $this->pmpro_rest_api_collection_response( $items, $total, $page, $per_page );
+		}
+
+		/**
+		 * Get the requested page number for a collection request. Minimum 1.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $params The request parameters.
+		 * @return int
+		 */
+		private function pmpro_rest_api_get_page( $params ) {
+			return isset( $params['page'] ) ? max( 1, (int) $params['page'] ) : 1;
+		}
+
+		/**
+		 * Get the requested per_page value for a collection request, clamped to a hard maximum.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $params The request parameters.
+		 * @return int
+		 */
+		private function pmpro_rest_api_get_per_page( $params ) {
+			$per_page = isset( $params['per_page'] ) ? (int) $params['per_page'] : 20;
+
+			/**
+			 * Filter the maximum number of items a PMPro REST collection endpoint will return per page.
+			 *
+			 * @since TBD
+			 *
+			 * @param int $max The maximum per_page value. Default 100.
+			 */
+			$max = (int) apply_filters( 'pmpro_rest_api_max_per_page', 100 );
+
+			if ( $per_page < 1 ) {
+				$per_page = 20;
+			}
+
+			return min( $per_page, $max );
+		}
+
+		/**
+		 * Parse the requested field list for a collection request.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $params The request parameters.
+		 * @return array Array of requested field names, or empty array for all fields.
+		 */
+		private function pmpro_rest_api_get_fields( $params ) {
+			if ( empty( $params['fields'] ) ) {
+				return array();
+			}
+			return array_filter( array_map( 'trim', explode( ',', (string) $params['fields'] ) ) );
+		}
+
+		/**
+		 * Reduce an item array to only the requested fields.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $item   The full item array.
+		 * @param array $fields The requested field names. Empty means all fields.
+		 * @return array
+		 */
+		private function pmpro_rest_api_apply_fields( $item, $fields ) {
+			if ( empty( $fields ) ) {
+				return $item;
+			}
+			return array_intersect_key( $item, array_flip( $fields ) );
+		}
+
+		/**
+		 * Format a stored datetime string as ISO 8601, returning null for empty or zero dates.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $date The datetime string.
+		 * @return string|null
+		 */
+		private function pmpro_rest_api_maybe_iso8601( $date ) {
+			if ( empty( $date ) || 0 === strpos( (string) $date, '0000-00-00' ) ) {
+				return null;
+			}
+			return pmpro_format_date_iso8601( $date );
+		}
+
+		/**
+		 * Build a collection response with pagination headers.
+		 *
+		 * @since TBD
+		 *
+		 * @param array $items    The response items.
+		 * @param int   $total    The total number of matching records.
+		 * @param int   $page     The current page.
+		 * @param int   $per_page The page size.
+		 * @return WP_REST_Response
+		 */
+		private function pmpro_rest_api_collection_response( $items, $total, $page, $per_page ) {
+			$response    = new WP_REST_Response( $items, 200 );
+			$total_pages = $per_page > 0 ? (int) ceil( $total / $per_page ) : 0;
+
+			$response->header( 'X-WP-Total', (string) $total );
+			$response->header( 'X-WP-TotalPages', (string) $total_pages );
+
+			return $response;
+		}
+
+		/**
 		 * Get the membership level IDs restricting a given post.
 		 *
 		 * @since 3.0
@@ -1817,6 +2177,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				'/pmpro/v1/me' => true,
 				'/pmpro/v1/recent_memberships' => 'pmpro_edit_members',
 				'/pmpro/v1/recent_orders' => 'pmpro_orders',
+				'/pmpro/v1/members' => 'pmpro_edit_members',
+				'/pmpro/v1/orders' => 'pmpro_orders',
+				'/pmpro/v1/subscriptions' => 'pmpro_edit_members',
 				'/pmpro/v1/post_restrictions' => array(
 					'capability' => 'edit_post',
 					'request_param' => 'post_id',

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -274,7 +274,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'search'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'orderby'  => array( 'sanitize_callback' => 'sanitize_key' ),
 						'order'    => array( 'sanitize_callback' => 'sanitize_key' ),
-						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'   => array(
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => function( $value ) {
+								return $this->pmpro_rest_api_validate_fields( $value, 'members' );
+							},
+						),
 					),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				)
@@ -301,7 +306,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'start_date' => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'end_date'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'orderby'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
-						'fields'     => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'     => array(
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => function( $value ) {
+								return $this->pmpro_rest_api_validate_fields( $value, 'orders' );
+							},
+						),
 					),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				)
@@ -326,7 +336,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'status'   => array(),
 						'gateway'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'orderby'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
-						'fields'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'fields'   => array(
+							'sanitize_callback' => 'sanitize_text_field',
+							'validate_callback' => function( $value ) {
+								return $this->pmpro_rest_api_validate_fields( $value, 'subscriptions' );
+							},
+						),
 					),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				)
@@ -1431,17 +1446,17 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			foreach ( (array) $orders as $order ) {
 				$item = array(
 					'id'                           => (int) $order->id,
-					'code'                         => $order->code,
+					'code'                         => (string) $order->code,
 					'user_id'                      => (int) $order->user_id,
 					'membership_id'                => (int) $order->membership_id,
-					'status'                       => $order->status,
-					'gateway'                      => $order->gateway,
-					'gateway_environment'          => $order->gateway_environment,
-					'subtotal'                     => $order->subtotal,
-					'tax'                          => $order->tax,
-					'total'                        => $order->total,
-					'payment_transaction_id'       => $order->payment_transaction_id,
-					'subscription_transaction_id'  => $order->subscription_transaction_id,
+					'status'                       => (string) $order->status,
+					'gateway'                      => (string) $order->gateway,
+					'gateway_environment'          => (string) $order->gateway_environment,
+					'subtotal'                     => (float) $order->subtotal,
+					'tax'                          => (float) $order->tax,
+					'total'                        => (float) $order->total,
+					'payment_transaction_id'       => (string) $order->payment_transaction_id,
+					'subscription_transaction_id'  => (string) $order->subscription_transaction_id,
 					'timestamp'                    => ! empty( $order->timestamp ) ? gmdate( DateTime::ATOM, (int) $order->timestamp ) : null,
 				);
 				$items[] = $this->pmpro_rest_api_apply_fields( $item, $fields );
@@ -1559,6 +1574,99 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				return array();
 			}
 			return array_filter( array_map( 'trim', explode( ',', (string) $params['fields'] ) ) );
+		}
+
+		/**
+		 * Get the field names a collection endpoint can return.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $collection One of 'members', 'orders' or 'subscriptions'.
+		 * @return array Array of valid field names.
+		 */
+		private function pmpro_rest_api_get_collection_fields( $collection ) {
+			$fields = array(
+				'members'       => array(
+					'user_id',
+					'user_login',
+					'user_email',
+					'display_name',
+					'membership_id',
+					'membership_name',
+					'status',
+					'joindate',
+					'startdate',
+					'enddate',
+				),
+				'orders'        => array(
+					'id',
+					'code',
+					'user_id',
+					'membership_id',
+					'status',
+					'gateway',
+					'gateway_environment',
+					'subtotal',
+					'tax',
+					'total',
+					'payment_transaction_id',
+					'subscription_transaction_id',
+					'timestamp',
+				),
+				'subscriptions' => array(
+					'id',
+					'user_id',
+					'membership_level_id',
+					'status',
+					'gateway',
+					'gateway_environment',
+					'subscription_transaction_id',
+					'billing_amount',
+					'cycle_number',
+					'cycle_period',
+					'startdate',
+					'enddate',
+					'next_payment_date',
+				),
+			);
+
+			return isset( $fields[ $collection ] ) ? $fields[ $collection ] : array();
+		}
+
+		/**
+		 * Validate a requested `fields` list against a collection's known fields.
+		 *
+		 * Unknown names are rejected rather than silently dropped so that callers
+		 * get told which fields actually exist.
+		 *
+		 * @since TBD
+		 *
+		 * @param mixed  $value      The `fields` parameter value.
+		 * @param string $collection One of 'members', 'orders' or 'subscriptions'.
+		 * @return true|WP_Error True when valid, WP_Error otherwise.
+		 */
+		private function pmpro_rest_api_validate_fields( $value, $collection ) {
+			if ( empty( $value ) ) {
+				return true;
+			}
+
+			$known   = $this->pmpro_rest_api_get_collection_fields( $collection );
+			$unknown = array_diff( array_filter( array_map( 'trim', explode( ',', (string) $value ) ) ), $known );
+
+			if ( ! empty( $unknown ) ) {
+				return new WP_Error(
+					'rest_invalid_param',
+					sprintf(
+						/* translators: 1: comma-separated list of unrecognized field names. 2: comma-separated list of valid field names. */
+						__( 'Unknown field(s): %1$s. Valid fields are: %2$s.', 'paid-memberships-pro' ),
+						implode( ', ', $unknown ),
+						implode( ', ', $known )
+					),
+					array( 'status' => 400 )
+				);
+			}
+
+			return true;
 		}
 
 		/**

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -150,6 +150,7 @@ require_once( PMPRO_DIR . '/includes/restricted-files.php' );		// Restrict acces
 
 require_once( PMPRO_DIR . '/includes/xmlrpc.php' );                 // xmlrpc methods
 require_once( PMPRO_DIR . '/includes/rest-api.php' );               // rest API endpoints
+require_once( PMPRO_DIR . '/includes/cli.php' );                    // WP-CLI commands (loaded only under WP-CLI)
 require_once( PMPRO_DIR . '/includes/widgets.php' );                // widgets for PMPro
 require_once( PMPRO_DIR . '/includes/gateway-request-handlers.php' ); // gateway request handlers
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds `wp pmpro subscription sync <id>...` to the core WP-CLI commands — re-syncs one or more subscriptions with their gateway via `PMPro_Subscription::update()`.

> **Depends on #3740** (pmpro-cli in core). Stacked on that branch; until it merges, this diff includes its commits. Only the last commit (`532270b`) is new — one file, `includes/cli/class-pmpro-cli-subscription.php`.

This ports the last production-useful command from the `strangerstudios/pmpro-cli` POC (`sync-subscriptions-to-gateway`); the POC's dev/test-data commands are moving to PMPro Toolkit's CLI in a separate PR. With both landed, the POC repo can be archived.

Details:
- Accepts subscription IDs **or** gateway transaction IDs (e.g. `sub_XXXX`) — non-numeric args are looked up via `subscription_transaction_id`, using `PMPro_Subscription::get_subscription()` instead of the POC's raw SQL.
- Supports multiple IDs in one call; all are resolved up front so a typo errors before anything syncs.
- `--dry-run` previews, and it prompts for confirmation unless `--yes` is passed — matching the other write commands in #3740.
- Surfaces the `sync_error` subscription meta that `update()` records, so a gateway-side failure shows as a warning instead of a silent "success".

### How to test the changes in this Pull Request:

1. `wp pmpro subscription sync <id> --dry-run` — previews, no change.
2. `wp pmpro subscription sync <gateway txn id>` — resolves by `subscription_transaction_id`, prompts, syncs.
3. `wp pmpro subscription sync 1 2 3 --yes` — syncs several; per-subscription result lines, non-zero exit if any fail.
4. Bogus ID errors out before any sync runs.

### Other information:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally? (dry-run, txn-ID lookup, multi-ID sync, and error paths verified on a seeded local site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)