### PR TITLE
Guard pmpro_setMessage() calls in PMPro_AddOns

### DIFF
--- a/classes/class-pmpro-addons.php
+++ b/classes/class-pmpro-addons.php
@@ -1124,7 +1124,10 @@ class PMPro_AddOns {
 
 		// Check for errors and if we're okay, save the addons formatted
 		if ( is_wp_error( $remote_addons ) ) {
-			pmpro_setMessage( 'Could not connect to the PMPro License Server to update addon information. Try again later.', 'error' );
+			// pmpro_setMessage() is only available when PMPro core is active.
+			if ( function_exists( 'pmpro_setMessage' ) ) {
+				pmpro_setMessage( 'Could not connect to the PMPro License Server to update addon information. Try again later.', 'error' );
+			}
 			// Return cached addons if available
 			return $this->addons ? : array();
 		} elseif ( ! empty( $remote_addons ) && $remote_addons['response']['code'] == 200 ) {
@@ -1136,7 +1139,10 @@ class PMPro_AddOns {
 
 			// If for some reason the addons are not formatted correctly
 			if ( empty( $addons ) ) {
-				pmpro_setMessage( 'No addons found.', 'error' );
+				// pmpro_setMessage() is only available when PMPro core is active.
+				if ( function_exists( 'pmpro_setMessage' ) ) {
+					pmpro_setMessage( 'No addons found.', 'error' );
+				}
 				return $addons;
 			}
 


### PR DESCRIPTION
## What

Wraps the two `pmpro_setMessage()` calls in `PMPro_AddOns::get_remote_addons()` with `function_exists()` checks.

## Why

Companion to strangerstudios/pmpro-update-manager#19. The Update Manager ships a renamed copy of this class that can run when PMPro core is inactive, where `pmpro_setMessage()` does not exist. Update Manager 1.0.2 handled that by declaring a stub, which caused a fatal "Cannot redeclare pmpro_setMessage()" error when activating core while Update Manager was active — blocking core activation entirely.

The fix guards the call sites instead of stubbing the function. The guard is always true in core; it exists here so the two copies of the class stay word-for-word identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)