### PR TITLE
BUG FIX: Hide password toggle text in narrow login widget containers

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -683,6 +683,27 @@
 		justify-self: end;
 	}
 
+	/* Container context for narrow login forms (e.g. sidebar widget) */
+	.pmpro_login_wrap {
+		container: pmpro-login-wrap / inline-size;
+	}
+
+	/* In narrow containers, visually hide toggle text to prevent label crush.
+	 * The eye icon stays interactive; screen readers still hear the text. */
+	@container pmpro-login-wrap (max-width: 280px) {
+		.pmpro_form_field-password-toggle-state {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
+		}
+	}
+
 	#resetpassform .pmpro_cols-2 {
 		container: resetpassform / inline-size;
 	}

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -678,6 +678,27 @@
 		justify-self: end;
 	}
 
+	/* Container context for narrow login forms (e.g. sidebar widget) */
+	.pmpro_login_wrap {
+		container: pmpro-login-wrap / inline-size;
+	}
+
+	/* In narrow containers, visually hide toggle text to prevent label crush.
+	 * The eye icon stays interactive; screen readers still hear the text. */
+	@container pmpro-login-wrap (max-width: 280px) {
+		.pmpro_form_field-password-toggle-state {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
+		}
+	}
+
 	#resetpassform .pmpro_cols-2 {
 		container: resetpassform / inline-size;
 	}


### PR DESCRIPTION
## Problem

The **Log In - PMPro** widget crushes the Password label in a narrow sidebar. When the widget renders in ~200px, the `variation_1.css` grid lays out the password row as `1fr auto`, putting the label and "Show Password" text side by side. The toggle text takes most of the row width, collapsing the label column to ~18px and wrapping "Password" letter-by-letter (worse with wide fonts like Xolonium).

Live repro (logged out): https://scifimovieguy.com/essential-scifi-movies/

The `/login/` page on the same site is fine — this only affects the widget in narrow sidebars.

Reported in #3752.

## Fix

Uses the same CSS container query pattern already in place for `#resetpassform .pmpro_cols-2`.

1. Establishes `.pmpro_login_wrap` as an inline-size container (`pmpro-login-wrap`).
2. Below 280px container width, visually hides `.pmpro_form_field-password-toggle-state` using the standard visually-hidden technique (not `display: none` — preserves screen reader access).

The eye icon remains visible and interactive. The `/login/` page, checkout, and profile pages are unaffected because their password fields are not inside `.pmpro_login_wrap`.

Applied to `variation_1.css` and `variation_high_contrast.css`.

## Testing

1. Add the **Log In - PMPro** widget to a narrow sidebar (e.g. Memberlite 9×3 layout).
2. View logged out — the Password label should render on one line; only the eye icon appears in the toggle column.
3. Clicking the eye should still toggle password visibility.
4. Check `/login/` — "Show Password" text should still appear normally (not hidden).
5. Repeat with high contrast variation active.

For a site-level workaround (child theme or Customizer CSS) while this ships: https://gist.github.com/flintfromthebasement/41e49dbd50842eb07b48a1da455b796b