### PR TITLE
ENHANCEMENT: Stripe Connect disconnect hash + dead-key reconnect

### DIFF
--- a/adminpages/wizard/save-steps.php
+++ b/adminpages/wizard/save-steps.php
@@ -133,6 +133,7 @@ function pmpro_init_save_wizard_data() {
 				array(
 					'action' => 'authorize',
 					'gateway_environment' => $environment,
+					'supports_hash' => '1',
 					'return_url' => rawurlencode( add_query_arg( 'pmpro_stripe_connect_nonce', wp_create_nonce( 'pmpro_stripe_connect_nonce' ), $next_step ) ),
 				),
 				esc_url( $connect_url_base )

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1304,7 +1304,8 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Test a Stripe secret (Connect or Restricted Key) with a cheap authenticated GET.
+	 * Test a Stripe secret (Connect or Restricted Key) with a cheap customers list.
+	 * Empty accounts still return a list; we only care that the key authenticates.
 	 *
 	 * @param string $secretkey Secret stored in options.
 	 * @return bool True if the key authenticates. Transient/network errors return true so we do not nag.
@@ -1317,9 +1318,9 @@ class PMProGateway_stripe extends PMProGateway {
 		self::loadStripeLibrary();
 
 		try {
-			$stripe  = new Stripe_Client( $secretkey );
-			$account = $stripe->accounts->retrieve();
-			return ( ! empty( $account ) && ! empty( $account->id ) );
+			$stripe    = new Stripe_Client( $secretkey );
+			$customers = $stripe->customers->all( array( 'limit' => 1 ) );
+			return ( is_object( $customers ) && isset( $customers->data ) );
 		} catch ( \Stripe\Exception\AuthenticationException $e ) {
 			return false;
 		} catch ( \Stripe\Exception\PermissionException $e ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -131,6 +131,7 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'wp_ajax_pmpro_stripe_create_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_create_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_delete_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_delete_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_rebuild_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_rebuild_webhook' ) );
+		add_action( 'wp_ajax_pmpro_stripe_check_connect_keys', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_check_connect_keys' ) );
 
 		//code to add at checkout if Stripe is the current gateway
 		$default_gateway = get_option( 'pmpro_gateway' );
@@ -1201,6 +1202,125 @@ class PMProGateway_stripe extends PMProGateway {
 
 		echo json_encode( $r ); // Values escaped above.
 		exit;
+	}
+
+	/**
+	 * AJAX callback to test saved Stripe Connect keys against the Stripe API.
+	 *
+	 * Secrets stay on the server. Success is silent; auth failures return
+	 * a reconnect URL for the payment settings page.
+	 */
+	public static function wp_ajax_pmpro_stripe_check_connect_keys() {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			echo wp_json_encode(
+				array(
+					'success' => false,
+					'results' => array(),
+				)
+			);
+			exit;
+		}
+
+		if ( false === check_ajax_referer( 'pmpro_stripe_connect_key_health', 'nonce', false ) ) {
+			echo wp_json_encode(
+				array(
+					'success' => false,
+					'results' => array(),
+				)
+			);
+			exit;
+		}
+
+		$results = array();
+		foreach ( array( 'live', 'sandbox' ) as $environment ) {
+			if ( ! self::has_connect_credentials( $environment ) ) {
+				continue;
+			}
+
+			if ( self::connect_secretkey_is_valid( get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ) {
+				continue;
+			}
+
+			$reconnect_url = self::get_connect_authorize_url( $environment );
+			$reconnect_link = '<a href="' . esc_url( $reconnect_url ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>';
+			$results[ $environment ] = array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %s: Reconnect with Stripe link */
+					esc_html__( 'We could not reach Stripe with the saved keys. %s', 'paid-memberships-pro' ),
+					$reconnect_link
+				),
+			);
+		}
+
+		echo wp_json_encode(
+			array(
+				'success' => true,
+				'results' => $results,
+			)
+		); // Message HTML escaped above.
+		exit;
+	}
+
+	/**
+	 * Build the Stripe Connect authorization URL.
+	 *
+	 * @param string $gateway_environment 'live' or 'sandbox'.
+	 * @return string
+	 */
+	private static function get_connect_authorize_url( $gateway_environment ) {
+		$environment2 = ( 'live' === $gateway_environment ) ? 'live' : 'test';
+		$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
+
+		return add_query_arg(
+			array(
+				'action' => 'authorize',
+				'gateway_environment' => $environment2,
+				'return_url' => rawurlencode(
+					add_query_arg(
+						array(
+							'page' => 'pmpro-paymentsettings',
+							'edit_gateway' => 'stripe',
+							'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ),
+						),
+						admin_url( 'admin.php' )
+					)
+				),
+			),
+			$connect_url_base
+		);
+	}
+
+	/**
+	 * Test a Stripe Connect secret with a cheap authenticated GET.
+	 *
+	 * @param string $secretkey Connect secret stored in options.
+	 * @return bool True if the key authenticates. Transient/network errors return true so we do not nag.
+	 */
+	private static function connect_secretkey_is_valid( $secretkey ) {
+		if ( empty( $secretkey ) ) {
+			return false;
+		}
+
+		self::loadStripeLibrary();
+
+		try {
+			$stripe  = new Stripe_Client( $secretkey );
+			$account = $stripe->accounts->retrieve();
+			return ( ! empty( $account ) && ! empty( $account->id ) );
+		} catch ( \Stripe\Exception\AuthenticationException $e ) {
+			return false;
+		} catch ( \Stripe\Exception\PermissionException $e ) {
+			return false;
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			$status = (int) $e->getHttpStatus();
+			if ( in_array( $status, array( 401, 403 ), true ) ) {
+				return false;
+			}
+			return true;
+		} catch ( \Throwable $e ) {
+			return true;
+		}
 	}
 
 	/**
@@ -2982,6 +3102,9 @@ class PMProGateway_stripe extends PMProGateway {
 									);
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
+									<div id="pmpro_stripe_connect_key_health_<?php echo esc_attr( $environment ); ?>" class="notice notice-error inline pmpro_stripe_connect_key_health" style="display: none;">
+										<p></p>
+									</div>
 									<p class="description">
 										<?php
 										if ( $livemode ) {
@@ -2993,14 +3116,7 @@ class PMProGateway_stripe extends PMProGateway {
 									</p>
 									<?php
 								} else {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'authorize',
-											'gateway_environment' => $environment2,
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
+									$connect_url = self::get_connect_authorize_url( $environment );
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Connect with Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1705,7 +1705,7 @@ class PMProGateway_stripe extends PMProGateway {
 		?>
 		<div class="notice notice-error inline">
 			<p><strong><?php esc_html_e( 'Important:', 'paid-memberships-pro' ); ?></strong> <?php esc_html_e( 'We recommend that you reconnect your Stripe connection.', 'paid-memberships-pro' ); ?></p>
-			<p>
+			<p class="pmpro_stripe_reconnect_actions">
 				<a href="<?php echo esc_url( $reconnect_url ); ?>" class="button button-primary pmpro_stripe_reconnect"><span class="dashicons dashicons-update-alt"></span> <?php esc_html_e( 'Reconnect', 'paid-memberships-pro' ); ?></a>
 				<a href="https://www.paidmembershipspro.com/blog/" class="button button-secondary" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn More', 'paid-memberships-pro' ); ?></a>
 			</p>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1702,31 +1702,15 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) {
 			return;
 		}
-
-		$allowed_html = array(
-			'div'    => array(
-				'class' => array(),
-			),
-			'p'      => array(),
-			'strong' => array(),
-			'a'      => array(
-				'href'   => array(),
-				'target' => array(),
-				'rel'    => array(),
-			),
-		);
-
-		$message = sprintf(
-			/* translators: 1: reconnect URL, 2: learn-more URL */
-			__( '<strong>Important:</strong> We recommend that you reconnect your Stripe connection. <a href="%1$s">Click here to reconnect</a>. <a href="%2$s" target="_blank" rel="noopener noreferrer">Click here to learn why reconnection is recommended</a>.', 'paid-memberships-pro' ),
-			esc_url( $reconnect_url ),
-			'https://www.paidmembershipspro.com/blog/'
-		);
-
-		echo wp_kses(
-			'<div class="notice notice-error inline"><p>' . $message . '</p></div>',
-			$allowed_html
-		);
+		?>
+		<div class="notice notice-error inline">
+			<p><strong><?php esc_html_e( 'Important:', 'paid-memberships-pro' ); ?></strong> <?php esc_html_e( 'We recommend that you reconnect your Stripe connection.', 'paid-memberships-pro' ); ?></p>
+			<p>
+				<a href="<?php echo esc_url( $reconnect_url ); ?>" class="button button-primary"><span class="dashicons dashicons-update-alt" style="vertical-align: text-bottom;"></span> <?php esc_html_e( 'Reconnect', 'paid-memberships-pro' ); ?></a>
+				<a href="https://www.paidmembershipspro.com/blog/" class="button button-secondary" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn More', 'paid-memberships-pro' ); ?></a>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**
@@ -2880,11 +2864,13 @@ class PMProGateway_stripe extends PMProGateway {
 							'action' => 'disconnect',
 							'gateway_environment' => $environment2,
 							'stripe_user_id' => $values[ $environment . '_stripe_connect_user_id'],
-							'key_hash' => hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ),
 							'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
 						),
 						$connect_url_base
 					);
+					if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) {
+						$connect_url = add_query_arg( 'key_hash', hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ), $connect_url );
+					}
 					?>
 					<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 					<?php
@@ -3041,11 +3027,13 @@ class PMProGateway_stripe extends PMProGateway {
 											'action' => 'disconnect',
 											'gateway_environment' => $environment2,
 											'stripe_user_id' => get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' ),
-											'key_hash' => hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ),
 											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
 										),
 										$connect_url_base
 									);
+									if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) {
+										$connect_url = add_query_arg( 'key_hash', hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ), $connect_url );
+									}
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1706,7 +1706,7 @@ class PMProGateway_stripe extends PMProGateway {
 		<div class="notice notice-error inline">
 			<p><strong><?php esc_html_e( 'Important:', 'paid-memberships-pro' ); ?></strong> <?php esc_html_e( 'We recommend that you reconnect your Stripe connection.', 'paid-memberships-pro' ); ?></p>
 			<p>
-				<a href="<?php echo esc_url( $reconnect_url ); ?>" class="button button-primary"><span class="dashicons dashicons-update-alt" style="vertical-align: text-bottom;"></span> <?php esc_html_e( 'Reconnect', 'paid-memberships-pro' ); ?></a>
+				<a href="<?php echo esc_url( $reconnect_url ); ?>" class="button button-primary pmpro_stripe_reconnect"><span class="dashicons dashicons-update-alt"></span> <?php esc_html_e( 'Reconnect', 'paid-memberships-pro' ); ?></a>
 				<a href="https://www.paidmembershipspro.com/blog/" class="button button-secondary" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn More', 'paid-memberships-pro' ); ?></a>
 			</p>
 		</div>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1678,6 +1678,7 @@ class PMProGateway_stripe extends PMProGateway {
 			return;
 		}
 
+
 		if ( $_REQUEST['pmpro_stripe_disconnected_environment'] === 'live' ) {
 			// Delete live keys.
 			delete_option( 'pmpro_live_stripe_connect_user_id' );
@@ -1691,6 +1692,41 @@ class PMProGateway_stripe extends PMProGateway {
 			delete_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
 			delete_option( 'pmpro_sandbox_stripe_connect_hashed' );
 		}
+	}
+
+	/**
+	 * Prompt reconnect when this connection predates hashed disconnect protection.
+	 * Reconnect (authorize again) issues new keys without deauthorizing other sites.
+	 */
+	private function maybe_show_stripe_reconnect_notice( $environment, $reconnect_url ) {
+		if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) {
+			return;
+		}
+
+		$allowed_html = array(
+			'div'    => array(
+				'class' => array(),
+			),
+			'p'      => array(),
+			'strong' => array(),
+			'a'      => array(
+				'href'   => array(),
+				'target' => array(),
+				'rel'    => array(),
+			),
+		);
+
+		$message = sprintf(
+			/* translators: 1: reconnect URL, 2: learn-more URL */
+			__( '<strong>Important:</strong> We recommend that you reconnect your Stripe connection. <a href="%1$s">Click here to reconnect</a>. <a href="%2$s" target="_blank" rel="noopener noreferrer">Click here to learn why reconnection is recommended</a>.', 'paid-memberships-pro' ),
+			esc_url( $reconnect_url ),
+			'https://www.paidmembershipspro.com/blog/'
+		);
+
+		echo wp_kses(
+			'<div class="notice notice-error inline"><p>' . $message . '</p></div>',
+			$allowed_html
+		);
 	}
 
 	/**
@@ -2851,6 +2887,18 @@ class PMProGateway_stripe extends PMProGateway {
 					);
 					?>
 					<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
+					<?php
+					$reconnect_url = add_query_arg(
+						array(
+							'action' => 'authorize',
+							'gateway_environment' => $environment2,
+							'supports_hash' => '1',
+							'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
+						),
+						$connect_url_base
+					);
+					$this->maybe_show_stripe_reconnect_notice( $environment, $reconnect_url );
+					?>
 					<p class="description">
 						<?php
 						if ( $livemode ) {
@@ -3000,6 +3048,18 @@ class PMProGateway_stripe extends PMProGateway {
 									);
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
+									<?php
+									$reconnect_url = add_query_arg(
+										array(
+											'action' => 'authorize',
+											'gateway_environment' => $environment2,
+											'supports_hash' => '1',
+											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
+										),
+										$connect_url_base
+									);
+									$this->maybe_show_stripe_reconnect_notice( $environment, $reconnect_url );
+									?>
 									<p class="description">
 										<?php
 										if ( $livemode ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1574,16 +1574,23 @@ class PMProGateway_stripe extends PMProGateway {
 			$error = __( 'Invalid response from the Stripe Connect server.', 'paid-memberships-pro' );
 		} else {
 			// Update keys.
+			$hashed = isset( $_REQUEST['pmpro_stripe_connect_hashed'] ) && 'true' === $_REQUEST['pmpro_stripe_connect_hashed'];
 			if ( $_REQUEST['pmpro_stripe_connected_environment'] === 'live' ) {
 				// Update live keys.
 				update_option( 'pmpro_live_stripe_connect_user_id', $_REQUEST['pmpro_stripe_user_id'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				update_option( 'pmpro_live_stripe_connect_secretkey', $_REQUEST['pmpro_stripe_access_token'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				update_option( 'pmpro_live_stripe_connect_publishablekey', $_REQUEST['pmpro_stripe_publishable_key'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				if ( $hashed ) {
+					update_option( 'pmpro_live_stripe_connect_hashed', true );
+				}
 			} else {
 				// Update sandbox keys.
 				update_option( 'pmpro_sandbox_stripe_connect_user_id', $_REQUEST['pmpro_stripe_user_id'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				update_option( 'pmpro_sandbox_stripe_connect_secretkey', $_REQUEST['pmpro_stripe_access_token'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				update_option( 'pmpro_sandbox_stripe_connect_publishablekey', $_REQUEST['pmpro_stripe_publishable_key'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				if ( $hashed ) {
+					update_option( 'pmpro_sandbox_stripe_connect_hashed', true );
+				}
 			}
 
 
@@ -1596,6 +1603,7 @@ class PMProGateway_stripe extends PMProGateway {
 			unset( $_GET['pmpro_stripe_user_id'] );
 			unset( $_GET['pmpro_stripe_access_token'] );
 			unset( $_GET['pmpro_stripe_publishable_key'] );
+			unset( $_GET['pmpro_stripe_connect_hashed'] );
 
 			// Set up a webhook if needed.
 			$stripe = new PMProGateway_stripe();
@@ -1665,16 +1673,23 @@ class PMProGateway_stripe extends PMProGateway {
 
 		}
 
+		// Only wipe local Connect credentials after a confirmed disconnect.
+		if ( 'true' !== $_REQUEST['pmpro_stripe_disconnected'] ) {
+			return;
+		}
+
 		if ( $_REQUEST['pmpro_stripe_disconnected_environment'] === 'live' ) {
 			// Delete live keys.
 			delete_option( 'pmpro_live_stripe_connect_user_id' );
 			delete_option( 'pmpro_live_stripe_connect_secretkey' );
 			delete_option( 'pmpro_live_stripe_connect_publishablekey' );
+			delete_option( 'pmpro_live_stripe_connect_hashed' );
 		} else {
 			// Delete sandbox keys.
 			delete_option( 'pmpro_sandbox_stripe_connect_user_id' );
 			delete_option( 'pmpro_sandbox_stripe_connect_secretkey' );
 			delete_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
+			delete_option( 'pmpro_sandbox_stripe_connect_hashed' );
 		}
 	}
 
@@ -2829,6 +2844,7 @@ class PMProGateway_stripe extends PMProGateway {
 							'action' => 'disconnect',
 							'gateway_environment' => $environment2,
 							'stripe_user_id' => $values[ $environment . '_stripe_connect_user_id'],
+							'key_hash' => hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ),
 							'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
 						),
 						$connect_url_base
@@ -2850,6 +2866,7 @@ class PMProGateway_stripe extends PMProGateway {
 						array(
 							'action' => 'authorize',
 							'gateway_environment' => $environment2,
+							'supports_hash' => '1',
 							'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
 						),
 						$connect_url_base
@@ -2976,6 +2993,7 @@ class PMProGateway_stripe extends PMProGateway {
 											'action' => 'disconnect',
 											'gateway_environment' => $environment2,
 											'stripe_user_id' => get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' ),
+											'key_hash' => hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ),
 											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
 										),
 										$connect_url_base
@@ -2997,6 +3015,7 @@ class PMProGateway_stripe extends PMProGateway {
 										array(
 											'action' => 'authorize',
 											'gateway_environment' => $environment2,
+											'supports_hash' => '1',
 											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
 										),
 										$connect_url_base

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1205,10 +1205,10 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * AJAX callback to test saved Stripe Connect keys against the Stripe API.
+	 * AJAX callback to test saved Stripe keys against the Stripe API.
 	 *
-	 * Secrets stay on the server. Success is silent; auth failures return
-	 * a reconnect URL for the payment settings page.
+	 * Secrets stay on the server. Success is silent. Connect auth failures
+	 * get a reconnect URL; API-key failures ask the admin to check the Restricted Key.
 	 */
 	public static function wp_ajax_pmpro_stripe_check_connect_keys() {
 		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
@@ -1232,25 +1232,36 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		$results = array();
-		foreach ( array( 'live', 'sandbox' ) as $environment ) {
-			if ( ! self::has_connect_credentials( $environment ) ) {
-				continue;
-			}
 
-			if ( self::connect_secretkey_is_valid( get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ) {
-				continue;
+		// API keys take precedence over Connect for Stripe calls — only test the keys actually used.
+		if ( self::using_api_keys() ) {
+			if ( ! self::connect_secretkey_is_valid( get_option( 'pmpro_stripe_secretkey' ) ) ) {
+				$results['api'] = array(
+					'success' => false,
+					'message' => esc_html__( 'We could not reach Stripe with the saved API keys. Check your Restricted Key.', 'paid-memberships-pro' ),
+				);
 			}
+		} else {
+			foreach ( array( 'live', 'sandbox' ) as $environment ) {
+				if ( ! self::has_connect_credentials( $environment ) ) {
+					continue;
+				}
 
-			$reconnect_url = self::get_connect_authorize_url( $environment );
-			$reconnect_link = '<a href="' . esc_url( $reconnect_url ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>';
-			$results[ $environment ] = array(
-				'success' => false,
-				'message' => sprintf(
-					/* translators: %s: Reconnect with Stripe link */
-					esc_html__( 'We could not reach Stripe with the saved keys. %s', 'paid-memberships-pro' ),
-					$reconnect_link
-				),
-			);
+				if ( self::connect_secretkey_is_valid( get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ) {
+					continue;
+				}
+
+				$reconnect_url = self::get_connect_authorize_url( $environment );
+				$reconnect_link = '<a href="' . esc_url( $reconnect_url ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>';
+				$results[ $environment ] = array(
+					'success' => false,
+					'message' => sprintf(
+						/* translators: %s: Reconnect with Stripe link */
+						esc_html__( 'We could not reach Stripe with the saved keys. %s', 'paid-memberships-pro' ),
+						$reconnect_link
+					),
+				);
+			}
 		}
 
 		echo wp_json_encode(
@@ -1292,9 +1303,9 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Test a Stripe Connect secret with a cheap authenticated GET.
+	 * Test a Stripe secret (Connect or Restricted Key) with a cheap authenticated GET.
 	 *
-	 * @param string $secretkey Connect secret stored in options.
+	 * @param string $secretkey Secret stored in options.
 	 * @return bool True if the key authenticates. Transient/network errors return true so we do not nag.
 	 */
 	private static function connect_secretkey_is_valid( $secretkey ) {
@@ -3198,6 +3209,9 @@ class PMProGateway_stripe extends PMProGateway {
 									</th>
 									<td>
 										<input type="text" id="stripe_secretkey" name="stripe_secretkey" value="<?php echo esc_attr( $secret_key ) ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
+										<div id="pmpro_stripe_api_key_health" class="notice notice-error inline pmpro_stripe_connect_key_health" style="display: none; margin-top: 8px;">
+											<p></p>
+										</div>
 									</td>
 								</tr>
 							</tbody>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -172,6 +172,7 @@ class PMProGateway_stripe extends PMProGateway {
 
 		// Stripe Connect functions.
 		add_action( 'admin_init', array( 'PMProGateway_stripe', 'stripe_connect_save_options' ) );
+		add_action( 'admin_init', array( 'PMProGateway_stripe', 'stripe_connect_clear_local' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_show_errors' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_deauthorize' ) );
 
@@ -1236,9 +1237,14 @@ class PMProGateway_stripe extends PMProGateway {
 		// API keys take precedence over Connect for Stripe calls — only test the keys actually used.
 		if ( self::using_api_keys() ) {
 			if ( ! self::connect_secretkey_is_valid( get_option( 'pmpro_stripe_secretkey' ) ) ) {
+				$docs_link = '<a href="' . esc_url( 'https://www.paidmembershipspro.com/gateway/stripe/switch-legacy-to-connect/' ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Check your Restricted Key', 'paid-memberships-pro' ) . '</a>';
 				$results['api'] = array(
 					'success' => false,
-					'message' => esc_html__( 'We could not reach Stripe with the saved API keys. Check your Restricted Key.', 'paid-memberships-pro' ),
+					'message' => sprintf(
+						/* translators: %s: Check your Restricted Key link */
+						esc_html__( 'We could not reach Stripe with the saved API keys. %s', 'paid-memberships-pro' ),
+						$docs_link
+					),
 				);
 			}
 		} else {
@@ -1311,7 +1317,8 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return bool True if the key authenticates. Transient/network errors return true so we do not nag.
 	 */
 	private static function connect_secretkey_is_valid( $secretkey ) {
-		if ( empty( $secretkey ) ) {
+		$secretkey = trim( (string) $secretkey );
+		if ( '' === $secretkey ) {
 			return false;
 		}
 
@@ -1324,6 +1331,8 @@ class PMProGateway_stripe extends PMProGateway {
 		} catch ( \Stripe\Exception\AuthenticationException $e ) {
 			return false;
 		} catch ( \Stripe\Exception\PermissionException $e ) {
+			return false;
+		} catch ( \InvalidArgumentException $e ) {
 			return false;
 		} catch ( \Stripe\Exception\ApiErrorException $e ) {
 			$status = (int) $e->getHttpStatus();
@@ -1804,6 +1813,22 @@ class PMProGateway_stripe extends PMProGateway {
 			);
 			echo wp_kses( sprintf( '<div class="%1$s"><p>%2$s</p></div>', $class, $message ), $allowed_html );
 
+			$environment = ( isset( $_REQUEST['pmpro_stripe_disconnected_environment'] ) && 'live' === $_REQUEST['pmpro_stripe_disconnected_environment'] ) ? 'live' : 'sandbox';
+			$reconnect_url = self::get_connect_authorize_url( $environment );
+			?>
+			<div class="notice notice-warning pmpro-stripe-disconnect-message">
+				<p class="pmpro_stripe_reconnect_actions">
+					<a href="<?php echo esc_url( $reconnect_url ); ?>" class="button button-primary pmpro_stripe_reconnect"><span class="dashicons dashicons-update-alt"></span> <?php esc_html_e( 'Reconnect with Stripe', 'paid-memberships-pro' ); ?></a>
+					<button type="submit" form="pmpro_stripe_clear_connect_<?php echo esc_attr( $environment ); ?>" class="button button-secondary"><?php esc_html_e( 'Remove connection from this site', 'paid-memberships-pro' ); ?></button>
+				</p>
+			</div>
+			<form id="pmpro_stripe_clear_connect_<?php echo esc_attr( $environment ); ?>" method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=pmpro-paymentsettings&edit_gateway=stripe' ) ); ?>">
+				<?php wp_nonce_field( 'pmpro_stripe_clear_connect', 'pmpro_stripe_clear_connect_nonce' ); ?>
+				<input type="hidden" name="pmpro_stripe_clear_connect" value="1" />
+				<input type="hidden" name="environment" value="<?php echo esc_attr( $environment ); ?>" />
+			</form>
+			<?php
+
 		}
 
 		// Only wipe local Connect credentials after a confirmed disconnect.
@@ -1828,6 +1853,31 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
+	 * Drop local Connect options without calling Stripe.
+	 * Used when disconnect is refused but this site still needs to clear keys.
+	 */
+	public static function stripe_connect_clear_local() {
+		if ( empty( $_POST['pmpro_stripe_clear_connect'] ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		if ( empty( $_POST['pmpro_stripe_clear_connect_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['pmpro_stripe_clear_connect_nonce'] ), 'pmpro_stripe_clear_connect' ) ) {
+			return;
+		}
+
+		$environment = ( isset( $_POST['environment'] ) && 'live' === $_POST['environment'] ) ? 'live' : 'sandbox';
+		delete_option( 'pmpro_' . $environment . '_stripe_connect_user_id' );
+		delete_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' );
+		delete_option( 'pmpro_' . $environment . '_stripe_connect_publishablekey' );
+		delete_option( 'pmpro_' . $environment . '_stripe_connect_hashed' );
+
+		wp_safe_redirect( admin_url( 'admin.php?page=pmpro-paymentsettings&edit_gateway=stripe' ) );
+		exit;
+	}
+
+	/**
 	 * Prompt reconnect when this connection predates hashed disconnect protection.
 	 * Reconnect (authorize again) issues new keys without deauthorizing other sites.
 	 */
@@ -1843,6 +1893,36 @@ class PMProGateway_stripe extends PMProGateway {
 				<a href="https://www.paidmembershipspro.com/blog/" class="button button-secondary" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn More', 'paid-memberships-pro' ); ?></a>
 			</p>
 		</div>
+		<?php
+	}
+
+	/**
+	 * Disconnect posts key_hash so it does not land in access logs or copied URLs.
+	 *
+	 * @param string $environment 'live' or 'sandbox'.
+	 */
+	private function show_stripe_disconnect_button( $environment ) {
+		$environment2 = ( 'live' === $environment ) ? 'live' : 'test';
+		$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
+		$action_url = add_query_arg( 'action', 'disconnect', $connect_url_base );
+		$return_url = add_query_arg(
+			array(
+				'page' => 'pmpro-paymentsettings',
+				'edit_gateway' => 'stripe',
+				'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ),
+			),
+			admin_url( 'admin.php' )
+		);
+		?>
+		<form method="post" action="<?php echo esc_url( $action_url ); ?>" class="pmpro_stripe_disconnect_form">
+			<input type="hidden" name="gateway_environment" value="<?php echo esc_attr( $environment2 ); ?>" />
+			<input type="hidden" name="stripe_user_id" value="<?php echo esc_attr( get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' ) ); ?>" />
+			<input type="hidden" name="return_url" value="<?php echo esc_attr( $return_url ); ?>" />
+			<?php if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) { ?>
+				<input type="hidden" name="key_hash" value="<?php echo esc_attr( hash( 'sha256', (string) get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ); ?>" />
+			<?php } ?>
+			<button type="submit" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></button>
+		</form>
 		<?php
 	}
 
@@ -2992,20 +3072,8 @@ class PMProGateway_stripe extends PMProGateway {
 				<?php
 				$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
 				if ( self::has_connect_credentials( $environment ) ) {
-					$connect_url = add_query_arg(
-						array(
-							'action' => 'disconnect',
-							'gateway_environment' => $environment2,
-							'stripe_user_id' => $values[ $environment . '_stripe_connect_user_id'],
-							'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
-						),
-						$connect_url_base
-					);
-					if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) {
-						$connect_url = add_query_arg( 'key_hash', hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ), $connect_url );
-					}
+					$this->show_stripe_disconnect_button( $environment );
 					?>
-					<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 					<?php
 					$reconnect_url = add_query_arg(
 						array(
@@ -3155,20 +3223,8 @@ class PMProGateway_stripe extends PMProGateway {
 								<?php
 								$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
 								if ( self::has_connect_credentials( $environment ) ) {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'disconnect',
-											'gateway_environment' => $environment2,
-											'stripe_user_id' => get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' ),
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
-									if ( get_option( 'pmpro_' . $environment . '_stripe_connect_hashed' ) ) {
-										$connect_url = add_query_arg( 'key_hash', hash( 'sha256', get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ), $connect_url );
-									}
+									$this->show_stripe_disconnect_button( $environment );
 									?>
-									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<div id="pmpro_stripe_connect_key_health_<?php echo esc_attr( $environment ); ?>" class="notice notice-error inline pmpro_stripe_connect_key_health" style="display: none;">
 										<p></p>
 									</div>

--- a/css/admin.css
+++ b/css/admin.css
@@ -2487,7 +2487,8 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	gap: 5px;
 }
 
-.wp-core-ui .pmpro_admin-pmpro-paymentsettings #pmpro_stripe_create_webhook .dashicons {
+.wp-core-ui .pmpro_admin-pmpro-paymentsettings #pmpro_stripe_create_webhook .dashicons,
+.wp-core-ui .pmpro_admin-pmpro-paymentsettings .pmpro_stripe_reconnect .dashicons {
 	line-height: 1;
 }
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -2487,6 +2487,13 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	gap: 5px;
 }
 
+.pmpro_admin-pmpro-paymentsettings .pmpro_stripe_reconnect_actions {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
 .pmpro_admin-pmpro-paymentsettings .pmpro_stripe_reconnect {
 	align-items: center;
 	display: inline-flex;

--- a/css/admin.css
+++ b/css/admin.css
@@ -2487,6 +2487,12 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	gap: 5px;
 }
 
+.pmpro_admin-pmpro-paymentsettings .pmpro_stripe_reconnect {
+	align-items: center;
+	display: inline-flex;
+	gap: 5px;
+}
+
 .wp-core-ui .pmpro_admin-pmpro-paymentsettings #pmpro_stripe_create_webhook .dashicons,
 .wp-core-ui .pmpro_admin-pmpro-paymentsettings .pmpro_stripe_reconnect .dashicons {
 	line-height: 1;

--- a/css/admin.css
+++ b/css/admin.css
@@ -2387,6 +2387,18 @@ table.pmprommpu_levels tr.remove_level td {background: #F2DEDE; }
 	color: var(--pmpro--color--alert-text);
 }
 
+.pmpro_admin-pmpro-paymentsettings .pmpro_stripe_disconnect_form {
+	display: inline-block;
+	margin: 0;
+}
+
+.pmpro_admin-pmpro-paymentsettings button.pmpro-stripe-connect {
+	appearance: none;
+	-webkit-appearance: none;
+	color: inherit;
+	font: inherit;
+}
+
 .pmpro_admin-pmpro-paymentsettings .pmpro-stripe-connect {
 	background-image: -webkit-linear-gradient(#28A0E5, #015E94);
 	background-image: -moz-linear-gradient(#28A0E5, #015E94);

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -157,6 +157,7 @@ function pmpro_admin_enqueue_scripts() {
 			'all_level_values_and_labels' => $all_level_values_and_labels,
 			'checkout_url' => pmpro_url( 'checkout' ),
 			'stripe_webhook_nonce' => wp_create_nonce( 'pmpro_stripe_webhook_nonce' ),
+			'stripe_connect_key_health_nonce' => wp_create_nonce( 'pmpro_stripe_connect_key_health' ),
 			'user_fields_blank_group' => $empty_field_group_html,
 			'user_fields_blank_field' => $empty_field_html,
 			// We want the core WP translation so we can check for it in JS.

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -385,8 +385,9 @@ jQuery(document).ready(function () {
 });
 
 /*
- * Test saved Stripe Connect keys after the payment settings page loads.
- * Secrets are never sent to the browser; failures get an inline reconnect link.
+ * Test saved Stripe keys after the payment settings page loads.
+ * Secrets are never sent to the browser. Connect failures get a reconnect link;
+ * API-key failures ask the admin to check the Restricted Key.
  */
 jQuery(document).ready(function () {
 	if (!jQuery('.pmpro_stripe_connect_key_health').length || typeof pmpro === 'undefined' || !pmpro.stripe_connect_key_health_nonce) {
@@ -416,9 +417,15 @@ jQuery(document).ready(function () {
 					return;
 				}
 
-				var notice = jQuery('#pmpro_stripe_connect_key_health_' + environment);
+				var notice = (environment === 'api')
+					? jQuery('#pmpro_stripe_api_key_health')
+					: jQuery('#pmpro_stripe_connect_key_health_' + environment);
 				if (!notice.length) {
 					return;
+				}
+
+				if (environment === 'api') {
+					jQuery('.pmpro_stripe_legacy_keys').show();
 				}
 
 				notice.children('p').html(result.message);

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -396,6 +396,7 @@ jQuery(document).ready(function () {
 
 	jQuery.ajax({
 		type: 'POST',
+		timeout: 15000,
 		data: {
 			action: 'pmpro_stripe_check_connect_keys',
 			nonce: pmpro.stripe_connect_key_health_nonce

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -384,6 +384,61 @@ jQuery(document).ready(function () {
 	});
 });
 
+/*
+ * Test saved Stripe Connect keys after the payment settings page loads.
+ * Secrets are never sent to the browser; failures get an inline reconnect link.
+ */
+jQuery(document).ready(function () {
+	if (!jQuery('.pmpro_stripe_connect_key_health').length || typeof pmpro === 'undefined' || !pmpro.stripe_connect_key_health_nonce) {
+		return;
+	}
+
+	jQuery.ajax({
+		type: 'POST',
+		data: {
+			action: 'pmpro_stripe_check_connect_keys',
+			nonce: pmpro.stripe_connect_key_health_nonce
+		},
+		url: ajaxurl,
+		success: function (response) {
+			try {
+				response = (typeof response === 'string') ? jQuery.parseJSON(response) : response;
+			} catch (e) {
+				return;
+			}
+
+			if (!response || !response.results) {
+				return;
+			}
+
+			jQuery.each(response.results, function (environment, result) {
+				if (!result || result.success !== false || !result.message) {
+					return;
+				}
+
+				var notice = jQuery('#pmpro_stripe_connect_key_health_' + environment);
+				if (!notice.length) {
+					return;
+				}
+
+				notice.children('p').html(result.message);
+				notice.show();
+
+				var section = notice.closest('.pmpro_section');
+				var thebutton = section.find('button.pmpro_section-toggle-button');
+				var buttonicon = thebutton.children('.dashicons');
+				var sectioninside = section.children('.pmpro_section_inside');
+				if (buttonicon.hasClass('dashicons-arrow-down-alt2')) {
+					sectioninside.show();
+					buttonicon.removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
+					section.attr('data-visibility', 'shown');
+					thebutton.attr('aria-expanded', 'true');
+				}
+			});
+		}
+	});
+});
+
 // Disable the webhook buttons if the API keys aren't complete yet.
 function pmpro_stripe_check_api_keys() {
 	if ((jQuery('#stripe_publishablekey').val().length > 0 && jQuery('#stripe_secretkey').val().length > 0) || jQuery('#live_stripe_connect_secretkey').val().length > 0) {


### PR DESCRIPTION
## Description
Combines hashed Connect disconnect protection with a payment-settings key health check.

When a site Connects, we send `supports_hash=1`. The Connect server stores `sha256(access_token)`. Disconnect sends `key_hash` only if this site is hashed. Mismatch does not deauthorize other sites — reconnect instead.

After Payment settings load, we ping Stripe `GET /v1/customers?limit=1` with the keys actually used (API keys take precedence over Connect). That is a permission PMPro actually needs; Restricted Keys usually cannot `GET /v1/account`. An empty Stripe account still returns a list, so we only care that the key authenticates. Auth failures show an inline notice. Connect: **Reconnect with Stripe** (same authorize URL, including `supports_hash`). Restricted Key: **Check your Restricted Key**. Working keys stay quiet. Secrets never hit the browser.

This supersedes #3776 (merged into this branch).

## Files
- `classes/gateways/class.pmprogateway_stripe.php`
- `css/admin.css`
- `includes/scripts.php`
- `js/pmpro-admin.js`

## To Test
**Hash handshake**
1. Connect on a site running this branch. `pmpro_{live|sandbox}_stripe_connect_hashed` is set. Disconnect URL includes `key_hash`.
2. Second site, same Stripe account, unhashed: Disconnect is refused. Reconnect notice with Reconnect / Learn More.
3. Reconnect on the unhashed site issues new keys without deauthorizing the first site.

**Key health**
1. Valid Connect keys: AJAX returns empty results, no banner.
2. Flip one character of the Connect secret: inline error + Reconnect with Stripe.
3. Restricted Key path: same ping (`customers?limit=1`), copy is “Check your Restricted Key”, no reconnect link. Empty Stripe account (no customers) must stay quiet.