### PR TITLE
fix(multisite): store expiration notices per site

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= TBD =
+* BUG FIX: Membership expiration reminder tracking is now per-site on multisite networks. The expiration notice is stored as a user option, and an upgrade script renames existing notices so each site on a network running its own PMPro copy tracks reminders separately. #3683 (@faisalahammad)
+
 = 3.8.5 - 2026-08-24 =
 * SECURITY: Fixed an issue where the payment amount was not re-verified after Strong Customer Authentication (3D Secure) in the Stripe on-site checkout. #3767 (@proxydom)
 * SECURITY: Fixed an access check bypass in the `getfile` service that could allow protected files to be served through `admin-ajax.php` without a membership access check. #3762 (@dparker1005)

--- a/classes/class-pmpro-recurring-actions.php
+++ b/classes/class-pmpro-recurring-actions.php
@@ -143,6 +143,8 @@ class PMPro_Recurring_Actions {
 		$interval_end   = date( 'Y-m-d H:i:s', strtotime( "+{$pmpro_email_days_before_expiration} days", current_time( 'timestamp' ) ) );
 
 		// look for memberships that are going to expire within one week (but we haven't emailed them within a week)
+		// User options are stored in usermeta with the blog prefix, so the
+		// expiration notice key has to match what update_user_option() writes.
 		$sqlQuery = $wpdb->prepare(
 			"SELECT DISTINCT
 						mu.user_id,
@@ -152,7 +154,7 @@ class PMPro_Recurring_Actions {
 						um.meta_value AS notice
 					FROM {$wpdb->pmpro_memberships_users} AS mu
 					LEFT JOIN {$wpdb->usermeta} AS um ON um.user_id = mu.user_id
-					AND um.meta_key = CONCAT( 'pmpro_expiration_notice_', mu.membership_id )
+					AND um.meta_key = CONCAT( %s, 'pmpro_expiration_notice_', mu.membership_id )
 				WHERE ( um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d DAY) < %s )
 					AND mu.status = 'active'
 					AND mu.enddate IS NOT NULL
@@ -162,6 +164,7 @@ class PMPro_Recurring_Actions {
 					AND mu.membership_id <> 0
 				ORDER BY mu.enddate
 				",
+			$wpdb->get_blog_prefix(),
 			$pmpro_email_days_before_expiration,
 			$today,
 			self::PMPRO_MAGIC_MIN_DATE,
@@ -247,8 +250,8 @@ class PMPro_Recurring_Actions {
 			}
 		}
 
-		// Update user meta so we don't email them again
-		update_user_meta( $user_id, 'pmpro_expiration_notice_' . $membership_id, current_time( 'Y-m-d H:i:s' ) );
+		// Update the user option so we don't email them again on this site.
+		update_user_option( $user_id, 'pmpro_expiration_notice_' . $membership_id, current_time( 'Y-m-d H:i:s' ) );
 	}
 
 	/**
@@ -371,8 +374,8 @@ class PMPro_Recurring_Actions {
 			$euser      = get_userdata( $user_id );
 			if ( ! empty( $euser ) ) {
 				$pmproemail->sendMembershipExpiredEmail( $euser, $membership_id );
-				// Delete the expiration notice for this membership
-				delete_user_meta( $user_id, 'pmpro_expiration_notice_' . $membership_id );
+				// Delete the expiration notice for this membership on this site
+				delete_user_option( $user_id, 'pmpro_expiration_notice_' . $membership_id );
 				if ( WP_DEBUG ) {
 					error_log( sprintf( __( 'Membership expired email sent to %s. ', 'paid-memberships-pro' ), $euser->user_email ) );
 				}

--- a/includes/updates/upgrade_3_8_5.php
+++ b/includes/updates/upgrade_3_8_5.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Upgrade to version 3.8.5
+ *
+ * Migrate expiration notice user meta to per-site user options.
+ *
+ * The expiration notice timestamp for a membership was stored as global
+ * user meta (pmpro_expiration_notice_{membership_id}). On a multisite
+ * network where each subsite runs its own copy of PMPro, subsites with
+ * the same membership ID clobbered each other's timestamps, which led
+ * to duplicate or missing expiration reminder emails. The notice is now
+ * stored with update_user_option(), which prefixes the key with the
+ * blog prefix, so each site tracks its own notices.
+ *
+ * This upgrade renames existing rows to the blog-prefixed key. Legacy rows
+ * are shared across the network with no record of which site wrote them, so
+ * on multisite only the main site claims them. Subsites leave the legacy
+ * rows untouched and start fresh with their own prefixed keys. Rows that
+ * were already renamed no longer match the LIKE pattern, so the update is
+ * safe to run more than once.
+ *
+ * @since 3.8.5
+ */
+function pmpro_upgrade_3_8_5() {
+	global $wpdb;
+
+	if ( is_multisite() && ! is_main_site() ) {
+		return;
+	}
+
+	$wpdb->query(
+		$wpdb->prepare(
+			"UPDATE {$wpdb->usermeta}
+			SET meta_key = CONCAT( %s, meta_key )
+			WHERE meta_key LIKE %s",
+			$wpdb->get_blog_prefix(),
+			$wpdb->esc_like( 'pmpro_expiration_notice_' ) . '%'
+		)
+	);
+}

--- a/includes/upgradecheck.php
+++ b/includes/upgradecheck.php
@@ -460,6 +460,16 @@ function pmpro_checkForUpgrades() {
 		update_option( 'pmpro_db_version', '3.84' );
 	}
 
+	/**
+	 * Version 3.8.5
+	 * Migrate expiration notice user meta to per-site user options.
+	 */
+	require_once( PMPRO_DIR . '/includes/updates/upgrade_3_8_5.php' );
+	if ( $pmpro_db_version < 3.85 ) {
+		pmpro_upgrade_3_8_5();
+		update_option( 'pmpro_db_version', '3.85' );
+	}
+
 }
 
 function pmpro_db_delta() {

--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,9 @@ Not sure? You can find out by doing a bit a research.
 4. [Ask using our contact form](https://www.paidmembershipspro.com/contact/)
 
 == Changelog ==
+= TBD =
+* BUG FIX: Membership expiration reminder tracking is now per-site on multisite networks. The expiration notice is stored as a user option, and an upgrade script renames existing notices so each site on a network running its own PMPro copy tracks reminders separately. #3683 (@faisalahammad)
+
 = 3.8.5 - 2026-08-24 =
 * SECURITY: Fixed an issue where the payment amount was not re-verified after Strong Customer Authentication (3D Secure) in the Stripe on-site checkout. #3767 (@proxydom)
 * SECURITY: Fixed an access check bypass in the `getfile` service that could allow protected files to be served through `admin-ajax.php` without a membership access check. #3762 (@dparker1005)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves #3683 (first step, one key at a time as suggested in the issue).

The expiration reminder timestamp is stored as user meta keyed `pmpro_expiration_notice_{membership_id}`. On a multisite network where each subsite runs its own copy of PMPro with its own `pmpro_memberships_users` table, `wp_usermeta` is still shared network-wide, so two subsites with the same membership ID overwrite each other's timestamps. A reminder sent on one site suppresses the reminder on the other, or a site re-sends a reminder the other site already sent. The same collision is what [pmpro-extra-expiration-warning-emails#39](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/issues/39) works around on the add-on side.

This PR moves that one key to the per-site user option API:

- `send_expiration_reminder_email()` writes with `update_user_option()` and `send_membership_expired_email()` deletes with `delete_user_option()`, both of which prefix the key with `$wpdb->get_blog_prefix()` (`wp_2_pmpro_expiration_notice_5` on subsite 2).
- The reminder query in `membership_expiration_reminders()` joins on the same prefixed key, with the blog prefix passed through `$wpdb->prepare()` as a bound parameter.
- A new upgrade routine (`includes/updates/upgrade_3_8_5.php`, gated at db version 3.85) renames existing `pmpro_expiration_notice_%` rows to the prefixed key. On multisite only the main site claims the legacy rows, because a shared row carries no record of which site wrote it; subsites start fresh with their own keys. The rename is idempotent since prefixed rows no longer match the LIKE pattern.

Other keys listed in #3683 (gateway customer IDs, consent log, admin UI state) are deliberately not touched here and can follow one at a time. No change is needed in pmpro-network-subsite: it clears PMPro crons on subsites, so only the main site ever writes these notices under that deployment model.

### How to test the changes in this Pull Request:

1. On a single site with a member expiring within 7 days, confirm a `pmpro_expiration_notice_{level_id}` row exists in `wp_usermeta`, then run the upgrade. Expected result: the row is renamed to `wp_pmpro_expiration_notice_{level_id}`, the reminder sends once, and repeated cron runs do not resend it.
2. On a multisite network with PMPro active independently on the main site and a subsite, create the same level ID on both and give one user an expiring membership on each. Run the reminder task on both sites. Expected result: each site sends its own reminder and writes its own prefixed timestamp (`wp_...` on the main site, `wp_2_...` on subsite 2), and a second cron run on either site sends nothing.
3. On a network using the Multisite Membership Add On, confirm behavior is unchanged: subsite crons stay cleared and only the main site sends reminders.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

There is no automated test suite in this repository, so I verified with the manual steps above plus PHP lint and PHPCS (`WordPress-Core`/`WordPress-Docs`) on the changed files. Worst case during the window between deployment and the upgrade running is one duplicate reminder per user, after which the prefixed key suppresses normally.

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

BUG FIX: Membership expiration reminder tracking is now per-site on multisite networks. The expiration notice is stored as a user option, and an upgrade script renames existing notices so each site on a network running its own PMPro copy tracks reminders separately. #3683 (@faisalahammad)