### PR TITLE
fix: end membership when gateway-cancelled subscription never ended it

### DIFF
--- a/includes/gateway-request-handlers.php
+++ b/includes/gateway-request-handlers.php
@@ -46,7 +46,14 @@ function pmpro_handle_subscription_cancellation_at_gateway( $subscription_transa
 
 	// Check if we have already cancelled the subscription in PMPro.
 	if ( 'cancelled' === $subscription->get_status() ) {
-		return 'We have already processed this cancellation. Probably originated from WP/PMPro. ( Subscription Transaction ID #' . $subscription_transaction_id . ')';
+		// Check if the user still has an active membership for this level with no end date.
+		$user_level = pmpro_getSpecificMembershipLevelForUser( $subscription->get_user_id(), $subscription->get_membership_level_id() );
+		$membership_still_open = ! empty( $user_level ) && empty( $user_level->enddate );
+		if ( ! $membership_still_open ) {
+			return 'We have already processed this cancellation. Probably originated from WP/PMPro. ( Subscription Transaction ID #' . $subscription_transaction_id . ')';
+		}
+		// The subscription is marked cancelled at the gateway but the membership
+		// was never ended. Continue to end it below.
 	}
 
 	// Store the old next payment date for the subscription for later.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a subscription is cancelled at the gateway, `pmpro_handle_subscription_cancellation_at_gateway()` returned early if `pmpro_subscriptions.status` was already `cancelled`. That status is not only set by a cancel that originated in WordPress. It is also set by gateway sync, for example when syncing a subscription from the admin Subscriptions page or during `PMPro_Subscription::update()`. Sync marks the subscription cancelled without ending the membership.

In that state, `pmpro_memberships_users` kept `status = 'active'` with an empty end date. The expiry cron skips memberships with no end date, so the member kept paid access forever. This was reported with 44 affected members on one site (issue #3743).

The fix checks whether the user still has an active membership for the subscription's level with no end date before returning early. If yes, the handler continues and ends the membership as it normally would. If the membership was really ended by a WordPress-side cancel, the early return works like before.

Resolves #3743.

### How to test the changes in this Pull Request:

1. Create a member with a recurring Stripe subscription.
2. In admin, go to Memberships > Subscriptions and use the sync action so `pmpro_subscriptions.status` becomes `cancelled` while `pmpro_memberships_users` stays active with no end date.
3. Send the `customer.subscription.deleted` webhook (Stripe CLI: `stripe trigger customer.subscription.deleted`).
4. Before this patch the membership stays active. With this patch the membership row gets `status = 'cancelled'` and an end date, and the cancel emails are sent.

Regression checks:

5. Cancel a membership in WordPress, then let the returning webhook arrive. It should still be ignored with "We have already processed this cancellation" and no double process.
6. A gateway cancel where the next payment date is still in the future should still extend the membership to that date (the `pmpro_cancel_on_next_payment_date` path).

Result: all tested manually and working on WordPress 6.x with PMPro 3.8.5 and Stripe test mode.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

There is no automated test suite in this repo at the moment, so I verified with `php -l`, PHPCS (`WordPress-Core`) against the changed block, and the manual steps above. Two extra notes on intended behavior:

- An admin who only cancels the subscription (not the membership) will now have the later webhook end the membership too. Previously it stayed open forever, which was the bug.
- A user with two active subscriptions on the same level: one gateway cancel now ends the shared level membership, same as what one webhook always did for a single subscription.

Backward compatible: no breaking changes to documented behavior; only the previously broken case behaves differently.

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX/ENHANCEMENT: Ended memberships are now correctly closed when a gateway cancellation webhook arrives after a subscription was already marked cancelled by a gateway sync.