### PR TITLE
Unwrap Liquid tags that TinyMCE wrapped in paragraph tags before rendering emails

### DIFF
--- a/classes/class-pmpro-liquid-renderer.php
+++ b/classes/class-pmpro-liquid-renderer.php
@@ -24,6 +24,9 @@ class PMPro_Liquid_Renderer {
 			return $content;
 		}
 
+		// Unwrap Liquid tags that a visual editor wrapped in paragraph tags.
+		$content = self::unautop( $content );
+
 		// Process conditionals first so we only render the winning branches.
 		$content = self::process_conditionals( $content, $data, $args );
 
@@ -31,6 +34,34 @@ class PMPro_Liquid_Renderer {
 		$content = self::process_output_tags( $content, $data, $args );
 
 		return $content;
+	}
+
+	/**
+	 * Remove paragraph tags that wrap nothing but Liquid tags.
+	 *
+	 * TinyMCE wraps bare text in <p> tags, so a template line that only contains
+	 * Liquid tags such as {% if %}, {{ variable }}, or {% endif %} is saved as
+	 * <p>{% endif %}</p>. Control tags render to nothing, so the paragraph would be
+	 * sent as an empty <p></p> or would split around the conditional and leave
+	 * unbalanced tags. This mirrors shortcode_unautop(). Paragraphs that contain
+	 * only output tags, like <p>{{ display_name }}</p>, are left alone.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $content The content to process.
+	 * @return string The content with paragraph tags around Liquid tags removed.
+	 */
+	private static function unautop( $content ) {
+		$tag_pattern = '(?:\{\{(?:(?!\}\}).)*\}\}|\{%(?:(?!%\}).)*%\})';
+
+		return preg_replace_callback(
+			'#<p>\s*((?:' . $tag_pattern . '\s*)+)</p>#s',
+			function ( $matches ) {
+				// Only unwrap when at least one control tag is present.
+				return ( strpos( $matches[1], '{%' ) !== false ) ? $matches[1] : $matches[0];
+			},
+			$content
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Kim noticed in Slack that email templates using Liquid end up with the Liquid tags wrapped in `<p>` tags, e.g. `<p>{% if ... %} {{ membership_level_confirmation_message }} {% else %}</p>`.

The cause is TinyMCE, not `wpautop()`. The template editor passes `wpautop => false`, and the save path never runs autop, but TinyMCE's `forced_root_block` still wraps any bare text node in a `<p>`. Every default template has Liquid tags sitting on their own line (`{% if membership_expiration %}{{ membership_expiration }}{% endif %}`, `{% if cardtype %}<p>...</p>{% endif %}`, etc.), so simply opening a template in the Visual editor and clicking Save stores `<p>{% if cardtype %}</p>`, `<p>{% endif %}</p>`, and so on. Multiple bare lines in a row get collapsed into a single paragraph, which is exactly what Kim's screenshot shows.

At send time those paragraphs render as empty `<p></p>` blocks (extra blank space in the email) or, when the paragraph mixes control tags with real content, as unbalanced `<p>` / `</p>` pairs.

## Fix

`PMPro_Liquid_Renderer::render()` now runs the content through a small `unautop()` step before evaluating conditionals, mirroring `shortcode_unautop()`. It removes `<p>...</p>` wrappers around paragraphs that contain nothing but Liquid tags and whitespace, as long as at least one of them is a `{% %}` control tag. Paragraphs like `<p>{{ display_name }}</p>` are intentionally left alone since the author clearly wanted a paragraph there.

Doing this at render time rather than on save means existing saved templates are fixed without a migration, and it also covers the header/footer templates since they are rendered as part of the assembled body.

## Verification

- Queried the dev.local database and found the saved `checkout_paid` body already contains `<p>{% if accountnumber %}</p>`, `<p>{% endif %}</p>`, and a collapsed mixed paragraph identical to Kim's screenshot.
- Rendered that saved body through the old and new renderer with sample data:

| | empty `<p></p>` | `<p>` opens | `</p>` closes |
|---|---|---|---|
| dev | 6 | 16 | 16 |
| this branch | 0 | 10 | 10 |

- Rendered again with every optional variable populated (confirmation message, expiration, discount code, card details): 0 empty paragraphs, 14 opens / 14 closes.
- A standalone PHP script with 12 cases (tag-only paragraphs, collapsed mixed paragraphs, `%` inside a quoted condition, output-only paragraphs that must be preserved, nested content that must not be touched) passes.

## Not covered

If a paragraph mixes Liquid control tags with literal text, e.g. `<p>{% if a %}Hello{% else %}</p><p>Bye</p>{% endif %}`, the tags are left in place and the branches can still produce an unclosed `<p>`. That requires a hand-authored template where the author put text and tags on the same line and then split the branches across paragraphs, so it is left as is.

## Proposed changelog entries

```
* BUG FIX: Liquid tags that the visual email template editor wrapped in paragraph tags no longer produce empty or unbalanced paragraphs in sent emails.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
