### PR TITLE
ENHANCEMENT: Add View Email Log button on Email Settings

### DIFF
--- a/adminpages/emailsettings.php
+++ b/adminpages/emailsettings.php
@@ -283,6 +283,8 @@
 							<td>
 								<input type="checkbox" id="email_logging_enabled" name="email_logging_enabled" value="1" <?php checked( $email_logging_enabled ); ?> />
 								<label for="email_logging_enabled"><?php esc_html_e( 'Enable email logging', 'paid-memberships-pro' ); ?></label>
+								&nbsp;
+								<a class="button button-secondary" href="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-reports&report=email_log' ) ); ?>"><?php esc_html_e( 'View Email Log', 'paid-memberships-pro' ); ?></a>
 								<p class="description">
 									<?php esc_html_e( 'Check this to log emails to the database.', 'paid-memberships-pro' ); ?>
 								</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Jason noticed this during a Coding with Sam session and asked Flint to open this PR.

The Email Logging section on Memberships → Settings → Email already has intro copy that links to the Email Log report (`View entries in the Email Log Report`). That link is easy to miss, and the actual enable checkbox only said “Check this to log emails to the database.”

The point of the button is findability: if someone comes back to Email Settings looking for the log — the same tab where they turned it on — they should be able to get there from here. This adds a secondary **View Email Log** button next to the “Enable email logging” checkbox so they can jump straight to Memberships → Reports → Email Log.

The report page still loads via that URL even when logging is currently disabled (`pmpro_report_email_log_page()` exists regardless of registration), so the button is also useful for reviewing leftover entries after turning logging off.

### How to test the changes in this Pull Request:

1. Go to Memberships → Settings → Email and expand **Email Logging**.
2. Confirm a **View Email Log** button appears next to “Enable email logging”.
3. Click it and confirm it opens Memberships → Reports → Email Log.
4. Toggle logging off, save, and confirm the button still works (report page still loads; it just will not appear as a widget on the Reports dashboard until logging is enabled again).
5. Confirm the existing intro sentence still links to the same report.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Added a View Email Log button next to the enable checkbox on the Email Settings page.

### Screenshot

From flintdev.test, Email Settings → Email Logging. Jason noticed the log was hard to find from this tab during a Coding with Sam session; the button is next to the enable checkbox so people coming back here can get to the log.

![Email Logging section with View Email Log button](https://raw.githubusercontent.com/flintfromthebasement/paid-memberships-pro/screenshot/pr-3766/email-logging-section.png)
