### PR TITLE
Captcha on login and password reset forms (login hooks + single captcha setting)

### DIFF
--- a/adminpages/securitysettings.php
+++ b/adminpages/securitysettings.php
@@ -174,7 +174,7 @@
 					'type'        => 'select',
 					'value'       => pmpro_captcha(),
 					'options'     => array( '' => __( 'No', 'paid-memberships-pro' ) ) + pmpro_get_captcha_services(),
-					'description' => __( 'Protect your checkout, login, and password reset forms with a captcha challenge. On login and password reset forms, the captcha is only shown after a failed login attempt from the visitor\'s IP address.', 'paid-memberships-pro' ),
+					'description' => __( 'Protect your checkout, login, and password reset forms with a captcha challenge. On login and password reset forms, the captcha is only shown after a failed login attempt or other suspicious activity from the visitor\'s IP address.', 'paid-memberships-pro' ),
 				),
 				array(
 					// The callbacks hooked here echo their own <tr> rows, so give them a table.

--- a/adminpages/securitysettings.php
+++ b/adminpages/securitysettings.php
@@ -18,6 +18,16 @@
 	// Save settings.
 	if( !empty( $_REQUEST['savesettings'] ) ) {
 		pmpro_setOption( "spamprotection", intval( $_POST['spamprotection'] ) );
+
+		// Save the captcha setting. Note: This must be saved before the
+		// pmpro_save_security_settings hook fires so that the captcha services
+		// saving their settings on that hook can see the updated value.
+		$captcha = isset( $_POST['captcha'] ) ? sanitize_text_field( $_POST['captcha'] ) : '';
+		if ( ! array_key_exists( $captcha, pmpro_get_captcha_services() ) ) {
+			$captcha = '';
+		}
+		pmpro_setOption( 'captcha', $captcha );
+
 		if ( isset( $_POST['use_ssl'] ) ) {
 			// REQUEST['use_ssl'] will not be set if the entire site is already over HTTPS.
 			pmpro_setOption( "use_ssl", intval( $_POST['use_ssl'] ) );
@@ -157,6 +167,14 @@
 						2 => __( 'Yes - Enable Spam Protection', 'paid-memberships-pro' ),
 					),
 					'description' => sprintf( esc_html__( 'Block IPs from checkout and login if there are more than %d failures within %d minutes.', 'paid-memberships-pro' ), (int) PMPRO_SPAM_ACTION_NUM_LIMIT, (int) round( PMPRO_SPAM_ACTION_TIME_LIMIT / 60, 2 ) ),
+				),
+				array(
+					'name'        => 'captcha',
+					'label'       => __( 'Captcha', 'paid-memberships-pro' ),
+					'type'        => 'select',
+					'value'       => pmpro_captcha(),
+					'options'     => array( '' => __( 'No', 'paid-memberships-pro' ) ) + pmpro_get_captcha_services(),
+					'description' => __( 'Protect your checkout, login, and password reset forms with a captcha challenge. On login and password reset forms, the captcha is only shown after a failed login attempt from the visitor\'s IP address.', 'paid-memberships-pro' ),
 				),
 				array(
 					// The callbacks hooked here echo their own <tr> rows, so give them a table.

--- a/adminpages/securitysettings.php
+++ b/adminpages/securitysettings.php
@@ -26,7 +26,7 @@
 		if ( ! array_key_exists( $captcha, pmpro_get_captcha_services() ) ) {
 			$captcha = '';
 		}
-		pmpro_setOption( 'captcha', $captcha );
+		update_option( 'pmpro_captcha', $captcha, false );
 
 		if ( isset( $_POST['use_ssl'] ) ) {
 			// REQUEST['use_ssl'] will not be set if the entire site is already over HTTPS.

--- a/includes/captcha.php
+++ b/includes/captcha.php
@@ -99,6 +99,35 @@ function pmpro_captcha_failed_error_message() {
 }
 
 /**
+ * Don't allow the frontend login page to be full-page cached while a captcha
+ * service is enabled.
+ *
+ * The captcha only renders for IPs with recent suspicious activity, so a
+ * cached copy of the page could serve a captcha-less form to a visitor whose
+ * submission would then be rejected.
+ *
+ * @since TBD
+ */
+function pmpro_captcha_nocache_login_page() {
+	// Bail if no captcha is enabled.
+	if ( empty( pmpro_captcha() ) ) {
+		return;
+	}
+
+	// Bail if we're not on the frontend login page.
+	$login_page_id = get_option( 'pmpro_login_page_id' );
+	if ( empty( $login_page_id ) || ! is_page( (int) $login_page_id ) ) {
+		return;
+	}
+
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', true );
+	}
+	nocache_headers();
+}
+add_action( 'template_redirect', 'pmpro_captcha_nocache_login_page' );
+
+/**
  * Check whether the current request includes a pmpro_captcha_failed error code
  * passed back to the login page in the URL.
  *

--- a/includes/captcha.php
+++ b/includes/captcha.php
@@ -68,16 +68,21 @@ function pmpro_captcha() {
 }
 
 /**
- * Check whether the current IP has recent failed login activity and should be
+ * Check whether the current IP has recent suspicious activity and should be
  * shown a captcha challenge on login and password reset forms.
  *
- * Uses the spam activity tracking in includes/spam.php.
+ * Uses the spam activity tracking in includes/spam.php. Failed logins always
+ * feed this signal while a captcha is enabled. If Spam Protection is also
+ * enabled, failed checkouts and invalid discount codes feed it too — that is
+ * intentional: an IP abusing checkout is also worth challenging at login.
+ * Activity is deliberately not cleared on a successful login, since on shared
+ * IPs that would let an attacker reset the signal; it expires on its own.
  *
  * @since TBD
  *
- * @return bool True if the current IP has recent failed login activity.
+ * @return bool True if the current IP has recent suspicious activity.
  */
-function pmpro_captcha_has_recent_failed_login() {
+function pmpro_captcha_has_recent_spam_activity() {
 	$activity = pmpro_get_spam_activity();
 	return ! empty( $activity );
 }

--- a/includes/captcha.php
+++ b/includes/captcha.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Shared code for captcha services.
+ *
+ * Each captcha service (reCAPTCHA, Cloudflare Turnstile) implements its own
+ * display and validation logic in its own includes file. This file only holds
+ * the code that is common to all captcha services.
+ */
+
+/**
+ * Get the registered captcha services.
+ *
+ * @since TBD
+ *
+ * @return array Captcha services as slug => label.
+ */
+function pmpro_get_captcha_services() {
+	/**
+	 * Filter the available captcha services.
+	 *
+	 * Captcha integrations should register themselves here as slug => label.
+	 * A registered service should also hook the login, password reset, and
+	 * checkout display and validation hooks and gate its logic on
+	 * pmpro_captcha() returning its slug.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $services Captcha services as slug => label.
+	 */
+	return apply_filters( 'pmpro_captcha_services', array() );
+}
+
+/**
+ * Get which captcha service is enabled, if any.
+ *
+ * @since TBD
+ *
+ * @return string The slug of the enabled captcha service, or an empty string if no captcha is enabled.
+ */
+function pmpro_captcha() {
+	$captcha = get_option( 'pmpro_captcha', false );
+
+	// Backwards compatibility with the separate reCAPTCHA and Turnstile settings
+	// used before the single captcha setting existed. Note: a saved value of ''
+	// means "No" was chosen and should not fall back to the old settings.
+	// These two legacy options are intentionally hardcoded here rather than run
+	// through the captcha services registry: this shim is about the past and
+	// will never need to cover additional services.
+	if ( false === $captcha ) {
+		if ( get_option( 'pmpro_recaptcha' ) ) {
+			// If both were enabled, reCAPTCHA takes priority.
+			$captcha = 'recaptcha';
+		} elseif ( get_option( 'pmpro_cloudflare_turnstile' ) ) {
+			$captcha = 'turnstile';
+		} else {
+			$captcha = '';
+		}
+	}
+
+	// Only return registered captcha services. If the enabled service is no
+	// longer registered (e.g. its plugin was deactivated), the site safely
+	// reverts to having no captcha.
+	if ( ! empty( $captcha ) && ! array_key_exists( $captcha, pmpro_get_captcha_services() ) ) {
+		$captcha = '';
+	}
+
+	return $captcha;
+}
+
+/**
+ * Check whether the current IP has recent failed login activity and should be
+ * shown a captcha challenge on login and password reset forms.
+ *
+ * Uses the spam activity tracking in includes/spam.php.
+ *
+ * @since TBD
+ *
+ * @return bool True if the current IP has recent failed login activity.
+ */
+function pmpro_captcha_has_recent_failed_login() {
+	$activity = pmpro_get_spam_activity();
+	return ! empty( $activity );
+}
+
+/**
+ * Get the error message to show when a captcha check fails on a login or password reset form.
+ *
+ * @since TBD
+ *
+ * @return string The error message. Escaped, may contain <strong> tags.
+ */
+function pmpro_captcha_failed_error_message() {
+	return wp_kses( __( '<strong>Error:</strong> Captcha verification failed. Please try again.', 'paid-memberships-pro' ), array( 'strong' => array() ) );
+}
+
+/**
+ * Check whether the current request includes a pmpro_captcha_failed error code
+ * passed back to the login page in the URL.
+ *
+ * @since TBD
+ *
+ * @return bool True if the request includes a captcha failed error code.
+ */
+function pmpro_is_captcha_failed_request() {
+	$error_params = array( 'action', 'errors', 'error' );
+	foreach ( $error_params as $param ) {
+		if ( empty( $_REQUEST[ $param ] ) ) {
+			continue;
+		}
+
+		// The errors param may contain a comma-separated list of error codes.
+		$codes = explode( ',', sanitize_text_field( $_REQUEST[ $param ] ) );
+		if ( in_array( 'pmpro_captcha_failed', $codes, true ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Show a message on the frontend login page when a captcha check failed.
+ *
+ * @since TBD
+ *
+ * @param string $message The message to show.
+ * @param string $msgt    The message type.
+ * @return string $message The message to show.
+ */
+function pmpro_captcha_failed_login_message( $message, $msgt ) {
+	if ( pmpro_is_captcha_failed_request() ) {
+		$message = pmpro_captcha_failed_error_message();
+	}
+
+	return $message;
+}
+add_filter( 'pmpro_login_forms_handler_message', 'pmpro_captcha_failed_login_message', 10, 2 );
+
+/**
+ * Set the message type for the captcha failed message on the frontend login page.
+ *
+ * @since TBD
+ *
+ * @param string $msgt The message type.
+ * @return string $msgt The message type.
+ */
+function pmpro_captcha_failed_login_msgt( $msgt ) {
+	if ( pmpro_is_captcha_failed_request() ) {
+		$msgt = 'pmpro_error';
+	}
+
+	return $msgt;
+}
+add_filter( 'pmpro_login_forms_handler_msgt', 'pmpro_captcha_failed_login_msgt' );

--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -175,7 +175,7 @@ add_action( 'pmpro_security_spam_fields', 'pmpro_cloudflare_turnstile_settings' 
  */
 function pmpro_cloudflare_turnstile_settings_save() {
 	// Keep the legacy on/off option in sync with the captcha setting for backwards compatibility.
-	pmpro_setOption( 'cloudflare_turnstile', 'turnstile' === pmpro_captcha() ? 1 : 0 );
+	update_option( 'pmpro_cloudflare_turnstile', 'turnstile' === pmpro_captcha() ? 1 : 0, false );
 	pmpro_setOption( 'cloudflare_turnstile_site_key', sanitize_text_field( $_POST['cloudflare_turnstile_site_key'] ) );
 	pmpro_setOption( 'cloudflare_turnstile_secret_key', sanitize_text_field( $_POST['cloudflare_turnstile_secret_key'] ) );
 }

--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -4,12 +4,26 @@
  */
 
 /**
+ * Register Cloudflare Turnstile as an available captcha service.
+ *
+ * @since TBD
+ *
+ * @param array $services Captcha services as slug => label.
+ * @return array $services Captcha services as slug => label.
+ */
+function pmpro_cloudflare_turnstile_register_captcha_service( $services ) {
+	$services['turnstile'] = __( 'Cloudflare Turnstile', 'paid-memberships-pro' );
+	return $services;
+}
+add_filter( 'pmpro_captcha_services', 'pmpro_cloudflare_turnstile_register_captcha_service' );
+
+/**
  * Show CloudFlare Turnstile on the checkout page.
  */
 function pmpro_cloudflare_turnstile_get_html() {
 
 	// If CloudFlare Turnstile is not enabled, bail.
-	if ( empty( get_option( 'pmpro_cloudflare_turnstile' ) ) ) {
+	if ( 'turnstile' !== pmpro_captcha() ) {
 		return;
 	}
 
@@ -43,7 +57,7 @@ function pmpro_cloudflare_turnstile_validation( $okay ) {
 	}
 
 	// If CloudFlare Turnstile is not enabled, bail.
-	if ( empty( get_option( 'pmpro_cloudflare_turnstile' ) ) ) {
+	if ( 'turnstile' !== pmpro_captcha() ) {
 		return $okay;
 	}
 
@@ -52,35 +66,51 @@ function pmpro_cloudflare_turnstile_validation( $okay ) {
 		return $okay;
 	}
 
-	// If the Turnstile is not passed, show an error.
-	if ( empty( $_POST['cf-turnstile-response'] ) ) {
-		pmpro_setMessage( __( 'Please complete the security check.', 'paid-memberships-pro' ), 'pmpro_error' );
+	// Verify the turnstile token. If the check failed, show an error.
+	$valid = pmpro_cloudflare_turnstile_verify_token( pmpro_getParam( 'cf-turnstile-response' ) );
+	if ( true !== $valid ) {
+		pmpro_setMessage( $valid, 'pmpro_error' );
 		return false;
+	}
+
+	// Only remember successful validations.
+	pmpro_set_session_var( 'pmpro_cloudflare_turnstile_validated', true );
+	return $okay;
+}
+
+/**
+ * Verify a CloudFlare Turnstile response token.
+ *
+ * @since TBD
+ *
+ * @param string $token The cf-turnstile-response token to verify.
+ * @return true|string True if the token is valid, or an error message to display if not.
+ */
+function pmpro_cloudflare_turnstile_verify_token( $token ) {
+	// An empty token means the user did not complete the challenge.
+	if ( empty( $token ) ) {
+		return __( 'Please complete the security check.', 'paid-memberships-pro' );
 	}
 
 	// Verify the turnstile check.
 	$headers = array(
 		'body' => array(
 			'secret'   => get_option( 'pmpro_cloudflare_turnstile_secret_key', '' ),
-			'response' => pmpro_getParam( 'cf-turnstile-response' ),
+			'response' => $token,
 		),
 	);
 	$verify   = wp_remote_post( 'https://challenges.cloudflare.com/turnstile/v0/siteverify', $headers );
 	$verify   = wp_remote_retrieve_body( $verify );
 	$response = json_decode( $verify );
 
-	// If the check failed, show an error.
+	// If the check failed, return an error message.
 	if ( empty( $response->success ) ) {
 		$error_messages    = pmpro_cloudflare_turnstile_get_error_message();
-		$error_code        = $response->{'error-codes'}[0];
-		$displayed_message = isset( $error_messages[ $error_code ] ) ? $error_messages[ $error_code ] : esc_html__( 'An error occurred while validating the security check.', 'paid-memberships-pro' );
-
-		pmpro_setMessage( $displayed_message, 'pmpro_error' );
-		$okay = false;
+		$error_code        = isset( $response->{'error-codes'}[0] ) ? $response->{'error-codes'}[0] : '';
+		return isset( $error_messages[ $error_code ] ) ? $error_messages[ $error_code ] : esc_html__( 'An error occurred while validating the security check.', 'paid-memberships-pro' );
 	}
 
-	pmpro_set_session_var( 'pmpro_cloudflare_turnstile_validated', true );
-	return $okay;
+	return true;
 }
 add_action( 'pmpro_checkout_checks', 'pmpro_cloudflare_turnstile_validation' );
 add_action( 'pmpro_billing_update_checks', 'pmpro_cloudflare_turnstile_validation' );
@@ -92,33 +122,17 @@ add_action( 'pmpro_billing_update_checks', 'pmpro_cloudflare_turnstile_validatio
  */
 function pmpro_cloudflare_turnstile_settings() {
 	// Get the options
-	$cloudflare_turnstile  = get_option( 'pmpro_cloudflare_turnstile', '0' );
 	$cloudflare_site_key = get_option( 'pmpro_cloudflare_turnstile_site_key', '' );
 	$cloudflare_secret_key = get_option( 'pmpro_cloudflare_turnstile_secret_key', '' );
 
 	$cloudflare_turnstile_depends = array(
 		array(
-			'id'    => 'cloudflare_turnstile',
-			'value' => '1',
+			'id'    => 'captcha',
+			'value' => 'turnstile',
 		),
 	);
 
 	// Output settings
-	pmpro_build_settings_field( array(
-		'name'        => 'cloudflare_turnstile',
-		'label'       => __( 'Use CloudFlare Turnstile?', 'paid-memberships-pro' ),
-		'type'        => 'select',
-		'value'       => $cloudflare_turnstile,
-		'options'     => array(
-			'0' => __( 'No', 'paid-memberships-pro' ),
-			'1' => __( 'Yes', 'paid-memberships-pro' ),
-		),
-		'description' => sprintf(
-			/* translators: %s: Link to CloudFlare Turnstile. */
-			__( 'A free CloudFlare Turnstile key is required. <a href="%s" target="_blank" rel="nofollow noopener">Click here to signup for CloudFlare Turnstile</a>.', 'paid-memberships-pro' ),
-			'https://www.cloudflare.com/products/turnstile/'
-		),
-	) );
 	pmpro_build_settings_field( array(
 		'name'      => 'cloudflare_turnstile_site_key',
 		'label'     => __( 'Turnstile Site Key', 'paid-memberships-pro' ),
@@ -127,6 +141,11 @@ function pmpro_cloudflare_turnstile_settings() {
 		'value'     => $cloudflare_site_key,
 		'row_class' => 'pmpro_cloudflare_turnstile_settings',
 		'depends'   => $cloudflare_turnstile_depends,
+		'description' => sprintf(
+			/* translators: %s: Link to CloudFlare Turnstile. */
+			__( 'A free CloudFlare Turnstile key is required. <a href="%s" target="_blank" rel="nofollow noopener">Click here to signup for CloudFlare Turnstile</a>.', 'paid-memberships-pro' ),
+			'https://www.cloudflare.com/products/turnstile/'
+		),
 	) );
 	pmpro_build_settings_field( array(
 		'name'      => 'cloudflare_turnstile_secret_key',
@@ -146,7 +165,8 @@ add_action( 'pmpro_security_spam_fields', 'pmpro_cloudflare_turnstile_settings' 
  * @since 3.2
  */
 function pmpro_cloudflare_turnstile_settings_save() {
-	pmpro_setOption( 'cloudflare_turnstile', intval( $_POST['cloudflare_turnstile'] ) );
+	// Keep the legacy on/off option in sync with the captcha setting for backwards compatibility.
+	pmpro_setOption( 'cloudflare_turnstile', 'turnstile' === pmpro_captcha() ? 1 : 0 );
 	pmpro_setOption( 'cloudflare_turnstile_site_key', sanitize_text_field( $_POST['cloudflare_turnstile_site_key'] ) );
 	pmpro_setOption( 'cloudflare_turnstile_secret_key', sanitize_text_field( $_POST['cloudflare_turnstile_secret_key'] ) );
 }
@@ -180,3 +200,92 @@ function pmpro_after_checkout_reset_cloudflare_turnstile() {
 }
 add_action( 'pmpro_after_checkout', 'pmpro_after_checkout_reset_cloudflare_turnstile' );
 add_action( 'pmpro_after_update_billing', 'pmpro_after_checkout_reset_cloudflare_turnstile' );
+
+/**
+ * Check whether login and password reset forms should be challenged with Turnstile.
+ *
+ * @since TBD
+ *
+ * @return bool True if forms should be challenged.
+ */
+function pmpro_cloudflare_turnstile_should_challenge_login() {
+	// Only challenge if Turnstile is the active captcha service.
+	if ( 'turnstile' !== pmpro_captcha() ) {
+		return false;
+	}
+
+	// Don't challenge without keys. We couldn't render or verify the captcha,
+	// and requiring a check that can't be completed would lock users out.
+	if ( ! get_option( 'pmpro_cloudflare_turnstile_site_key' ) || ! get_option( 'pmpro_cloudflare_turnstile_secret_key' ) ) {
+		return false;
+	}
+
+	// Only challenge IPs that have recently failed to log in.
+	return pmpro_captcha_has_recent_failed_login();
+}
+
+/**
+ * Show Turnstile on PMPro and WP core login and lost password forms
+ * once a failed login attempt has been tracked for the current IP.
+ *
+ * @since TBD
+ */
+function pmpro_cloudflare_turnstile_login_forms_html() {
+	if ( ! pmpro_cloudflare_turnstile_should_challenge_login() ) {
+		return;
+	}
+
+	pmpro_cloudflare_turnstile_get_html();
+}
+add_action( 'pmpro_login_form_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );
+add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );
+add_action( 'login_form', 'pmpro_cloudflare_turnstile_login_forms_html' );
+add_action( 'lostpassword_form', 'pmpro_cloudflare_turnstile_login_forms_html' );
+
+/**
+ * Require a valid Turnstile token on login attempts once the current IP has failed a login.
+ *
+ * @since TBD
+ *
+ * @param WP_User|WP_Error|null $user     WP_User if the login is valid so far, otherwise WP_Error or null.
+ * @param string                $username The username being used to log in.
+ * @return WP_User|WP_Error|null $user
+ */
+function pmpro_cloudflare_turnstile_login_check( $user, $username ) {
+	if ( ! pmpro_cloudflare_turnstile_should_challenge_login() ) {
+		return $user;
+	}
+
+	if ( true !== pmpro_cloudflare_turnstile_verify_token( pmpro_getParam( 'cf-turnstile-response' ) ) ) {
+		return new WP_Error( 'pmpro_captcha_failed', pmpro_captcha_failed_error_message() );
+	}
+
+	return $user;
+}
+add_filter( 'pmpro_authenticate_login_checks', 'pmpro_cloudflare_turnstile_login_check', 10, 2 );
+
+/**
+ * Require a valid Turnstile token on lost password submissions once the current IP has failed a login.
+ *
+ * @since TBD
+ *
+ * @param WP_Error      $errors    Error object to add a captcha error to.
+ * @param WP_User|false $user_data WP_User object if found, false if the user does not exist.
+ */
+function pmpro_cloudflare_turnstile_lostpassword_check( $errors, $user_data ) {
+	// Only check submissions from the PMPro or wp-login.php lost password forms. This hook
+	// also fires for other plugins that call retrieve_password() from their own forms,
+	// which never displayed our captcha.
+	if ( empty( $_REQUEST['pmpro_login_form_used'] ) && ! did_action( 'login_form_lostpassword' ) && ! did_action( 'login_form_retrievepassword' ) ) {
+		return;
+	}
+
+	if ( ! pmpro_cloudflare_turnstile_should_challenge_login() ) {
+		return;
+	}
+
+	if ( true !== pmpro_cloudflare_turnstile_verify_token( pmpro_getParam( 'cf-turnstile-response' ) ) ) {
+		$errors->add( 'pmpro_captcha_failed', pmpro_captcha_failed_error_message() );
+	}
+}
+add_action( 'lostpassword_post', 'pmpro_cloudflare_turnstile_lostpassword_check', 10, 2 );

--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -220,8 +220,8 @@ function pmpro_cloudflare_turnstile_should_challenge_login() {
 		return false;
 	}
 
-	// Only challenge IPs that have recently failed to log in.
-	return pmpro_captcha_has_recent_failed_login();
+	// Only challenge IPs with recent suspicious activity, e.g. failed logins.
+	return pmpro_captcha_has_recent_spam_activity();
 }
 
 /**
@@ -231,11 +231,19 @@ function pmpro_cloudflare_turnstile_should_challenge_login() {
  * @since TBD
  */
 function pmpro_cloudflare_turnstile_login_forms_html() {
+	static $already_shown = false;
+
+	// Make sure that we only show the captcha once per page.
+	if ( $already_shown ) {
+		return;
+	}
+
 	if ( ! pmpro_cloudflare_turnstile_should_challenge_login() ) {
 		return;
 	}
 
 	pmpro_cloudflare_turnstile_get_html();
+	$already_shown = true;
 }
 add_action( 'pmpro_login_form_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );
 add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );

--- a/includes/cloudflare-turnstile.php
+++ b/includes/cloudflare-turnstile.php
@@ -21,6 +21,7 @@ add_filter( 'pmpro_captcha_services', 'pmpro_cloudflare_turnstile_register_captc
  * Show CloudFlare Turnstile on the checkout page.
  */
 function pmpro_cloudflare_turnstile_get_html() {
+	static $script_shown = false;
 
 	// If CloudFlare Turnstile is not enabled, bail.
 	if ( 'turnstile' !== pmpro_captcha() ) {
@@ -36,8 +37,16 @@ function pmpro_cloudflare_turnstile_get_html() {
 	if ( $cf_theme !== 'light' ) {
 		$cf_theme = 'dark';
 	}
+
+	// Only load the Turnstile API script once per page. A widget is output on
+	// every call since Turnstile renders every .cf-turnstile element on the page.
+	if ( ! $script_shown ) {
+		?>
+		<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+		<?php
+		$script_shown = true;
+	}
 	?>
-	<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
 	<div class="cf-turnstile" data-sitekey="<?php echo esc_attr( get_option( 'pmpro_cloudflare_turnstile_site_key' ) ); ?>" data-theme="<?php echo esc_attr( $cf_theme ); ?>"></div>
 	<?php
 
@@ -225,30 +234,46 @@ function pmpro_cloudflare_turnstile_should_challenge_login() {
 }
 
 /**
- * Show Turnstile on PMPro and WP core login and lost password forms
- * once a failed login attempt has been tracked for the current IP.
+ * Show Turnstile on login and lost password forms once a challenge is
+ * active for the current IP.
+ *
+ * A widget is output for every form on the page since every form's submission
+ * is validated server-side; pmpro_cloudflare_turnstile_get_html() only loads
+ * the API script once.
  *
  * @since TBD
  */
 function pmpro_cloudflare_turnstile_login_forms_html() {
-	static $already_shown = false;
-
-	// Make sure that we only show the captcha once per page.
-	if ( $already_shown ) {
-		return;
-	}
-
 	if ( ! pmpro_cloudflare_turnstile_should_challenge_login() ) {
 		return;
 	}
 
 	pmpro_cloudflare_turnstile_get_html();
-	$already_shown = true;
 }
-add_action( 'pmpro_login_form_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );
-add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );
 add_action( 'login_form', 'pmpro_cloudflare_turnstile_login_forms_html' );
 add_action( 'lostpassword_form', 'pmpro_cloudflare_turnstile_login_forms_html' );
+add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_cloudflare_turnstile_login_forms_html' );
+
+/**
+ * Show Turnstile inside forms built with wp_login_form() — including PMPro's
+ * own login forms — once a challenge is active. These are exactly the forms
+ * that post to wp-login.php and are validated by pmpro_authenticate_login_checks,
+ * so every form that is validated also displays the challenge.
+ *
+ * @since TBD
+ *
+ * @param string $content Content to display. Default empty.
+ * @param array  $args    Array of login form arguments.
+ * @return string $content Content to display.
+ */
+function pmpro_cloudflare_turnstile_login_form_middle( $content, $args ) {
+	ob_start();
+	pmpro_cloudflare_turnstile_login_forms_html();
+	// Late priority and a (string) cast so that earlier callbacks that echo
+	// and return null (instead of returning their content) can't wipe the widget.
+	return (string) $content . ob_get_clean();
+}
+add_filter( 'login_form_middle', 'pmpro_cloudflare_turnstile_login_form_middle', 100, 2 );
 
 /**
  * Require a valid Turnstile token on login attempts once the current IP has failed a login.

--- a/includes/lib/recaptchalib.php
+++ b/includes/lib/recaptchalib.php
@@ -77,9 +77,16 @@ class pmpro_ReCaptcha
         $response = wp_remote_post($path, [
             'method' => 'POST',
             'body'   => $data,
-        ])['body'];
+        ]);
 
-        return $response;
+        // If the request failed, e.g. a network error reaching the reCAPTCHA
+        // server, return an empty string so that verification fails safely
+        // instead of fatal erroring when trying to index a WP_Error.
+        if ( is_wp_error( $response ) ) {
+            return '';
+        }
+
+        return wp_remote_retrieve_body( $response );
     }
 
     /**

--- a/includes/login.php
+++ b/includes/login.php
@@ -1110,8 +1110,12 @@ function pmpro_apply_custom_login_checks( $user, $username, $password ) {
 		return $user;
 	}
 
-	// Only run checks for login attempts from the PMPro login form or the form on wp-login.php.
-	// Other login flows (XML-RPC, other plugins' login forms, direct wp_signon() calls, etc.) are intentionally not affected.
+	// Only run checks for login attempts that post through wp-login.php. That covers
+	// PMPro's login forms, wp-login.php's own form, and any form built with
+	// wp_login_form() — captcha services render into all of those via the login_form
+	// action and login_form_middle filter. Other login flows (XML-RPC, plugins that
+	// call wp_signon() directly or authenticate with their own handlers, e.g.
+	// WooCommerce) are intentionally not affected.
 	if ( empty( $_REQUEST['pmpro_login_form_used'] ) && ! did_action( 'login_form_login' ) ) {
 		return $user;
 	}

--- a/includes/login.php
+++ b/includes/login.php
@@ -245,6 +245,33 @@ function pmpro_login_form_hidden_field( $html ) {
 }
 
 /**
+ * Add content before the submit button on our login form.
+ * Hooks into the WP core filter login_form_middle. This filter is
+ * added right before wp_login_form() is called in pmpro_login_form()
+ * and removed right after so that it only runs on PMPro login forms.
+ *
+ * @since TBD
+ *
+ * @param string $content Content to display. Default empty.
+ * @param array  $args    Array of login form arguments.
+ * @return string $content Content to display.
+ */
+function pmpro_login_form_middle( $content, $args ) {
+	ob_start();
+
+	/**
+	 * Fires before the submit button on the PMPro login form.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Array of login form arguments.
+	 */
+	do_action( 'pmpro_login_form_before_submit_button', $args );
+
+	return $content . ob_get_clean();
+}
+
+/**
  * Filter the_title based on the form action of the Log In Page assigned to $pmpro_pages['login'].
  *
  * @since 2.3
@@ -457,6 +484,28 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 		}
 	}
 
+	/**
+	 * Filter the message shown above the frontend login form.
+	 * Allows custom messages to be shown for custom error codes
+	 * passed back to the login page in the URL.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $message The message to show. Empty string if no message.
+	 * @param string $msgt    The message type, e.g. pmpro_error, pmpro_success, pmpro_alert.
+	 */
+	$message = apply_filters( 'pmpro_login_forms_handler_message', $message, $msgt );
+
+	/**
+	 * Filter the type of the message shown above the frontend login form.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $msgt    The message type, e.g. pmpro_error, pmpro_success, pmpro_alert.
+	 * @param string $message The message to show. Empty string if no message.
+	 */
+	$msgt = apply_filters( 'pmpro_login_forms_handler_msgt', $msgt, $message );
+
 	ob_start();
 	?>
 
@@ -598,6 +647,7 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 function pmpro_login_form( $args = array() ) {
 	static $pmpro_login_form_counter = 1;
 	add_filter( 'login_form_top', 'pmpro_login_form_hidden_field' );
+	add_filter( 'login_form_middle', 'pmpro_login_form_middle', 10, 2 );
 	wp_login_form( $args );
 	?>
 	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field-password-toggle' ) ); ?>">
@@ -649,6 +699,7 @@ function pmpro_login_form( $args = array() ) {
 	</script>
 	<?php
 	remove_filter( 'login_form_top', 'pmpro_login_form_hidden_field' );
+	remove_filter( 'login_form_middle', 'pmpro_login_form_middle' );
 	$pmpro_login_form_counter++;
 }
 
@@ -793,7 +844,7 @@ function pmpro_reset_password_form() {
 
 			$msgt = 'pmpro_error';
 			echo '<div class="' . esc_attr( pmpro_get_element_class( 'pmpro_message ' . $msgt, esc_attr( $msgt ) ) ) . '">'. esc_html( $message ) .'</div>';
-			echo wp_kses_post( pmpro_lost_password_form() );
+			pmpro_lost_password_form(); // This function echoes the form directly.
 			return;
 		}
 
@@ -1022,24 +1073,62 @@ add_filter( 'wp_new_user_notification_email', 'pmpro_password_reset_email_filter
 	// check what page the login attempt is coming from
 	$referrer = wp_get_referer();
 
-	if ( !empty( $referrer ) && is_wp_error( $user ) ) {
+	if ( ! empty( $referrer ) && is_wp_error( $user ) ) {
 
 		$error = $user->get_error_code();
 
-		if ( $error ) {
-				$error_args = array(
-					'action' => urlencode( $error ),
-					'username' => urlencode( sanitize_text_field( $username ) )
-				);
-				wp_redirect( add_query_arg( $error_args, pmpro_login_url() ) );
-			} else {
-				wp_redirect( pmpro_login_url() );
-			}
+		// Only redirect here for error codes that WP core "ignores" and won't fire wp_login_failed for.
+		// All other failed logins are redirected by pmpro_login_failed() hooked to wp_login_failed.
+		if ( in_array( $error, array( 'empty_username', 'empty_password' ), true ) ) {
+			$error_args = array(
+				'action' => urlencode( $error ),
+				'username' => urlencode( sanitize_text_field( $username ) )
+			);
+			wp_redirect( add_query_arg( $error_args, pmpro_login_url() ) );
+			exit;
+		}
 	}
 
 	return $user;
 }
 add_filter( 'authenticate', 'pmpro_authenticate_username_password', 30, 3);
+
+/**
+ * Allow custom checks (e.g. captchas) for login attempts made from the
+ * PMPro login form or the WP default login form on wp-login.php.
+ *
+ * @since TBD
+ *
+ * @param WP_User|WP_Error|null $user     WP_User if the login is valid so far, otherwise WP_Error or null.
+ * @param string                $username The username being used to log in.
+ * @param string                $password The password being used to log in.
+ * @return WP_User|WP_Error|null $user
+ */
+function pmpro_apply_custom_login_checks( $user, $username, $password ) {
+	// Bail if no login was attempted. wp-login.php runs the authenticate filter on every page load.
+	if ( empty( $username ) && empty( $password ) ) {
+		return $user;
+	}
+
+	// Only run checks for login attempts from the PMPro login form or the form on wp-login.php.
+	// Other login flows (XML-RPC, other plugins' login forms, direct wp_signon() calls, etc.) are intentionally not affected.
+	if ( empty( $_REQUEST['pmpro_login_form_used'] ) && ! did_action( 'login_form_login' ) ) {
+		return $user;
+	}
+
+	/**
+	 * Allow custom checks for login attempts from the PMPro login form or wp-login.php.
+	 * Runs after WP core has checked the user's credentials.
+	 * Return a WP_Error to block the login and show that error's message.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_User|WP_Error|null $user     WP_User if the login is valid so far, otherwise WP_Error or null.
+	 * @param string                $username The username being used to log in.
+	 */
+	return apply_filters( 'pmpro_authenticate_login_checks', $user, $username );
+}
+add_filter( 'authenticate', 'pmpro_apply_custom_login_checks', 40, 3 );
 
 /**
  * Redirect failed login to referrer for frontend user login.

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -364,21 +364,19 @@ function pmpro_recaptcha_verify_token( $token ) {
 }
 
 /**
- * Outputs the HTML needed to display reCAPTCHA in login and password reset forms.
+ * Outputs the HTML needed to display reCAPTCHA in a login or password reset form.
  *
  * Unlike pmpro_recaptcha_get_html(), this does not use the checkout JS or the
  * AJAX/session validation flow. The token is submitted with the form and
  * verified server-side when the submission is processed.
  *
+ * A widget is output for every form on the page since every form's submission
+ * is validated server-side. Shared assets (scripts) are only output once.
+ *
  * @since TBD
  */
 function pmpro_recaptcha_get_login_html() {
-	static $already_shown = false;
-
-	// Make sure that we only show the captcha once per page.
-	if ( $already_shown ) {
-		return;
-	}
+	static $assets_shown = false;
 
 	$recaptcha_publickey = get_option( 'pmpro_recaptcha_publickey' );
 
@@ -395,52 +393,123 @@ function pmpro_recaptcha_get_login_html() {
 
 	// Check which version of reCAPTCHA we are using.
 	$recaptcha_version = get_option( 'pmpro_recaptcha_version' );
-	?>
-	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
-		<?php if ( $recaptcha_version == '3_invisible' ) { ?>
-			<div id="pmpro_recaptcha_login" class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey ); ?>" data-size="invisible" data-callback="pmpro_recaptcha_login_token_callback"></div>
+
+	if ( $recaptcha_version == '3_invisible' ) {
+		// One invisible widget container per form. The shared script below renders
+		// each container explicitly with its own widget ID so that multiple forms
+		// per page and other plugins' reCAPTCHA usage can coexist.
+		?>
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
+			<div class="pmpro_recaptcha_login" data-sitekey="<?php echo esc_attr( $recaptcha_publickey ); ?>"></div>
+		</div>
+		<?php
+		if ( ! $assets_shown ) {
+			?>
 			<script>
-				// Once reCAPTCHA has generated a token, submit the form. The token is verified server-side.
-				var pmpro_recaptcha_login_has_token = false;
-				function pmpro_recaptcha_login_token_callback( token ) {
-					pmpro_recaptcha_login_has_token = true;
-					var widget = document.getElementById( 'pmpro_recaptcha_login' );
-					var form = widget ? widget.closest( 'form' ) : null;
-					if ( form ) {
-						// Call the prototype method directly in case the form has an input named "submit".
-						HTMLFormElement.prototype.submit.call( form );
-					}
-				}
-				document.addEventListener( 'DOMContentLoaded', function() {
-					var widget = document.getElementById( 'pmpro_recaptcha_login' );
-					var form = widget ? widget.closest( 'form' ) : null;
-					if ( ! form ) {
+			(function() {
+				var pmpro_recaptcha_login_setup_done = false;
+
+				// Explicitly render an invisible widget in each form and intercept that
+				// form's submission until reCAPTCHA has generated a token. If anything
+				// fails, the form submits normally and the server rejects the tokenless
+				// submission with an error the user can retry.
+				function pmpro_recaptcha_login_setup() {
+					if ( pmpro_recaptcha_login_setup_done || typeof grecaptcha === 'undefined' || typeof grecaptcha.render !== 'function' ) {
 						return;
 					}
-					form.addEventListener( 'submit', function( event ) {
-						// If we already have a token or reCAPTCHA hasn't loaded, let the
-						// form submit. The server will reject submissions without a valid token.
-						if ( pmpro_recaptcha_login_has_token || typeof grecaptcha === 'undefined' || typeof grecaptcha.execute !== 'function' ) {
+					pmpro_recaptcha_login_setup_done = true;
+					document.querySelectorAll( '.pmpro_recaptcha_login' ).forEach( function( el ) {
+						var form = el.closest( 'form' );
+						if ( ! form ) {
 							return;
 						}
-						event.preventDefault();
-						grecaptcha.execute();
+						var hasToken = false;
+						var widgetId = null;
+						try {
+							widgetId = grecaptcha.render( el, {
+								'sitekey': el.getAttribute( 'data-sitekey' ),
+								'size': 'invisible',
+								'callback': function( token ) {
+									hasToken = true;
+									// Call the prototype method directly in case the form has an input named "submit".
+									HTMLFormElement.prototype.submit.call( form );
+								}
+							} );
+						} catch ( e ) {
+							return;
+						}
+						form.addEventListener( 'submit', function( event ) {
+							if ( hasToken || null === widgetId ) {
+								return;
+							}
+							event.preventDefault();
+							try {
+								grecaptcha.execute( widgetId );
+							} catch ( e ) {
+								HTMLFormElement.prototype.submit.call( form );
+							}
+						} );
 					} );
-				} );
-			</script>
-		<?php } else { ?>
-			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey ); ?>"></div>
-		<?php } ?>
-		<script src="https://www.google.com/recaptcha/api.js?hl=<?php echo esc_attr( $lang ); ?>" async defer></script>
-	</div>
-	<?php
+				}
 
-	$already_shown = true;
+				window.pmpro_recaptcha_login_onload = function() {
+					pmpro_recaptcha_login_setup();
+				};
+
+				document.addEventListener( 'DOMContentLoaded', function() {
+					// If another script on the page (e.g. PMPro checkout) already loaded the
+					// reCAPTCHA API, reuse it rather than loading it twice.
+					if ( window.grecaptcha && typeof window.grecaptcha.render === 'function' ) {
+						pmpro_recaptcha_login_setup();
+						return;
+					}
+
+					// Load the reCAPTCHA API if nothing else on the page is loading it.
+					if ( ! document.querySelector( 'script[src*="google.com/recaptcha/api.js"]' ) ) {
+						var script = document.createElement( 'script' );
+						script.src = 'https://www.google.com/recaptcha/api.js?onload=pmpro_recaptcha_login_onload&render=explicit&hl=<?php echo esc_js( $lang ); ?>';
+						script.async = true;
+						document.head.appendChild( script );
+						return;
+					}
+
+					// Another script tag is loading the API; wait for it to become available.
+					var tries = 0;
+					var timer = setInterval( function() {
+						if ( window.grecaptcha && typeof window.grecaptcha.render === 'function' ) {
+							clearInterval( timer );
+							pmpro_recaptcha_login_setup();
+						} else if ( ++tries > 100 ) {
+							clearInterval( timer );
+						}
+					}, 100 );
+				} );
+			})();
+			</script>
+			<?php
+			$assets_shown = true;
+		}
+	} else {
+		// v2 checkbox: one widget container per form, auto-rendered by the API script.
+		?>
+		<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
+			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey ); ?>"></div>
+		</div>
+		<?php
+		if ( ! $assets_shown ) {
+			// defer (not async) so that every widget container on the page exists
+			// before the API's auto-render pass runs.
+			?>
+			<script src="https://www.google.com/recaptcha/api.js?hl=<?php echo esc_attr( $lang ); ?>" defer></script>
+			<?php
+			$assets_shown = true;
+		}
+	}
 }
 
 /**
- * Show reCAPTCHA on PMPro and WP core login and lost password forms
- * once a failed login attempt has been tracked for the current IP.
+ * Show reCAPTCHA on login and lost password forms once a challenge is
+ * active for the current IP.
  *
  * @since TBD
  */
@@ -451,10 +520,30 @@ function pmpro_recaptcha_login_forms_html() {
 
 	pmpro_recaptcha_get_login_html();
 }
-add_action( 'pmpro_login_form_before_submit_button', 'pmpro_recaptcha_login_forms_html' );
-add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_recaptcha_login_forms_html' );
 add_action( 'login_form', 'pmpro_recaptcha_login_forms_html' );
 add_action( 'lostpassword_form', 'pmpro_recaptcha_login_forms_html' );
+add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_recaptcha_login_forms_html' );
+
+/**
+ * Show reCAPTCHA inside forms built with wp_login_form() — including PMPro's
+ * own login forms — once a challenge is active. These are exactly the forms
+ * that post to wp-login.php and are validated by pmpro_authenticate_login_checks,
+ * so every form that is validated also displays the challenge.
+ *
+ * @since TBD
+ *
+ * @param string $content Content to display. Default empty.
+ * @param array  $args    Array of login form arguments.
+ * @return string $content Content to display.
+ */
+function pmpro_recaptcha_login_form_middle( $content, $args ) {
+	ob_start();
+	pmpro_recaptcha_login_forms_html();
+	// Late priority and a (string) cast so that earlier callbacks that echo
+	// and return null (instead of returning their content) can't wipe the widget.
+	return (string) $content . ob_get_clean();
+}
+add_filter( 'login_form_middle', 'pmpro_recaptcha_login_form_middle', 100, 2 );
 
 /**
  * Require a valid reCAPTCHA on login attempts once the current IP has failed a login.

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -338,8 +338,8 @@ function pmpro_recaptcha_should_challenge_login() {
 		return false;
 	}
 
-	// Only challenge IPs that have recently failed to log in.
-	return pmpro_captcha_has_recent_failed_login();
+	// Only challenge IPs with recent suspicious activity, e.g. failed logins.
+	return pmpro_captcha_has_recent_spam_activity();
 }
 
 /**

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -312,7 +312,7 @@ add_action( 'pmpro_security_spam_fields', 'pmpro_recaptcha_settings' );
  */
 function pmpro_recaptcha_settings_save() {
 	// Keep the legacy on/off option in sync with the captcha setting for backwards compatibility.
-	pmpro_setOption( "recaptcha", 'recaptcha' === pmpro_captcha() ? 2 : 0 );
+	update_option( 'pmpro_recaptcha', 'recaptcha' === pmpro_captcha() ? 2 : 0, false );
 	pmpro_setOption( "recaptcha_version", sanitize_text_field( $_POST['recaptcha_version'] ) );
 	pmpro_setOption( "recaptcha_publickey", sanitize_text_field( $_POST['recaptcha_publickey'] ) );
 	pmpro_setOption( "recaptcha_privatekey", sanitize_text_field( $_POST['recaptcha_privatekey'] ) );

--- a/includes/recaptcha.php
+++ b/includes/recaptcha.php
@@ -1,5 +1,19 @@
 <?php
 /**
+ * Register reCAPTCHA as an available captcha service.
+ *
+ * @since TBD
+ *
+ * @param array $services Captcha services as slug => label.
+ * @return array $services Captcha services as slug => label.
+ */
+function pmpro_recaptcha_register_captcha_service( $services ) {
+	$services['recaptcha'] = __( 'Google reCAPTCHA', 'paid-memberships-pro' );
+	return $services;
+}
+add_filter( 'pmpro_captcha_services', 'pmpro_recaptcha_register_captcha_service' );
+
+/**
  * Sets up our JS code to validate ReCAPTCHA on form submission if needed.
  */
 function pmpro_init_recaptcha() {
@@ -7,7 +21,7 @@ function pmpro_init_recaptcha() {
 	// global $recaptcha for backwards compatibility.
 	// TODO: Remove this in a future version.
 	global $recaptcha;
-	$recaptcha = get_option( 'pmpro_recaptcha' );
+	$recaptcha = ( 'recaptcha' === pmpro_captcha() ) ? 2 : false;
 	if ( empty( $recaptcha ) ) {
 		return;
 	}
@@ -68,7 +82,7 @@ function pmpro_recaptcha_get_html() {
 	}
 
 	// If ReCAPTCHA is not enabled, bail.
-	if ( empty( get_option( 'pmpro_recaptcha' ) ) ) {
+	if ( 'recaptcha' !== pmpro_captcha() ) {
 		return;
 	}
 
@@ -218,7 +232,7 @@ function pmpro_recaptcha_validation_check( $continue = true ) {
 	}
 
 	// If ReCAPTCHA is not enabled, return.
-	if ( empty( get_option( 'pmpro_recaptcha' ) ) ) {
+	if ( 'recaptcha' !== pmpro_captcha() ) {
 		return true;
 	}
 
@@ -242,34 +256,17 @@ add_filter( 'pmpro_billing_update_checks', 'pmpro_recaptcha_validation_check', 1
  */
 function pmpro_recaptcha_settings() {
 	// Get the current options.
-	$recaptcha = get_option( 'pmpro_recaptcha' );
 	$recaptcha_version = get_option( 'pmpro_recaptcha_version' );
 	$recaptcha_publickey = get_option( 'pmpro_recaptcha_publickey' );
 	$recaptcha_privatekey = get_option( 'pmpro_recaptcha_privatekey' );
 
-	$recaptcha_value   = $recaptcha > 0 ? 2 : 0;
 	$recaptcha_depends = array(
 		array(
-			'id'    => 'recaptcha',
-			'value' => '2',
+			'id'    => 'captcha',
+			'value' => 'recaptcha',
 		),
 	);
 
-	pmpro_build_settings_field( array(
-		'name'        => 'recaptcha',
-		'label'       => __( 'Use reCAPTCHA?', 'paid-memberships-pro' ),
-		'type'        => 'select',
-		'value'       => $recaptcha_value,
-		'options'     => array(
-			0 => __( 'No', 'paid-memberships-pro' ),
-			2 => __( 'Yes - All memberships.', 'paid-memberships-pro' ),
-		),
-		'description' => sprintf(
-			/* translators: %s: Link to create a Google reCAPTCHA key. */
-			__( 'A free reCAPTCHA key is required. <a href="%s" target="_blank" rel="nofollow noopener">Click here to signup for reCAPTCHA</a>.', 'paid-memberships-pro' ),
-			'https://www.google.com/recaptcha/admin/create'
-		),
-	) );
 	pmpro_build_settings_field( array(
 		'name'        => 'recaptcha_version',
 		'label'       => __( 'reCAPTCHA Version', 'paid-memberships-pro' ),
@@ -281,7 +278,11 @@ function pmpro_recaptcha_settings() {
 			'2_checkbox'   => __( 'v2 - Checkbox', 'paid-memberships-pro' ),
 			'3_invisible' => __( 'v3 - Invisible', 'paid-memberships-pro' ),
 		),
-		'description' => __( 'Changing your version will require new API keys.', 'paid-memberships-pro' ),
+		'description' => sprintf(
+			/* translators: %s: Link to create a Google reCAPTCHA key. */
+			__( 'Changing your version will require new API keys. A free reCAPTCHA key is required. <a href="%s" target="_blank" rel="nofollow noopener">Click here to signup for reCAPTCHA</a>.', 'paid-memberships-pro' ),
+			'https://www.google.com/recaptcha/admin/create'
+		),
 	) );
 	pmpro_build_settings_field( array(
 		'name'      => 'recaptcha_publickey',
@@ -310,9 +311,197 @@ add_action( 'pmpro_security_spam_fields', 'pmpro_recaptcha_settings' );
  * @since 3.2
  */
 function pmpro_recaptcha_settings_save() {
-	pmpro_setOption( "recaptcha", intval( $_POST['recaptcha'] ) );
+	// Keep the legacy on/off option in sync with the captcha setting for backwards compatibility.
+	pmpro_setOption( "recaptcha", 'recaptcha' === pmpro_captcha() ? 2 : 0 );
 	pmpro_setOption( "recaptcha_version", sanitize_text_field( $_POST['recaptcha_version'] ) );
 	pmpro_setOption( "recaptcha_publickey", sanitize_text_field( $_POST['recaptcha_publickey'] ) );
 	pmpro_setOption( "recaptcha_privatekey", sanitize_text_field( $_POST['recaptcha_privatekey'] ) );
 }
 add_action( 'pmpro_save_security_settings', 'pmpro_recaptcha_settings_save' );
+
+/**
+ * Check whether login and password reset forms should be challenged with reCAPTCHA.
+ *
+ * @since TBD
+ *
+ * @return bool True if forms should be challenged.
+ */
+function pmpro_recaptcha_should_challenge_login() {
+	// Only challenge if reCAPTCHA is the active captcha service.
+	if ( 'recaptcha' !== pmpro_captcha() ) {
+		return false;
+	}
+
+	// Don't challenge without keys. We couldn't render or verify the captcha,
+	// and requiring a check that can't be completed would lock users out.
+	if ( ! get_option( 'pmpro_recaptcha_publickey' ) || ! get_option( 'pmpro_recaptcha_privatekey' ) ) {
+		return false;
+	}
+
+	// Only challenge IPs that have recently failed to log in.
+	return pmpro_captcha_has_recent_failed_login();
+}
+
+/**
+ * Verify a reCAPTCHA response token with Google.
+ *
+ * @since TBD
+ *
+ * @param string $token The g-recaptcha-response token to verify.
+ * @return bool True if the token is valid.
+ */
+function pmpro_recaptcha_verify_token( $token ) {
+	// An empty token means the user did not complete the challenge.
+	if ( empty( $token ) ) {
+		return false;
+	}
+
+	require_once( PMPRO_DIR . '/includes/lib/recaptchalib.php' );
+	$reCaptcha = new pmpro_ReCaptcha( get_option( 'pmpro_recaptcha_privatekey' ) );
+	$resp = $reCaptcha->verifyResponse( pmpro_get_ip(), sanitize_text_field( $token ) );
+
+	return ! empty( $resp->success );
+}
+
+/**
+ * Outputs the HTML needed to display reCAPTCHA in login and password reset forms.
+ *
+ * Unlike pmpro_recaptcha_get_html(), this does not use the checkout JS or the
+ * AJAX/session validation flow. The token is submitted with the form and
+ * verified server-side when the submission is processed.
+ *
+ * @since TBD
+ */
+function pmpro_recaptcha_get_login_html() {
+	static $already_shown = false;
+
+	// Make sure that we only show the captcha once per page.
+	if ( $already_shown ) {
+		return;
+	}
+
+	$recaptcha_publickey = get_option( 'pmpro_recaptcha_publickey' );
+
+	// Figure out language.
+	$locale = get_locale();
+	if ( ! empty( $locale ) ) {
+		$parts = explode( '_', $locale );
+		$lang = $parts[0];
+	} else {
+		$lang = 'en';
+	}
+	/** This filter is documented in includes/recaptcha.php */
+	$lang = apply_filters( 'pmpro_recaptcha_lang', $lang );
+
+	// Check which version of reCAPTCHA we are using.
+	$recaptcha_version = get_option( 'pmpro_recaptcha_version' );
+	?>
+	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_captcha' ) ); ?>">
+		<?php if ( $recaptcha_version == '3_invisible' ) { ?>
+			<div id="pmpro_recaptcha_login" class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey ); ?>" data-size="invisible" data-callback="pmpro_recaptcha_login_token_callback"></div>
+			<script>
+				// Once reCAPTCHA has generated a token, submit the form. The token is verified server-side.
+				var pmpro_recaptcha_login_has_token = false;
+				function pmpro_recaptcha_login_token_callback( token ) {
+					pmpro_recaptcha_login_has_token = true;
+					var widget = document.getElementById( 'pmpro_recaptcha_login' );
+					var form = widget ? widget.closest( 'form' ) : null;
+					if ( form ) {
+						// Call the prototype method directly in case the form has an input named "submit".
+						HTMLFormElement.prototype.submit.call( form );
+					}
+				}
+				document.addEventListener( 'DOMContentLoaded', function() {
+					var widget = document.getElementById( 'pmpro_recaptcha_login' );
+					var form = widget ? widget.closest( 'form' ) : null;
+					if ( ! form ) {
+						return;
+					}
+					form.addEventListener( 'submit', function( event ) {
+						// If we already have a token or reCAPTCHA hasn't loaded, let the
+						// form submit. The server will reject submissions without a valid token.
+						if ( pmpro_recaptcha_login_has_token || typeof grecaptcha === 'undefined' || typeof grecaptcha.execute !== 'function' ) {
+							return;
+						}
+						event.preventDefault();
+						grecaptcha.execute();
+					} );
+				} );
+			</script>
+		<?php } else { ?>
+			<div class="g-recaptcha" data-sitekey="<?php echo esc_attr( $recaptcha_publickey ); ?>"></div>
+		<?php } ?>
+		<script src="https://www.google.com/recaptcha/api.js?hl=<?php echo esc_attr( $lang ); ?>" async defer></script>
+	</div>
+	<?php
+
+	$already_shown = true;
+}
+
+/**
+ * Show reCAPTCHA on PMPro and WP core login and lost password forms
+ * once a failed login attempt has been tracked for the current IP.
+ *
+ * @since TBD
+ */
+function pmpro_recaptcha_login_forms_html() {
+	if ( ! pmpro_recaptcha_should_challenge_login() ) {
+		return;
+	}
+
+	pmpro_recaptcha_get_login_html();
+}
+add_action( 'pmpro_login_form_before_submit_button', 'pmpro_recaptcha_login_forms_html' );
+add_action( 'pmpro_lost_password_before_submit_button', 'pmpro_recaptcha_login_forms_html' );
+add_action( 'login_form', 'pmpro_recaptcha_login_forms_html' );
+add_action( 'lostpassword_form', 'pmpro_recaptcha_login_forms_html' );
+
+/**
+ * Require a valid reCAPTCHA on login attempts once the current IP has failed a login.
+ *
+ * @since TBD
+ *
+ * @param WP_User|WP_Error|null $user     WP_User if the login is valid so far, otherwise WP_Error or null.
+ * @param string                $username The username being used to log in.
+ * @return WP_User|WP_Error|null $user
+ */
+function pmpro_recaptcha_login_check( $user, $username ) {
+	if ( ! pmpro_recaptcha_should_challenge_login() ) {
+		return $user;
+	}
+
+	$token = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( $_POST['g-recaptcha-response'] ) : '';
+	if ( ! pmpro_recaptcha_verify_token( $token ) ) {
+		return new WP_Error( 'pmpro_captcha_failed', pmpro_captcha_failed_error_message() );
+	}
+
+	return $user;
+}
+add_filter( 'pmpro_authenticate_login_checks', 'pmpro_recaptcha_login_check', 10, 2 );
+
+/**
+ * Require a valid reCAPTCHA on lost password submissions once the current IP has failed a login.
+ *
+ * @since TBD
+ *
+ * @param WP_Error      $errors    Error object to add a captcha error to.
+ * @param WP_User|false $user_data WP_User object if found, false if the user does not exist.
+ */
+function pmpro_recaptcha_lostpassword_check( $errors, $user_data ) {
+	// Only check submissions from the PMPro or wp-login.php lost password forms. This hook
+	// also fires for other plugins that call retrieve_password() from their own forms,
+	// which never displayed our captcha.
+	if ( empty( $_REQUEST['pmpro_login_form_used'] ) && ! did_action( 'login_form_lostpassword' ) && ! did_action( 'login_form_retrievepassword' ) ) {
+		return;
+	}
+
+	if ( ! pmpro_recaptcha_should_challenge_login() ) {
+		return;
+	}
+
+	$token = isset( $_POST['g-recaptcha-response'] ) ? sanitize_text_field( $_POST['g-recaptcha-response'] ) : '';
+	if ( ! pmpro_recaptcha_verify_token( $token ) ) {
+		$errors->add( 'pmpro_captcha_failed', pmpro_captcha_failed_error_message() );
+	}
+}
+add_action( 'lostpassword_post', 'pmpro_recaptcha_lostpassword_check', 10, 2 );

--- a/includes/spam.php
+++ b/includes/spam.php
@@ -231,9 +231,10 @@ add_filter( 'pmpro_check_discount_code', 'pmpro_check_discount_code_spam_check',
  * @param string $username The username that failed to login.
  */
 function pmpro_track_login_spam( $username ) {
-	// Bail if Spam Protection is disabled.
+	// Bail if Spam Protection is disabled, unless a captcha is enabled.
+	// Captchas use this failed login activity to decide when to show a challenge.
 	$spamprotection = get_option( 'pmpro_spamprotection' );
-	if ( empty( $spamprotection ) ) {
+	if ( empty( $spamprotection ) && empty( pmpro_captcha() ) ) {
 		return;
 	}
 

--- a/paid-memberships-pro.php
+++ b/paid-memberships-pro.php
@@ -133,6 +133,7 @@ require_once( PMPRO_DIR . '/includes/email.php' );                  // code rela
 require_once( PMPRO_DIR . '/includes/email-logging.php' );           // email logging functionality
 require_once( PMPRO_DIR . '/includes/fields.php' );                  // user fields
 require_once( PMPRO_DIR . '/includes/settings-fields.php' );         // render-only helpers for admin settings sections
+require_once( PMPRO_DIR . '/includes/captcha.php' );                // shared code for captcha services
 require_once( PMPRO_DIR . '/includes/recaptcha.php' );              // load recaptcha files if needed
 require_once( PMPRO_DIR . '/includes/cloudflare-turnstile.php' );   // load CloudFlare Turnstile files if needed
 require_once( PMPRO_DIR . '/includes/terms-of-service.php' );       // code to add a terms of service checkbox to checkout


### PR DESCRIPTION
Phases 1 and 2 of the captcha-on-login work discussed for 3.9 (replaces the approach in #3493; phase 3 is the spam activity table in #3640).

## Phase 1: Generic login flow hooks (commit 1, `includes/login.php` only)

Gives captchas (and anything else) clean hook points in the login flow, mirroring how checkout isolates captcha code:

* **`pmpro_login_form_before_submit_button`** — fires inside the PMPro login form, via a `login_form_middle` filter added/removed around `wp_login_form()` (same pattern as the existing hidden-field filter), so it only ever runs on PMPro's forms.
* **`pmpro_authenticate_login_checks`** — filter on `authenticate` at priority 40, gated to PMPro-form submissions (`pmpro_login_form_used`) or real wp-login.php login submissions (`did_action( 'login_form_login' )`). XML-RPC, other plugins' login forms, and programmatic `wp_signon()` calls are never touched, so a captcha can't lock out a flow that didn't display it.
* **`pmpro_login_forms_handler_message` / `pmpro_login_forms_handler_msgt`** — lets custom error codes passed back to the login page display messages.
* Cleanup: `pmpro_authenticate_username_password()` now only redirects for `empty_username`/`empty_password` (the codes WP core never fires `wp_login_failed` for) and exits after redirecting. All other failures flow through `pmpro_login_failed()` — previously both functions called `wp_redirect()` in the same request and the second one happened to win.

## Phase 2: Captchas use the hooks (commit 2)

* **Single "Captcha" setting** (No / Google reCAPTCHA / Cloudflare Turnstile) on the Security Settings page replaces the two independent on/off settings, so only one captcha runs at a time. Back compat: the old options are read when the new setting has never been saved (a saved "No" does not fall back), and the old options are kept in sync on save for anything that reads them (e.g. Wisdom telemetry).
* **Captcha service registry**: new `pmpro_captcha_services` filter in `includes/captcha.php`. reCAPTCHA and Turnstile register themselves from their own files, and a future captcha add on can drop in the same way with no core changes. If a registered service disappears (add on deactivated), the site fails safe to no captcha.
* **Captcha on login and lost password forms** (PMPro pages + wp-login.php), shown **only after suspicious activity from the visitor's IP** — a failed login attempt while a captcha is enabled, or failed checkouts/invalid discount codes when Spam Protection is also on — and only when keys are configured, so a misconfigured captcha can't lock admins out. The signal is the existing spam activity API, which phase 3 (#3640) will re-point at the new table with no changes here. It is deliberately not cleared on successful login (on shared IPs that would let attackers reset it); it expires with the tracking window.
* Validation is fully server-side. reCAPTCHA v2 and Turnstile need no custom JS on login forms; v3-invisible uses a small inline script that fails open to server-side rejection if Google's script doesn't load. The checkout JS files are untouched.
* Failed logins are now tracked when a captcha is enabled even if Spam Protection is off.
* **Bug fix found along the way**: Turnstile checkout validation set the "validated" session var even when verification *failed*, so a failed captcha was bypassed on retry. Now only successful validations are remembered.

## Review follow-ups (commit 3)

Addressing @flintfromthebasement's review:

* **reCAPTCHA lib hardening**: `pmpro_ReCaptcha::_submitHTTPPost()` indexed `wp_remote_post()`'s return as an array, which fatals on PHP 8 when a network error to Google returns a `WP_Error`. Pre-existing on checkout, but this PR made it reachable from login — now guarded so verification fails safely (the user sees a captcha error and can retry) instead of a 500.
* **Shared spam signal documented as intentional**: the challenge trigger is a broader "recent suspicious activity" signal, not strictly failed logins — renamed `pmpro_captcha_has_recent_failed_login()` to `pmpro_captcha_has_recent_spam_activity()`, documented the semantics (including why it isn't cleared on successful login), and updated the setting description.
* **Turnstile login output** got the same show-once static guard the reCAPTCHA output already had.
* Not changed: the `action`/`errors`/`error` param handling in `pmpro_is_captcha_failed_request()` — the review confirmed the flow is correct; the code only ever emits the fixed `pmpro_captcha_failed` code. Verified against WP core that `lostpassword`/`retrievepassword` are the only wp-login.php lost-password action aliases, and any hypothetical third path would fail open (captcha skipped), not lock anyone out.


## Deep review sweep (commit 4)

A multi-agent adversarial review pass (5 dimensions, every finding independently verified against plugin + WP core source) surfaced four real issues, all fixed:

* **Third-party `wp_login_form()` forms were validated but never displayed the captcha.** Any form built with `wp_login_form()` posts to wp-login.php and trips the validation gate, but the widget only rendered on PMPro forms and wp-login.php itself — a theme header/popup login form would hard-fail for a challenged IP. Fixed by rendering through the core `login_form_middle` filter (late priority), which covers exactly the set of forms the gate validates. Narrowing the gate instead was rejected: any request-derived narrowing (e.g. requiring `testcookie`) would let bots bypass the captcha by omitting a field.
* **Only the first login form on a page got a widget while every form was validated** (e.g. a login block in a header template part + the login page form = an unsolvable challenge on one of them). Now every form gets its own widget; only shared script assets are deduped once per page.
* **reCAPTCHA v3-invisible JS hardening**: explicit per-widget rendering with tracked widget IDs (a bare `grecaptcha.execute()` could execute another plugin's widget or throw with no fallback, deadening the submit button when keys were invalid), single API script load reused if already present, and fail-open-to-server-rejection on any render/execute failure. v2 uses `defer` so all containers exist before auto-render.
* **Page caching**: the frontend login page now sends nocache headers while a captcha is enabled, so a cached captcha-less copy can't be served to an IP that will be required to solve one.

Found along the way: the **PMPro Magic Login add-on** echoes its `login_form_middle` output and returns null, wiping every other callback's content on that filter — core PMPro now defends against this (late priority + string cast), but the add-on needs its own one-line fix.

Confirmed-but-deferred (not this PR's scope): the challenge signal keys off `pmpro_get_ip()`, which trusts spoofable forwarded headers — an attacker rotating `X-Forwarded-For` per request evades tracking (and the pre-existing spam block) entirely. That's a property of the existing spam infrastructure shared by all its consumers; the fix (trusted-proxy-aware IP resolution) belongs in the #3640 table work.

## Testing done

Full curl-based pass on a local site: hook plumbing proven with a throwaway consumer; login/logout/lost password/reset password behavior verified unchanged with captcha off; with dummy keys, challenge lifecycle verified for both services on all four forms (no captcha before a failure, widget after, correct-password-but-no-token rejected with a displayed error, lost password blocked without sending email); checkout gating verified for both services incl. legacy-option derivation; registry verified with a fake third-party service (registers, saves, fails safe when removed); reCAPTCHA verify exercised over real HTTP with an invalid token (graceful failure, no fatal).

Still needs a browser pass with real keys: actual successful token round trips, the v3-invisible inline JS, and the settings show/hide toggling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
