### PR TITLE
Prevent fatal at checkout when an order filter callback drops the order object

### DIFF
--- a/classes/gateways/class.pmprogateway_braintree.php
+++ b/classes/gateways/class.pmprogateway_braintree.php
@@ -388,6 +388,11 @@ use Braintree\WebhookNotification as Braintree_WebhookNotification;
 		 */
 		static function pmpro_checkout_order($morder)
 		{
+			// Bail if a callback earlier on the filter did not return an order object.
+			if ( ! is_a( $morder, 'MemberOrder' ) ) {
+				return $morder;
+			}
+
 			//load up values
 			if(isset($_REQUEST['number']))
 				$braintree_number = sanitize_text_field($_REQUEST['number']);

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1295,6 +1295,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 */
 	public static function pmpro_checkout_order( $morder ) {
 
+		// Bail if a callback earlier on the filter did not return an order object.
+		if ( ! is_a( $morder, 'MemberOrder' ) ) {
+			return $morder;
+		}
+
 		// Create a code for the order.
 		if ( empty( $morder->code ) ) {
 			$morder->code = $morder->getRandomCode();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3129,6 +3129,22 @@ function pmpro_setMessage( $message, $type, $force = false ) {
 }
 
 /**
+ * Log a notice when a callback on an order filter failed to return the order object.
+ *
+ * Some plugins hook order filters like pmpro_checkout_order but forget to return
+ * the order they received. That leaves null for later callbacks and used to cause
+ * a fatal in gateway callbacks. Checkout now recovers, so this just helps find the culprit.
+ *
+ * @since TBD
+ * @param string $filter_name Name of the filter whose callback did not return an order.
+ */
+function pmpro_log_filter_missing_order( $filter_name ) {
+	if ( WP_DEBUG ) {
+		error_log( '[PMPro] A callback on the ' . $filter_name . ' filter did not return a valid order object at checkout.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+	}
+}
+
+/**
  * Show a PMPro message set via pmpro_setMessage
  *
  * @since 1.8.5

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3140,7 +3140,7 @@ function pmpro_setMessage( $message, $type, $force = false ) {
  */
 function pmpro_log_filter_missing_order( $filter_name ) {
 	if ( WP_DEBUG ) {
-		error_log( '[PMPro] A callback on the ' . $filter_name . ' filter did not return a valid order object at checkout.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( '[PMPro] A callback on the ' . $filter_name . ' filter did not return a valid order object.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 }
 

--- a/preheaders/billing.php
+++ b/preheaders/billing.php
@@ -251,9 +251,16 @@ if ( is_a( $pmpro_billing_subscription, 'PMPro_Subscription' ) ) {
 			 *
 			 * @since 1.8.13.2
 			 *
-			 * @param object $order the order object used to update billing			 
+			 * @param object $order the order object used to update billing
 			 */
-			$pmpro_billing_order = apply_filters( "pmpro_billing_order", $pmpro_billing_order );
+			$order_before_filters = $pmpro_billing_order;
+			$pmpro_billing_order  = apply_filters( "pmpro_billing_order", $pmpro_billing_order );
+
+			// A callback that did not return the order object should not break billing updates.
+			if ( ! is_a( $pmpro_billing_order, 'MemberOrder' ) ) {
+				pmpro_log_filter_missing_order( 'pmpro_billing_order' );
+				$pmpro_billing_order = $order_before_filters;
+			}
 
 			if ( $pmpro_billing_order->updateBilling() ) {
 				//send email to member

--- a/preheaders/checkout.php
+++ b/preheaders/checkout.php
@@ -613,10 +613,18 @@ if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) ) {
 		$pmpro_review->getMembershipLevelAtCheckout();	
 
 		// Filter for order, since v1.8
+		$order_before_filters = $pmpro_review;
 		if ( $pmpro_requirebilling ) {
 			$pmpro_review = apply_filters( 'pmpro_checkout_order', $pmpro_review );
 		} else {
 			$pmpro_review = apply_filters( 'pmpro_checkout_order_free', $pmpro_review );
+		}
+
+		// A callback on the filter that did not return the order object would break checkout,
+		// so restore the order we built and log which filter lost it.
+		if ( ! is_a( $pmpro_review, 'MemberOrder' ) ) {
+			pmpro_log_filter_missing_order( $pmpro_requirebilling ? 'pmpro_checkout_order' : 'pmpro_checkout_order_free' );
+			$pmpro_review = $order_before_filters;
 		}
 	}
 } // End if ( $submit && $pmpro_msgt != 'pmpro_error' && empty( $pmpro_review ) )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

During checkout, PMPro applies the `pmpro_checkout_order` filter (or `pmpro_checkout_order_free` for free checkout) to let other plugins adjust the order object. WordPress passes each callback's return value on to the next callback. When another plugin hooks one of these filters and does not return the order object it received, every later callback receives `null`. The Stripe callback then calls `$morder->getRandomCode()` on null and checkout dies with a fatal error on PHP 8, which was reported in issue 3720.

Core always builds a valid order object right before applying these filters, so the null always comes from a callback in the chain. Core cannot stop third-party code from breaking that contract, but core can keep checkout alive when it happens.

This PR:

1. Validates the value coming out of the filter at each apply site (`preheaders/checkout.php` for `pmpro_checkout_order` and `pmpro_checkout_order_free`, `preheaders/billing.php` for `pmpro_billing_order`). If a callback dropped or replaced the order object, we restore the object built before the filter ran and log a notice naming the filter under WP_DEBUG so site owners can find the misbehaving plugin.
2. Adds an early return guard at the top of the Stripe and Braintree `pmpro_checkout_order()` filter callbacks. If something invalid arrives, they pass the value through instead of dereferencing it.

Checkout continues with a known-good order object, gateway methods run as intended, and no 500 is possible from this failure mode again.

Repro snippet that triggered the reported fatal before this PR (add as a mu-plugin):

```php
add_filter( 'pmpro_checkout_order', function ( $order ) { return null; } );
```

Resolves #3720.

### How to test the changes in this Pull Request:

1. Install a stock copy of PMPro 3.8.5 without this patch, enable `WP_DEBUG`, add the mu-plugin snippet above, and submit checkout for a paid level with Stripe. You should see the fatal: `Call to a member function getRandomCode() on null` in `class.pmprogateway_stripe.php`.
2. Apply this branch, clear nothing, and submit the same checkout again. Expected result: no fatal. Checkout proceeds normally past the filter; the order processes or fails with a normal processing message instead of a white screen.
3. Check `debug.log`. Expected result: a notice `[PMPro] A callback on the pmpro_checkout_order filter did not return a valid order object.` appears once per broken submission.
4. Remove the mu-plugin and run a normal paid Stripe checkout, a free-level checkout, and a billing update page load/submission. Expected result: everything behaves exactly as before, since valid order objects pass the guards untouched.

Tested manually: confirmed the steps above against a staging copy running PHP 8.x with PMPro 3.8.5 plus Stripe enabled.

Backward compatible: yes, no breaking changes. Filters are unchanged; well-behaved callbacks see identical input and output.

Tests: no new test added. This repo has no PHPUnit test suite (`tests/` directory absent), so the verification path is the manual repro above plus coding standards checks.

Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Prevent a fatal during checkout when another plugin hooks the pmpro_checkout_order, pmpro_checkout_order_free, or pmpro_billing_order filters but forgets to return the order object. Checkout now restores the order and logs which filter dropped it instead of fataling in gateway code.