### PR TITLE
fix(wizard): require pmpro_wizard cap in save handler

### DIFF
--- a/adminpages/wizard/save-steps.php
+++ b/adminpages/wizard/save-steps.php
@@ -11,6 +11,11 @@ function pmpro_init_save_wizard_data() {
 		return;
 	}
 
+	// Check that the current user can access the wizard.
+	if ( ! current_user_can( 'pmpro_wizard' ) ) {
+		wp_die( esc_html__( 'Sorry, you are not allowed to access this page.', 'paid-memberships-pro' ) );
+	}
+
 	// Clear things up on the completed page.
 	if ( ! empty( $_REQUEST['step'] ) && $_REQUEST['step'] === 'done' ) {
 		delete_option( 'pmpro_wizard_collect_payment' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`pmpro_init_save_wizard_data()` runs on `admin_init` and handles all wizard step saves. It verified the per-step nonces but never checked a capability, while the handler creates pages, saves site and payment settings, writes membership levels, can start Stripe connect, and can install the Update Manager plugin. The nonces are only printed on the wizard page today, but that is one nonce leak or a `pmpro_wizard`-without-settings-caps role grant away from a low-privilege user triggering those writes.

This PR adds a `current_user_can( 'pmpro_wizard' )` check at the top of the handler, right after the page check. It uses the same capability that gates the wizard page itself (the `add_submenu_page()` registration), so the save handler can no longer run for a user who could not load the page. The check also covers the `step=done` cleanup, which previously deleted an option and reset `wizard_step` on any GET request with no nonce and no submit check.

Repro on the old code: as a wp-admin user without `pmpro_wizard` (e.g. after `wp cap remove administrator pmpro_wizard`), request `wp-admin/admin.php?page=pmpro-wizard&step=done&submit=1`. The wizard completion data is reset silently. With this change the request is denied.

Resolves #3761.

### How to test the changes in this Pull Request:

1. Log in as an administrator and complete the setup wizard from Membership > Dashboard > "Set Up Membership Site". Each step should save and redirect as before.
2. Remove the `pmpro_wizard` capability from a role (e.g. `wp cap remove administrator pmpro_wizard`) and log in as that user.
3. Request `wp-admin/admin.php?page=pmpro-wizard&step=done&submit=1` directly. You should get a "Sorry, you are not allowed to access this page." error instead of a silent wizard data reset.
4. Re-add the capability (`wp cap add administrator pmpro_wizard`) and confirm the wizard works again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

SECURITY: Added a missing capability check to the setup wizard save handler so it can only run for users with the `pmpro_wizard` capability. #3761 (@faisalahammad)