### PR TITLE
BUG FIX: Refresh Stripe Connect platform publishable keys

### DIFF
--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1213,7 +1213,7 @@ class PMProGateway_stripe extends PMProGateway {
 	public static function wp_ajax_pmpro_stripe_refresh_publishable_key() {
 		check_ajax_referer( 'pmpro_stripe_refresh_publishable_key', 'nonce' );
 
-		if ( self::using_api_keys() ) {
+		if ( self::using_api_keys() || ! self::has_connect_credentials() ) {
 			wp_send_json_error();
 		}
 
@@ -1239,7 +1239,7 @@ class PMProGateway_stripe extends PMProGateway {
 				$stripe = new PMProGateway_stripe();
 				$localize_vars = array(
 					'publishableKey' => $stripe->get_publishablekey(),
-					'publishableKeyRefreshNonce' => self::using_api_keys() ? '' : wp_create_nonce( 'pmpro_stripe_refresh_publishable_key' ),
+					'publishableKeyRefreshNonce' => ( self::using_api_keys() || ! self::has_connect_credentials() ) ? '' : wp_create_nonce( 'pmpro_stripe_refresh_publishable_key' ),
 					'msgPublishableKeyRefreshed' => __( 'There was a problem connecting to the payment gateway. Please reload this page and try again.', 'paid-memberships-pro' ),
 					'user_id'        => $stripe->get_connect_user_id(),
 					'verifyAddress'  => apply_filters( 'pmpro_stripe_verify_address', get_option( 'pmpro_stripe_billingaddress' ) ),
@@ -1941,10 +1941,10 @@ class PMProGateway_stripe extends PMProGateway {
 			! is_array( $keys ) ||
 			! isset( $keys['live']['publishable_key'] ) ||
 			! is_string( $keys['live']['publishable_key'] ) ||
-			strpos( $keys['live']['publishable_key'], 'pk_live_' ) !== 0 ||
+			! preg_match( '/^pk_live_[A-Za-z0-9]+$/', $keys['live']['publishable_key'] ) ||
 			! isset( $keys['test']['publishable_key'] ) ||
 			! is_string( $keys['test']['publishable_key'] ) ||
-			strpos( $keys['test']['publishable_key'], 'pk_test_' ) !== 0
+			! preg_match( '/^pk_test_[A-Za-z0-9]+$/', $keys['test']['publishable_key'] )
 		) {
 			return false;
 		}
@@ -4510,9 +4510,9 @@ class PMProGateway_stripe extends PMProGateway {
 	private static function get_cached_connect_publishable_key( $gateway_environment ) {
 		$keys        = get_option( 'pmpro_stripe_connect_platform_keys' );
 		$environment = $gateway_environment === 'live' ? 'live' : 'test';
-		$prefix      = $environment === 'live' ? 'pk_live_' : 'pk_test_';
+		$pattern     = $environment === 'live' ? '/^pk_live_[A-Za-z0-9]+$/' : '/^pk_test_[A-Za-z0-9]+$/';
 
-		if ( ! is_array( $keys ) || ! isset( $keys[ $environment ] ) || ! is_string( $keys[ $environment ] ) || strpos( $keys[ $environment ], $prefix ) !== 0 ) {
+		if ( ! is_array( $keys ) || ! isset( $keys[ $environment ] ) || ! is_string( $keys[ $environment ] ) || ! preg_match( $pattern, $keys[ $environment ] ) ) {
 			return '';
 		}
 

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -131,6 +131,8 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'wp_ajax_pmpro_stripe_create_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_create_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_delete_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_delete_webhook' ) );
 		add_action( 'wp_ajax_pmpro_stripe_rebuild_webhook', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_rebuild_webhook' ) );
+		add_action( 'wp_ajax_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_refresh_publishable_key' ) );
+		add_action( 'wp_ajax_nopriv_pmpro_stripe_refresh_publishable_key', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_refresh_publishable_key' ) );
 
 		//code to add at checkout if Stripe is the current gateway
 		$default_gateway = get_option( 'pmpro_gateway' );
@@ -1204,6 +1206,21 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
+	 * Refresh the Stripe Connect publishable key after a browser failure.
+	 *
+	 * @since TBD
+	 */
+	public static function wp_ajax_pmpro_stripe_refresh_publishable_key() {
+		check_ajax_referer( 'pmpro_stripe_refresh_publishable_key', 'nonce' );
+
+		if ( self::using_api_keys() ) {
+			wp_send_json_error();
+		}
+
+		wp_send_json_success( array( 'refreshed' => (bool) self::refresh_connect_publishable_keys() ) );
+	}
+
+	/**
 	 * Code added to checkout preheader.
 	 *
 	 * @since 1.8
@@ -1218,9 +1235,12 @@ class PMProGateway_stripe extends PMProGateway {
 			wp_enqueue_script( "stripe", "https://js.stripe.com/v3/", array(), null );
 
 			if ( ! function_exists( 'pmpro_stripe_javascript' ) ) {
+				self::maybe_refresh_connect_publishable_keys();
 				$stripe = new PMProGateway_stripe();
 				$localize_vars = array(
 					'publishableKey' => $stripe->get_publishablekey(),
+					'publishableKeyRefreshNonce' => self::using_api_keys() ? '' : wp_create_nonce( 'pmpro_stripe_refresh_publishable_key' ),
+					'msgPublishableKeyRefreshed' => __( 'There was a problem connecting to the payment gateway. Please reload this page and try again.', 'paid-memberships-pro' ),
 					'user_id'        => $stripe->get_connect_user_id(),
 					'verifyAddress'  => apply_filters( 'pmpro_stripe_verify_address', get_option( 'pmpro_stripe_billingaddress' ) ),
 					'ajaxUrl'        => admin_url( "admin-ajax.php" ),
@@ -1890,6 +1910,72 @@ class PMProGateway_stripe extends PMProGateway {
 				get_option( 'pmpro_sandbox_stripe_connect_secretkey' ) &&
 				get_option( 'pmpro_sandbox_stripe_connect_publishablekey' )
 			);
+		}
+	}
+
+	/**
+	 * Refresh the cached Stripe Connect platform publishable keys.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the keys were refreshed.
+	 */
+	public static function refresh_connect_publishable_keys() {
+		if ( get_transient( 'pmpro_stripe_connect_platform_keys_checked' ) ) {
+			return false;
+		}
+
+		set_transient( 'pmpro_stripe_connect_platform_keys_checked', true, 5 * MINUTE_IN_SECONDS );
+
+		$response = wp_safe_remote_get(
+			apply_filters( 'pmpro_stripe_connect_publishable_key_manifest_url', 'https://connect.paidmembershipspro.com/stripe/v1/platform-keys.json' ),
+			array( 'timeout' => 5 )
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		$keys = json_decode( wp_remote_retrieve_body( $response ), true );
+		if (
+			! is_array( $keys ) ||
+			! isset( $keys['live']['publishable_key'] ) ||
+			! is_string( $keys['live']['publishable_key'] ) ||
+			strpos( $keys['live']['publishable_key'], 'pk_live_' ) !== 0 ||
+			! isset( $keys['test']['publishable_key'] ) ||
+			! is_string( $keys['test']['publishable_key'] ) ||
+			strpos( $keys['test']['publishable_key'], 'pk_test_' ) !== 0
+		) {
+			return false;
+		}
+
+		update_option(
+			'pmpro_stripe_connect_platform_keys',
+			array(
+				'live'       => $keys['live']['publishable_key'],
+				'test'       => $keys['test']['publishable_key'],
+				'checked_at' => time(),
+			),
+			false
+		);
+
+		return true;
+	}
+
+	/**
+	 * Refresh stale Stripe Connect platform publishable keys.
+	 *
+	 * @since TBD
+	 */
+	public static function maybe_refresh_connect_publishable_keys() {
+		if ( self::using_api_keys() || ! self::has_connect_credentials() ) {
+			return;
+		}
+
+		$keys           = get_option( 'pmpro_stripe_connect_platform_keys' );
+		$cache_lifetime = apply_filters( 'pmpro_stripe_connect_publishable_key_cache_lifetime', WEEK_IN_SECONDS );
+		if ( ! is_array( $keys ) || empty( $keys['checked_at'] ) || $keys['checked_at'] < time() - $cache_lifetime ) {
+			self::refresh_connect_publishable_keys();
 		}
 	}
 
@@ -4401,11 +4487,36 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( self::using_api_keys() ) {
 			$publishablekey = get_option( 'pmpro_stripe_publishablekey' );
 		} else {
-			$publishablekey = get_option( 'pmpro_gateway_environment' ) === 'live'
-				? get_option( 'pmpro_live_stripe_connect_publishablekey' )
-				: get_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
+			// Prefer the current platform key from the manifest cache and fall back to the key saved during OAuth.
+			$gateway_environment = get_option( 'pmpro_gateway_environment' );
+			$publishablekey      = self::get_cached_connect_publishable_key( $gateway_environment );
+			if ( empty( $publishablekey ) ) {
+				$publishablekey = $gateway_environment === 'live'
+					? get_option( 'pmpro_live_stripe_connect_publishablekey' )
+					: get_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
+			}
 		}
 		return $publishablekey;
+	}
+
+	/**
+	 * Get a cached Stripe Connect platform publishable key.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $gateway_environment The gateway environment.
+	 * @return string The cached publishable key.
+	 */
+	private static function get_cached_connect_publishable_key( $gateway_environment ) {
+		$keys        = get_option( 'pmpro_stripe_connect_platform_keys' );
+		$environment = $gateway_environment === 'live' ? 'live' : 'test';
+		$prefix      = $environment === 'live' ? 'pk_live_' : 'pk_test_';
+
+		if ( ! is_array( $keys ) || ! isset( $keys[ $environment ] ) || ! is_string( $keys[ $environment ] ) || strpos( $keys[ $environment ], $prefix ) !== 0 ) {
+			return '';
+		}
+
+		return $keys[ $environment ];
 	}
 
 	/**

--- a/js/pmpro-stripe.js
+++ b/js/pmpro-stripe.js
@@ -217,11 +217,22 @@ jQuery( document ).ready( function( $ ) {
 	 */
 	function pmpro_stripeResponseHandler( response ) {
 
-		var form, data, card, paymentMethodId;
+		var form, data, card, paymentMethodId, errorMessage, publishableKeyError;
 
 		form = $('#pmpro_form, .pmpro_form');
 
 		if (response.error) {
+			errorMessage = response.error.message;
+			publishableKeyError = $.inArray( response.error.code, [ 'api_key_expired', 'platform_api_key_expired', 'invalid_api_key' ] ) !== -1 ||
+				( response.error.type === 'invalid_request_error' && typeof errorMessage === 'string' && ( errorMessage.indexOf( 'Invalid API Key provided' ) === 0 || errorMessage.indexOf( 'Expired API Key provided' ) === 0 ) );
+			if ( publishableKeyError && pmproStripe.publishableKeyRefreshNonce ) {
+				$.post( pmproStripe.ajaxUrl, {
+					action: 'pmpro_stripe_refresh_publishable_key',
+					nonce: pmproStripe.publishableKeyRefreshNonce
+				} );
+				errorMessage = pmproStripe.msgPublishableKeyRefreshed;
+			}
+
 			// There was an issue with the payment method supplied or card authentication failed.
 			// Re-enable the submit button.
 			$('.pmpro_btn-submit-checkout,.pmpro_btn-submit').removeAttr('disabled');
@@ -230,8 +241,8 @@ jQuery( document ).ready( function( $ ) {
 			$('#pmpro_processing_message').css('visibility', 'hidden');
 
 			// error message
-			$( '#pmpro_message' ).text( response.error.message ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
-			$( '#pmpro_message_bottom' ).text( response.error.message ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
+			$( '#pmpro_message' ).text( errorMessage ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
+			$( '#pmpro_message_bottom' ).text( errorMessage ).addClass( 'pmpro_error' ).removeClass( 'pmpro_alert' ).removeClass( 'pmpro_success' ).attr('role', 'alert').show();
 			
 		} else if ( response.paymentMethod ) {			
 			// A payment method was created successfully. Submit the checkout form and finish the checkout in PHP.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:

Stripe Connect sites save the platform publishable key returned during OAuth forever. Rotating that platform key breaks onsite Stripe Elements checkout and billing updates even though the connected account and secret key are still valid.

This is the minimal fix, replacing the larger #3789:

- When the checkout or billing page renders for a Connect site, fetch the current platform keys from `https://connect.paidmembershipspro.com/stripe/v1/platform-keys.json` if the cache is missing or older than a week (`pmpro_stripe_connect_publishable_key_cache_lifetime` filter, manifest URL filterable via `pmpro_stripe_connect_publishable_key_manifest_url`).
- Cache both live and test keys in the `pmpro_stripe_connect_platform_keys` option. `get_publishablekey()` prefers the cached key for the current environment and falls back to the key saved during OAuth.
- When Stripe.js rejects the publishable key in the browser (`api_key_expired`, `platform_api_key_expired`, `invalid_api_key`, or the code-less "Invalid/Expired API Key provided" message), the checkout JS fires a nonce-protected AJAX request that refreshes the cache and shows "There was a problem connecting to the payment gateway. Please reload this page and try again." No automatic reload.
- Refreshes are throttled to one attempt per 5 minutes regardless of outcome. A failed or invalid manifest response leaves the existing cache untouched.
- Sites using their own API keys never fetch the manifest and never get the refresh nonce.

No settings UI, admin notices, or Site Health changes. Those can follow separately.

### How to test the changes in this Pull Request:

1. Configure Stripe Connect in sandbox mode with the onsite payment flow and load checkout. Confirm `pmpro_stripe_connect_platform_keys` is populated and `pmproStripe.publishableKey` matches the manifest test key.
2. Set `pmpro_sandbox_stripe_connect_publishablekey` to a bogus `pk_test_…` value and delete the `pmpro_stripe_connect_platform_keys` option. Load checkout: the manifest is fetched on render and the correct key is used, so checkout works.
3. Set the cached `test` key in `pmpro_stripe_connect_platform_keys` to a bogus `pk_test_…` value and delete the `pmpro_stripe_connect_platform_keys_checked` transient. Submit checkout: Stripe.js rejects the key, the "reload this page and try again" message shows, and the option is refreshed with the real key. Reload and checkout succeeds.
4. Repeat step 3 immediately: the throttle transient prevents a second manifest request within 5 minutes.
5. Configure a restricted key pair instead of Connect. Confirm no manifest request and no `publishableKeyRefreshNonce` in the localized script data.
6. Submit a normal card error such as `card_declined` and confirm it is displayed unchanged.

### Changelog entry

BUG FIX: Stripe Connect sites now refresh the platform publishable key from Paid Memberships Pro instead of using the key saved during the initial connection forever, so onsite checkout keeps working after the platform key is rotated.
