### PR TITLE
Remove PayPal Express Add On promo from Stripe payment settings

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -649,20 +649,7 @@ class PMProGateway_stripe extends PMProGateway {
 				<p class="description"><?php esc_html_e( 'Tax IDs are only collected if you have enabled Stripe Tax. Stripe only performs automatic validation for ABN, EU VAT, and GB VAT numbers. You must verify that provided tax IDs are valid during the Session for all other numbers.', 'paid-memberships-pro' ); ?></p>
 			</td>
 		</tr>
-		<?php if ( ! function_exists( 'pmproappe_pmpro_valid_gateways' ) ) {
-				$allowed_appe_html = array (
-					'a' => array (
-						'href' => array(),
-						'target' => array(),
-						'title' => array(),
-					),
-				);
-				echo '<tr class="gateway gateway_stripe"';
-				if ( $gateway != "stripe" ) {
-					echo ' style="display: none;"';
-				}
-				echo '><th>&nbsp;</th><td><p class="description">' . sprintf( wp_kses( __( 'Optional: Offer PayPal Express as an option at checkout using the <a target="_blank" href="%s" title="Paid Memberships Pro - Add PayPal Express Option at Checkout Add On">Add PayPal Express Add On</a>.', 'paid-memberships-pro' ), $allowed_appe_html ), 'https://www.paidmembershipspro.com/add-ons/pmpro-add-paypal-express-option-checkout/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=add-ons&utm_content=pmpro-add-paypal-express-option-checkout' ) . '</p></td></tr>';
-		}
+		<?php
 	}
 
 	/**
@@ -1051,21 +1038,6 @@ class PMProGateway_stripe extends PMProGateway {
 						jQuery('#stripe_tax').change();
 					});
 				</script>
-				<?php
-					if ( ! function_exists( 'pmproappe_pmpro_valid_gateways' ) ) {
-						?>
-						<p>
-							<?php
-								printf(
-									/* translators: %s: URL to the Add PayPal Express Add On documentation. */
-									esc_html__( 'Optional: Offer PayPal Express as an option at checkout using the %s.', 'paid-memberships-pro' ),
-									'<a href="https://www.paidmembershipspro.com/add-ons/pmpro-add-paypal-express-option-checkout/?utm_source=plugin&utm_medium=pmpro-paymentsettings&utm_campaign=add-ons&utm_content=pmpro-add-paypal-express-option-checkout" target="_blank">' . esc_html__( 'Add PayPal Express Add On', 'paid-memberships-pro' ) . '</a>'
-								);
-							?>
-						</p>
-						<?php
-					}
-				?>
 			</div>
 		</div>
 		<?php

--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,9 @@ Not sure? You can find out by doing a bit a research.
 4. [Ask using our contact form](https://www.paidmembershipspro.com/contact/)
 
 == Changelog ==
+= TBD =
+* ENHANCEMENT: Removed the notices on the Stripe payment settings recommending the deprecated Add PayPal Express Add On. #3751 (@flintfromthebasement)
+
 = 3.8.4 - 2026-08-06 =
 * ENHANCEMENT: Added new `--pmpro--btn--border-radius`, `--pmpro--btn--top-bottom-padding`, and `--pmpro--btn--left-right-padding` CSS variables so that button styles can be customized separately from other elements that share the base variables. #3747 (@RachelRVasquez)
 * BUG FIX: Fixed an issue where Stripe Checkout orders paid with delayed notification payment methods such as SEPA Direct Debit could be completed without their subscription and payment transaction IDs, which prevented membership cancellations from being sent to Stripe. An upgrade script now recovers the missing IDs for previously affected orders. #3745 (@dparker1005)


### PR DESCRIPTION
## What

Fixes #3750 — removes both "Optional: Offer PayPal Express as an option at checkout using the Add PayPal Express Add On." notices from the Stripe gateway settings (`class.pmprogateway_stripe.php`): the payment-settings table row and the Stripe Checkout panel paragraph.

## Why

PayPal Express is deprecated as of 3.7.1 and PayPal no longer issues the NVP/SOAP credentials a new setup would need, so this copy recommends a dead end. Both blocks are gated on `! function_exists( 'pmproappe_pmpro_valid_gateways' )` — they only ever rendered for sites *without* the add-on, exactly the sites that should not adopt it now. It directly caused support ticket 712886, where a customer read this text and asked whether PayPal Express had become newly available.

Pure removal — no replacement copy. If we want to point users at the modern PayPal Gateway Add On here instead, happy to follow up, but that's a product/marketing wording decision.

I'll add the readme changelog entry with this PR's number as a follow-up commit on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)