### PR TITLE
Update orders directly in the 3.8.4 transaction ID recovery instead of calling saveOrder()

### DIFF
--- a/includes/updates/upgrade_3_8_4.php
+++ b/includes/updates/upgrade_3_8_4.php
@@ -138,8 +138,17 @@ function pmpro_stripe_recover_checkout_transaction_ids() {
 			$checkout_session = null;
 		}
 		if ( empty( $checkout_session ) ) {
+			// Write the note directly rather than calling saveOrder(), which would
+			// fire the pmpro_update_order/pmpro_updated_order hooks (Zapier, etc.)
+			// for a change that no integration needs to be notified about.
 			$order->add_order_note( __( 'Could not retrieve the Stripe Checkout Session for this order while trying to recover its missing transaction IDs.', 'paid-memberships-pro' ) );
-			$order->saveOrder();
+			$wpdb->update(
+				$wpdb->pmpro_membership_orders,
+				array( 'notes' => $order->notes ),
+				array( 'id' => $order->id ),
+				array( '%s' ),
+				array( '%d' )
+			);
 			update_pmpro_membership_order_meta( $order->id, 'stripe_checkout_transaction_id_recovery', 'failed' );
 			continue;
 		}
@@ -194,8 +203,21 @@ function pmpro_stripe_recover_checkout_transaction_ids() {
 			continue;
 		}
 
+		// Write the recovered IDs and note directly rather than calling saveOrder(),
+		// which would rewrite the whole row and fire the pmpro_update_order/
+		// pmpro_updated_order hooks (Zapier, etc.) for every affected order.
 		$order->add_order_note( __( 'Missing transaction IDs for this order were recovered from its Stripe Checkout Session.', 'paid-memberships-pro' ) );
-		$order->saveOrder();
+		$wpdb->update(
+			$wpdb->pmpro_membership_orders,
+			array(
+				'payment_transaction_id'      => $order->payment_transaction_id,
+				'subscription_transaction_id' => $order->subscription_transaction_id,
+				'notes'                       => $order->notes,
+			),
+			array( 'id' => $order->id ),
+			array( '%s', '%s', '%s' ),
+			array( '%d' )
+		);
 		update_pmpro_membership_order_meta( $order->id, 'stripe_checkout_transaction_id_recovery', 'recovered' );
 
 		// Make sure a subscription record exists for recovered subscription orders.


### PR DESCRIPTION
## Summary

The 3.8.4 upgrade's Stripe Checkout transaction ID recovery task called `MemberOrder::saveOrder()` for every affected order. `saveOrder()` rewrites the entire order row and fires `pmpro_update_order` / `pmpro_updated_order`, so every recovered order produced an "order updated" event. Sites with many affected orders hit Zapier zap limits and had other order-update integrations run for a change that only touched transaction IDs and a note.

This replaces both `saveOrder()` calls with direct `$wpdb->update()` writes:

- Failure path (Checkout Session could not be retrieved): writes `notes` only.
- Success path: writes `payment_transaction_id`, `subscription_transaction_id`, and `notes`.

`add_order_note()` is still used so note formatting is unchanged. Nothing else in the recovery depended on `saveOrder()` side effects; the subscription record is already created explicitly afterward.

Only sites that have not yet run (or are mid-way through) the recovery chain are affected, since processed orders are marked in order meta.

## Testing

- PHP lint passes.
- Verified by reading code; not run against a live Stripe account.

## Proposed changelog entry

- BUG FIX: The 3.8.4 upgrade no longer fires order update hooks (e.g. Zapier) for every order whose Stripe transaction IDs were recovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
