### PR TITLE
fix(orders): full-width expanded rows on mobile

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -4812,6 +4812,17 @@ button.pmpro_report_th_closed:before {
 		word-wrap: break-word;
 	}
 
+	/* Orders list expanded rows: each cell (including the primary cell) takes the full row width. Fixes #3713. */
+	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) td,
+	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) th {
+		flex: 0 1 100%;
+	}
+
+	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) td.column-primary,
+	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) th.column-primary {
+		flex: 1 1 100%;
+	}
+
 	.wrap.pmpro_admin .row-actions {
 		align-items: center;
 		color: #a7aaad;

--- a/css/admin.css
+++ b/css/admin.css
@@ -4812,17 +4812,6 @@ button.pmpro_report_th_closed:before {
 		word-wrap: break-word;
 	}
 
-	/* Orders list expanded rows: each cell (including the primary cell) takes the full row width. Fixes #3713. */
-	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) td,
-	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) th {
-		flex: 0 1 100%;
-	}
-
-	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) td.column-primary,
-	.pmpro_admin-pmpro-orders .wp-list-table tr:not(.inline-edit-row):not(.no-items) th.column-primary {
-		flex: 1 1 100%;
-	}
-
 	.wrap.pmpro_admin .row-actions {
 		align-items: center;
 		color: #a7aaad;
@@ -4908,6 +4897,12 @@ button.pmpro_report_th_closed:before {
 	.pmpro_responsive_table tbody tr td::before,
 	.pmpro_responsive_table tfoot tr td::before {
 		content: attr(data-colname) ": ";
+	}
+
+	/* Expanded Orders rows: every cell takes the full width. Fixes #3713. */
+	.pmpro_admin-pmpro-orders .wp-list-table .is-expanded td,
+	.pmpro_admin-pmpro-orders .wp-list-table .is-expanded th {
+		flex: 0 1 100%;
 	}
 
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

On mobile (viewport 782px or narrower), WordPress core renders list table rows as flex containers and already gives expanded cells a full-width flex basis (`tr td:nth-child(n+3)`). The Orders table has no `cb` column, so the ID cell is the odd one out: as the first cell in the row it keeps its default sizing and shares the first line with the primary column instead of taking the full width (screenshot in #3713).

This change adds one small orders-scoped rule to the existing `@media only screen and (max-width: 782px)` section of `css/admin.css`:

```css
.pmpro_admin-pmpro-orders .wp-list-table .is-expanded td,
.pmpro_admin-pmpro-orders .wp-list-table .is-expanded th {
	flex: 0 1 100%;
}
```

Every cell in an expanded Orders row now takes a full row on mobile, so expanded fields (User, Level, Total, Billing, Gateway, Transaction IDs, Status, Date) span the full table width. The rule is scoped to `.is-expanded`, which the core `toggle-row` script only ever adds to `tbody` rows, so the header row (`thead`/`tfoot`) and the collapsed mobile view are untouched. Both `td` and `th` are targeted because on newer WordPress versions the primary column cell is rendered as a `th` (see the WordPress 7.1 field guide note on list table row headers). Desktop rendering and all other admin pages (the rule is scoped to `.pmpro_admin-pmpro-orders`) are untouched. CSS only, no PHP or JS changes.

The same root cause likely affects the Members, Subscriptions, and Discount Codes list tables. Left out of this PR to keep the change scoped to the reported issue; happy to extend it in a follow-up.

Resolves #3713.

### How to test the changes in this Pull Request:

1. Go to Memberships > Orders on desktop and confirm the table renders exactly as before with all columns.
2. Narrow the viewport below 782px (or use a phone browser). Confirm the collapsed view still shows ID and Code with the expand toggle, and the header row still renders as a single line, same as before.
3. Tap the expand toggle on a row. Expected result: every field in the expanded section takes the full table width instead of about 25%.
4. Tap the toggle again to collapse, expand a different row, and confirm the same behavior.
5. Open the Members, Subscriptions, and Discount Codes pages on mobile and confirm their layout is unchanged (the new rule does not apply to them).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

Tested manually on a WP install at 375px and desktop widths. The test confirmation did not include the WordPress version. The flex row layout used by this fix is in WordPress 7.1 and later.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX: Order fields in expanded rows on the Orders list now take the full table width on mobile. #3713 (@faisalahammad)