### PR TITLE
BUG FIX: Render strong tags in Stripe Connect error notices

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1619,7 +1619,10 @@ class PMProGateway_stripe extends PMProGateway {
 		global $pmpro_stripe_error;
 		if ( ! empty( $pmpro_stripe_error ) ) {
 			$class   = 'notice notice-error pmpro-stripe-connect-message';
-			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), esc_html( $pmpro_stripe_error ) );
+			$allowed_html = array(
+				'strong' => array(),
+			);
+			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), wp_kses( $pmpro_stripe_error, $allowed_html ) );
 		}
 	}
 


### PR DESCRIPTION
## Description
The Stripe Connect connection failure string includes `<strong>Error:</strong>`, but `stripe_connect_show_errors()` ran it through `esc_html()`, so the tag showed as literal text. Allow `strong` via `wp_kses`. The error reason was already escaped when the message was built.

Disconnect notices in the same file already allow `strong`.

## Testing
1. Force a Stripe Connect failure (invalid response / cancel).
2. Confirm the admin notice shows **Error:** in bold, with the reason still escaped.

Fixes the display of https://github.com/strangerstudios/paid-memberships-pro/blob/dev/classes/gateways/class.pmprogateway_stripe.php#L1608-L1624