### PR TITLE
ENHANCEMENT: Change 'Edit Membership' button text to 'Update Membership'

### DIFF
--- a/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
+++ b/adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php
@@ -282,7 +282,7 @@ class PMPro_Member_Edit_Panel_Memberships extends PMPro_Member_Edit_Panel {
 									</div>
 
 									<div class="pmpro-level_change-action-footer">
-										<button type="submit" name="pmpro-member-edit-memberships-panel-edit_level" class="button button-primary" value="<?php echo (int)$shown_level->id; ?>"><?php esc_html_e( 'Edit Membership', 'paid-memberships-pro' ) ?></button>
+										<button type="submit" name="pmpro-member-edit-memberships-panel-edit_level" class="button button-primary" value="<?php echo (int)$shown_level->id; ?>"><?php esc_html_e( 'Update Membership', 'paid-memberships-pro' ) ?></button>
 										<input type="button" name="cancel-edit-level" value="<?php esc_attr_e( 'Close', 'paid-memberships-pro' ); ?>" class="button button-secondary">
 									</div>
 								</div> <!-- end pmpro-level_change-actions -->


### PR DESCRIPTION
## Summary
Renames the primary submit button in the member-edit memberships panel from "Edit Membership" to "Update Membership".

## The Issue
Admins/users found the "Edit Membership" button label confusing — it functions as the save/submit action for the level change form, not as an entry point into an edit mode. This led at least one user to click "Close" instead, losing their changes.

Discussed and agreed on in the [community forum thread](https://www.paidmembershipspro.com/forums/topic/enhancement-requests-to-the-ui-when-editing-an-accounts-membership-expiration/) by Kim White, Andrew Lima, and David Parker — consensus landed on "Update Membership".

## The Fix
One-line text change in `adminpages/member-edit/pmpro-class-member-edit-panel-memberships.php` (line 285): button label `Edit Membership` → `Update Membership`. The section heading ("Edit Membership") and row action ("Edit") are unchanged.

## Testing
1. In wp-admin, go to Users > edit a member with an active membership level.
2. Click "Edit" next to a membership level to expand the change form.
3. Confirm the primary submit button now reads "Update Membership".
4. Confirm clicking it still saves the level change as before.