### PR TITLE
BUG FIX: Refresh Stripe Connect publishable keys and detect rejected Stripe credentials

### DIFF
--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -272,6 +272,11 @@ class PMPro_Site_Health {
 				$gateway_text .= ' (' . __( 'API Version', 'paid-memberships-pro' ) . ': ' . PMPRO_STRIPE_API_VERSION . ')';
 			}
 
+			$connection_error = $stripe->get_connection_error();
+			if ( ! empty( $connection_error ) ) {
+				$gateway_text .= ' (' . __( 'Connection Error', 'paid-memberships-pro' ) . ': ' . wp_strip_all_tags( $connection_error ) . ')';
+			}
+
 			if ( $legacy ) {
 				$gateway_text .= ' (' . __( 'Legacy Keys', 'paid-memberships-pro' ) . ')';
 				return $gateway_text . ' [' . $gateway . ':legacy-keys]';

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1689,9 +1689,6 @@ class PMProGateway_stripe extends PMProGateway {
 					<?php esc_html_e( 'This may be a temporary connection problem. Wait a few minutes, then try again. Onsite checkout and billing updates may remain unavailable in the meantime.', 'paid-memberships-pro' ); ?>
 				<?php } ?>
 			</p>
-			<p>
-				<a class="button button-secondary" href="<?php echo esc_url( self::get_publishable_key_refresh_url() ); ?>"><?php esc_html_e( 'Try checking again', 'paid-memberships-pro' ); ?></a>
-			</p>
 		</div>
 		<?php
 	}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -131,6 +131,8 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'wp_ajax_pmpro_stripe_create_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_create_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_delete_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_delete_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_rebuild_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_rebuild_webhook' ) );
+		add_action( 'wp_ajax_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_refresh_publishable_key' ) );
+		add_action( 'wp_ajax_nopriv_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_refresh_publishable_key' ) );
 
 		//code to add at checkout if Stripe is the current gateway
 		$default_gateway = get_option( 'pmpro_gateway' );
@@ -1214,6 +1216,8 @@ class PMProGateway_stripe extends PMProGateway {
 		$default_gateway = get_option( "pmpro_gateway" );
 
 		if ( $gateway == "stripe" || $default_gateway == "stripe" ) {
+			self::maybe_refresh_connect_publishable_keys();
+
 			//stripe js library
 			wp_enqueue_script( "stripe", "https://js.stripe.com/v3/", array(), null );
 
@@ -1222,6 +1226,9 @@ class PMProGateway_stripe extends PMProGateway {
 				$localize_vars = array(
 					'publishableKey' => $stripe->get_publishablekey(),
 					'user_id'        => $stripe->get_connect_user_id(),
+					'publishableKeyRefreshNonce' => wp_create_nonce( 'pmpro_stripe_refresh_publishable_key' ),
+					'msgRefreshingPublishableKey' => __( 'Refreshing the connection to Stripe. Please wait.', 'paid-memberships-pro' ),
+					'msgPublishableKeyRefreshed' => __( 'The connection to Stripe was refreshed. Please re-enter your payment details.', 'paid-memberships-pro' ),
 					'verifyAddress'  => apply_filters( 'pmpro_stripe_verify_address', get_option( 'pmpro_stripe_billingaddress' ) ),
 					'ajaxUrl'        => admin_url( "admin-ajax.php" ),
 					'msgAuthenticationValidated' => __( 'Verification steps confirmed. Your payment is processing.', 'paid-memberships-pro' ),
@@ -1585,6 +1592,7 @@ class PMProGateway_stripe extends PMProGateway {
 				update_option( 'pmpro_sandbox_stripe_connect_secretkey', $_REQUEST['pmpro_stripe_access_token'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				update_option( 'pmpro_sandbox_stripe_connect_publishablekey', $_REQUEST['pmpro_stripe_publishable_key'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
+			delete_option( 'pmpro_stripe_connect_platform_keys' );
 
 
 			// Delete option for user API key.
@@ -1891,6 +1899,211 @@ class PMProGateway_stripe extends PMProGateway {
 				get_option( 'pmpro_sandbox_stripe_connect_publishablekey' )
 			);
 		}
+	}
+
+	/**
+	 * Refresh cached Stripe Connect platform publishable keys when they are stale.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return true|WP_Error True when no refresh is needed or the refresh succeeds. WP_Error on failure.
+	 */
+	public static function maybe_refresh_connect_publishable_keys() {
+		if ( self::using_api_keys() || ! self::has_connect_account_credentials() ) {
+			return true;
+		}
+
+		$cache = get_option( 'pmpro_stripe_connect_platform_keys', array() );
+		if ( ! is_array( $cache ) ) {
+			$cache = array();
+		}
+		$cache_lifetime = (int) apply_filters( 'pmpro_stripe_connect_publishable_key_cache_lifetime', 6 * HOUR_IN_SECONDS );
+		if ( ! empty( $cache['checked_at'] ) && ( time() - (int) $cache['checked_at'] ) < max( 0, $cache_lifetime ) ) {
+			return true;
+		}
+
+		return self::refresh_connect_publishable_keys();
+	}
+
+	/**
+	 * Retrieve and cache the Stripe Connect platform publishable-key manifest.
+	 *
+	 * The existing cache is only replaced after the complete response passes validation.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return array|WP_Error The validated cache or a WP_Error on failure.
+	 */
+	public static function refresh_connect_publishable_keys() {
+		if ( get_transient( 'pmpro_stripe_connect_platform_keys_refreshing' ) ) {
+			return new WP_Error( 'pmpro_stripe_connect_platform_keys_refreshing', __( 'The Stripe publishable keys are already being refreshed.', 'paid-memberships-pro' ) );
+		}
+
+		set_transient( 'pmpro_stripe_connect_platform_keys_refreshing', 1, MINUTE_IN_SECONDS );
+
+		$manifest_url = apply_filters(
+			'pmpro_stripe_connect_publishable_key_manifest_url',
+			'https://connect.paidmembershipspro.com/stripe/v1/platform-keys.json'
+		);
+		$response = wp_safe_remote_get(
+			$manifest_url,
+			array(
+				'timeout'             => 5,
+				'redirection'         => 2,
+				'limit_response_size' => 8192,
+				'headers'             => array( 'Accept' => 'application/json' ),
+			)
+		);
+
+		delete_transient( 'pmpro_stripe_connect_platform_keys_refreshing' );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return new WP_Error( 'pmpro_stripe_connect_manifest_http_error', __( 'The Stripe publishable-key manifest could not be retrieved.', 'paid-memberships-pro' ) );
+		}
+
+		$manifest = json_decode( wp_remote_retrieve_body( $response ), true );
+		$manifest = self::validate_connect_publishable_key_manifest( $manifest );
+		if ( is_wp_error( $manifest ) ) {
+			return $manifest;
+		}
+
+		$manifest['checked_at'] = time();
+		update_option( 'pmpro_stripe_connect_platform_keys', $manifest, false );
+		$stored_manifest = get_option( 'pmpro_stripe_connect_platform_keys', array() );
+		if ( $stored_manifest !== $manifest ) {
+			return new WP_Error( 'pmpro_stripe_connect_manifest_cache_error', __( 'The Stripe publishable-key manifest could not be cached.', 'paid-memberships-pro' ) );
+		}
+
+		return $stored_manifest;
+	}
+
+	/**
+	 * Validate and normalize a Stripe Connect platform publishable-key manifest.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @param mixed $manifest Decoded manifest response.
+	 * @return array|WP_Error The normalized manifest or a WP_Error on failure.
+	 */
+	private static function validate_connect_publishable_key_manifest( $manifest ) {
+		if (
+			! is_array( $manifest ) ||
+			1 !== ( $manifest['schema_version'] ?? null ) ||
+			empty( $manifest['generated_at'] ) ||
+			! is_string( $manifest['generated_at'] ) ||
+			strlen( $manifest['generated_at'] ) > 50 ||
+			false === strtotime( $manifest['generated_at'] )
+		) {
+			return new WP_Error( 'pmpro_stripe_connect_manifest_invalid', __( 'The Stripe publishable-key manifest is invalid.', 'paid-memberships-pro' ) );
+		}
+
+		$normalized = array(
+			'schema_version' => 1,
+			'generated_at'   => (string) $manifest['generated_at'],
+		);
+
+		foreach ( array( 'live', 'test' ) as $mode ) {
+			$prefix = 'live' === $mode ? 'pk_live_' : 'pk_test_';
+			if ( empty( $manifest[ $mode ] ) || ! is_array( $manifest[ $mode ] ) ) {
+				return new WP_Error( 'pmpro_stripe_connect_manifest_invalid', __( 'The Stripe publishable-key manifest is invalid.', 'paid-memberships-pro' ) );
+			}
+			$key     = $manifest[ $mode ]['publishable_key'] ?? '';
+			$version = $manifest[ $mode ]['version'] ?? '';
+			if (
+				! is_string( $key ) ||
+				0 !== strpos( $key, $prefix ) ||
+				strlen( $key ) <= strlen( $prefix ) ||
+				strlen( $key ) > 255 ||
+				! preg_match( '/^[A-Za-z0-9_]+$/', $key ) ||
+				! is_string( $version ) ||
+				'' === $version ||
+				strlen( $version ) > 100 ||
+				! preg_match( '/^[A-Za-z0-9._-]+$/', $version )
+			) {
+				return new WP_Error( 'pmpro_stripe_connect_manifest_invalid', __( 'The Stripe publishable-key manifest is invalid.', 'paid-memberships-pro' ) );
+			}
+
+			$normalized[ $mode ] = array(
+				'publishable_key' => $key,
+				'version'         => $version,
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Get the cached platform publishable key for an environment.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @param string $gateway_environment The PMPro gateway environment.
+	 * @return string The cached publishable key, or an empty string when unavailable.
+	 */
+	private static function get_cached_connect_publishable_key( $gateway_environment ) {
+		$cache = get_option( 'pmpro_stripe_connect_platform_keys', array() );
+		if ( ! is_array( $cache ) ) {
+			return '';
+		}
+		$mode  = 'live' === $gateway_environment ? 'live' : 'test';
+		$key    = $cache[ $mode ]['publishable_key'] ?? '';
+		$prefix = 'live' === $mode ? 'pk_live_' : 'pk_test_';
+
+		if (
+			! is_string( $key ) ||
+			0 !== strpos( $key, $prefix ) ||
+			strlen( $key ) <= strlen( $prefix ) ||
+			strlen( $key ) > 255 ||
+			! preg_match( '/^[A-Za-z0-9_]+$/', $key )
+		) {
+			return '';
+		}
+
+		return $key;
+	}
+
+	/**
+	 * Determine whether the account credentials needed to refresh a Connect key exist.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return bool Whether the current environment has a Connect account and access token.
+	 */
+	private static function has_connect_account_credentials() {
+		$gateway_environment = get_option( 'pmpro_gateway_environment' );
+		$prefix = 'live' === $gateway_environment ? 'pmpro_live_' : 'pmpro_sandbox_';
+
+		return ! empty( get_option( $prefix . 'stripe_connect_user_id' ) ) && ! empty( get_option( $prefix . 'stripe_connect_secretkey' ) );
+	}
+
+	/**
+	 * Force a publishable-key refresh after Stripe reports an expired platform key.
+	 *
+	 * @since 3.8.6
+	 */
+	public static function wp_ajax_pmpro_stripe_refresh_publishable_key() {
+		check_ajax_referer( 'pmpro_stripe_refresh_publishable_key', 'nonce' );
+
+		if ( self::using_api_keys() || ! self::has_connect_account_credentials() ) {
+			wp_send_json_error( array( 'message' => __( 'Stripe Connect is not configured.', 'paid-memberships-pro' ) ), 400 );
+		}
+
+		$cache = self::refresh_connect_publishable_keys();
+		if ( is_wp_error( $cache ) ) {
+			wp_send_json_error( array( 'message' => $cache->get_error_message() ), 503 );
+		}
+
+		$gateway_environment = get_option( 'pmpro_gateway_environment' );
+		$mode                = 'live' === $gateway_environment ? 'live' : 'test';
+		wp_send_json_success(
+			array(
+				'publishableKey' => $cache[ $mode ]['publishable_key'],
+			)
+		);
 	}
 
 	/**
@@ -4401,9 +4614,13 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( self::using_api_keys() ) {
 			$publishablekey = get_option( 'pmpro_stripe_publishablekey' );
 		} else {
-			$publishablekey = get_option( 'pmpro_gateway_environment' ) === 'live'
-				? get_option( 'pmpro_live_stripe_connect_publishablekey' )
-				: get_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
+			$gateway_environment = get_option( 'pmpro_gateway_environment' );
+			$publishablekey      = self::get_cached_connect_publishable_key( $gateway_environment );
+			if ( empty( $publishablekey ) ) {
+				$publishablekey = 'live' === $gateway_environment
+					? get_option( 'pmpro_live_stripe_connect_publishablekey' )
+					: get_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
+			}
 		}
 		return $publishablekey;
 	}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -175,6 +175,7 @@ class PMProGateway_stripe extends PMProGateway {
 		// Stripe Connect functions.
 		add_action( 'admin_init', array( 'PMProGateway_stripe', 'stripe_connect_save_options' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_show_errors' ) );
+		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_publishable_key_refresh_notice' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_deauthorize' ) );
 
 		// Show warning if webhooks are not set up.
@@ -1639,6 +1640,63 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
+	 * Show the result of a manual Stripe Connect publishable-key check.
+	 *
+	 * @since 3.8.6
+	 */
+	public static function show_publishable_key_refresh_notice() {
+		if (
+			( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) ||
+			! isset( $_GET['page'] ) ||
+			'pmpro-paymentsettings' !== sanitize_key( wp_unslash( $_GET['page'] ) ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			self::using_api_keys()
+		) {
+			return;
+		}
+
+		$gateway_environment = get_option( 'pmpro_gateway_environment' );
+		if ( ! self::has_connect_credentials( $gateway_environment, false ) ) {
+			return;
+		}
+
+		$refresh_status = self::get_publishable_key_refresh_status();
+		if ( ! in_array( $refresh_status, array( 'error', 'unchanged', 'success' ), true ) ) {
+			return;
+		}
+
+		$publishable_key_issue = self::get_connect_publishable_key_issue( $gateway_environment );
+		if ( ( 'success' === $refresh_status && $publishable_key_issue ) || ( 'success' !== $refresh_status && ! $publishable_key_issue ) ) {
+			return;
+		}
+
+		if ( 'success' === $refresh_status ) {
+			?>
+			<div class="notice notice-success pmpro-stripe-connect-message">
+				<p><?php esc_html_e( 'The Stripe publishable key was updated.', 'paid-memberships-pro' ); ?></p>
+			</div>
+			<?php
+			return;
+		}
+
+		?>
+		<div class="notice notice-error pmpro-stripe-connect-message">
+			<p>
+				<?php if ( 'unchanged' === $refresh_status ) { ?>
+					<strong><?php esc_html_e( 'No updated Stripe key is available yet.', 'paid-memberships-pro' ); ?></strong><br />
+					<?php esc_html_e( 'The check completed, but the available key has not changed. Wait a few minutes and try again. If the problem continues, contact Paid Memberships Pro support.', 'paid-memberships-pro' ); ?>
+				<?php } else { ?>
+					<strong><?php esc_html_e( 'We couldn\'t check for an updated Stripe key.', 'paid-memberships-pro' ); ?></strong><br />
+					<?php esc_html_e( 'This may be a temporary connection problem. Wait a few minutes, then try again. Onsite checkout and billing updates may remain unavailable in the meantime.', 'paid-memberships-pro' ); ?>
+				<?php } ?>
+			</p>
+			<p>
+				<a class="button button-secondary" href="<?php echo esc_url( self::get_publishable_key_refresh_url() ); ?>"><?php esc_html_e( 'Try checking again', 'paid-memberships-pro' ); ?></a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
 	 * Disconnects user from the Stripe Connected App.
 	 */
 	public static function stripe_connect_deauthorize() {
@@ -2164,6 +2222,33 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		return $issues[ $mode ];
+	}
+
+	/**
+	 * Get the publishable-key refresh result from the current request.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return string The sanitized refresh status, or an empty string.
+	 */
+	private static function get_publishable_key_refresh_status() {
+		return isset( $_GET['pmpro_stripe_publishable_key_refresh'] )
+			? sanitize_key( wp_unslash( $_GET['pmpro_stripe_publishable_key_refresh'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			: '';
+	}
+
+	/**
+	 * Get the URL used to manually refresh Stripe Connect publishable keys.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return string The nonce-protected refresh URL.
+	 */
+	private static function get_publishable_key_refresh_url() {
+		return wp_nonce_url(
+			admin_url( 'admin-post.php?action=pmpro_stripe_refresh_publishable_key' ),
+			'pmpro_stripe_refresh_publishable_key'
+		);
 	}
 
 	/**
@@ -3286,14 +3371,12 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		// Determine if this is the active environment.
-		$active_environment              = $environment === get_option( 'pmpro_gateway_environment' );
-		$publishable_key_issue            = false;
+		$active_environment = $environment === get_option( 'pmpro_gateway_environment' );
+		$publishable_key_issue = false;
 		$publishable_key_refresh_status = '';
 		if ( $active_environment && ! self::using_api_keys() && self::has_connect_credentials( $environment, false ) ) {
-			$publishable_key_issue = self::get_connect_publishable_key_issue( $environment );
-			$publishable_key_refresh_status = isset( $_GET['pmpro_stripe_publishable_key_refresh'] )
-				? sanitize_key( wp_unslash( $_GET['pmpro_stripe_publishable_key_refresh'] ) )
-				: '';
+			$publishable_key_issue          = self::get_connect_publishable_key_issue( $environment );
+			$publishable_key_refresh_status = self::get_publishable_key_refresh_status();
 		}
 
 		?>
@@ -3335,22 +3418,15 @@ class PMProGateway_stripe extends PMProGateway {
 								<td colspan="2">
 									<div class="notice notice-large notice-error inline">
 										<p>
-											<strong><?php esc_html_e( 'Stripe could not refresh its publishable key.', 'paid-memberships-pro' ); ?></strong><br />
-											<?php esc_html_e( 'Onsite checkout or billing updates may be unavailable until an updated key can be retrieved.', 'paid-memberships-pro' ); ?>
-											<?php if ( 'unchanged' === $publishable_key_refresh_status ) { ?>
-												<br /><?php esc_html_e( 'No updated Stripe publishable key is available yet. The existing key was left unchanged.', 'paid-memberships-pro' ); ?>
-											<?php } elseif ( 'error' === $publishable_key_refresh_status ) { ?>
-												<br /><?php esc_html_e( 'Paid Memberships Pro could not check for an updated key. The existing key was left unchanged.', 'paid-memberships-pro' ); ?>
-											<?php } ?>
-											<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=pmpro_stripe_refresh_publishable_key' ), 'pmpro_stripe_refresh_publishable_key' ) ); ?>"><?php esc_html_e( 'Check for an updated Stripe key', 'paid-memberships-pro' ); ?></a>
+											<strong><?php esc_html_e( 'Stripe checkout may be unavailable.', 'paid-memberships-pro' ); ?></strong><br />
+											<?php esc_html_e( 'Paid Memberships Pro could not automatically retrieve an updated Stripe publishable key. Onsite checkout and billing updates may be unavailable.', 'paid-memberships-pro' ); ?>
+										</p>
+										<p>
+											<a class="button button-secondary" href="<?php echo esc_url( self::get_publishable_key_refresh_url() ); ?>">
+												<?php echo esc_html( in_array( $publishable_key_refresh_status, array( 'error', 'unchanged' ), true ) ? __( 'Try checking again', 'paid-memberships-pro' ) : __( 'Check for an updated Stripe key', 'paid-memberships-pro' ) ); ?>
+											</a>
 										</p>
 									</div>
-								</td>
-							</tr>
-						<?php } elseif ( 'success' === $publishable_key_refresh_status ) { ?>
-							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
-								<td colspan="2">
-									<div class="notice notice-large notice-success inline"><p><?php esc_html_e( 'The Stripe publishable key was updated.', 'paid-memberships-pro' ); ?></p></div>
 								</td>
 							</tr>
 						<?php } ?>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -133,6 +133,7 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'wp_ajax_pmpro_stripe_rebuild_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_rebuild_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_refresh_publishable_key' ) );
 		add_action( 'wp_ajax_nopriv_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_refresh_publishable_key' ) );
+		add_action( 'admin_post_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'admin_post_refresh_publishable_key' ) );
 
 		//code to add at checkout if Stripe is the current gateway
 		$default_gateway = get_option( 'pmpro_gateway' );
@@ -1223,10 +1224,12 @@ class PMProGateway_stripe extends PMProGateway {
 
 			if ( ! function_exists( 'pmpro_stripe_javascript' ) ) {
 				$stripe = new PMProGateway_stripe();
+				$using_connect = ! self::using_api_keys() && self::has_connect_credentials( null, false );
 				$localize_vars = array(
 					'publishableKey' => $stripe->get_publishablekey(),
-					'user_id'        => $stripe->get_connect_user_id(),
-					'publishableKeyRefreshNonce' => wp_create_nonce( 'pmpro_stripe_refresh_publishable_key' ),
+					'user_id'        => $using_connect ? $stripe->get_connect_user_id() : '',
+					'usingConnect'   => $using_connect,
+					'publishableKeyRefreshNonce' => $using_connect ? wp_create_nonce( 'pmpro_stripe_refresh_publishable_key' ) : '',
 					'msgRefreshingPublishableKey' => __( 'Refreshing the connection to Stripe. Please wait.', 'paid-memberships-pro' ),
 					'msgPublishableKeyRefreshed' => __( 'The connection to Stripe was refreshed. Please re-enter your payment details.', 'paid-memberships-pro' ),
 					'verifyAddress'  => apply_filters( 'pmpro_stripe_verify_address', get_option( 'pmpro_stripe_billingaddress' ) ),
@@ -1593,6 +1596,7 @@ class PMProGateway_stripe extends PMProGateway {
 				update_option( 'pmpro_sandbox_stripe_connect_publishablekey', $_REQUEST['pmpro_stripe_publishable_key'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			}
 			delete_option( 'pmpro_stripe_connect_platform_keys' );
+			self::clear_connect_publishable_key_issue( $_REQUEST['pmpro_stripe_connected_environment'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 
 			// Delete option for user API key.
@@ -1688,6 +1692,7 @@ class PMProGateway_stripe extends PMProGateway {
 			delete_option( 'pmpro_sandbox_stripe_connect_secretkey' );
 			delete_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
 		}
+		self::clear_connect_publishable_key_issue( $_REQUEST['pmpro_stripe_disconnected_environment'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 	}
 
 	/**
@@ -1918,7 +1923,7 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( ! is_array( $cache ) ) {
 			$cache = array();
 		}
-		$cache_lifetime = (int) apply_filters( 'pmpro_stripe_connect_publishable_key_cache_lifetime', 6 * HOUR_IN_SECONDS );
+		$cache_lifetime = (int) apply_filters( 'pmpro_stripe_connect_publishable_key_cache_lifetime', WEEK_IN_SECONDS );
 		if ( ! empty( $cache['checked_at'] ) && ( time() - (int) $cache['checked_at'] ) < max( 0, $cache_lifetime ) ) {
 			return true;
 		}
@@ -2097,6 +2102,71 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
+	 * Record that Stripe rejected the platform publishable key for an environment.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @param string $gateway_environment The PMPro gateway environment.
+	 * @param string $error_code          The Stripe or refresh error code.
+	 * @return void
+	 */
+	private static function record_connect_publishable_key_issue( $gateway_environment, $error_code ) {
+		$issues = get_option( 'pmpro_stripe_connect_publishable_key_issues', array() );
+		if ( ! is_array( $issues ) ) {
+			$issues = array();
+		}
+
+		$mode = 'live' === $gateway_environment ? 'live' : 'test';
+		$issues[ $mode ] = array(
+			'detected_at' => time(),
+			'error_code'  => sanitize_key( $error_code ),
+		);
+		update_option( 'pmpro_stripe_connect_publishable_key_issues', $issues, false );
+	}
+
+	/**
+	 * Clear a platform publishable-key issue for an environment.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @param string $gateway_environment The PMPro gateway environment.
+	 * @return void
+	 */
+	private static function clear_connect_publishable_key_issue( $gateway_environment ) {
+		$issues = get_option( 'pmpro_stripe_connect_publishable_key_issues', array() );
+		if ( ! is_array( $issues ) ) {
+			delete_option( 'pmpro_stripe_connect_publishable_key_issues' );
+			return;
+		}
+
+		$mode = 'live' === $gateway_environment ? 'live' : 'test';
+		unset( $issues[ $mode ] );
+		if ( empty( $issues ) ) {
+			delete_option( 'pmpro_stripe_connect_publishable_key_issues' );
+		} else {
+			update_option( 'pmpro_stripe_connect_publishable_key_issues', $issues, false );
+		}
+	}
+
+	/**
+	 * Get a detected platform publishable-key issue for an environment.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @param string $gateway_environment The PMPro gateway environment.
+	 * @return array|false The issue details, or false when no issue is recorded.
+	 */
+	private static function get_connect_publishable_key_issue( $gateway_environment ) {
+		$issues = get_option( 'pmpro_stripe_connect_publishable_key_issues', array() );
+		$mode   = 'live' === $gateway_environment ? 'live' : 'test';
+		if ( ! is_array( $issues ) || empty( $issues[ $mode ] ) || ! is_array( $issues[ $mode ] ) ) {
+			return false;
+		}
+
+		return $issues[ $mode ];
+	}
+
+	/**
 	 * Force a publishable-key refresh after Stripe reports an expired platform key.
 	 *
 	 * @since 3.8.6
@@ -2108,18 +2178,98 @@ class PMProGateway_stripe extends PMProGateway {
 			wp_send_json_error( array( 'message' => __( 'Stripe Connect is not configured.', 'paid-memberships-pro' ) ), 400 );
 		}
 
+		$error_code = isset( $_POST['errorCode'] ) ? sanitize_key( wp_unslash( $_POST['errorCode'] ) ) : '';
+		if ( ! in_array( $error_code, array( 'api_key_expired', 'platform_api_key_expired' ), true ) ) {
+			wp_send_json_error( array( 'message' => __( 'Stripe did not report an expired publishable key.', 'paid-memberships-pro' ) ), 400 );
+		}
+
+		$gateway_environment      = get_option( 'pmpro_gateway_environment' );
+		$attempted_publishable_key = isset( $_POST['publishableKey'] ) ? sanitize_text_field( wp_unslash( $_POST['publishableKey'] ) ) : '';
+		$expected_prefix           = 'live' === $gateway_environment ? 'pk_live_' : 'pk_test_';
+		if (
+			0 !== strpos( $attempted_publishable_key, $expected_prefix ) ||
+			strlen( $attempted_publishable_key ) <= strlen( $expected_prefix ) ||
+			strlen( $attempted_publishable_key ) > 255 ||
+			! preg_match( '/^[A-Za-z0-9_]+$/', $attempted_publishable_key )
+		) {
+			wp_send_json_error( array( 'message' => __( 'The expired Stripe publishable key was invalid.', 'paid-memberships-pro' ) ), 400 );
+		}
+
+		$report_only = isset( $_POST['reportOnly'] ) && 'true' === sanitize_key( wp_unslash( $_POST['reportOnly'] ) );
+		if ( $report_only ) {
+			self::record_connect_publishable_key_issue( $gateway_environment, $error_code );
+			wp_send_json_success();
+		}
+
 		$cache = self::refresh_connect_publishable_keys();
 		if ( is_wp_error( $cache ) ) {
+			self::record_connect_publishable_key_issue( $gateway_environment, $error_code );
 			wp_send_json_error( array( 'message' => $cache->get_error_message() ), 503 );
 		}
 
-		$gateway_environment = get_option( 'pmpro_gateway_environment' );
-		$mode                = 'live' === $gateway_environment ? 'live' : 'test';
+		$mode = 'live' === $gateway_environment ? 'live' : 'test';
+		if ( $attempted_publishable_key === $cache[ $mode ]['publishable_key'] ) {
+			self::record_connect_publishable_key_issue( $gateway_environment, $error_code );
+			wp_send_json_error( array( 'message' => __( 'No updated Stripe publishable key is available yet.', 'paid-memberships-pro' ) ), 409 );
+		}
+
+		self::clear_connect_publishable_key_issue( $gateway_environment );
 		wp_send_json_success(
 			array(
 				'publishableKey' => $cache[ $mode ]['publishable_key'],
 			)
 		);
+	}
+
+	/**
+	 * Manually check for an updated Stripe Connect platform publishable key.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return void
+	 */
+	public static function admin_post_refresh_publishable_key() {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage Stripe settings.', 'paid-memberships-pro' ) );
+		}
+
+		check_admin_referer( 'pmpro_stripe_refresh_publishable_key' );
+
+		$redirect_url = add_query_arg(
+			array(
+				'page'         => 'pmpro-paymentsettings',
+				'edit_gateway' => 'stripe',
+			),
+			admin_url( 'admin.php' )
+		);
+		$gateway_environment = get_option( 'pmpro_gateway_environment' );
+		if ( self::using_api_keys() || ! self::has_connect_credentials( $gateway_environment, false ) ) {
+			$redirect_url = add_query_arg( 'pmpro_stripe_publishable_key_refresh', 'unavailable', $redirect_url );
+			wp_safe_redirect( $redirect_url );
+			exit;
+		}
+
+		$stripe                   = new PMProGateway_stripe();
+		$previous_publishable_key = $stripe->get_publishablekey();
+		$cache                    = self::refresh_connect_publishable_keys();
+		if ( is_wp_error( $cache ) ) {
+			self::record_connect_publishable_key_issue( $gateway_environment, $cache->get_error_code() );
+			$refresh_status = 'error';
+		} else {
+			$mode                      = 'live' === $gateway_environment ? 'live' : 'test';
+			$refreshed_publishable_key = $cache[ $mode ]['publishable_key'];
+			if ( $previous_publishable_key === $refreshed_publishable_key ) {
+				self::record_connect_publishable_key_issue( $gateway_environment, 'key_unchanged' );
+				$refresh_status = 'unchanged';
+			} else {
+				self::clear_connect_publishable_key_issue( $gateway_environment );
+				$refresh_status = 'success';
+			}
+		}
+
+		$redirect_url = add_query_arg( 'pmpro_stripe_publishable_key_refresh', $refresh_status, $redirect_url );
+		wp_safe_redirect( $redirect_url );
+		exit;
 	}
 
 	/**
@@ -3136,7 +3286,15 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		// Determine if this is the active environment.
-		$active_environment = $environment === get_option( 'pmpro_gateway_environment' );
+		$active_environment              = $environment === get_option( 'pmpro_gateway_environment' );
+		$publishable_key_issue            = false;
+		$publishable_key_refresh_status = '';
+		if ( $active_environment && ! self::using_api_keys() && self::has_connect_credentials( $environment, false ) ) {
+			$publishable_key_issue = self::get_connect_publishable_key_issue( $environment );
+			$publishable_key_refresh_status = isset( $_GET['pmpro_stripe_publishable_key_refresh'] )
+				? sanitize_key( wp_unslash( $_GET['pmpro_stripe_publishable_key_refresh'] ) )
+				: '';
+		}
 
 		?>
 		<div id="pmpro_stripe_<?php echo esc_attr( $environment); ?>" class="pmpro_section" data-visibility="<?php echo esc_attr( $active_environment ? 'shown' : 'hidden' ); ?>" data-activated="<?php echo esc_attr( $active_environment ? 'true' : 'false' ); ?>">
@@ -3169,6 +3327,30 @@ class PMProGateway_stripe extends PMProGateway {
 										}
 									?>
 									</span>
+								</td>
+							</tr>
+						<?php } ?>
+						<?php if ( $publishable_key_issue ) { ?>
+							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
+								<td colspan="2">
+									<div class="notice notice-large notice-error inline">
+										<p>
+											<strong><?php esc_html_e( 'Stripe could not refresh its publishable key.', 'paid-memberships-pro' ); ?></strong><br />
+											<?php esc_html_e( 'Onsite checkout or billing updates may be unavailable until an updated key can be retrieved.', 'paid-memberships-pro' ); ?>
+											<?php if ( 'unchanged' === $publishable_key_refresh_status ) { ?>
+												<br /><?php esc_html_e( 'No updated Stripe publishable key is available yet. The existing key was left unchanged.', 'paid-memberships-pro' ); ?>
+											<?php } elseif ( 'error' === $publishable_key_refresh_status ) { ?>
+												<br /><?php esc_html_e( 'Paid Memberships Pro could not check for an updated key. The existing key was left unchanged.', 'paid-memberships-pro' ); ?>
+											<?php } ?>
+											<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=pmpro_stripe_refresh_publishable_key' ), 'pmpro_stripe_refresh_publishable_key' ) ); ?>"><?php esc_html_e( 'Check for an updated Stripe key', 'paid-memberships-pro' ); ?></a>
+										</p>
+									</div>
+								</td>
+							</tr>
+						<?php } elseif ( 'success' === $publishable_key_refresh_status ) { ?>
+							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
+								<td colspan="2">
+									<div class="notice notice-large notice-success inline"><p><?php esc_html_e( 'The Stripe publishable key was updated.', 'paid-memberships-pro' ); ?></p></div>
 								</td>
 							</tr>
 						<?php } ?>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -178,7 +178,9 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_publishable_key_refresh_notice' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_deauthorize' ) );
 
-		// Show warning if webhooks are not set up.
+		// Show warnings if Stripe rejects the saved credentials or webhooks are not set up.
+		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_error_notice' ) );
+		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_publishable_key_issue_notice' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_webhook_setup_notice' ) );
 
 		add_filter( 'pmpro_process_refund_stripe', array( 'PMProGateway_stripe', 'process_refund' ), 10, 2 );
@@ -691,6 +693,8 @@ class PMProGateway_stripe extends PMProGateway {
 					// Show a message that Stripe must be conntected before webhook information is displayed.
 					if ( ! $stripe->get_secretkey() ) {
 						echo '<p>' . esc_html__( 'You must connect to Stripe before you can set up a webhook.', 'paid-memberships-pro' ) . '</p>';
+					} elseif ( $stripe->get_connection_error() ) {
+						echo '<p>' . esc_html__( 'Stripe is not accepting the credentials saved for this site. Restore the connection above before setting up a webhook.', 'paid-memberships-pro' ) . '</p>';
 					} else { ?>
 						<table class="form-table">
 							<?php
@@ -1069,6 +1073,9 @@ class PMProGateway_stripe extends PMProGateway {
 				update_option( 'pmpro_' . $setting, sanitize_text_field( $_REQUEST[ $setting ] ) );
 			}
 		}
+
+		// The saved keys may have changed, so check the connection again on the next load.
+		self::clear_connection_error_cache();
 	}
 
 	/**
@@ -1583,6 +1590,9 @@ class PMProGateway_stripe extends PMProGateway {
 			|| ! isset( $_REQUEST['pmpro_stripe_access_token'] )
 		) {
 			$error = __( 'Invalid response from the Stripe Connect server.', 'paid-memberships-pro' );
+		} elseif ( self::is_different_connected_account( $_REQUEST['pmpro_stripe_connected_environment'], $_REQUEST['pmpro_stripe_user_id'] ) ) {
+			// Reconnecting with a different account would orphan every existing customer and subscription.
+			$error = __( 'The Stripe account you just connected is not the account this site was already connected to, so the connection was left unchanged. Existing memberships are tied to the original account. To switch Stripe accounts, disconnect from Stripe first.', 'paid-memberships-pro' );
 		} else {
 			// Update keys.
 			if ( $_REQUEST['pmpro_stripe_connected_environment'] === 'live' ) {
@@ -1603,6 +1613,9 @@ class PMProGateway_stripe extends PMProGateway {
 			// Delete option for user API key.
 			delete_option( 'pmpro_stripe_secretkey' );
 			delete_option( 'pmpro_stripe_publishablekey' );
+
+			// The credentials changed, so check the connection again on the next load.
+			self::clear_connection_error_cache();
 
 			unset( $_GET['pmpro_stripe_connected'] );
 			unset( $_GET['pmpro_stripe_connected_environment'] );
@@ -1656,6 +1669,11 @@ class PMProGateway_stripe extends PMProGateway {
 
 		$gateway_environment = get_option( 'pmpro_gateway_environment' );
 		if ( ! self::has_connect_credentials( $gateway_environment, false ) ) {
+			return;
+		}
+
+		$stripe = new PMProGateway_stripe();
+		if ( $stripe->get_connection_error() ) {
 			return;
 		}
 
@@ -1748,6 +1766,9 @@ class PMProGateway_stripe extends PMProGateway {
 			delete_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
 		}
 		self::clear_connect_publishable_key_issue( $_REQUEST['pmpro_stripe_disconnected_environment'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		// The credentials changed, so check the connection again on the next load.
+		self::clear_connection_error_cache();
 	}
 
 	/**
@@ -1762,6 +1783,117 @@ class PMProGateway_stripe extends PMProGateway {
 		_deprecated_function( __FUNCTION__, '3.0.4' );
 		global $pmpro_stripe_old_payment_flow;
 		$pmpro_stripe_old_payment_flow = empty( $old_value ) ? 'onsite' : $old_value;
+	}
+
+	/**
+	 * If Stripe is the current gateway but it is rejecting the saved credentials, show an admin notice.
+	 *
+	 * @since TBD
+	 */
+	public static function show_stripe_connection_error_notice() {
+		// Only show to users who can fix the connection.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// If Stripe isn't the current gateway, we don't need to show the notice.
+		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return;
+		}
+
+		// Only show on PMPro admin pages, except for the Stripe settings screen, which shows the status inline.
+		$page         = isset( $_REQUEST['page'] ) && is_string( $_REQUEST['page'] ) ? $_REQUEST['page'] : '';
+		$edit_gateway = isset( $_REQUEST['edit_gateway'] ) && is_string( $_REQUEST['edit_gateway'] ) ? $_REQUEST['edit_gateway'] : '';
+		if ( false === strpos( $page, 'pmpro' ) || ( 'pmpro-paymentsettings' === $page && 'stripe' === $edit_gateway ) ) {
+			return;
+		}
+
+		$stripe           = new PMProGateway_stripe();
+		$connection_error = $stripe->get_connection_error();
+		if ( empty( $connection_error ) ) {
+			return;
+		}
+		?>
+		<div class="notice notice-error" id="pmpro-stripe_connection_error-notice">
+			<p><strong><?php esc_html_e( 'Important Notice: Your Stripe Connection Is No Longer Valid', 'paid-memberships-pro' ); ?></strong></p>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: The error message returned by Stripe. */
+					esc_html__( 'Stripe rejected the credentials saved for this site with the error "%s". Members will not be able to check out or update their billing information until the connection is restored.', 'paid-memberships-pro' ),
+					esc_html( $connection_error )
+				);
+				?>
+			</p>
+			<p>
+				<?php
+				if ( self::using_api_keys() ) {
+					echo '<a href="' . esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe' ), admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Update your Stripe API keys', 'paid-memberships-pro' ) . '</a>';
+				} else {
+					printf(
+						/* translators: %s: Link with the text "Reconnect with Stripe". */
+						esc_html__( '%s using the same Stripe account that this site was previously connected to.', 'paid-memberships-pro' ),
+						'<a href="' . esc_url( self::get_connect_url( get_option( 'pmpro_gateway_environment' ), 'authorize' ) ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>'
+					);
+				}
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * If the Stripe Connect publishable key could not be refreshed, show an admin notice.
+	 *
+	 * @since TBD
+	 */
+	public static function show_stripe_publishable_key_issue_notice() {
+		// Only show to users who can fix the connection.
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			return;
+		}
+
+		// If Stripe isn't the current gateway, we don't need to show the notice.
+		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return;
+		}
+
+		// Only show on PMPro admin pages, except for the Stripe settings screen, which shows the status inline.
+		$page         = isset( $_REQUEST['page'] ) && is_string( $_REQUEST['page'] ) ? $_REQUEST['page'] : '';
+		$edit_gateway = isset( $_REQUEST['edit_gateway'] ) && is_string( $_REQUEST['edit_gateway'] ) ? $_REQUEST['edit_gateway'] : '';
+		if ( false === strpos( $page, 'pmpro' ) || ( 'pmpro-paymentsettings' === $page && 'stripe' === $edit_gateway ) ) {
+			return;
+		}
+
+		if ( self::using_api_keys() ) {
+			return;
+		}
+
+		$environment = 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox';
+		if ( ! self::has_connect_credentials( $environment, false ) || ! self::get_connect_publishable_key_issue( $environment ) ) {
+			return;
+		}
+
+		$stripe = new PMProGateway_stripe();
+		if ( $stripe->get_connection_error() ) {
+			return;
+		}
+		?>
+		<div class="notice notice-error" id="pmpro-stripe_publishable_key_issue-notice">
+			<p><strong><?php esc_html_e( 'Important Notice: Your Stripe Connection Needs Attention', 'paid-memberships-pro' ); ?></strong></p>
+			<p><?php esc_html_e( 'Paid Memberships Pro could not automatically retrieve an updated Stripe publishable key. Onsite checkout and billing updates may be unavailable.', 'paid-memberships-pro' ); ?></p>
+			<p>
+				<a href="<?php echo esc_url( self::get_publishable_key_refresh_url() ); ?>"><?php esc_html_e( 'Check for an updated Stripe key', 'paid-memberships-pro' ); ?></a>
+				<?php
+				printf(
+					/* translators: %s: Link with the text "Reconnect with Stripe". */
+					esc_html__( 'or %s using the same Stripe account.', 'paid-memberships-pro' ),
+					'<a href="' . esc_url( self::get_connect_url( $environment, 'authorize' ) ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>'
+				);
+				?>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**
@@ -1780,8 +1912,14 @@ class PMProGateway_stripe extends PMProGateway {
 			return;
 		}
 
-		// Get webhook data from Stripe.
+		// If Stripe is rejecting the saved credentials, the connection error notice covers it
+		// and any webhook check would fail for the wrong reason.
 		$stripe = new PMProGateway_stripe();
+		if ( $stripe->get_connection_error() ) {
+			return;
+		}
+
+		// Get webhook data from Stripe.
 		$webhook = $stripe->does_webhook_exist();
 
 		if ( empty( $webhook ) || ! is_array( $webhook ) ) {
@@ -2352,6 +2490,20 @@ class PMProGateway_stripe extends PMProGateway {
 		$redirect_url = add_query_arg( 'pmpro_stripe_publishable_key_refresh', $refresh_status, $redirect_url );
 		wp_safe_redirect( $redirect_url );
 		exit;
+	}
+
+	/**
+	 * Check whether a Stripe account returned by the Connect server differs from the one already saved for an environment.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $gateway_environment The environment being connected, 'live' or 'sandbox'.
+	 * @param string $stripe_user_id      The Stripe account ID returned by the Connect server.
+	 * @return bool True if a different account is already saved for this environment.
+	 */
+	private static function is_different_connected_account( $gateway_environment, $stripe_user_id ) {
+		$saved_user_id = get_option( 'pmpro_' . ( 'live' === $gateway_environment ? 'live' : 'sandbox' ) . '_stripe_connect_user_id' );
+		return ! empty( $saved_user_id ) && $saved_user_id !== $stripe_user_id;
 	}
 
 	/**
@@ -3358,24 +3510,28 @@ class PMProGateway_stripe extends PMProGateway {
 	 */
 	private function show_connection_settings_section( $livemode ) {
 		$environment = $livemode ? 'live' : 'sandbox';
-		$environment2 = $livemode ? 'live' : 'test'; // For when 'test' is used instead of 'sandbox'.
+
+		// Determine if this is the active environment. Anything other than 'live' uses the sandbox keys.
+		$active_environment = $environment === ( 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox' );
+
+		// Check whether Stripe is accepting the saved credentials. Only the active environment's credentials are in use.
+		$connection_error = $active_environment ? $this->get_connection_error() : false;
 
 		// Determine if the gateway is connected in live mode and set var.
-		if ( self::has_connect_credentials( $environment ) || self::using_api_keys() ) {
+		if ( ! empty( $connection_error ) ) {
+			$connection_selector = 'error';
+		} elseif ( self::has_connect_credentials( $environment ) || self::using_api_keys() ) {
 			$connection_selector = $livemode ? 'success' : 'alert';
 		} else {
 			$connection_selector = $livemode ? 'error' : 'alert';
 		}
 
-		// Determine if this is the active environment.
-		$active_environment = $environment === get_option( 'pmpro_gateway_environment' );
-		$publishable_key_issue = false;
+		$publishable_key_issue          = false;
 		$publishable_key_refresh_status = '';
-		if ( $active_environment && ! self::using_api_keys() && self::has_connect_credentials( $environment, false ) ) {
+		if ( $active_environment && empty( $connection_error ) && ! self::using_api_keys() && self::has_connect_credentials( $environment, false ) ) {
 			$publishable_key_issue          = self::get_connect_publishable_key_issue( $environment );
 			$publishable_key_refresh_status = self::get_publishable_key_refresh_status();
 		}
-
 		?>
 		<div id="pmpro_stripe_<?php echo esc_attr( $environment); ?>" class="pmpro_section" data-visibility="<?php echo esc_attr( $active_environment ? 'shown' : 'hidden' ); ?>" data-activated="<?php echo esc_attr( $active_environment ? 'true' : 'false' ); ?>">
 			<div class="pmpro_section_toggle">
@@ -3396,17 +3552,49 @@ class PMProGateway_stripe extends PMProGateway {
 									<span class="pmpro_tag pmpro_tag-<?php echo esc_attr( $connection_selector ); ?>">
 									<?php
 										echo ( $livemode ? esc_html__( 'Live Mode:', 'paid-memberships-pro' ) : esc_html__( 'Test Mode:', 'paid-memberships-pro' ) ) . ' ';
-										if ( self::using_legacy_keys() ) {
+										if ( ! empty( $connection_error ) ) {
+											esc_html_e( 'Connection Error', 'paid-memberships-pro' );
+										} elseif ( self::using_legacy_keys() ) {
 											esc_html_e( 'Connected with Legacy Keys', 'paid-memberships-pro' );
 										} elseif ( self::using_api_keys() ) {
 											esc_html_e( 'Connected with API Keys', 'paid-memberships-pro' );
-										} elseif( self::has_connect_credentials( $environment ) ) {
+										} elseif ( self::has_connect_credentials( $environment ) ) {
 											esc_html_e( 'Connected', 'paid-memberships-pro' );
 										} else {
 											esc_html_e( 'Not Connected', 'paid-memberships-pro' );
 										}
 									?>
 									</span>
+								</td>
+							</tr>
+						<?php } ?>
+						<?php if ( ! empty( $connection_error ) ) { ?>
+							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
+								<td colspan="2">
+									<div class="notice notice-large notice-error inline">
+										<p>
+											<strong><?php esc_html_e( 'Stripe is no longer accepting the credentials saved for this site.', 'paid-memberships-pro' ); ?></strong><br />
+											<?php
+											printf(
+												/* translators: %s: The error message returned by Stripe. */
+												esc_html__( 'Stripe returned the error "%s". Members will not be able to check out or update their billing information until the connection is restored.', 'paid-memberships-pro' ),
+												esc_html( $connection_error )
+											);
+											?>
+											<br />
+											<?php
+											if ( self::using_api_keys() ) {
+												esc_html_e( 'Enter a new Restricted Key below to restore the connection.', 'paid-memberships-pro' );
+											} else {
+												printf(
+													/* translators: %s: Link with the text "Reconnect with Stripe". */
+													esc_html__( '%s using the same Stripe account that this site was previously connected to.', 'paid-memberships-pro' ),
+													'<a href="' . esc_url( self::get_connect_url( $environment, 'authorize' ) ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>'
+												);
+											}
+											?>
+										</p>
+									</div>
 								</td>
 							</tr>
 						<?php } ?>
@@ -3422,6 +3610,8 @@ class PMProGateway_stripe extends PMProGateway {
 											<a class="button button-secondary" href="<?php echo esc_url( self::get_publishable_key_refresh_url() ); ?>">
 												<?php echo esc_html( in_array( $publishable_key_refresh_status, array( 'error', 'unchanged' ), true ) ? __( 'Try checking again', 'paid-memberships-pro' ) : __( 'Check for an updated Stripe key', 'paid-memberships-pro' ) ); ?>
 											</a>
+											<?php esc_html_e( 'or', 'paid-memberships-pro' ); ?>
+											<a href="<?php echo esc_url( self::get_connect_url( $environment, 'authorize' ) ); ?>"><?php esc_html_e( 'Reconnect with Stripe', 'paid-memberships-pro' ); ?></a>
 										</p>
 									</div>
 								</td>
@@ -3457,17 +3647,8 @@ class PMProGateway_stripe extends PMProGateway {
 							</th>
 							<td>
 								<?php
-								$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
 								if ( self::has_connect_credentials( $environment ) ) {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'disconnect',
-											'gateway_environment' => $environment2,
-											'stripe_user_id' => get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' ),
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
+									$connect_url = self::get_connect_url( $environment, 'disconnect' );
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<p class="description">
@@ -3481,14 +3662,7 @@ class PMProGateway_stripe extends PMProGateway {
 									</p>
 									<?php
 								} else {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'authorize',
-											'gateway_environment' => $environment2,
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
+									$connect_url = self::get_connect_url( $environment, 'authorize' );
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Connect with Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<?php
@@ -3580,6 +3754,116 @@ class PMProGateway_stripe extends PMProGateway {
 			</div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Build the URL used to start or end a Stripe Connect session for an environment.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $environment The gateway environment, 'live' or 'sandbox'.
+	 * @param string $action      The Connect action, 'authorize' or 'disconnect'.
+	 * @return string The URL on the Connect server to send the admin to.
+	 */
+	private static function get_connect_url( $environment, $action ) {
+		$environment = 'live' === $environment ? 'live' : 'sandbox';
+
+		$return_url_args = array(
+			'page'         => 'pmpro-paymentsettings',
+			'edit_gateway' => 'stripe',
+		);
+		$connect_args = array(
+			'action'              => $action,
+			'gateway_environment' => 'live' === $environment ? 'live' : 'test', // The Connect server uses 'test' instead of 'sandbox'.
+		);
+		if ( 'disconnect' === $action ) {
+			$connect_args['stripe_user_id'] = get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' );
+			$return_url_args['pmpro_stripe_connect_deauthorize_nonce'] = wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' );
+		} else {
+			$return_url_args['pmpro_stripe_connect_nonce'] = wp_create_nonce( 'pmpro_stripe_connect_nonce' );
+		}
+		$connect_args['return_url'] = rawurlencode( add_query_arg( $return_url_args, admin_url( 'admin.php' ) ) );
+
+		return add_query_arg( $connect_args, apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' ) );
+	}
+
+	/**
+	 * Check whether Stripe is accepting the credentials saved for the active gateway environment.
+	 *
+	 * Makes one small read-only request to Stripe and caches the result. Only an authentication
+	 * failure (a 401 response) counts as a rejected credential. Permission errors from a restricted
+	 * key and network problems do not, since the credentials themselves may be fine.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|false The error message returned by Stripe if the credentials were rejected, false otherwise.
+	 */
+	public function get_connection_error() {
+		// Nothing to check if the library didn't load or there is no key to test.
+		if ( ! self::$is_loaded || empty( $this->get_secretkey() ) ) {
+			return false;
+		}
+
+		$cache_key = 'pmpro_stripe_connection_error_' . ( 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox' );
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) && array_key_exists( 'error', $cached ) ) {
+			return $cached['error'];
+		}
+
+		// Pass the key explicitly so the probe never depends on whatever key was last set globally.
+		$exception = null;
+		try {
+			Stripe_Customer::all( array( 'limit' => 1 ), array( 'api_key' => $this->get_secretkey() ) );
+		} catch ( \Throwable $e ) {
+			$exception = $e;
+		} catch ( \Exception $e ) {
+			$exception = $e;
+		}
+
+		// Classify by HTTP status rather than exception class so this still works when another
+		// plugin loaded an older Stripe library before we could load ours.
+		$error      = false;
+		$cache_time = HOUR_IN_SECONDS;
+		if ( ! empty( $exception ) ) {
+			$status = method_exists( $exception, 'getHttpStatus' ) ? (int) $exception->getHttpStatus() : 0;
+			if ( 401 === $status ) {
+				// Stripe rejected the key. Check again soon so the notice clears quickly once it is fixed.
+				$error      = $exception->getMessage() ? $exception->getMessage() : __( 'Invalid API key.', 'paid-memberships-pro' );
+				$cache_time = 5 * MINUTE_IN_SECONDS;
+			} elseif ( empty( $status ) || $status >= 500 || 429 === $status ) {
+				// Network trouble or a Stripe outage. Don't trust the result for long.
+				$cache_time = 5 * MINUTE_IN_SECONDS;
+			}
+			// Anything else, such as a restricted key without permission for this endpoint, is not a rejected key.
+		}
+
+		set_transient( $cache_key, array( 'error' => $error ), $cache_time );
+
+		return $error;
+	}
+
+	/**
+	 * Get the result of the last connection check without contacting Stripe.
+	 *
+	 * Safe to call on any request, including the frontend, since it only reads the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @return string|false The cached error message from Stripe, or false if none is cached.
+	 */
+	public static function get_cached_connection_error() {
+		$cached = get_transient( 'pmpro_stripe_connection_error_' . ( 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox' ) );
+		return ( is_array( $cached ) && ! empty( $cached['error'] ) ) ? $cached['error'] : false;
+	}
+
+	/**
+	 * Forget the cached connection check so that the next admin page load checks again.
+	 *
+	 * @since TBD
+	 */
+	public static function clear_connection_error_cache() {
+		delete_transient( 'pmpro_stripe_connection_error_live' );
+		delete_transient( 'pmpro_stripe_connection_error_sandbox' );
 	}
 
 	/**

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -179,8 +179,7 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_deauthorize' ) );
 
 		// Show warnings if Stripe rejects the saved credentials or webhooks are not set up.
-		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_error_notice' ) );
-		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_publishable_key_issue_notice' ) );
+		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_notices' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_webhook_setup_notice' ) );
 
 		add_filter( 'pmpro_process_refund_stripe', array( 'PMProGateway_stripe', 'process_refund' ), 10, 2 );
@@ -1786,13 +1785,13 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * If Stripe is the current gateway but it is rejecting the saved credentials, show an admin notice.
+	 * If Stripe is the current gateway and the saved credentials or publishable key are not working, show an admin notice.
 	 *
 	 * @since TBD
 	 */
-	public static function show_stripe_connection_error_notice() {
+	public static function show_stripe_connection_notices() {
 		// Only show to users who can fix the connection.
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
 			return;
 		}
 
@@ -1810,9 +1809,29 @@ class PMProGateway_stripe extends PMProGateway {
 
 		$stripe           = new PMProGateway_stripe();
 		$connection_error = $stripe->get_connection_error();
-		if ( empty( $connection_error ) ) {
+		if ( ! empty( $connection_error ) ) {
+			self::show_stripe_connection_error_notice( $connection_error );
 			return;
 		}
+
+		if ( self::using_api_keys() ) {
+			return;
+		}
+
+		$environment = 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox';
+		if ( self::has_connect_credentials( $environment, false ) && self::get_connect_publishable_key_issue( $environment ) ) {
+			self::show_stripe_publishable_key_issue_notice( $environment );
+		}
+	}
+
+	/**
+	 * If Stripe is rejecting the saved credentials, show an admin notice.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $connection_error The error message returned by Stripe.
+	 */
+	private static function show_stripe_connection_error_notice( $connection_error ) {
 		?>
 		<div class="notice notice-error" id="pmpro-stripe_connection_error-notice">
 			<p><strong><?php esc_html_e( 'Important Notice: Your Stripe Connection Is No Longer Valid', 'paid-memberships-pro' ); ?></strong></p>
@@ -1846,38 +1865,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * If the Stripe Connect publishable key could not be refreshed, show an admin notice.
 	 *
 	 * @since TBD
+	 *
+	 * @param string $environment The Stripe environment with the publishable key issue.
 	 */
-	public static function show_stripe_publishable_key_issue_notice() {
-		// Only show to users who can fix the connection.
-		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
-			return;
-		}
-
-		// If Stripe isn't the current gateway, we don't need to show the notice.
-		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
-			return;
-		}
-
-		// Only show on PMPro admin pages, except for the Stripe settings screen, which shows the status inline.
-		$page         = isset( $_REQUEST['page'] ) && is_string( $_REQUEST['page'] ) ? $_REQUEST['page'] : '';
-		$edit_gateway = isset( $_REQUEST['edit_gateway'] ) && is_string( $_REQUEST['edit_gateway'] ) ? $_REQUEST['edit_gateway'] : '';
-		if ( false === strpos( $page, 'pmpro' ) || ( 'pmpro-paymentsettings' === $page && 'stripe' === $edit_gateway ) ) {
-			return;
-		}
-
-		if ( self::using_api_keys() ) {
-			return;
-		}
-
-		$environment = 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox';
-		if ( ! self::has_connect_credentials( $environment, false ) || ! self::get_connect_publishable_key_issue( $environment ) ) {
-			return;
-		}
-
-		$stripe = new PMProGateway_stripe();
-		if ( $stripe->get_connection_error() ) {
-			return;
-		}
+	private static function show_stripe_publishable_key_issue_notice( $environment ) {
 		?>
 		<div class="notice notice-error" id="pmpro-stripe_publishable_key_issue-notice">
 			<p><strong><?php esc_html_e( 'Important Notice: Your Stripe Connection Needs Attention', 'paid-memberships-pro' ); ?></strong></p>

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1875,11 +1875,12 @@ class PMProGateway_stripe extends PMProGateway {
 	/**
 	 * Determine whether the site has Stripe Connect credentials set based on gateway environment.
 	 *
-	 * @param null|string $gateway_environment The gateway environment to use, default uses the current saved setting.
+	 * @param null|string $gateway_environment    The gateway environment to use, default uses the current saved setting.
+	 * @param bool        $require_publishable_key Whether a saved publishable key is required.
 	 *
 	 * @return bool Whether the site has Stripe Connect credentials set.
 	 */
-	public static function has_connect_credentials( $gateway_environment = null ) {
+	public static function has_connect_credentials( $gateway_environment = null, $require_publishable_key = true ) {
 		if ( empty( $gateway_environment ) ) {
 			$gateway_environment = get_option( 'pmpro_gateway_environment' );
 		}
@@ -1889,14 +1890,14 @@ class PMProGateway_stripe extends PMProGateway {
 			return (
 				get_option( 'pmpro_live_stripe_connect_user_id' ) &&
 				get_option( 'pmpro_live_stripe_connect_secretkey' ) &&
-				get_option( 'pmpro_live_stripe_connect_publishablekey' )
+				( ! $require_publishable_key || get_option( 'pmpro_live_stripe_connect_publishablekey' ) )
 			);
 		} else {
 			// Return whether Stripe is connected for sandbox gateway environment.
 			return (
 				get_option( 'pmpro_sandbox_stripe_connect_user_id' ) &&
 				get_option( 'pmpro_sandbox_stripe_connect_secretkey' ) &&
-				get_option( 'pmpro_sandbox_stripe_connect_publishablekey' )
+				( ! $require_publishable_key || get_option( 'pmpro_sandbox_stripe_connect_publishablekey' ) )
 			);
 		}
 	}
@@ -1909,7 +1910,7 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return true|WP_Error True when no refresh is needed or the refresh succeeds. WP_Error on failure.
 	 */
 	public static function maybe_refresh_connect_publishable_keys() {
-		if ( self::using_api_keys() || ! self::has_connect_account_credentials() ) {
+		if ( self::using_api_keys() || ! self::has_connect_credentials( null, false ) ) {
 			return true;
 		}
 
@@ -1919,6 +1920,9 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 		$cache_lifetime = (int) apply_filters( 'pmpro_stripe_connect_publishable_key_cache_lifetime', 6 * HOUR_IN_SECONDS );
 		if ( ! empty( $cache['checked_at'] ) && ( time() - (int) $cache['checked_at'] ) < max( 0, $cache_lifetime ) ) {
+			return true;
+		}
+		if ( get_transient( 'pmpro_stripe_connect_platform_keys_refresh_failed' ) ) {
 			return true;
 		}
 
@@ -1935,50 +1939,76 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return array|WP_Error The validated cache or a WP_Error on failure.
 	 */
 	public static function refresh_connect_publishable_keys() {
-		if ( get_transient( 'pmpro_stripe_connect_platform_keys_refreshing' ) ) {
+		$lock_option = 'pmpro_stripe_connect_platform_keys_refresh_lock';
+		$lock_time   = (int) get_option( $lock_option );
+		if ( $lock_time && ( time() - $lock_time ) >= MINUTE_IN_SECONDS ) {
+			delete_option( $lock_option );
+		}
+		if ( ! add_option( $lock_option, time(), '', false ) ) {
 			return new WP_Error( 'pmpro_stripe_connect_platform_keys_refreshing', __( 'The Stripe publishable keys are already being refreshed.', 'paid-memberships-pro' ) );
 		}
 
-		set_transient( 'pmpro_stripe_connect_platform_keys_refreshing', 1, MINUTE_IN_SECONDS );
+		try {
+			$manifest_url = apply_filters(
+				'pmpro_stripe_connect_publishable_key_manifest_url',
+				'https://connect.paidmembershipspro.com/stripe/v1/platform-keys.json'
+			);
+			$response = wp_safe_remote_get(
+				$manifest_url,
+				array(
+					'timeout'             => 5,
+					'redirection'         => 2,
+					'limit_response_size' => 8192,
+					'headers'             => array( 'Accept' => 'application/json' ),
+				)
+			);
 
-		$manifest_url = apply_filters(
-			'pmpro_stripe_connect_publishable_key_manifest_url',
-			'https://connect.paidmembershipspro.com/stripe/v1/platform-keys.json'
-		);
-		$response = wp_safe_remote_get(
-			$manifest_url,
-			array(
-				'timeout'             => 5,
-				'redirection'         => 2,
-				'limit_response_size' => 8192,
-				'headers'             => array( 'Accept' => 'application/json' ),
-			)
-		);
+			if ( is_wp_error( $response ) ) {
+				self::record_connect_publishable_key_refresh_failure();
+				return $response;
+			}
 
-		delete_transient( 'pmpro_stripe_connect_platform_keys_refreshing' );
+			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				self::record_connect_publishable_key_refresh_failure();
+				return new WP_Error( 'pmpro_stripe_connect_manifest_http_error', __( 'The Stripe publishable-key manifest could not be retrieved.', 'paid-memberships-pro' ) );
+			}
 
-		if ( is_wp_error( $response ) ) {
-			return $response;
+			$manifest = json_decode( wp_remote_retrieve_body( $response ), true );
+			$manifest = self::validate_connect_publishable_key_manifest( $manifest );
+			if ( is_wp_error( $manifest ) ) {
+				self::record_connect_publishable_key_refresh_failure();
+				return $manifest;
+			}
+
+			$manifest['checked_at'] = time();
+			update_option( 'pmpro_stripe_connect_platform_keys', $manifest, false );
+			$stored_manifest = get_option( 'pmpro_stripe_connect_platform_keys', array() );
+			if ( $stored_manifest !== $manifest ) {
+				self::record_connect_publishable_key_refresh_failure();
+				return new WP_Error( 'pmpro_stripe_connect_manifest_cache_error', __( 'The Stripe publishable-key manifest could not be cached.', 'paid-memberships-pro' ) );
+			}
+
+			delete_transient( 'pmpro_stripe_connect_platform_keys_refresh_failed' );
+			return $stored_manifest;
+		} finally {
+			delete_option( $lock_option );
 		}
+	}
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'pmpro_stripe_connect_manifest_http_error', __( 'The Stripe publishable-key manifest could not be retrieved.', 'paid-memberships-pro' ) );
+	/**
+	 * Briefly pause automatic manifest checks after a failed refresh.
+	 *
+	 * @since 3.8.6
+	 *
+	 * @return void
+	 */
+	private static function record_connect_publishable_key_refresh_failure() {
+		$retry_interval = (int) apply_filters( 'pmpro_stripe_connect_publishable_key_failure_retry_interval', 5 * MINUTE_IN_SECONDS );
+		if ( $retry_interval > 0 ) {
+			set_transient( 'pmpro_stripe_connect_platform_keys_refresh_failed', 1, $retry_interval );
+		} else {
+			delete_transient( 'pmpro_stripe_connect_platform_keys_refresh_failed' );
 		}
-
-		$manifest = json_decode( wp_remote_retrieve_body( $response ), true );
-		$manifest = self::validate_connect_publishable_key_manifest( $manifest );
-		if ( is_wp_error( $manifest ) ) {
-			return $manifest;
-		}
-
-		$manifest['checked_at'] = time();
-		update_option( 'pmpro_stripe_connect_platform_keys', $manifest, false );
-		$stored_manifest = get_option( 'pmpro_stripe_connect_platform_keys', array() );
-		if ( $stored_manifest !== $manifest ) {
-			return new WP_Error( 'pmpro_stripe_connect_manifest_cache_error', __( 'The Stripe publishable-key manifest could not be cached.', 'paid-memberships-pro' ) );
-		}
-
-		return $stored_manifest;
 	}
 
 	/**
@@ -2067,20 +2097,6 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Determine whether the account credentials needed to refresh a Connect key exist.
-	 *
-	 * @since 3.8.6
-	 *
-	 * @return bool Whether the current environment has a Connect account and access token.
-	 */
-	private static function has_connect_account_credentials() {
-		$gateway_environment = get_option( 'pmpro_gateway_environment' );
-		$prefix = 'live' === $gateway_environment ? 'pmpro_live_' : 'pmpro_sandbox_';
-
-		return ! empty( get_option( $prefix . 'stripe_connect_user_id' ) ) && ! empty( get_option( $prefix . 'stripe_connect_secretkey' ) );
-	}
-
-	/**
 	 * Force a publishable-key refresh after Stripe reports an expired platform key.
 	 *
 	 * @since 3.8.6
@@ -2088,7 +2104,7 @@ class PMProGateway_stripe extends PMProGateway {
 	public static function wp_ajax_pmpro_stripe_refresh_publishable_key() {
 		check_ajax_referer( 'pmpro_stripe_refresh_publishable_key', 'nonce' );
 
-		if ( self::using_api_keys() || ! self::has_connect_account_credentials() ) {
+		if ( self::using_api_keys() || ! self::has_connect_credentials( null, false ) ) {
 			wp_send_json_error( array( 'message' => __( 'Stripe Connect is not configured.', 'paid-memberships-pro' ) ), 400 );
 		}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2167,7 +2167,7 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Force a publishable-key refresh after Stripe reports an expired platform key.
+	 * Force a publishable-key refresh after Stripe rejects the platform key.
 	 *
 	 * @since 3.8.6
 	 */
@@ -2179,8 +2179,8 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		$error_code = isset( $_POST['errorCode'] ) ? sanitize_key( wp_unslash( $_POST['errorCode'] ) ) : '';
-		if ( ! in_array( $error_code, array( 'api_key_expired', 'platform_api_key_expired' ), true ) ) {
-			wp_send_json_error( array( 'message' => __( 'Stripe did not report an expired publishable key.', 'paid-memberships-pro' ) ), 400 );
+		if ( ! in_array( $error_code, array( 'api_key_expired', 'platform_api_key_expired', 'invalid_api_key' ), true ) ) {
+			wp_send_json_error( array( 'message' => __( 'Stripe did not report a rejected publishable key.', 'paid-memberships-pro' ) ), 400 );
 		}
 
 		$gateway_environment      = get_option( 'pmpro_gateway_environment' );

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -3843,20 +3843,6 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Get the result of the last connection check without contacting Stripe.
-	 *
-	 * Safe to call on any request, including the frontend, since it only reads the cache.
-	 *
-	 * @since TBD
-	 *
-	 * @return string|false The cached error message from Stripe, or false if none is cached.
-	 */
-	public static function get_cached_connection_error() {
-		$cached = get_transient( 'pmpro_stripe_connection_error_' . ( 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox' ) );
-		return ( is_array( $cached ) && ! empty( $cached['error'] ) ) ? $cached['error'] : false;
-	}
-
-	/**
 	 * Forget the cached connection check so that the next admin page load checks again.
 	 *
 	 * @since TBD

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -3,7 +3,23 @@ var pmpro_require_billing;
 // Wire up the form for Stripe.
 jQuery( document ).ready( function( $ ) {
 
-	var stripe, elements, cardNumber, cardExpiry, cardCvc;
+	var stripe, elements, cardNumber, cardExpiry, cardCvc, publishableKeyRefreshAttempted = false;
+	var publishableKeyRefreshStorageKey = 'pmpro_stripe_publishable_key_refresh_attempted';
+	var publishableKeyRefreshNoticeKey = 'pmpro_stripe_publishable_key_refresh_notice';
+
+	try {
+		if ( window.sessionStorage.getItem( publishableKeyRefreshNoticeKey ) === pmproStripe.publishableKey ) {
+			window.sessionStorage.removeItem( publishableKeyRefreshNoticeKey );
+			$( '#pmpro_message, #pmpro_message_bottom' )
+				.text( pmproStripe.msgPublishableKeyRefreshed )
+				.addClass( 'pmpro_alert' )
+				.removeClass( 'pmpro_error pmpro_success' )
+				.attr( 'role', 'status' )
+				.show();
+		}
+	} catch ( storageError ) {
+		// Session storage may be unavailable in privacy-restricted browsers.
+	}
 
 	/**
 	 * Identify with Stripe.
@@ -222,18 +238,18 @@ jQuery( document ).ready( function( $ ) {
 		form = $('#pmpro_form, .pmpro_form');
 
 		if (response.error) {
-			// There was an issue with the payment method supplied or card authentication failed.
-			// Re-enable the submit button.
-			$('.pmpro_btn-submit-checkout,.pmpro_btn-submit').removeAttr('disabled');
+			if ( pmpro_maybe_refresh_stripe_publishable_key( response.error ) ) {
+				return;
+			}
+			if ( [ 'api_key_expired', 'platform_api_key_expired' ].indexOf( response.error.code ) === -1 ) {
+				pmpro_clear_publishable_key_refresh_attempt();
+			}
 
-			// Hide processing message.
-			$('#pmpro_processing_message').css('visibility', 'hidden');
-
-			// error message
-			$( '#pmpro_message' ).text( response.error.message ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
-			$( '#pmpro_message_bottom' ).text( response.error.message ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
+			pmpro_show_stripe_error( response.error.message );
 			
-		} else if ( response.paymentMethod ) {			
+		} else if ( response.paymentMethod ) {
+			pmpro_clear_publishable_key_refresh_attempt();
+
 			// A payment method was created successfully. Submit the checkout form and finish the checkout in PHP.
 			paymentMethodId = response.paymentMethod.id;
 			card = response.paymentMethod.card;			
@@ -257,6 +273,8 @@ jQuery( document ).ready( function( $ ) {
 			form.submit();			
 			
 		} else if ( response.paymentIntent || response.setupIntent ) {
+			pmpro_clear_publishable_key_refresh_attempt();
+
 			// Card authentication was successful. Finish the checkout in PHP.
 			// success message
 			$( '#pmpro_message' ).text( pmproStripe.msgAuthenticationValidated ).addClass( 'pmpro_success' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_error' ).show();
@@ -292,6 +310,103 @@ jQuery( document ).ready( function( $ ) {
 			form.append( '<input type="hidden" name="ExpirationYear" value="' + card.exp_year + '"/>' );
 			form.submit();
 			return true;
+		}
+	}
+
+	/**
+	 * Refresh an expired Stripe Connect platform key and reload Elements once.
+	 *
+	 * Stripe Elements cannot move an existing card Element to a new Stripe instance, so a reload
+	 * is required after the key changes. Session storage prevents a reload loop.
+	 *
+	 * @param {Object} error Stripe.js error response.
+	 * @return {boolean} Whether key recovery was started.
+	 */
+	function pmpro_maybe_refresh_stripe_publishable_key( error ) {
+		var expiredKeyCodes = [ 'api_key_expired', 'platform_api_key_expired' ];
+		var attemptedKey = '';
+
+		if ( ! error || expiredKeyCodes.indexOf( error.code ) === -1 || ! pmproStripe.user_id || publishableKeyRefreshAttempted ) {
+			return false;
+		}
+
+		try {
+			attemptedKey = window.sessionStorage.getItem( publishableKeyRefreshStorageKey );
+		} catch ( storageError ) {
+			attemptedKey = '';
+		}
+
+		if ( attemptedKey === pmproStripe.publishableKey ) {
+			return false;
+		}
+
+		publishableKeyRefreshAttempted = true;
+		try {
+			window.sessionStorage.setItem( publishableKeyRefreshStorageKey, pmproStripe.publishableKey );
+		} catch ( storageError ) {
+			// The in-memory guard still prevents another attempt on this page.
+		}
+
+		$( '#pmpro_message, #pmpro_message_bottom' )
+			.text( pmproStripe.msgRefreshingPublishableKey )
+			.addClass( 'pmpro_alert' )
+			.removeClass( 'pmpro_error pmpro_success' )
+			.attr( 'role', 'status' )
+			.show();
+
+		$.post(
+			pmproStripe.ajaxUrl,
+			{
+				action: 'pmpro_stripe_refresh_publishable_key',
+				nonce: pmproStripe.publishableKeyRefreshNonce,
+			}
+		).done( function( response ) {
+			if (
+				response.success && response.data && response.data.publishableKey &&
+				response.data.publishableKey !== pmproStripe.publishableKey
+			) {
+				try {
+					window.sessionStorage.setItem( publishableKeyRefreshStorageKey, response.data.publishableKey );
+					window.sessionStorage.setItem( publishableKeyRefreshNoticeKey, response.data.publishableKey );
+				} catch ( storageError ) {
+					// The in-memory guard still prevents another attempt on this page.
+				}
+				window.location.reload();
+				return;
+			}
+
+			pmpro_show_stripe_error( error.message );
+		} ).fail( function() {
+			pmpro_show_stripe_error( error.message );
+		} );
+
+		return true;
+	}
+
+	/**
+	 * Show a Stripe.js error and restore the checkout controls.
+	 *
+	 * @param {string} message Error message to show.
+	 */
+	function pmpro_show_stripe_error( message ) {
+		$( '.pmpro_btn-submit-checkout,.pmpro_btn-submit' ).removeAttr( 'disabled' );
+		$( '#pmpro_processing_message' ).css( 'visibility', 'hidden' );
+		$( '#pmpro_message, #pmpro_message_bottom' )
+			.text( message )
+			.addClass( 'pmpro_error' )
+			.removeClass( 'pmpro_alert pmpro_success' )
+			.attr( 'role', 'alert' )
+			.show();
+	}
+
+	/**
+	 * Allow recovery from a future key rotation after Stripe accepts the current key.
+	 */
+	function pmpro_clear_publishable_key_refresh_attempt() {
+		try {
+			window.sessionStorage.removeItem( publishableKeyRefreshStorageKey );
+		} catch ( storageError ) {
+			// Session storage may be unavailable in privacy-restricted browsers.
 		}
 	}
 });

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -241,7 +241,7 @@ jQuery( document ).ready( function( $ ) {
 			if ( pmpro_maybe_refresh_stripe_publishable_key( response.error ) ) {
 				return;
 			}
-			if ( [ 'api_key_expired', 'platform_api_key_expired' ].indexOf( response.error.code ) === -1 ) {
+			if ( [ 'api_key_expired', 'platform_api_key_expired', 'invalid_api_key' ].indexOf( response.error.code ) === -1 ) {
 				pmpro_clear_publishable_key_refresh_attempt();
 			}
 
@@ -314,7 +314,7 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	/**
-	 * Refresh an expired Stripe Connect platform key and reload Elements once.
+	 * Refresh a rejected Stripe Connect platform key and reload Elements once.
 	 *
 	 * Stripe Elements cannot move an existing card Element to a new Stripe instance, so a reload
 	 * is required after the key changes. Session storage prevents a reload loop.
@@ -323,10 +323,17 @@ jQuery( document ).ready( function( $ ) {
 	 * @return {boolean} Whether key recovery was started.
 	 */
 	function pmpro_maybe_refresh_stripe_publishable_key( error ) {
-		var expiredKeyCodes = [ 'api_key_expired', 'platform_api_key_expired' ];
+		var publishableKeyErrorCodes = [ 'api_key_expired', 'platform_api_key_expired', 'invalid_api_key' ];
 		var attemptedKey = '';
 
-		if ( ! error || expiredKeyCodes.indexOf( error.code ) === -1 || ! pmproStripe.usingConnect || publishableKeyRefreshAttempted ) {
+		if (
+			error && ! error.code && 'invalid_request_error' === error.type &&
+			error.message && 0 === error.message.indexOf( 'Invalid API Key provided' )
+		) {
+			error.code = 'invalid_api_key';
+		}
+
+		if ( ! error || publishableKeyErrorCodes.indexOf( error.code ) === -1 || ! pmproStripe.usingConnect || publishableKeyRefreshAttempted ) {
 			return false;
 		}
 

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -326,7 +326,7 @@ jQuery( document ).ready( function( $ ) {
 		var expiredKeyCodes = [ 'api_key_expired', 'platform_api_key_expired' ];
 		var attemptedKey = '';
 
-		if ( ! error || expiredKeyCodes.indexOf( error.code ) === -1 || ! pmproStripe.user_id || publishableKeyRefreshAttempted ) {
+		if ( ! error || expiredKeyCodes.indexOf( error.code ) === -1 || ! pmproStripe.usingConnect || publishableKeyRefreshAttempted ) {
 			return false;
 		}
 
@@ -337,6 +337,16 @@ jQuery( document ).ready( function( $ ) {
 		}
 
 		if ( attemptedKey === pmproStripe.publishableKey ) {
+			$.post(
+				pmproStripe.ajaxUrl,
+				{
+					action: 'pmpro_stripe_refresh_publishable_key',
+					nonce: pmproStripe.publishableKeyRefreshNonce,
+					errorCode: error.code,
+					publishableKey: pmproStripe.publishableKey,
+					reportOnly: true,
+				}
+			);
 			return false;
 		}
 
@@ -359,6 +369,8 @@ jQuery( document ).ready( function( $ ) {
 			{
 				action: 'pmpro_stripe_refresh_publishable_key',
 				nonce: pmproStripe.publishableKeyRefreshNonce,
+				errorCode: error.code,
+				publishableKey: pmproStripe.publishableKey,
 			}
 		).done( function( response ) {
 			if (

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -403,6 +403,7 @@ jQuery( document ).ready( function( $ ) {
 	 * Allow recovery from a future key rotation after Stripe accepts the current key.
 	 */
 	function pmpro_clear_publishable_key_refresh_attempt() {
+		publishableKeyRefreshAttempted = false;
 		try {
 			window.sessionStorage.removeItem( publishableKeyRefreshStorageKey );
 		} catch ( storageError ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Stripe Connect currently saves the platform publishable key returned during OAuth forever. Rotating that platform key breaks on-site Stripe Elements checkout and billing updates, even though the connected account and access token remain valid.

This PR:

- Fetches the combined live/test platform-key manifest proposed in [pmpro-stripe-connect-server#1](https://github.com/strangerstudios/pmpro-stripe-connect-server/pull/1) when an on-site Connect checkout or billing page is rendered.
- Validates the complete response before atomically replacing one durable one-week cache record.
- Keeps both the prior validated manifest and the original OAuth-returned publishable key as last-known-good fallbacks when HTTP, JSON, validation, or storage fails.
- Recognizes Stripe.js `api_key_expired`, `platform_api_key_expired`, and its code-less `Invalid API Key provided` response, performs one nonce-protected refresh through `admin-ajax.php`, and reloads Elements once if the key changed.
- Records an environment-specific issue when automatic recovery fails, returns the same key, or the refreshed key is rejected again.
- Shows a contextual Payment Settings error and nonce-protected “Check for an updated Stripe key” button only while that issue is present. Manual checks also show a standard top-of-page notice that distinguishes a temporary connection failure from a completed check where the key was unchanged; a successful changed-key refresh clears the issue.
- Prevents all manifest refresh and recovery behavior from engaging when a complete local API-key pair takes precedence, including mixed states where old Connect credentials remain stored.
- Prevents reload loops with session storage and explains that payment details must be re-entered after recovery because an existing Stripe Element cannot be moved to a new Stripe instance.
- Adds filters for the manifest URL and cache lifetime.

This intentionally does not redesign the payment settings UI or establish a longer-term retry/backoff policy.

### How to test the changes in this Pull Request:

1. Configure Stripe Connect in sandbox mode and select the on-site payment flow.
2. Filter `pmpro_stripe_connect_publishable_key_manifest_url` or `pre_http_request` to return a schema-version-1 manifest with dummy live/test publishable keys.
3. Load checkout and confirm the current-mode manifest key is cached and localized to `pmpro-stripe.js`.
4. Return malformed JSON, a non-200 response, or an `sk_...` value and confirm the prior cached key remains unchanged.
5. Simulate `api_key_expired` from Stripe.js and confirm one AJAX refresh/reload occurs when the manifest key changes; repeat with the refreshed key and confirm there is no second reload.
6. Confirm a failed, unchanged, or repeatedly rejected recovery records an issue and displays the conditional check link in the active Stripe Connection section.
7. Use the link and confirm a changed key clears the issue, while an unchanged or failed response preserves the prior key and warning.
8. Configure a complete restricted-key pair while leaving Connect credentials stored. Confirm no manifest request occurs, the local keys remain effective, no Connect account is localized to Stripe.js, and the warning/link remains hidden.
9. Submit a normal card error such as `card_declined` and confirm it does not trigger key recovery.

Verified on `flintdev.test` with intercepted HTTP responses:

- valid live/test manifests cache successfully;
- invalid manifests preserve the prior cache;
- a two-day-old cache makes no additional request under the one-week lifetime;
- a missing cache refreshes lazily from the manifest;
- anonymous AJAX refresh succeeds with a valid nonce and rejects an invalid nonce with HTTP 403;
- the check link is hidden normally, appears for a detected Connect issue, and remains hidden for restricted-key sites;
- restricted keys bypass manifest HTTP and remain the effective secret/publishable-key pair even when Connect credentials remain stored;
- isolated Stripe.js tests pass for one-shot recovery, reload-loop prevention, and non-key errors;
- PHP and JavaScript syntax checks pass.

### Merged from #3783 (@dparker1005)

This PR now also includes the Stripe connection check from #3783, rebased onto `dev`, so #3783 can be closed:

- `get_connection_error()` probes Stripe with the active environment's secret key (one Customer list, 401 = rejected credentials), cached per environment in a transient (1 hour healthy, 5 minutes on a 401 or transient failure). Cache clears on Stripe settings save, Connect return, and disconnect.
- Payment settings: the Status tag becomes **Connection Error** with an inline notice showing Stripe's message and a **Reconnect with Stripe** link (Connect) or a prompt to enter a new Restricted Key (API keys). The webhook section stops probing until the connection is restored.
- Admin notice on all PMPro admin pages for `manage_options` users with the same reconnect link. The misleading webhook notice is suppressed while the connection error is present.
- Site Health gateway line includes the connection error.
- Same-account guard: the Connect return handler refuses to overwrite an existing connection with a different Stripe account.
- Inline Connect URL building moved into `get_connect_url()`.

### How the two error states combine

- **Secret key rejected (with or without a publishable-key issue):** only the secret-key messaging above is shown. Reconnecting fixes the publishable key too, so the publishable-key row and notice are suppressed until the secret key works again.
- **Publishable key issue only:** the existing "Stripe checkout may be unavailable" row in the payment settings table, plus a new admin notice on all PMPro admin pages wired like the connection error notice. Both offer **Check for an updated Stripe key** or **Reconnect with Stripe**.

### Additional testing for the merged behavior

10. Connect in sandbox, then revoke the token from the Stripe dashboard (Settings → Authorized applications) or roll the Restricted Key. Within 5 minutes (or after saving Stripe settings) the Status tag, inline notice, and admin notice on other PMPro pages should all flip; the webhook notice should stop showing.
11. Click **Reconnect with Stripe** with the same account. Everything should clear immediately.
12. Reconnect with a *different* account. The connection should stay unchanged and the error should explain why.
13. With both a rejected secret key and a recorded publishable-key issue, only the secret-key messaging should appear. After reconnecting, both should clear.
14. With a working secret key and a recorded publishable-key issue, the publishable-key notice should appear on PMPro admin pages (not on the Stripe settings screen, where the inline row covers it).

### Changelog entry

BUG FIX: Refresh Stripe Connect platform publishable keys for on-site Stripe Elements checkout and billing updates.
ENHANCEMENT: Detect when Stripe no longer accepts the saved Stripe credentials and show the admin a notice with an option to reconnect. #3783 #3789 (@dparker1005)
BUG FIX: The Stripe webhook notice no longer reports a missing webhook when the real problem is that Stripe is rejecting the saved credentials. #3783 #3789 (@dparker1005)
BUG FIX: Connecting to Stripe now refuses to overwrite an existing connection with a different Stripe account. #3783 #3789 (@dparker1005)
