### PR TITLE
Fix Stripe Connect environment and error handling

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1648,6 +1648,7 @@ class PMProGateway_stripe extends PMProGateway {
 		if (
 			'false' === $_REQUEST['pmpro_stripe_disconnected']
 			&& isset( $_REQUEST['error_code'] )
+			&& isset( $_REQUEST['error_message'] )
 		) {
 
 			$class   = 'notice notice-warning pmpro-stripe-disconnect-message';
@@ -1872,7 +1873,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 */
 	public static function has_connect_credentials( $gateway_environment = null ) {
 		if ( empty( $gateway_environment ) ) {
-			$gateway_environment = get_option( 'pmpro_pmpro_gateway_environment' );
+			$gateway_environment = get_option( 'pmpro_gateway_environment' );
 		}
 
 		if ( $gateway_environment === 'live' ) {


### PR DESCRIPTION
## Description

Fix two pre-existing Stripe Connect bugs:

- Avoid reading a missing `error_message` parameter after a failed disconnect response.
- Read the actual `pmpro_gateway_environment` option when `has_connect_credentials()` uses its default environment. The previous double-prefixed option name made the no-argument call used by Site Health fall back to checking sandbox credentials.

## Testing

- `php -l classes/gateways/class.pmprogateway_stripe.php`
- `git diff --check`
- Verified the only no-argument caller is `PMPro_Site_Health::get_gateway()`; other callers pass `live` or `sandbox` explicitly.
