### PR TITLE
Show only the icon for the password visibility toggle in narrow layouts

### DIFF
--- a/css/frontend/variation_1.css
+++ b/css/frontend/variation_1.css
@@ -462,6 +462,7 @@
 		margin: 0;
 		min-height: 1px;
 		padding: 0;
+		position: relative;
 	}
 
 	.pmpro_form_field-password-toggle button:focus,
@@ -480,6 +481,20 @@
 	.pmpro_form_field-password-toggle button:focus .pmpro_icon-eye svg,
 	.pmpro_form_field-password-toggle button:active .pmpro_icon-eye svg {
 		stroke: var(--pmpro--color--accent--variation);
+	}
+
+	/* Show only the icon in the login widget, leaving the state text for screen readers */
+	.pmpro_login-widget .pmpro_form_field-password-toggle-state {
+		border: 0;
+		clip-path: inset( 50% );
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+		word-wrap: normal;
 	}
 
 	.pmpro_form_field-select2 {
@@ -1232,6 +1247,20 @@
 
 		#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) {
 			width: 100%;
+		}
+
+		/* Show only the icon, leaving the state text for screen readers */
+		.pmpro_form_field-password-toggle-state {
+			border: 0;
+			clip-path: inset( 50% );
+			height: 1px;
+			margin: -1px;
+			overflow: hidden;
+			padding: 0;
+			position: absolute;
+			white-space: nowrap;
+			width: 1px;
+			word-wrap: normal;
 		}
 
 	}

--- a/css/frontend/variation_high_contrast.css
+++ b/css/frontend/variation_high_contrast.css
@@ -459,6 +459,7 @@
 		margin: 0;
 		min-height: 1px;
 		padding: 0;
+		position: relative;
 	}
 
 	.pmpro_form_field-password-toggle button:focus,
@@ -477,6 +478,20 @@
 	.pmpro_form_field-password-toggle button:focus .pmpro_icon-eye svg,
 	.pmpro_form_field-password-toggle button:active .pmpro_icon-eye svg {
 		stroke: var(--pmpro--color--accent--variation);
+	}
+
+	/* Show only the icon in the login widget, leaving the state text for screen readers */
+	.pmpro_login-widget .pmpro_form_field-password-toggle-state {
+		border: 0;
+		clip-path: inset( 50% );
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		white-space: nowrap;
+		width: 1px;
+		word-wrap: normal;
 	}
 
 	.pmpro_form_field-select2 {
@@ -1215,6 +1230,20 @@
 
 		#pmpro_user_fields .pmpro_form_field-password:has(.pmpro_form_field-password-toggle) {
 			width: 100%;
+		}
+
+		/* Show only the icon, leaving the state text for screen readers */
+		.pmpro_form_field-password-toggle-state {
+			border: 0;
+			clip-path: inset( 50% );
+			height: 1px;
+			margin: -1px;
+			overflow: hidden;
+			padding: 0;
+			position: absolute;
+			white-space: nowrap;
+			width: 1px;
+			word-wrap: normal;
 		}
 
 	}

--- a/includes/login.php
+++ b/includes/login.php
@@ -457,11 +457,17 @@ function pmpro_login_forms_handler( $show_menu = true, $show_logout_link = true,
 		}
 	}
 
+	// Flag widget instances so narrow-column styles can be applied.
+	$pmpro_login_section_class = 'pmpro_section';
+	if ( $location === 'widget' ) {
+		$pmpro_login_section_class .= ' pmpro_login-widget';
+	}
+
 	ob_start();
 	?>
 
 	<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro' ) ); ?>">
-		<section id="pmpro_login" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_section', 'pmpro_login' ) ); ?>">
+		<section id="pmpro_login" class="<?php echo esc_attr( pmpro_get_element_class( $pmpro_login_section_class, 'pmpro_login' ) ); ?>">
 			<?php
 				// Note we don't show messages on the widget form.
 				if ( $message && $location !== 'widget' ) {


### PR DESCRIPTION
## Problem

The password visibility toggle button includes the words "Show Password" / "Hide Password" alongside the eye icon. In the two-column grid the button shares with the field label:

```
grid-template-areas:
	"label toggle"
	"input input";
grid-template-columns: 1fr auto;
```

that text makes the `toggle` column wide enough that on small screens the label and the button wrap into each other. It shows up in the log in widget (always narrow), and on small screens in the log in block/shortcode, the reset password form, the Change Password section of Member Profile Edit, and checkout.

## Approach

Visually hide the `.pmpro_form_field-password-toggle-state` span so only the icon remains, on two different triggers:

- **Log in widget** — icon-only at every width, since a widget column is always narrow. `pmpro_login_forms_handler()` now adds a `pmpro_login-widget` class to the `#pmpro_login` section when `$location === 'widget'`, which the stylesheets key off of. (The `[pmpro_login location="widget"]` shortcode attribute triggers this too, which is the desired behavior for a sidebar.)
- **Everywhere else** — icon-only below 768px, the existing smallest breakpoint in the frontend stylesheets. Full icon + text at 768px and up.

The text is only *visually* hidden, never removed. Both toggle scripts (`js/pmpro-login.js`, `js/pmpro-checkout.js`, and the inline script in `pmpro_login_form()`) set `state.textContent`, so the span keeps getting swapped between "Show Password" and "Hide Password" and screen readers still announce the current state.

`position: relative` was added to the toggle button so the now-absolutely-positioned span is contained rather than escaping to a distant positioned ancestor.

## Notes

- The rules live in `variation_1.css` and `variation_high_contrast.css` rather than `base.css`. That duplicates them, but it matches how those files already each carry their own full copy of the password-toggle styles — and the grid that causes the wrapping is only defined in the variations. The additions are byte-identical between the two files.
- High contrast gets the same icon-only treatment as variation 1, intentionally.
- No RTL changes needed: `base-rtl.css` doesn't touch the toggle, the `.rtl` blocks only pad the wrapper, and the hiding declarations are direction-symmetric.

## Testing

Browser-verified. Worth checking:

1. Log in widget in a narrow sidebar — icon only, at any window width. Toggle still reveals the password.
2. Log in block / `[pmpro_login]` / log in page, reset password form, Member Profile Edit → Change Password, and checkout — icon only below 768px, icon + text at 768px and up, no wrapping at the boundary.
3. With a screen reader, confirm the button still announces "Show Password" and then "Hide Password" after activating it, in the icon-only state.
4. Both style variations.

## Screenshots

<img width="794" height="536" alt="Screenshot 2026-08-25 at 9 45 52 AM" src="https://github.com/user-attachments/assets/786cf0b4-2899-4ba0-aff4-6a9781eaf5f7" />

<img width="1008" height="696" alt="Screenshot 2026-08-25 at 9 46 06 AM" src="https://github.com/user-attachments/assets/a8d1fbe2-f671-480a-8d89-a39db32d6154" />

<img width="721" height="599" alt="Screenshot 2026-08-25 at 9 46 23 AM" src="https://github.com/user-attachments/assets/3c9d12ca-0810-4bb8-b266-cf477d3ed993" />

<img width="803" height="511" alt="Screenshot 2026-08-25 at 9 46 36 AM" src="https://github.com/user-attachments/assets/2037707d-e227-4ea9-82c5-c055cc894d83" />

<img width="1017" height="331" alt="Screenshot 2026-08-25 at 9 46 40 AM" src="https://github.com/user-attachments/assets/3b576a07-a941-4453-a766-67f2e2be763e" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)