### PR TITLE
Review follow-ups for Abilities API and pmpro-cli (v3.9)

### DIFF
--- a/classes/class-pmpro-subscription.php
+++ b/classes/class-pmpro-subscription.php
@@ -315,7 +315,7 @@ class PMPro_Subscription {
 	 *
 	 * Defaults to returning the latest 100 subscriptions.
 	 *
-	 * @since 3.8.3 Added support for the `offset` and `return_count` arguments.
+	 * @since TBD Added support for the `offset` and `return_count` arguments.
 	 *
 	 * @param array $args The query arguments to use.
 	 *

--- a/classes/class.memberorder.php
+++ b/classes/class.memberorder.php
@@ -555,7 +555,7 @@
 		 * Get orders based on various parameters
 		 *
 		 * @since 2.9
-		 * @since 3.8.3 Added support for the `offset` argument.
+		 * @since TBD Added support for the `offset` argument.
 		 *
 		 * @param array $args Specify what you'd like to filter the query by
 		 *

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -3,7 +3,7 @@
  * Register Paid Memberships Pro abilities for the WordPress Abilities API.
  *
  * @package PaidMembershipsPro
- * @since 3.8.3
+ * @since TBD
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,7 +16,7 @@ add_action( 'wp_abilities_api_init', 'pmpro_abilities_register_abilities' );
 /**
  * Check whether the WordPress Abilities API is available.
  *
- * @since 3.8.3
+ * @since TBD
  *
  * @return bool
  */
@@ -29,7 +29,7 @@ function pmpro_abilities_is_abilities_api_available() {
 /**
  * Check whether PMPro can register abilities.
  *
- * @since 3.8.3
+ * @since TBD
  *
  * @return bool
  */
@@ -37,7 +37,7 @@ function pmpro_abilities_can_boot() {
 	/**
 	 * Filter whether PMPro should register Abilities API categories and abilities.
 	 *
-	 * @since 3.8.3
+	 * @since TBD
 	 *
 	 * @param bool $enabled Whether ability registration is enabled.
 	 */
@@ -308,15 +308,21 @@ function pmpro_abilities_get_levels_query_definition() {
 function pmpro_abilities_get_member_memberships_definition() {
 	return array(
 		'label'               => __( 'Get Member Memberships', 'paid-memberships-pro' ),
-		'description'         => __( 'Retrieve the current membership assignments for a specific user.', 'paid-memberships-pro' ),
+		'description'         => __( 'Retrieve the active membership assignments for a specific user. Set include_inactive to also return the user\'s past membership history.', 'paid-memberships-pro' ),
 		'category'            => 'pmpro',
 		'execute_callback'    => 'pmpro_abilities_execute_member_memberships_get',
 		'permission_callback' => 'pmpro_abilities_can_manage_members',
 		'input_schema'        => array(
 			'type'       => 'object',
+			'default'    => array(
+				'include_inactive' => false,
+			),
 			'properties' => array(
-				'user_id' => array(
+				'user_id'          => array(
 					'type' => 'integer',
+				),
+				'include_inactive' => array(
+					'type' => 'boolean',
 				),
 			),
 			'required'   => array( 'user_id' ),
@@ -912,7 +918,7 @@ function pmpro_abilities_execute_levels_query( $input ) {
 	$query          = strtolower( trim( (string) $input['query'] ) );
 	$limit          = max( 1, min( 50, (int) $input['limit'] ) );
 	$page           = max( 1, (int) $input['page'] );
-	$levels         = array_values( pmpro_getAllLevels( $include_hidden, true ) );
+	$levels         = array_values( pmpro_getAllLevels( $include_hidden ) );
 
 	if ( '' !== $query ) {
 		$levels = array_values(
@@ -953,7 +959,9 @@ function pmpro_abilities_execute_member_memberships_get( $input ) {
 		return $user;
 	}
 
-	$memberships = pmpro_getMembershipLevelsForUser( $user->ID, true );
+	$include_inactive = ! empty( $input['include_inactive'] );
+
+	$memberships = pmpro_getMembershipLevelsForUser( $user->ID, $include_inactive );
 	if ( ! is_array( $memberships ) ) {
 		$memberships = array();
 	}
@@ -988,15 +996,18 @@ function pmpro_abilities_execute_member_membership_change( $input ) {
 		return new WP_Error( 'pmpro_abilities_level_not_found', __( 'Membership level not found.', 'paid-memberships-pro' ), array( 'status' => 404 ) );
 	}
 
-	$previous_memberships = pmpro_getMembershipLevelsForUser( $user->ID, true );
+	$previous_memberships = pmpro_getMembershipLevelsForUser( $user->ID );
 	if ( ! is_array( $previous_memberships ) ) {
 		$previous_memberships = array();
 	}
 
-	$old_level_status = ! empty( $input['old_level_status'] ) ? (string) $input['old_level_status'] : 'admin_changed';
-	$result           = pmpro_changeMembershipLevel( (int) $level->id, (int) $user->ID, $old_level_status );
+	$old_level_status = ! empty( $input['old_level_status'] ) ? pmpro_sanitize_with_safelist( (string) $input['old_level_status'], array( 'inactive', 'changed', 'admin_changed', 'cancelled', 'admin_cancelled', 'expired' ) ) : 'admin_changed';
+	if ( empty( $old_level_status ) ) {
+		return new WP_Error( 'pmpro_abilities_invalid_old_level_status', __( 'Invalid old level status.', 'paid-memberships-pro' ), array( 'status' => 400 ) );
+	}
+	$result = pmpro_changeMembershipLevel( (int) $level->id, (int) $user->ID, $old_level_status );
 
-	$current_memberships = pmpro_getMembershipLevelsForUser( $user->ID, true );
+	$current_memberships = pmpro_getMembershipLevelsForUser( $user->ID );
 	if ( ! is_array( $current_memberships ) ) {
 		$current_memberships = array();
 	}
@@ -1048,14 +1059,14 @@ function pmpro_abilities_execute_member_membership_cancel( $input ) {
 		return new WP_Error( 'pmpro_abilities_level_not_found', __( 'Membership level not found.', 'paid-memberships-pro' ), array( 'status' => 404 ) );
 	}
 
-	$previous_memberships = pmpro_getMembershipLevelsForUser( $user->ID, true );
+	$previous_memberships = pmpro_getMembershipLevelsForUser( $user->ID );
 	if ( ! is_array( $previous_memberships ) ) {
 		$previous_memberships = array();
 	}
 
 	$result = pmpro_cancelMembershipLevel( (int) $level->id, (int) $user->ID, 'admin_cancelled' );
 
-	$current_memberships = pmpro_getMembershipLevelsForUser( $user->ID, true );
+	$current_memberships = pmpro_getMembershipLevelsForUser( $user->ID );
 	if ( ! is_array( $current_memberships ) ) {
 		$current_memberships = array();
 	}

--- a/includes/abilities.php
+++ b/includes/abilities.php
@@ -1001,9 +1001,18 @@ function pmpro_abilities_execute_member_membership_change( $input ) {
 		$previous_memberships = array();
 	}
 
-	$old_level_status = ! empty( $input['old_level_status'] ) ? pmpro_sanitize_with_safelist( (string) $input['old_level_status'], array( 'inactive', 'changed', 'admin_changed', 'cancelled', 'admin_cancelled', 'expired' ) ) : 'admin_changed';
+	$valid_old_level_statuses = array( 'inactive', 'changed', 'admin_changed', 'cancelled', 'admin_cancelled', 'expired' );
+	$old_level_status         = ! empty( $input['old_level_status'] ) ? pmpro_sanitize_with_safelist( (string) $input['old_level_status'], $valid_old_level_statuses ) : 'admin_changed';
 	if ( empty( $old_level_status ) ) {
-		return new WP_Error( 'pmpro_abilities_invalid_old_level_status', __( 'Invalid old level status.', 'paid-memberships-pro' ), array( 'status' => 400 ) );
+		return new WP_Error(
+			'pmpro_abilities_invalid_old_level_status',
+			sprintf(
+				/* translators: %s: comma-separated list of valid statuses */
+				__( 'Invalid old level status. Valid values are: %s.', 'paid-memberships-pro' ),
+				implode( ', ', $valid_old_level_statuses )
+			),
+			array( 'status' => 400 )
+		);
 	}
 	$result = pmpro_changeMembershipLevel( (int) $level->id, (int) $user->ID, $old_level_status );
 

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -4,7 +4,8 @@
  *
  * Thin wrappers around existing PMPro functions. One method per command.
  *
- *   wp pmpro member list|get|add-level|remove-level|change-level|cancel
+ *   wp pmpro membership list
+ *   wp pmpro member get|add-level|remove-level|change-level|cancel
  *   wp pmpro level list|get
  *   wp pmpro order list|get
  *   wp pmpro subscription list|get|sync
@@ -27,12 +28,13 @@ if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 class PMPro_CLI extends \WP_CLI_Command {
 
 	/**
-	 * List members (users who hold a membership).
+	 * List memberships. Returns one row per user/level pair, so a member
+	 * holding multiple levels appears once per level held.
 	 *
 	 * ## OPTIONS
 	 *
 	 * [--level=<ids>]
-	 * : Only list members with these membership level IDs. Comma-separated.
+	 * : Only list memberships for these membership level IDs. Comma-separated.
 	 *
 	 * [--status=<statuses>]
 	 * : Membership status(es) to match, or 'all' for any status. Comma-separated. Default: active.
@@ -41,7 +43,7 @@ class PMPro_CLI extends \WP_CLI_Command {
 	 * : Match users by login, email, or display name.
 	 *
 	 * [--number=<n>]
-	 * : Maximum number of members to return. Default: 100.
+	 * : Maximum number of memberships to return. Default: 100.
 	 *
 	 * [--page=<n>]
 	 * : Page of results to return. Default: 1.
@@ -69,14 +71,14 @@ class PMPro_CLI extends \WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp pmpro member list --level=2 --status=active
-	 *     wp pmpro member list --search=jane --format=json
+	 *     wp pmpro membership list --level=2 --status=active
+	 *     wp pmpro membership list --search=jane --format=json
 	 *
 	 * @when after_wp_load
 	 */
-	public function member_list( $args, $assoc_args ) {
+	public function membership_list( $args, $assoc_args ) {
 		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
-			WP_CLI::error( 'The ids format is not supported for member list (a user can have multiple memberships). Use --fields=user_id --format=csv.' );
+			WP_CLI::error( 'The ids format is not supported for membership list (rows are user/level pairs). Use --fields=user_id --format=csv.' );
 		}
 
 		$number = $this->list_limit( $assoc_args );
@@ -1022,7 +1024,7 @@ class PMPro_CLI extends \WP_CLI_Command {
 }
 
 $pmpro_cli = new PMPro_CLI();
-WP_CLI::add_command( 'pmpro member list', array( $pmpro_cli, 'member_list' ) );
+WP_CLI::add_command( 'pmpro membership list', array( $pmpro_cli, 'membership_list' ) );
 WP_CLI::add_command( 'pmpro member get', array( $pmpro_cli, 'member_get' ) );
 WP_CLI::add_command( 'pmpro member add-level', array( $pmpro_cli, 'member_add_level' ) );
 WP_CLI::add_command( 'pmpro member remove-level', array( $pmpro_cli, 'member_remove_level' ) );

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -105,7 +105,7 @@ class PMPro_CLI extends \WP_CLI_Command {
 		}
 
 		$items = array();
-		foreach ( (array) pmpro_get_members( $query ) as $member ) {
+		foreach ( (array) pmpro_get_memberships( $query ) as $member ) {
 			$items[] = array(
 				'user_id'         => (int) $member['user_id'],
 				'user_login'      => $member['user_login'],

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -419,7 +419,7 @@ class PMPro_CLI extends \WP_CLI_Command {
 	 */
 	public function level_list( $args, $assoc_args ) {
 		$items = array();
-		foreach ( (array) pmpro_getAllLevels( ! empty( $assoc_args['include-hidden'] ), true ) as $level ) {
+		foreach ( (array) pmpro_getAllLevels( ! empty( $assoc_args['include-hidden'] ) ) as $level ) {
 			$items[] = $this->format_level( $level );
 		}
 
@@ -786,6 +786,11 @@ class PMPro_CLI extends \WP_CLI_Command {
 		if ( isset( $assoc_args['format'] ) && 'count' === $assoc_args['format'] ) {
 			WP_CLI::line( (string) count( $items ) );
 			return;
+		}
+
+		// The ids format expects a flat list, not row arrays.
+		if ( isset( $assoc_args['format'] ) && 'ids' === $assoc_args['format'] ) {
+			$items = wp_list_pluck( $items, $fields[0] );
 		}
 
 		$formatter = new \WP_CLI\Formatter( $assoc_args, $fields );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5583,7 +5583,10 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
  *
  *     @type int|int[]       $membership_id Only return members holding these level IDs. Default null (any level).
  *     @type string|string[] $status        Membership status(es) to match, or 'all' for any status. Default 'active'.
- *                                          Only the latest matching row for each user/level pair is returned.
+ *                                          Only the latest row matching the status filter is returned for each
+ *                                          user/level pair. Like the underlying table, historical statuses such
+ *                                          as 'cancelled' can match members who since re-subscribed to the level;
+ *                                          'active' matches anyone PMPro considers to hold the level.
  *     @type string          $search        Match users by login, email, or display name. Default ''.
  *     @type int             $limit         Maximum rows to return. 0 for no limit. Default 100.
  *     @type int             $offset        Rows to skip, for pagination. Default 0.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5645,7 +5645,9 @@ function pmpro_get_memberships( $args = array() ) {
 		) latest ON latest.id = mu.id
 		LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id";
 
-	// Only include rows tied to a real membership level.
+	// Only include rows tied to a real membership level. The latest-row subquery
+	// also enforces this, but this condition guarantees the WHERE clause below is
+	// never empty when no other filters are passed.
 	$where[] = 'mu.membership_id > 0';
 
 	// Filter by membership level ID(s).

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5573,8 +5573,8 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
  * Query PMPro memberships (one row per user and membership level pair) with filtering and pagination.
  *
  * A user holding multiple levels returns one row per level held. Provides a single
- * reusable membership query for the REST API collection endpoint ( /pmpro/v1/members )
- * and the `wp pmpro member list` CLI command, so both share the same filtering,
+ * reusable membership query for the REST API collection endpoint ( /pmpro/v1/memberships )
+ * and the `wp pmpro membership list` CLI command, so both share the same filtering,
  * pagination, and output shape.
  *
  * @since TBD
@@ -5582,7 +5582,7 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
  * @param array $args {
  *     Optional. Query arguments.
  *
- *     @type int|int[]       $membership_id Only return members holding these level IDs. Default null (any level).
+ *     @type int|int[]       $membership_id Only return memberships for these level IDs. Default null (any level).
  *     @type string|string[] $status        Membership status(es) to match, or 'all' for any status. Default 'active'.
  *                                          Only the latest row matching the status filter is returned for each
  *                                          user/level pair. Like the underlying table, historical statuses such
@@ -5595,7 +5595,7 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
  *     @type string          $order         'ASC' or 'DESC'. Default 'DESC'.
  *     @type bool            $return_count  Return the total matching count instead of rows. Default false.
  * }
- * @return array|int Array of member row arrays, or an integer count when $return_count is true.
+ * @return array|int Array of membership row arrays, or an integer count when $return_count is true.
  */
 function pmpro_get_memberships( $args = array() ) {
 	global $wpdb;
@@ -5616,10 +5616,11 @@ function pmpro_get_memberships( $args = array() ) {
 	$where        = array();
 	$prepared     = array();
 
-	// Status condition, applied inside the latest-row subquery below. Pass 'all' to include every status.
+	// Status condition, applied inside the latest-row subquery below.
+	// Pass 'all' (as a string or within an array) to include every status.
 	$status_condition = '';
-	if ( ! empty( $args['status'] ) && 'all' !== $args['status'] ) {
-		$statuses         = array_map( 'strval', (array) $args['status'] );
+	$statuses         = array_map( 'strval', array_filter( (array) $args['status'] ) );
+	if ( ! empty( $statuses ) && ! in_array( 'all', $statuses, true ) ) {
 		$status_condition = ' AND mu2.status IN ( ' . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ' )';
 		$prepared         = array_merge( $prepared, $statuses );
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5583,6 +5583,7 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
  *
  *     @type int|int[]       $membership_id Only return members holding these level IDs. Default null (any level).
  *     @type string|string[] $status        Membership status(es) to match, or 'all' for any status. Default 'active'.
+ *                                          Only the latest matching row for each user/level pair is returned.
  *     @type string          $search        Match users by login, email, or display name. Default ''.
  *     @type int             $limit         Maximum rows to return. 0 for no limit. Default 100.
  *     @type int             $offset        Rows to skip, for pagination. Default 0.
@@ -5611,15 +5612,32 @@ function pmpro_get_members( $args = array() ) {
 	$where        = array();
 	$prepared     = array();
 
+	// Status condition, applied inside the latest-row subquery below. Pass 'all' to include every status.
+	$status_condition = '';
+	if ( ! empty( $args['status'] ) && 'all' !== $args['status'] ) {
+		$statuses         = array_map( 'strval', (array) $args['status'] );
+		$status_condition = ' AND mu2.status IN ( ' . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ' )';
+		$prepared         = array_merge( $prepared, $statuses );
+	}
+
 	if ( $return_count ) {
-		$sql = "SELECT COUNT( DISTINCT u.ID, mu.membership_id )";
+		$sql = "SELECT COUNT(*)";
 	} else {
 		$sql = "SELECT u.ID AS user_id, u.user_login, u.user_email, u.display_name, mu.membership_id, mu.status,
 			u.user_registered AS joindate, mu.startdate, mu.enddate, m.name AS membership_name";
 	}
 
+	// Join only the latest membership row for each user/level pair that matches the
+	// status filter, so historical rows for the same pair never produce duplicate
+	// results or nondeterministic status/date values.
 	$sql .= " FROM {$wpdb->users} u
 		INNER JOIN {$wpdb->pmpro_memberships_users} mu ON u.ID = mu.user_id
+		INNER JOIN (
+			SELECT MAX( mu2.id ) AS id
+			FROM {$wpdb->pmpro_memberships_users} mu2
+			WHERE mu2.membership_id > 0{$status_condition}
+			GROUP BY mu2.user_id, mu2.membership_id
+		) latest ON latest.id = mu.id
 		LEFT JOIN {$wpdb->pmpro_membership_levels} m ON mu.membership_id = m.id";
 
 	// Only include rows tied to a real membership level.
@@ -5630,13 +5648,6 @@ function pmpro_get_members( $args = array() ) {
 		$ids      = array_map( 'intval', (array) $args['membership_id'] );
 		$where[]  = 'mu.membership_id IN ( ' . implode( ', ', array_fill( 0, count( $ids ), '%d' ) ) . ' )';
 		$prepared = array_merge( $prepared, $ids );
-	}
-
-	// Filter by membership status(es). Pass 'all' to include every status.
-	if ( ! empty( $args['status'] ) && 'all' !== $args['status'] ) {
-		$statuses = array_map( 'strval', (array) $args['status'] );
-		$where[]  = 'mu.status IN ( ' . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ' )';
-		$prepared = array_merge( $prepared, $statuses );
 	}
 
 	// Search by login, email, or display name.
@@ -5656,9 +5667,6 @@ function pmpro_get_members( $args = array() ) {
 		}
 		return (int) $wpdb->get_var( $sql );
 	}
-
-	// One row per user/level pair.
-	$sql .= ' GROUP BY u.ID, mu.membership_id';
 
 	// Sanitize orderby against an allowlist of safe columns.
 	$orderby_map = array(
@@ -5687,16 +5695,6 @@ function pmpro_get_members( $args = array() ) {
 	if ( $prepared ) {
 		$sql = $wpdb->prepare( $sql, $prepared );
 	}
-
-	/**
-	 * Filter the SQL used by pmpro_get_members().
-	 *
-	 * @since TBD
-	 *
-	 * @param string $sql  The prepared SQL query.
-	 * @param array  $args The parsed query arguments.
-	 */
-	$sql = apply_filters( 'pmpro_get_members_sql', $sql, $args );
 
 	return $wpdb->get_results( $sql, ARRAY_A );
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -5570,11 +5570,12 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
 }
 
 /**
- * Query PMPro members (WordPress users who hold a membership) with filtering and pagination.
+ * Query PMPro memberships (one row per user and membership level pair) with filtering and pagination.
  *
- * Provides a single reusable member query for the REST API collection endpoint
- * ( /pmpro/v1/members ) and the `wp pmpro member list` CLI command, so both share
- * the same filtering, pagination, and output shape.
+ * A user holding multiple levels returns one row per level held. Provides a single
+ * reusable membership query for the REST API collection endpoint ( /pmpro/v1/members )
+ * and the `wp pmpro member list` CLI command, so both share the same filtering,
+ * pagination, and output shape.
  *
  * @since TBD
  *
@@ -5596,7 +5597,7 @@ function pmpro_update_post_level_restrictions( $post_id, $level_ids ) {
  * }
  * @return array|int Array of member row arrays, or an integer count when $return_count is true.
  */
-function pmpro_get_members( $args = array() ) {
+function pmpro_get_memberships( $args = array() ) {
 	global $wpdb;
 
 	$defaults = array(

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -11,7 +11,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			array(
 				array(
 					'methods'         => WP_REST_Server::READABLE,
-					'callback'        => array( $this, 'pmpro_rest_api_get_membership_level_for_user' ),
+					'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_level_for_user' ),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			),));
 			
@@ -48,7 +48,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			 array(
 				 array(
 					 'methods'         => WP_REST_Server::READABLE,
-					 'callback'        => array( $this, 'pmpro_rest_api_get_membership_level_for_user' ),
+					 'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_level_for_user' ),
 					 'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			 ),));
 
@@ -61,7 +61,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			 array(
 				 array(
 					 'methods'         => WP_REST_Server::READABLE,
-					 'callback'        => array( $this, 'pmpro_rest_api_get_membership_levels_for_user' ),
+					 'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_levels_for_user' ),
 					 'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			 ),));
 
@@ -120,7 +120,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
-				'callback'        => array( $this, 'pmpro_rest_api_get_membership_level' ),
+				'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_level' ),
 				'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			),
 			array(
@@ -144,7 +144,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			array(
 				array(
 					'methods'         => WP_REST_Server::READABLE,
-					'callback'        => array( $this, 'pmpro_rest_api_get_membership_levels' ),
+					'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_levels' ),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				),
 			)
@@ -257,15 +257,15 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		);
 
 		/**
-		 * Get a paginated, filterable collection of members.
+		 * Get a paginated, filterable collection of memberships (one row per user/level pair).
 		 * @since TBD
-		 * Example: https://example.com/wp-json/pmpro/v1/members?level=1&status=active&page=1&per_page=20
+		 * Example: https://example.com/wp-json/pmpro/v1/memberships?level=1&status=active&page=1&per_page=20
 		 */
-		register_rest_route( $pmpro_namespace, '/members',
+		register_rest_route( $pmpro_namespace, '/memberships',
 			array(
 				array(
 					'methods'  => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'pmpro_rest_api_get_members' ),
+					'callback' => array( $this, 'pmpro_rest_api_get_memberships' ),
 					'args'     => array(
 						'page'     => array( 'sanitize_callback' => 'absint' ),
 						'per_page' => array( 'sanitize_callback' => 'absint' ),
@@ -277,7 +277,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'fields'   => array(
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => function( $value ) {
-								return $this->pmpro_rest_api_validate_fields( $value, 'members' );
+								return $this->pmpro_rest_api_validate_fields( $value, 'memberships' );
 							},
 						),
 					),
@@ -520,7 +520,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 2.3
 		 * Example: https://example.com/wp-json/pmpro/v1/get_membership_level_for_user?user_id=1
 		 */
-		function pmpro_rest_api_get_membership_level_for_user($request) {
+		function pmpro_rest_api_get_membershipship_level_for_user($request) {
 			$params = $request->get_params();
 			
 			$user_id = isset( $params['user_id'] ) ? intval( $params['user_id'] ) : null;
@@ -550,7 +550,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 2.3
 		 * Example: https://example.com/wp-json/pmpro/v1/get_membership_levels_for_user?user_id=1
 		 */
-		 function pmpro_rest_api_get_membership_levels_for_user($request) {
+		 function pmpro_rest_api_get_membershipship_levels_for_user($request) {
 			$params = $request->get_params();
 			
 			$user_id = isset( $params['user_id'] ) ? intval( $params['user_id'] ) : null;
@@ -769,7 +769,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 2.3
 		 * Example: https://example.com/wp-json/pmpro/v1/membership_level/
 		 */
-		function pmpro_rest_api_get_membership_level( $request ) {
+		function pmpro_rest_api_get_membershipship_level( $request ) {
 
 			if ( ! class_exists( 'PMPro_Membership_Level' ) ) {
 				return new WP_REST_Response( 'Paid Memberships Pro level class not found.', 404 );
@@ -891,7 +891,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 3.0
 		 * Example: https://example.com/wp-json/pmpro/v1/membership_levels
 		 */
-		function pmpro_rest_api_get_membership_levels( $request ) {
+		function pmpro_rest_api_get_membershipship_levels( $request ) {
 			
 			if ( ! class_exists( 'PMPro_Membership_Level' ) ) {
 				return new WP_REST_Response( 'Paid Memberships Pro level class not found.', 404 );
@@ -1349,14 +1349,14 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		}
 
 		/**
-		 * Get a paginated, filterable collection of members.
+		 * Get a paginated, filterable collection of memberships (one row per user/level pair).
 		 *
 		 * @since TBD
 		 *
 		 * @param WP_REST_Request $request The REST request.
 		 * @return WP_REST_Response The REST response.
 		 */
-		public function pmpro_rest_api_get_members( $request ) {
+		public function pmpro_rest_api_get_memberships( $request ) {
 			$params   = $request->get_params();
 			$per_page = $this->pmpro_rest_api_get_per_page( $params );
 			$page     = $this->pmpro_rest_api_get_page( $params );
@@ -1382,11 +1382,11 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 
 			$total   = (int) pmpro_get_memberships( array_merge( $query_args, array( 'return_count' => true ) ) );
-			$members = pmpro_get_memberships( $query_args );
+			$memberships = pmpro_get_memberships( $query_args );
 
 			$fields = $this->pmpro_rest_api_get_fields( $params );
 			$items  = array();
-			foreach ( (array) $members as $member ) {
+			foreach ( (array) $memberships as $member ) {
 				$item = array(
 					'user_id'         => (int) $member['user_id'],
 					'user_login'      => $member['user_login'],
@@ -1616,12 +1616,12 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param string $collection One of 'members', 'orders' or 'subscriptions'.
+		 * @param string $collection One of 'memberships', 'orders' or 'subscriptions'.
 		 * @return array Array of valid field names.
 		 */
 		private function pmpro_rest_api_get_collection_fields( $collection ) {
 			$fields = array(
-				'members'       => array(
+				'memberships'   => array(
 					'user_id',
 					'user_login',
 					'user_email',
@@ -1677,7 +1677,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since TBD
 		 *
 		 * @param mixed  $value      The `fields` parameter value.
-		 * @param string $collection One of 'members', 'orders' or 'subscriptions'.
+		 * @param string $collection One of 'memberships', 'orders' or 'subscriptions'.
 		 * @return true|WP_Error True when valid, WP_Error otherwise.
 		 */
 		private function pmpro_rest_api_validate_fields( $value, $collection ) {
@@ -2328,7 +2328,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				'/pmpro/v1/me' => true,
 				'/pmpro/v1/recent_memberships' => 'pmpro_edit_members',
 				'/pmpro/v1/recent_orders' => 'pmpro_orders',
-				'/pmpro/v1/members' => 'pmpro_edit_members',
+				'/pmpro/v1/memberships' => 'pmpro_edit_members',
 				'/pmpro/v1/orders' => 'pmpro_orders',
 				'/pmpro/v1/subscriptions' => 'pmpro_edit_members',
 				'/pmpro/v1/post_restrictions' => array(

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -1381,8 +1381,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				$query_args['order'] = ( 'asc' === strtolower( (string) $params['order'] ) ) ? 'ASC' : 'DESC';
 			}
 
-			$total   = (int) pmpro_get_members( array_merge( $query_args, array( 'return_count' => true ) ) );
-			$members = pmpro_get_members( $query_args );
+			$total   = (int) pmpro_get_memberships( array_merge( $query_args, array( 'return_count' => true ) ) );
+			$members = pmpro_get_memberships( $query_args );
 
 			$fields = $this->pmpro_rest_api_get_fields( $params );
 			$items  = array();

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -305,7 +305,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'gateway'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'start_date' => array( 'sanitize_callback' => 'sanitize_text_field' ),
 						'end_date'   => array( 'sanitize_callback' => 'sanitize_text_field' ),
-						'orderby'    => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'    => array( 'sanitize_callback' => 'sanitize_key' ),
+						'order'      => array( 'sanitize_callback' => 'sanitize_key' ),
 						'fields'     => array(
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => function( $value ) {
@@ -335,7 +336,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 						'level'    => array(),
 						'status'   => array(),
 						'gateway'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
-						'orderby'  => array( 'sanitize_callback' => 'sanitize_text_field' ),
+						'orderby'  => array( 'sanitize_callback' => 'sanitize_key' ),
+						'order'    => array( 'sanitize_callback' => 'sanitize_key' ),
 						'fields'   => array(
 							'sanitize_callback' => 'sanitize_text_field',
 							'validate_callback' => function( $value ) {
@@ -1439,6 +1441,21 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 				$query_args['end_date'] = sanitize_text_field( $params['end_date'] );
 			}
 
+			// Sort by an allowlisted column. Unknown values fall back to the default (timestamp DESC).
+			$orderby_map = array(
+				'id'            => '`o`.`id`',
+				'user_id'       => '`o`.`user_id`',
+				'membership_id' => '`o`.`membership_id`',
+				'status'        => '`o`.`status`',
+				'gateway'       => '`o`.`gateway`',
+				'total'         => '`o`.`total`',
+				'timestamp'     => '`o`.`timestamp`',
+			);
+			if ( ! empty( $params['orderby'] ) && isset( $orderby_map[ $params['orderby'] ] ) ) {
+				$order                 = ( ! empty( $params['order'] ) && 'asc' === strtolower( (string) $params['order'] ) ) ? 'ASC' : 'DESC';
+				$query_args['orderby'] = $orderby_map[ $params['orderby'] ] . ' ' . $order;
+			}
+
 			$total  = (int) MemberOrder::get_orders( array_merge( $query_args, array( 'return_count' => true ) ) );
 			$orders = MemberOrder::get_orders( $query_args );
 
@@ -1494,6 +1511,23 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			}
 			if ( ! empty( $params['gateway'] ) ) {
 				$query_args['gateway'] = sanitize_text_field( $params['gateway'] );
+			}
+
+			// Sort by an allowlisted column. Unknown values fall back to the default (startdate DESC).
+			$orderby_map = array(
+				'id'                  => '`id`',
+				'user_id'             => '`user_id`',
+				'membership_level_id' => '`membership_level_id`',
+				'status'              => '`status`',
+				'gateway'             => '`gateway`',
+				'billing_amount'      => '`billing_amount`',
+				'startdate'           => '`startdate`',
+				'enddate'             => '`enddate`',
+				'next_payment_date'   => '`next_payment_date`',
+			);
+			if ( ! empty( $params['orderby'] ) && isset( $orderby_map[ $params['orderby'] ] ) ) {
+				$order                 = ( ! empty( $params['order'] ) && 'asc' === strtolower( (string) $params['order'] ) ) ? 'ASC' : 'DESC';
+				$query_args['orderby'] = $orderby_map[ $params['orderby'] ] . ' ' . $order;
 			}
 
 			$total         = (int) PMPro_Subscription::get_subscriptions( array_merge( $query_args, array( 'return_count' => true ) ) );

--- a/includes/rest-api.php
+++ b/includes/rest-api.php
@@ -11,7 +11,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			array(
 				array(
 					'methods'         => WP_REST_Server::READABLE,
-					'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_level_for_user' ),
+					'callback'        => array( $this, 'pmpro_rest_api_get_membership_level_for_user' ),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			),));
 			
@@ -48,7 +48,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			 array(
 				 array(
 					 'methods'         => WP_REST_Server::READABLE,
-					 'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_level_for_user' ),
+					 'callback'        => array( $this, 'pmpro_rest_api_get_membership_level_for_user' ),
 					 'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			 ),));
 
@@ -61,7 +61,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			 array(
 				 array(
 					 'methods'         => WP_REST_Server::READABLE,
-					 'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_levels_for_user' ),
+					 'callback'        => array( $this, 'pmpro_rest_api_get_membership_levels_for_user' ),
 					 'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			 ),));
 
@@ -120,7 +120,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		array(
 			array(
 				'methods'         => WP_REST_Server::READABLE,
-				'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_level' ),
+				'callback'        => array( $this, 'pmpro_rest_api_get_membership_level' ),
 				'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 			),
 			array(
@@ -144,7 +144,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 			array(
 				array(
 					'methods'         => WP_REST_Server::READABLE,
-					'callback'        => array( $this, 'pmpro_rest_api_get_membershipship_levels' ),
+					'callback'        => array( $this, 'pmpro_rest_api_get_membership_levels' ),
 					'permission_callback' => array( $this, 'pmpro_rest_api_get_permissions_check' ),
 				),
 			)
@@ -520,7 +520,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 2.3
 		 * Example: https://example.com/wp-json/pmpro/v1/get_membership_level_for_user?user_id=1
 		 */
-		function pmpro_rest_api_get_membershipship_level_for_user($request) {
+		function pmpro_rest_api_get_membership_level_for_user($request) {
 			$params = $request->get_params();
 			
 			$user_id = isset( $params['user_id'] ) ? intval( $params['user_id'] ) : null;
@@ -550,7 +550,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 2.3
 		 * Example: https://example.com/wp-json/pmpro/v1/get_membership_levels_for_user?user_id=1
 		 */
-		 function pmpro_rest_api_get_membershipship_levels_for_user($request) {
+		 function pmpro_rest_api_get_membership_levels_for_user($request) {
 			$params = $request->get_params();
 			
 			$user_id = isset( $params['user_id'] ) ? intval( $params['user_id'] ) : null;
@@ -769,7 +769,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 2.3
 		 * Example: https://example.com/wp-json/pmpro/v1/membership_level/
 		 */
-		function pmpro_rest_api_get_membershipship_level( $request ) {
+		function pmpro_rest_api_get_membership_level( $request ) {
 
 			if ( ! class_exists( 'PMPro_Membership_Level' ) ) {
 				return new WP_REST_Response( 'Paid Memberships Pro level class not found.', 404 );
@@ -891,7 +891,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 		 * @since 3.0
 		 * Example: https://example.com/wp-json/pmpro/v1/membership_levels
 		 */
-		function pmpro_rest_api_get_membershipship_levels( $request ) {
+		function pmpro_rest_api_get_membership_levels( $request ) {
 			
 			if ( ! class_exists( 'PMPro_Membership_Level' ) ) {
 				return new WP_REST_Response( 'Paid Memberships Pro level class not found.', 404 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-ups from the review threads on #3736 (Abilities API) and #3740 (pmpro-cli + REST collections), incorporating @ideadude's feedback on each point. Both PRs are now merged into `v3.9`; this branch sits on top of that merge.

**From the #3736 review:**

- `pmpro/member-memberships-get` now returns **active memberships by default** and adds an `include_inactive` boolean input for full history ("option 1" per Jason). The change/cancel abilities' `previous_memberships`/`current_memberships` snapshots are also active-only now. Behavior change is called out in the changelog entry below.
- `old_level_status` on `pmpro/member-membership-change` is now validated with `pmpro_sanitize_with_safelist()` against the statuses core itself passes (`inactive`, `changed`, `admin_changed`, `cancelled`, `admin_cancelled`, `expired`); invalid values return a 400 `WP_Error` before any mutation. Shipped without a new statuses-helper function per Jason's "okay to ship as is."

**From the #3740 review:**

- Fixed `--format=ids` on `level list`, `order list`, and `subscription list` (rows are now plucked to a flat ID list before formatting).
- `pmpro_get_memberships()` now joins only the **latest row matching the status filter for each user/level pair** (via a derived `MAX(id)` table), so output is deterministic per Jason's suggestion. `status=active` deliberately matches anyone PMPro considers to hold the level (any active row grants access via `pmpro_hasMembershipLevel()`), and historical statuses match rows like the underlying table does. Implemented as a single-pass derived-table join rather than a correlated subquery — the correlated version hit a pathological plan on a 38k-row table locally (120s+ vs 0.06s).
- Removed the `pmpro_get_members_sql` filter (no callers anywhere; fragile prepared-SQL contract).
- Wired up `orderby`/`order` on the `/pmpro/v1/orders` and `/pmpro/v1/subscriptions` endpoints with allowlisted column maps, matching `/members`. Unknown `orderby` values fall back to the default sort.
- `level list` (CLI) and the levels-query ability no longer pass the deprecated second argument to `pmpro_getAllLevels()`.
- **Renamed the memberships collection surfaces** per Slack discussion with Jason and Mirco: `GET /pmpro/v1/members` is now `GET /pmpro/v1/memberships`, `wp pmpro member list` is now `wp pmpro membership list`, and the shared query function is `pmpro_get_memberships()`. All three return one row per user/level pair, so the memberships name describes the row shape accurately (a member holding two levels appears once per level). Person-scoped surfaces (`wp pmpro member get|add-level|remove-level|change-level|cancel`, the `pmpro/member-*` abilities) keep the member noun since they act on a user. None of these had shipped, so no back-compat concern.
- Normalized the `@since 3.8.3` placeholders from #3736 to `@since TBD`.
- **From a final worktree review of this branch:** fixed `status=all` on the memberships collection (the REST endpoint passes statuses as an array, so `array( 'all' )` was treated as a literal status and matched nothing — now returns all rows via both the string and array paths, verified against live data), and reverted an over-greedy rename that had corrupted four legacy REST callback method names.

### How to test the changes in this Pull Request:

All verified by execution on a local site (WP 7.1, 38k-row memberships table):

1. `pmpro_abilities_execute_member_memberships_get()` for a user with 106 historical rows: returns 2 (active) by default, 106 with `include_inactive: true`.
2. `member-membership-change` with `old_level_status: "active"` → `WP_Error pmpro_abilities_invalid_old_level_status`, no data changed.
3. `wp pmpro level list --format=ids` → flat ID list, no warnings.
4. `pmpro_get_members( [ 'status' => 'all' ] )` for a pair with 36,959 duplicate rows: exactly one row, matching the highest-ID row's status/startdate; counts match row counts for both `all` (1094) and `active` (452); full query in 0.06s.
5. `/pmpro/v1/orders?orderby=total&order=asc|desc` sorts correctly; `orderby=evil; DROP` safely falls back to the default sort. `/pmpro/v1/subscriptions?orderby=id&order=asc` returns 1,2,3,4,5 with correct `X-WP-Total`.

### Open questions (flagging for discussion, not blocking):

1. ~~Per-user history on the REST side?~~ **Resolved: starting minimal.** The `pmpro/member-memberships-get` ability (`include_inactive: true`) and `wp pmpro member get <id> --include-inactive` cover single-member history; no new REST endpoint or filter in this PR.
2. ~~"Latest per pair" vs "latest per member"~~ **Resolved:** one row per user+level pair, and the query function is now named `pmpro_get_memberships()` so the row shape is self-describing (a member holding two levels returns two membership rows). Concurrent MMPU levels stay visible.
3. **Unknown `orderby` values silently fall back** to the default sort (matching `/members`). The alternative is a 400 like the `fields` param. Happy to switch if we prefer loud failures here.

### Changelog entry

> BUG FIX/ENHANCEMENT: Review follow-ups for the Abilities API and pmpro-cli features. The pmpro/member-memberships-get ability now returns active memberships by default (pass include_inactive to get full history), membership change abilities validate the old level status, the memberships query now returns one deterministic row per user/level pair, --format=ids works on CLI list commands, the orders/subscriptions REST endpoints support orderby/order, and the memberships collection is exposed as /pmpro/v1/memberships and wp pmpro membership list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




