### PR TITLE
Tighten request validation in admin AJAX and service handlers

### DIFF
--- a/classes/class-pmpro-wisdom-tracker.php
+++ b/classes/class-pmpro-wisdom-tracker.php
@@ -1066,6 +1066,9 @@ class PMPro_Wisdom_Tracker {
 	 */
 	public function goodbye_form_callback() {
 		check_ajax_referer( 'wisdom_goodbye_form', 'security' );
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			wp_die();
+		}
 		if ( isset( $_POST['values'] ) ) {
 			$values = json_encode( wp_unslash( sanitize_text_field( $_POST['values'] ) ) );
 			update_option( 'wisdom_deactivation_reason_' . $this->plugin_name, $values );

--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -26,20 +26,6 @@ class PMProGateway_authorizenet extends PMProGateway
 		//add fields to payment settings
 		add_filter('pmpro_payment_options', array('PMProGateway_authorizenet', 'pmpro_payment_options'));
 		add_filter('pmpro_payment_option_fields', array('PMProGateway_authorizenet', 'pmpro_payment_option_fields'), 10, 2);
-
-		//make sure sites using Authorize.net have a Silent Post token set
-		add_action('pmpro_after_saved_payment_options', array('PMProGateway_authorizenet', 'maybe_generate_silent_post_token'));
-	}
-
-	/**
-	 * Generate a Silent Post token if Authorize.net is set up but none is saved yet.
-	 *
-	 * @since TBD
-	 */
-	static function maybe_generate_silent_post_token() {
-		if ( ! empty( get_option( 'pmpro_loginname' ) ) && empty( get_option( 'pmpro_authnet_silent_post_token' ) ) ) {
-			update_option( 'pmpro_authnet_silent_post_token', wp_generate_password( 32, false ) );
-		}
 	}
 
 	/**

--- a/classes/gateways/class.pmprogateway_authorizenet.php
+++ b/classes/gateways/class.pmprogateway_authorizenet.php
@@ -26,6 +26,20 @@ class PMProGateway_authorizenet extends PMProGateway
 		//add fields to payment settings
 		add_filter('pmpro_payment_options', array('PMProGateway_authorizenet', 'pmpro_payment_options'));
 		add_filter('pmpro_payment_option_fields', array('PMProGateway_authorizenet', 'pmpro_payment_option_fields'), 10, 2);
+
+		//make sure sites using Authorize.net have a Silent Post token set
+		add_action('pmpro_after_saved_payment_options', array('PMProGateway_authorizenet', 'maybe_generate_silent_post_token'));
+	}
+
+	/**
+	 * Generate a Silent Post token if Authorize.net is set up but none is saved yet.
+	 *
+	 * @since TBD
+	 */
+	static function maybe_generate_silent_post_token() {
+		if ( ! empty( get_option( 'pmpro_loginname' ) ) && empty( get_option( 'pmpro_authnet_silent_post_token' ) ) ) {
+			update_option( 'pmpro_authnet_silent_post_token', wp_generate_password( 32, false ) );
+		}
 	}
 
 	/**

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -139,7 +139,7 @@ function pmpro_handle_pause_mode_actions() {
 	// Can the current user view the dashboard?
 	if ( current_user_can( 'pmpro_manage_pause_mode' ) ) {
 		//We're attempting to reactivate all services.
-		if( ! empty( $_REQUEST['pmpro-reactivate-services'] ) ) {			
+		if( ! empty( $_REQUEST['pmpro-reactivate-services'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'pmpro_reactivate_services' ) ) {
 			delete_option( 'pmpro_last_known_url' );
 		}
 	}
@@ -190,7 +190,7 @@ function pmpro_pause_mode_notice() {
 				<?php if ( current_user_can( 'pmpro_manage_pause_mode' ) ) { ?>
 				<p>
 					<a href='#' id="hide_pause_notification_button" class='button' value="hide_pause_notification"><?php esc_html_e( 'Dismiss notice and keep all services paused', 'paid-memberships-pro' ); ?></a>
-					<a href='<?php echo esc_url( admin_url( '?pmpro-reactivate-services=true' ) ); ?>' class='button button-secondary'><?php esc_html_e( 'Update my primary domain and reactivate all services', 'paid-memberships-pro' ); ?></a>
+					<a href='<?php echo esc_url( wp_nonce_url( admin_url( '?pmpro-reactivate-services=true' ), 'pmpro_reactivate_services' ) ); ?>' class='button button-secondary'><?php esc_html_e( 'Update my primary domain and reactivate all services', 'paid-memberships-pro' ); ?></a>
 				</p>
 				<?php } else { ?>
 					<p><?php echo wp_kses_post( __( 'Only users with the <code>pmpro_manage_pause_mode</code> capability are able to deactivate pause mode.', 'paid-memberships-pro' ) ); ?></p>

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -57,7 +57,7 @@ add_action('admin_enqueue_scripts', 'pmpro_enqueue_update_js');
 */
 function pmpro_wp_ajax_pmpro_updates() {
 	// Only admins can run updates.
-	if ( ! current_user_can( 'manage_options' ) ) {
+	if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_updates' ) ) {
 		die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
 	}
 

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -47,6 +47,7 @@ function pmpro_removeUpdate($update) {
 function pmpro_enqueue_update_js() {
 	if(!empty($_REQUEST['page']) && $_REQUEST['page'] == 'pmpro-updates') {
 		wp_enqueue_script( 'pmpro-updates', plugin_dir_url( dirname(__FILE__) ) . 'js/updates.js', array('jquery'), PMPRO_VERSION );
+		wp_localize_script( 'pmpro-updates', 'pmpro_updates_l10n', array( 'nonce' => wp_create_nonce( 'pmpro_updates' ) ) );
 	}
 }
 add_action('admin_enqueue_scripts', 'pmpro_enqueue_update_js');
@@ -55,6 +56,14 @@ add_action('admin_enqueue_scripts', 'pmpro_enqueue_update_js');
 	Load an update via AJAX
 */
 function pmpro_wp_ajax_pmpro_updates() {
+	// Only admins can run updates.
+	if ( ! current_user_can( 'manage_options' ) ) {
+		die( esc_html__( 'You do not have permissions to perform this action.', 'paid-memberships-pro' ) );
+	}
+
+	// Check the nonce.
+	check_ajax_referer( 'pmpro_updates', 'nonce' );
+
 	//get updates
 	$updates = array_values(get_option('pmpro_updates', array()));
 

--- a/js/updates.js
+++ b/js/updates.js
@@ -18,7 +18,7 @@ jQuery(document).ready(function() {
 			jQuery.ajax({
 				url: ajaxurl,type:'GET', timeout: $timeout * 1000,
 				dataType: 'html',
-				data: 'action=pmpro_updates',
+				data: 'action=pmpro_updates&nonce=' + pmpro_updates_l10n.nonce,
 				error: function( xml, status, error ) {
 					$error_count++;
 					// If we haven't failed 3 times, try again.


### PR DESCRIPTION
A few handlers were missing validation that sibling handlers already have:

- **`pmpro_updates` AJAX** (includes/updates.php): now requires `manage_options`/`pmpro_updates` and a nonce, matching the updates page capability and the report CSV export endpoints. The nonce is localized with the updates script.
- **Pause mode reactivation** (includes/admin.php): the `pmpro-reactivate-services` link in the admin notice now carries a nonce, which is verified before `pmpro_last_known_url` is deleted.
- **Deactivation feedback callback** (class-pmpro-wisdom-tracker.php): now requires `activate_plugins` in addition to the existing nonce check.

**Testing:** run a pending DB update from the PMPro Updates page (should complete normally); toggle pause mode reactivation from the notice link.