### PR TITLE
ENHANCEMENT: Add SECURITY.md for private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+Paid Memberships Pro takes the security of our plugin, Add Ons, and website seriously.
+
+## Reporting a Vulnerability
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+If you believe you have found a vulnerability in Paid Memberships Pro, any of our Add Ons, or our website, please disclose it privately:
+
+1. Prefer our contact form and clearly note that you are reporting a security vulnerability:  
+   https://www.paidmembershipspro.com/contact/
+2. Or email **info@paidmembershipspro.com** with **Security Vulnerability** in the subject line.
+
+Please include as much detail as possible so we can reproduce and fix the issue quickly (affected versions, steps to reproduce, impact, and any proof-of-concept if available).
+
+We appreciate responsible disclosure. We do not run an official bug bounty program, but we have paid rewards for security disclosures in the past and may do so at our discretion based on severity.
+
+## Policy and security.txt
+
+- Full security / disclosure policy: https://www.paidmembershipspro.com/documentation/advanced/security/
+- Website `security.txt` (RFC 9116): https://www.paidmembershipspro.com/.well-known/security.txt
+
+## Supported Versions
+
+Please report issues against the latest release of Paid Memberships Pro whenever possible. We prioritize fixes for supported current releases.


### PR DESCRIPTION
## Summary

Adds a root `SECURITY.md` so GitHub (and humans) have a clear private disclosure path for Paid Memberships Pro.

Content matches existing guidance in:
- `.github/CONTRIBUTING.md` (private email to info@ with “Security Vulnerability” in the subject)
- https://www.paidmembershipspro.com/documentation/advanced/security/
- Live site `security.txt` at https://www.paidmembershipspro.com/.well-known/security.txt

### Why not ship `security.txt` in the plugin?

RFC 9116 `security.txt` belongs on the **organization website** at `/.well-known/security.txt`. That file is already live on www.paidmembershipspro.com and is valid through 2027-12-31. Putting `security.txt` inside the plugin would not serve that path on customer sites and is the wrong place for org-level disclosure contacts.

## Test plan

- [ ] Confirm GitHub Security Policy page shows this file after merge (`/security/policy`)
- [ ] Spot-check links: contact form, security docs, live `security.txt`
- [ ] No plugin runtime/load path changes (docs-only)