### PR TITLE
Remove display grid from login widget

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -1202,11 +1202,6 @@
 		.pmpro_cols-3 > * {
 			width: auto;
 		}
-
-		#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) {
-			width: 100%;
-		}
-
 	}
 
 }

--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -656,33 +656,6 @@
 		opacity: .7;
 	}
 
-	/* Move password toggle before field visually but structurally after */
-	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle),
-	.pmpro_section #loginform .login-password {
-		align-items: center;
-		display: grid;
-		grid-template-areas:
-			"label toggle"
-			"input input";
-		grid-template-columns: 1fr auto;
-	}
-
-	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) label,
-	.pmpro_section #loginform .login-password label {
-		grid-area: label;
-	}
-
-	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) input,
-	.pmpro_section #loginform .login-password input {
-		grid-area: input;
-	}
-
-	#pmpro_user_fields .pmpro_form_field-password .pmpro_form_field-password-toggle,
-	.pmpro_section #loginform .login-password .pmpro_form_field-password-toggle {
-		grid-area: toggle;
-		justify-self: end;
-	}
-
 	#resetpassform .pmpro_cols-2 {
 		container: resetpassform / inline-size;
 	}

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -651,33 +651,6 @@
 		border-radius: 0;
 	}
 
-	/* Move password toggle before field visually but structurally after */
-	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle),
-	.pmpro_section #loginform .login-password {
-		align-items: center;
-		display: grid;
-		grid-template-areas:
-			"label toggle"
-			"input input";
-		grid-template-columns: 1fr auto;
-	}
-
-	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) label,
-	.pmpro_section #loginform .login-password label {
-		grid-area: label;
-	}
-
-	#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) input,
-	.pmpro_section #loginform .login-password input {
-		grid-area: input;
-	}
-
-	#pmpro_user_fields .pmpro_form_field-password .pmpro_form_field-password-toggle,
-	.pmpro_section #loginform .login-password .pmpro_form_field-password-toggle {
-		grid-area: toggle;
-		justify-self: end;
-	}
-
 	#resetpassform .pmpro_cols-2 {
 		container: resetpassform / inline-size;
 	}

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -1185,11 +1185,6 @@
 		.pmpro_cols-3 > * {
 			width: auto;
 		}
-
-		#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) {
-			width: 100%;
-		}
-
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Bug:** Form looks squished/broken on narrow widths due to `display: grid` styles that place the "Show Password" button inline, to the right of the field label.

<img width="282" height="574" alt="image" src="https://github.com/user-attachments/assets/05f2014e-76c5-4e4c-96c7-f0f89c974317" />

**Flint's solution:** https://gist.github.com/flintfromthebasement/41e49dbd50842eb07b48a1da455b796b

**Alternate solution in this PR:** Remove that CSS. Let the form stack elements normally. Tab order now also matches the visual order for accessibility.

<img width="276" height="557" alt="image" src="https://github.com/user-attachments/assets/44bd9920-9c3a-4e69-8547-edea3f6b5be7" />

Styles have been removed from both the `variation_1.css` and `variation_high_contrast.css` files.

**Recommendation for a separate PR:** Adding `aria-pressed` to the "Show Password" button. Reference: https://medium.com/@web-accessibility-education/dos-and-donts-of-accessible-show-password-buttons-9a5fbc2c566b

Screen readers need to know when that "Show Password" button is active. Short video of NVDA reading the password field as protected bullets until you toggle the button so that it can read what's in the password field.

https://www.awesomescreenshot.com/video/55660850?key=8d1093d09b503911bff79f42a55c1cde

### How to test the changes in this Pull Request:

1. Easiest to test with Memberlite due to the "Columns Ratio" setting under Appearance > Customize > Posts & Archives.
2. Set the "Columns Ratio" to something really narrow, like 9x3.
3. If your sidebar doesn't already have the login widget, add it.
4. Check the front-end and confirm whether the "Show Password" now shows beneath the password field and the password label is no longer squished/broken.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove display grid styles on login form widget. "Show Password" toggle now displays beneath the password field. Resolves issue on narrow screens where the "Show Password" was crashing into the label and breaking it.
