### PR TITLE
Fix getfile access check bypass via admin-ajax

### DIFF
--- a/services/getfile.php
+++ b/services/getfile.php
@@ -65,8 +65,8 @@
 	$filename = ABSPATH . $new_uri;
 	$pathParts = pathinfo($filename);			
 		
-	//only checking if the image is pulled from outside the admin
-	if(!is_admin())
+	//skip the access check for users who can manage the site (e.g. admins previewing files); check everyone else
+	if(!current_user_can('manage_options'))
 	{
 		//get some info to use
 		$upload_dir = wp_upload_dir();			//wp upload dir


### PR DESCRIPTION
Fixes #3759.

## Problem

The membership access check in `services/getfile.php` is gated behind `! is_admin()`. The intent was "only apply the membership gate when the file is pulled from outside wp-admin," but `is_admin()` reports whether the request targets the admin area, not whether the current user is an administrator. Under `admin-ajax.php` — including the `wp_ajax_nopriv_getfile` route — `is_admin()` returns `true` for every caller, including anonymous users, so the `pmpro_has_membership_access()` check is skipped entirely.

## Fix

Replace the `! is_admin()` gate with `! current_user_can( 'manage_options' )`. This preserves the original intent (site admins previewing files bypass the membership gate) while ensuring the access check runs for everyone else, including anonymous callers hitting the nopriv AJAX route.

```diff
-	//only checking if the image is pulled from outside the admin
-	if(!is_admin())
+	//skip the access check for users who can manage the site (e.g. admins previewing files); check everyone else
+	if(!current_user_can('manage_options'))
```

Note: `getfile` still requires the `PMPRO_GETFILE_ENABLED` constant to be defined, and path traversal / blocklisted extensions remain enforced. This change only closes the access-check bypass.

## Testing

- With `PMPRO_GETFILE_ENABLED` on, request a protected file as an anonymous user via the getfile route — should now get a 503 instead of the file contents.
- Request the same file as an admin — should still receive the file (preview bypass preserved).
- Request a file with no restriction — unchanged.