### PR TITLE
Send whether the site is a PMPro Hosting site with Wisdom tracking data

### DIFF
--- a/classes/class-pmpro-wisdom-integration.php
+++ b/classes/class-pmpro-wisdom-integration.php
@@ -324,6 +324,9 @@ class PMPro_Wisdom_Integration {
 		$stats['plugin_options_fields']['pmpro_license_key']  = get_option( 'pmpro_license_key', 'No Value' );
 		$stats['plugin_options_fields']['pmpro_license_plan'] = $license_plan;
 
+		// Hosting info.
+		$stats['plugin_options_fields']['pmpro_hosting'] = defined( 'PMPRO_HOSTING_IS_MU_PLUGIN' ) && PMPRO_HOSTING_IS_MU_PLUGIN ? 'yes' : 'no';
+
 		// Gateway info.
 		$stats['plugin_options_fields'] = array_merge( $stats['plugin_options_fields'], $this->get_gateway_info() );
 


### PR DESCRIPTION
## What this does

Adds a `pmpro_hosting` field (`yes`/`no`) to the Wisdom tracking stats in `PMPro_Wisdom_Integration::add_stats()`, based on `defined( 'PMPRO_HOSTING_IS_MU_PLUGIN' ) && PMPRO_HOSTING_IS_MU_PLUGIN`.

The hosting plugin defines that constant itself based on whether it's actually loaded from `mu-plugins/`, so a copy sitting in the regular `plugins/` directory correctly reports `no`. Hosting sites currently don't appear in Wisdom's plugin lists at all, since the tracker only reads `get_plugins()` and the `active_plugins` option — mu-plugins are invisible to both.

Companion PR to store/report the field on asimov: strangerstudios/asimov-site-customizations#4

## Notes

- Uses the lowercase `yes`/`no` string convention matching the other boolean-ish fields in `plugin_options_fields`.
- Safe to merge in either order relative to the asimov PR — asimov ignores unknown POST keys, and older asimov just won't store the field until its PR ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)