### PR TITLE
ENHANCEMENT: Detect invalid Stripe Connect keys and offer reconnect

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -131,6 +131,7 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'wp_ajax_pmpro_stripe_create_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_create_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_delete_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_delete_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_rebuild_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_rebuild_webhook' ) );
+		add_action( 'wp_ajax_pmpro_stripe_check_connect_keys', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_check_connect_keys' ) );
 
 		//code to add at checkout if Stripe is the current gateway
 		$default_gateway = get_option( 'pmpro_gateway' );
@@ -1201,6 +1202,125 @@ class PMProGateway_stripe extends PMProGateway {
 
 		echo json_encode( $r ); // Values escaped above.
 		exit;
+	}
+
+	/**
+	 * AJAX callback to test saved Stripe Connect keys against the Stripe API.
+	 *
+	 * Secrets stay on the server. Success is silent; auth failures return
+	 * a reconnect URL for the payment settings page.
+	 */
+	public static function wp_ajax_pmpro_stripe_check_connect_keys() {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			echo wp_json_encode(
+				array(
+					'success' => false,
+					'results' => array(),
+				)
+			);
+			exit;
+		}
+
+		if ( false === check_ajax_referer( 'pmpro_stripe_connect_key_health', 'nonce', false ) ) {
+			echo wp_json_encode(
+				array(
+					'success' => false,
+					'results' => array(),
+				)
+			);
+			exit;
+		}
+
+		$results = array();
+		foreach ( array( 'live', 'sandbox' ) as $environment ) {
+			if ( ! self::has_connect_credentials( $environment ) ) {
+				continue;
+			}
+
+			if ( self::connect_secretkey_is_valid( get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ) {
+				continue;
+			}
+
+			$reconnect_url = self::get_connect_authorize_url( $environment );
+			$reconnect_link = '<a href="' . esc_url( $reconnect_url ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>';
+			$results[ $environment ] = array(
+				'success' => false,
+				'message' => sprintf(
+					/* translators: %s: Reconnect with Stripe link */
+					esc_html__( 'We could not reach Stripe with the saved keys. %s', 'paid-memberships-pro' ),
+					$reconnect_link
+				),
+			);
+		}
+
+		echo wp_json_encode(
+			array(
+				'success' => true,
+				'results' => $results,
+			)
+		); // Message HTML escaped above.
+		exit;
+	}
+
+	/**
+	 * Build the Stripe Connect authorization URL.
+	 *
+	 * @param string $gateway_environment 'live' or 'sandbox'.
+	 * @return string
+	 */
+	private static function get_connect_authorize_url( $gateway_environment ) {
+		$environment2 = ( 'live' === $gateway_environment ) ? 'live' : 'test';
+		$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
+
+		return add_query_arg(
+			array(
+				'action' => 'authorize',
+				'gateway_environment' => $environment2,
+				'return_url' => rawurlencode(
+					add_query_arg(
+						array(
+							'page' => 'pmpro-paymentsettings',
+							'edit_gateway' => 'stripe',
+							'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ),
+						),
+						admin_url( 'admin.php' )
+					)
+				),
+			),
+			$connect_url_base
+		);
+	}
+
+	/**
+	 * Test a Stripe Connect secret with a cheap authenticated GET.
+	 *
+	 * @param string $secretkey Connect secret stored in options.
+	 * @return bool True if the key authenticates. Transient/network errors return true so we do not nag.
+	 */
+	private static function connect_secretkey_is_valid( $secretkey ) {
+		if ( empty( $secretkey ) ) {
+			return false;
+		}
+
+		self::loadStripeLibrary();
+
+		try {
+			$stripe  = new Stripe_Client( $secretkey );
+			$account = $stripe->accounts->retrieve();
+			return ( ! empty( $account ) && ! empty( $account->id ) );
+		} catch ( \Stripe\Exception\AuthenticationException $e ) {
+			return false;
+		} catch ( \Stripe\Exception\PermissionException $e ) {
+			return false;
+		} catch ( \Stripe\Exception\ApiErrorException $e ) {
+			$status = (int) $e->getHttpStatus();
+			if ( in_array( $status, array( 401, 403 ), true ) ) {
+				return false;
+			}
+			return true;
+		} catch ( \Throwable $e ) {
+			return true;
+		}
 	}
 
 	/**
@@ -2982,6 +3102,9 @@ class PMProGateway_stripe extends PMProGateway {
 									);
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
+									<div id="pmpro_stripe_connect_key_health_<?php echo esc_attr( $environment ); ?>" class="notice notice-error inline pmpro_stripe_connect_key_health" style="display: none;">
+										<p></p>
+									</div>
 									<p class="description">
 										<?php
 										if ( $livemode ) {
@@ -2993,14 +3116,7 @@ class PMProGateway_stripe extends PMProGateway {
 									</p>
 									<?php
 								} else {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'authorize',
-											'gateway_environment' => $environment2,
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
+									$connect_url = self::get_connect_authorize_url( $environment );
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Connect with Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1205,10 +1205,10 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * AJAX callback to test saved Stripe Connect keys against the Stripe API.
+	 * AJAX callback to test saved Stripe keys against the Stripe API.
 	 *
-	 * Secrets stay on the server. Success is silent; auth failures return
-	 * a reconnect URL for the payment settings page.
+	 * Secrets stay on the server. Success is silent. Connect auth failures
+	 * get a reconnect URL; API-key failures ask the admin to check the Restricted Key.
 	 */
 	public static function wp_ajax_pmpro_stripe_check_connect_keys() {
 		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
@@ -1232,25 +1232,36 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		$results = array();
-		foreach ( array( 'live', 'sandbox' ) as $environment ) {
-			if ( ! self::has_connect_credentials( $environment ) ) {
-				continue;
-			}
 
-			if ( self::connect_secretkey_is_valid( get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ) {
-				continue;
+		// API keys take precedence over Connect for Stripe calls — only test the keys actually used.
+		if ( self::using_api_keys() ) {
+			if ( ! self::connect_secretkey_is_valid( get_option( 'pmpro_stripe_secretkey' ) ) ) {
+				$results['api'] = array(
+					'success' => false,
+					'message' => esc_html__( 'We could not reach Stripe with the saved API keys. Check your Restricted Key.', 'paid-memberships-pro' ),
+				);
 			}
+		} else {
+			foreach ( array( 'live', 'sandbox' ) as $environment ) {
+				if ( ! self::has_connect_credentials( $environment ) ) {
+					continue;
+				}
 
-			$reconnect_url = self::get_connect_authorize_url( $environment );
-			$reconnect_link = '<a href="' . esc_url( $reconnect_url ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>';
-			$results[ $environment ] = array(
-				'success' => false,
-				'message' => sprintf(
-					/* translators: %s: Reconnect with Stripe link */
-					esc_html__( 'We could not reach Stripe with the saved keys. %s', 'paid-memberships-pro' ),
-					$reconnect_link
-				),
-			);
+				if ( self::connect_secretkey_is_valid( get_option( 'pmpro_' . $environment . '_stripe_connect_secretkey' ) ) ) {
+					continue;
+				}
+
+				$reconnect_url = self::get_connect_authorize_url( $environment );
+				$reconnect_link = '<a href="' . esc_url( $reconnect_url ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>';
+				$results[ $environment ] = array(
+					'success' => false,
+					'message' => sprintf(
+						/* translators: %s: Reconnect with Stripe link */
+						esc_html__( 'We could not reach Stripe with the saved keys. %s', 'paid-memberships-pro' ),
+						$reconnect_link
+					),
+				);
+			}
 		}
 
 		echo wp_json_encode(
@@ -1292,9 +1303,9 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Test a Stripe Connect secret with a cheap authenticated GET.
+	 * Test a Stripe secret (Connect or Restricted Key) with a cheap authenticated GET.
 	 *
-	 * @param string $secretkey Connect secret stored in options.
+	 * @param string $secretkey Secret stored in options.
 	 * @return bool True if the key authenticates. Transient/network errors return true so we do not nag.
 	 */
 	private static function connect_secretkey_is_valid( $secretkey ) {
@@ -3198,6 +3209,9 @@ class PMProGateway_stripe extends PMProGateway {
 									</th>
 									<td>
 										<input type="text" id="stripe_secretkey" name="stripe_secretkey" value="<?php echo esc_attr( $secret_key ) ?>" autocomplete="off" class="regular-text code pmpro-admin-secure-key" />
+										<div id="pmpro_stripe_api_key_health" class="notice notice-error inline pmpro_stripe_connect_key_health" style="display: none; margin-top: 8px;">
+											<p></p>
+										</div>
 									</td>
 								</tr>
 							</tbody>

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -157,6 +157,7 @@ function pmpro_admin_enqueue_scripts() {
 			'all_level_values_and_labels' => $all_level_values_and_labels,
 			'checkout_url' => pmpro_url( 'checkout' ),
 			'stripe_webhook_nonce' => wp_create_nonce( 'pmpro_stripe_webhook_nonce' ),
+			'stripe_connect_key_health_nonce' => wp_create_nonce( 'pmpro_stripe_connect_key_health' ),
 			'user_fields_blank_group' => $empty_field_group_html,
 			'user_fields_blank_field' => $empty_field_html,
 			// We want the core WP translation so we can check for it in JS.

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -385,8 +385,9 @@ jQuery(document).ready(function () {
 });
 
 /*
- * Test saved Stripe Connect keys after the payment settings page loads.
- * Secrets are never sent to the browser; failures get an inline reconnect link.
+ * Test saved Stripe keys after the payment settings page loads.
+ * Secrets are never sent to the browser. Connect failures get a reconnect link;
+ * API-key failures ask the admin to check the Restricted Key.
  */
 jQuery(document).ready(function () {
 	if (!jQuery('.pmpro_stripe_connect_key_health').length || typeof pmpro === 'undefined' || !pmpro.stripe_connect_key_health_nonce) {
@@ -416,9 +417,15 @@ jQuery(document).ready(function () {
 					return;
 				}
 
-				var notice = jQuery('#pmpro_stripe_connect_key_health_' + environment);
+				var notice = (environment === 'api')
+					? jQuery('#pmpro_stripe_api_key_health')
+					: jQuery('#pmpro_stripe_connect_key_health_' + environment);
 				if (!notice.length) {
 					return;
+				}
+
+				if (environment === 'api') {
+					jQuery('.pmpro_stripe_legacy_keys').show();
 				}
 
 				notice.children('p').html(result.message);

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -384,6 +384,61 @@ jQuery(document).ready(function () {
 	});
 });
 
+/*
+ * Test saved Stripe Connect keys after the payment settings page loads.
+ * Secrets are never sent to the browser; failures get an inline reconnect link.
+ */
+jQuery(document).ready(function () {
+	if (!jQuery('.pmpro_stripe_connect_key_health').length || typeof pmpro === 'undefined' || !pmpro.stripe_connect_key_health_nonce) {
+		return;
+	}
+
+	jQuery.ajax({
+		type: 'POST',
+		data: {
+			action: 'pmpro_stripe_check_connect_keys',
+			nonce: pmpro.stripe_connect_key_health_nonce
+		},
+		url: ajaxurl,
+		success: function (response) {
+			try {
+				response = (typeof response === 'string') ? jQuery.parseJSON(response) : response;
+			} catch (e) {
+				return;
+			}
+
+			if (!response || !response.results) {
+				return;
+			}
+
+			jQuery.each(response.results, function (environment, result) {
+				if (!result || result.success !== false || !result.message) {
+					return;
+				}
+
+				var notice = jQuery('#pmpro_stripe_connect_key_health_' + environment);
+				if (!notice.length) {
+					return;
+				}
+
+				notice.children('p').html(result.message);
+				notice.show();
+
+				var section = notice.closest('.pmpro_section');
+				var thebutton = section.find('button.pmpro_section-toggle-button');
+				var buttonicon = thebutton.children('.dashicons');
+				var sectioninside = section.children('.pmpro_section_inside');
+				if (buttonicon.hasClass('dashicons-arrow-down-alt2')) {
+					sectioninside.show();
+					buttonicon.removeClass('dashicons-arrow-down-alt2').addClass('dashicons-arrow-up-alt2');
+					section.attr('data-visibility', 'shown');
+					thebutton.attr('aria-expanded', 'true');
+				}
+			});
+		}
+	});
+});
+
 // Disable the webhook buttons if the API keys aren't complete yet.
 function pmpro_stripe_check_api_keys() {
 	if ((jQuery('#stripe_publishablekey').val().length > 0 && jQuery('#stripe_secretkey').val().length > 0) || jQuery('#live_stripe_connect_secretkey').val().length > 0) {


### PR DESCRIPTION
## Description
When Stripe credentials are saved, the payment settings page now tests those keys in the background. If Stripe rejects them (invalid key, 401/403), we show an inline error. Working keys stay quiet — no extra green banner.

This is separate from hashed Connect options (PR #3775).

## What it does
1. After Memberships → Settings → Payment (Stripe) loads, admin JS fires `pmpro_stripe_check_connect_keys`.
2. The AJAX handler never receives a secret. It reads the keys actually used from options and calls Stripe `GET /v1/account`.
3. If the site is using API keys (`pmpro_stripe_secretkey` + publishable key), only that Restricted Key is tested. Otherwise live and sandbox Connect secrets are tested when credentials exist.
4. Connect auth failures show: “We could not reach Stripe with the saved keys.” plus **Reconnect with Stripe** (same `action=authorize` URL as Connect with Stripe, including `pmpro_stripe_connect_nonce`).
5. API-key auth failures show: “We could not reach Stripe with the saved API keys. Check your Restricted Key.” No reconnect — that is a Connect action.
6. Transient/network errors do not nag. Page load is not blocked.

## Files
- `classes/gateways/class.pmprogateway_stripe.php`
- `includes/scripts.php`
- `js/pmpro-admin.js`

## To Test
**Connect happy path**
1. On flintdev.test, go to Memberships → Settings → Payment with Stripe Connect already connected (live and/or test).
2. Load the page. DevTools → Network: `admin-ajax.php?action=pmpro_stripe_check_connect_keys` returns `{ success: true, results: {} }`.
3. No extra success banner. Secret key is not in the AJAX request payload.

**Connect failure path**
1. Temporarily replace `pmpro_live_stripe_connect_secretkey` or `pmpro_sandbox_stripe_connect_secretkey` with garbage (keep user id + publishable key so Connect still looks connected).
2. Reload Payment settings.
3. Inline error appears under Disconnect From Stripe in that environment’s section (collapsed sections expand).
4. Reconnect with Stripe uses the same authorize URL as Connect with Stripe and completes a normal reconnect.

**API key / Restricted Key path**
1. Site using Restricted Keys (no Connect, or API keys taking precedence).
2. Load Payment settings. Valid keys stay quiet.
3. Replace `pmpro_stripe_secretkey` with garbage and reload.
4. Inline error under Restricted Key: check your Restricted Key. API key table is shown. No Reconnect with Stripe link.

**Also**
- Invalid keys should not break the rest of the settings page.