### PR TITLE
ENHANCEMENT: Stripe connection test on the payment settings page

### DIFF
--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -238,13 +238,15 @@
 												}
 											}
 
-											// Let the gateway add its own status tags, such as a connection error.
-											if ( ! empty( $gateway_class_name ) && class_exists( $gateway_class_name ) && method_exists( $gateway_class_name, 'get_status_tags_for_gateway_settings' ) ) {
-												$gateway_status_tags = call_user_func( array( $gateway_class_name, 'get_status_tags_for_gateway_settings' ) );
-												if ( ! empty( $gateway_status_tags ) ) {
-													$gateway_status_html .= ' ' . $gateway_status_tags;
-												}
-											}
+											/**
+											 * Filter the status HTML shown for a gateway in the payment gateways list.
+											 *
+											 * @since TBD
+											 *
+											 * @param string $gateway_status_html The status HTML, typically one or more pmpro_tag spans.
+											 * @param string $gateway_slug        The gateway being shown.
+											 */
+											$gateway_status_html = apply_filters( 'pmpro_payment_settings_gateway_status_html', $gateway_status_html, $gateway_slug );
 
 											echo wp_kses_post( $gateway_status_html );
 										?>

--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -238,15 +238,13 @@
 												}
 											}
 
-											/**
-											 * Filter the status HTML shown for a gateway in the payment gateways list.
-											 *
-											 * @since TBD
-											 *
-											 * @param string $gateway_status_html The status HTML, typically one or more pmpro_tag spans.
-											 * @param string $gateway_slug        The gateway being shown.
-											 */
-											$gateway_status_html = apply_filters( 'pmpro_payment_settings_gateway_status_html', $gateway_status_html, $gateway_slug );
+											// Let the gateway add its own status tags, such as a connection error.
+											if ( ! empty( $gateway_class_name ) && class_exists( $gateway_class_name ) && method_exists( $gateway_class_name, 'get_status_tags_for_gateway_settings' ) ) {
+												$gateway_status_tags = call_user_func( array( $gateway_class_name, 'get_status_tags_for_gateway_settings' ) );
+												if ( ! empty( $gateway_status_tags ) ) {
+													$gateway_status_html .= ' ' . $gateway_status_tags;
+												}
+											}
 
 											echo wp_kses_post( $gateway_status_html );
 										?>

--- a/adminpages/paymentsettings.php
+++ b/adminpages/paymentsettings.php
@@ -238,6 +238,16 @@
 												}
 											}
 
+											/**
+											 * Filter the status HTML shown for a gateway in the payment gateways list.
+											 *
+											 * @since TBD
+											 *
+											 * @param string $gateway_status_html The status HTML, typically one or more pmpro_tag spans.
+											 * @param string $gateway_slug        The gateway being shown.
+											 */
+											$gateway_status_html = apply_filters( 'pmpro_payment_settings_gateway_status_html', $gateway_status_html, $gateway_slug );
+
 											echo wp_kses_post( $gateway_status_html );
 										?>
 										</td>

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -272,6 +272,13 @@ class PMPro_Site_Health {
 				$gateway_text .= ' (' . __( 'API Version', 'paid-memberships-pro' ) . ': ' . PMPRO_STRIPE_API_VERSION . ')';
 			}
 
+			$connection_test = $stripe->get_connection_test_results();
+			if ( ! empty( $connection_test ) ) {
+				$failed = $stripe->get_failed_connection_tests( $connection_test );
+				// translators: %1$s: "passed" or a comma-separated list of failed checks. %2$s: The date of the last test.
+				$gateway_text .= ' (' . sprintf( __( 'Connection Test: %1$s on %2$s', 'paid-memberships-pro' ), empty( $failed ) ? __( 'passed', 'paid-memberships-pro' ) : __( 'failed', 'paid-memberships-pro' ) . ' ' . implode( ', ', $failed ), gmdate( 'Y-m-d', (int) $connection_test['timestamp'] ) ) . ')';
+			}
+
 			if ( $legacy ) {
 				$gateway_text .= ' (' . __( 'Legacy Keys', 'paid-memberships-pro' ) . ')';
 				return $gateway_text . ' [' . $gateway . ':legacy-keys]';

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -274,9 +274,14 @@ class PMPro_Site_Health {
 
 			$connection_test = PMProGateway_stripe::get_connection_test_results();
 			if ( ! empty( $connection_test ) ) {
-				$failed = PMProGateway_stripe::get_failed_connection_tests( $connection_test );
-				// translators: %1$s: "passed" or a comma-separated list of failed checks. %2$s: The date of the last test.
-				$gateway_text .= ' (' . sprintf( __( 'Connection Test: %1$s on %2$s', 'paid-memberships-pro' ), empty( $failed ) ? __( 'passed', 'paid-memberships-pro' ) : __( 'failed', 'paid-memberships-pro' ) . ' ' . implode( ', ', $failed ), gmdate( 'Y-m-d', (int) $connection_test['timestamp'] ) ) . ')';
+				$not_passed = array();
+				foreach ( $connection_test['results'] as $check => $result ) {
+					if ( 'pass' !== $result['status'] ) {
+						$not_passed[] = $check . ':' . $result['status'];
+					}
+				}
+				// translators: %1$s: "passed" or a comma-separated list of checks that did not pass. %2$s: The date of the last test.
+				$gateway_text .= ' (' . sprintf( __( 'Connection Test: %1$s on %2$s', 'paid-memberships-pro' ), empty( $not_passed ) ? __( 'passed', 'paid-memberships-pro' ) : implode( ', ', $not_passed ), gmdate( 'Y-m-d', (int) $connection_test['timestamp'] ) ) . ')';
 			}
 
 			if ( $legacy ) {

--- a/classes/class-pmpro-site-health.php
+++ b/classes/class-pmpro-site-health.php
@@ -272,9 +272,9 @@ class PMPro_Site_Health {
 				$gateway_text .= ' (' . __( 'API Version', 'paid-memberships-pro' ) . ': ' . PMPRO_STRIPE_API_VERSION . ')';
 			}
 
-			$connection_test = $stripe->get_connection_test_results();
+			$connection_test = PMProGateway_stripe::get_connection_test_results();
 			if ( ! empty( $connection_test ) ) {
-				$failed = $stripe->get_failed_connection_tests( $connection_test );
+				$failed = PMProGateway_stripe::get_failed_connection_tests( $connection_test );
 				// translators: %1$s: "passed" or a comma-separated list of failed checks. %2$s: The date of the last test.
 				$gateway_text .= ' (' . sprintf( __( 'Connection Test: %1$s on %2$s', 'paid-memberships-pro' ), empty( $failed ) ? __( 'passed', 'paid-memberships-pro' ) : __( 'failed', 'paid-memberships-pro' ) . ' ' . implode( ', ', $failed ), gmdate( 'Y-m-d', (int) $connection_test['timestamp'] ) ) . ')';
 			}

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -334,6 +334,19 @@
 		}
 
 		/**
+		 * Get extra status tags to show after this gateway's status in the payment gateways list.
+		 *
+		 * Gateways can override this to surface problems such as a failed connection test.
+		 *
+		 * @since TBD
+		 *
+		 * @return string HTML for zero or more pmpro_tag spans, or an empty string.
+		 */
+		public static function get_status_tags_for_gateway_settings() {
+			return '';
+		}
+
+		/**
 		 * Get a description for this gateway.
 		 *
 		 * @since 3.5

--- a/classes/gateways/class.pmprogateway.php
+++ b/classes/gateways/class.pmprogateway.php
@@ -334,19 +334,6 @@
 		}
 
 		/**
-		 * Get extra status tags to show after this gateway's status in the payment gateways list.
-		 *
-		 * Gateways can override this to surface problems such as a failed connection test.
-		 *
-		 * @since TBD
-		 *
-		 * @return string HTML for zero or more pmpro_tag spans, or an empty string.
-		 */
-		public static function get_status_tags_for_gateway_settings() {
-			return '';
-		}
-
-		/**
 		 * Get a description for this gateway.
 		 *
 		 * @since 3.5

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -14,6 +14,7 @@ use Stripe\ApplePayDomain as Stripe_ApplePayDomain;
 use Stripe\WebhookEndpoint as Stripe_Webhook;
 use Stripe\StripeClient as Stripe_Client; // Used for deleting webhook as of 2.4
 use Stripe\Account as Stripe_Account;
+use Stripe\Token as Stripe_Token;
 use Stripe\Checkout\Session as Stripe_Checkout_Session;
 
 define( "PMPRO_STRIPE_API_VERSION", "2025-09-30.clover" );
@@ -175,6 +176,12 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'admin_init', array( 'PMProGateway_stripe', 'stripe_connect_save_options' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_show_errors' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'stripe_connect_deauthorize' ) );
+
+		// Connection test: run daily, run on demand from the payment settings page, and warn admins about failures.
+		add_action( 'pmpro_schedule_daily', array( 'PMProGateway_stripe', 'run_scheduled_connection_test' ) );
+		add_action( 'admin_init', array( 'PMProGateway_stripe', 'maybe_run_connection_test_on_demand' ) );
+		add_action( 'wp_ajax_pmpro_stripe_run_connection_test', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_run_connection_test' ) );
+		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_notice' ) );
 
 		// Show warning if webhooks are not set up.
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_webhook_setup_notice' ) );
@@ -1067,6 +1074,9 @@ class PMProGateway_stripe extends PMProGateway {
 				update_option( 'pmpro_' . $setting, sanitize_text_field( $_REQUEST[ $setting ] ) );
 			}
 		}
+
+		// The saved keys may have changed, so the last connection test no longer applies.
+		self::clear_connection_test_results();
 	}
 
 	/**
@@ -1592,6 +1602,9 @@ class PMProGateway_stripe extends PMProGateway {
 			|| ! isset( $_REQUEST['pmpro_stripe_access_token'] )
 		) {
 			$error = __( 'Invalid response from the Stripe Connect server.', 'paid-memberships-pro' );
+		} elseif ( self::is_different_connected_account( $_REQUEST['pmpro_stripe_connected_environment'], $_REQUEST['pmpro_stripe_user_id'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			// Reconnecting with a different account would orphan every existing customer and subscription.
+			$error = __( 'The Stripe account you just connected is not the account this site was already connected to, so the connection was left unchanged. Existing memberships are tied to the original account. To switch Stripe accounts, disconnect from Stripe first. Note that disconnecting will disconnect all sites using the original Stripe account.', 'paid-memberships-pro' );
 		} else {
 			// Update keys.
 			if ( $_REQUEST['pmpro_stripe_connected_environment'] === 'live' ) {
@@ -1610,6 +1623,9 @@ class PMProGateway_stripe extends PMProGateway {
 			// Delete option for user API key.
 			delete_option( 'pmpro_stripe_secretkey' );
 			delete_option( 'pmpro_stripe_publishablekey' );
+
+			// The credentials changed, so the last connection test no longer applies.
+			self::clear_connection_test_results();
 
 			unset( $_GET['pmpro_stripe_connected'] );
 			unset( $_GET['pmpro_stripe_connected_environment'] );
@@ -1700,6 +1716,9 @@ class PMProGateway_stripe extends PMProGateway {
 			delete_option( 'pmpro_sandbox_stripe_connect_secretkey' );
 			delete_option( 'pmpro_sandbox_stripe_connect_publishablekey' );
 		}
+
+		// The credentials changed, so the last connection test no longer applies.
+		self::clear_connection_test_results();
 	}
 
 	/**
@@ -1717,6 +1736,54 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
+	 * If Stripe is the current gateway and the last connection test found that Stripe is rejecting the saved keys, show an admin notice.
+	 *
+	 * @since TBD
+	 */
+	public static function show_stripe_connection_notice() {
+		// Only show to users who can fix the connection.
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			return;
+		}
+
+		// If Stripe isn't the current gateway, we don't need to show the notice.
+		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return;
+		}
+
+		// Only show on PMPro admin pages except for the payment settings page, which shows the results inline.
+		$page = isset( $_REQUEST['page'] ) && is_string( $_REQUEST['page'] ) ? $_REQUEST['page'] : '';
+		if ( false === strpos( $page, 'pmpro' ) || 'pmpro-paymentsettings' === $page ) {
+			return;
+		}
+
+		// Nothing to test if Stripe isn't connected.
+		$stripe = new PMProGateway_stripe();
+		if ( empty( $stripe->get_secretkey() ) ) {
+			return;
+		}
+
+		// Only warn about failures the admin can fix. Reachability problems are usually temporary.
+		$results = self::get_connection_test_results();
+		$failed  = array_intersect( self::get_failed_connection_tests( $results ), array( 'secret_key', 'publishable_key' ) );
+		if ( empty( $failed ) ) {
+			return;
+		}
+		?>
+		<div class="notice notice-error" id="pmpro-stripe_connection-notice">
+			<p><strong><?php esc_html_e( 'Important Notice: Your Stripe Connection Needs Attention', 'paid-memberships-pro' ); ?></strong></p>
+			<p><?php esc_html_e( 'The most recent Stripe connection test found problems that may prevent members from checking out or updating their billing information:', 'paid-memberships-pro' ); ?></p>
+			<ul>
+				<?php foreach ( $failed as $test ) { ?>
+					<li><strong><?php echo esc_html( self::get_connection_test_label( $test ) ); ?>:</strong> <?php echo esc_html( $results['results'][ $test ]['message'] ); ?></li>
+				<?php } ?>
+			</ul>
+			<p><a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe' ), admin_url( 'admin.php' ) ) . '#pmpro_stripe_connection_test' ); ?>"><?php esc_html_e( 'Review the Stripe connection test', 'paid-memberships-pro' ); ?></a></p>
+		</div>
+		<?php
+	}
+
+	/**
 	 * If Stripe is the current gateway but webhooks are not set up, show an admin notice.
 	 *
 	 * @since 3.1.2
@@ -1729,6 +1796,12 @@ class PMProGateway_stripe extends PMProGateway {
 
 		// Only show on PMPro admin pages except for the payment settings page.
 		if ( empty( $_REQUEST['page'] ) || strpos( $_REQUEST['page'], 'pmpro' ) === false || 'pmpro-paymentsettings' === $_REQUEST['page'] ) {
+			return;
+		}
+
+		// If Stripe is rejecting the saved secret key, the connection notice covers it and any webhook check would fail for the wrong reason.
+		$connection_test = self::get_connection_test_results();
+		if ( ! empty( $connection_test ) && in_array( 'secret_key', self::get_failed_connection_tests( $connection_test ), true ) ) {
 			return;
 		}
 
@@ -1977,6 +2050,387 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( ! is_array( $keys ) || empty( $keys['checked_at'] ) || $keys['checked_at'] < time() - $cache_lifetime ) {
 			self::refresh_connect_publishable_keys();
 		}
+	}
+
+	/**
+	 * Test the Stripe connection and save the results.
+	 *
+	 * Checks whether Stripe and the Paid Memberships Pro Connect server can be reached, and whether Stripe
+	 * accepts the saved secret key and the publishable key that checkout uses. Each check has a status of
+	 * 'pass', 'fail', or 'unknown' and a message. Only an authentication failure (a 401 response) counts as
+	 * a rejected key. Permission errors from a restricted key do not, since the key itself is fine.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The saved results. See get_connection_test_results().
+	 */
+	public function run_connection_test() {
+		$results             = array();
+		$gateway_environment = 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox';
+		$secret_key          = $this->get_secretkey();
+
+		// Use short timeouts so a host that silently drops Stripe traffic can't stall the request for the library's 30 second default.
+		$http_client      = self::$is_loaded && class_exists( '\Stripe\HttpClient\CurlClient' ) ? \Stripe\HttpClient\CurlClient::instance() : null;
+		$default_timeouts = null;
+		if ( $http_client && method_exists( $http_client, 'getTimeout' ) && method_exists( $http_client, 'setTimeout' ) && method_exists( $http_client, 'getConnectTimeout' ) && method_exists( $http_client, 'setConnectTimeout' ) ) {
+			$default_timeouts = array( $http_client->getTimeout(), $http_client->getConnectTimeout() );
+			$http_client->setTimeout( 10 );
+			$http_client->setConnectTimeout( 5 );
+		}
+
+		// Stripe API reachability and secret key. One small read-only request answers both.
+		if ( ! self::$is_loaded || empty( $secret_key ) ) {
+			$results['stripe_api'] = array( 'status' => 'unknown', 'message' => __( 'Skipped because no Stripe credentials are saved for this environment.', 'paid-memberships-pro' ) );
+			$results['secret_key'] = array( 'status' => 'fail', 'message' => __( 'No Stripe credentials are saved for this environment.', 'paid-memberships-pro' ) );
+		} else {
+			$exception = null;
+			try {
+				// Pass the key explicitly so the check never depends on whatever key was last set globally.
+				Stripe_Customer::all( array( 'limit' => 1 ), array( 'api_key' => $secret_key ) );
+			} catch ( \Throwable $e ) {
+				$exception = $e;
+			} catch ( \Exception $e ) {
+				$exception = $e;
+			}
+
+			if ( empty( $exception ) ) {
+				$results['stripe_api'] = array( 'status' => 'pass', 'message' => __( 'Stripe responded normally.', 'paid-memberships-pro' ) );
+				$results['secret_key'] = array( 'status' => 'pass', 'message' => __( 'Stripe accepted the saved secret key.', 'paid-memberships-pro' ) );
+			} else {
+				// Classify by HTTP status rather than exception class so this still works when another plugin loaded an older Stripe library.
+				$status  = method_exists( $exception, 'getHttpStatus' ) ? (int) $exception->getHttpStatus() : 0;
+				$message = $exception->getMessage() ? $exception->getMessage() : __( 'Unknown error.', 'paid-memberships-pro' );
+				if ( empty( $status ) || $status >= 500 ) {
+					// No response or a Stripe outage. The key itself is not the problem.
+					if ( empty( $status ) ) {
+						// The library's connection error is several sentences long. Keep only the network reason.
+						$message = preg_match( '/\(Network error[^:]*:\s*(.+?)\)\s*$/s', $message, $matches )
+							/* translators: %s: The network error reported when trying to reach Stripe. */
+							? sprintf( __( 'Stripe could not be reached. %s.', 'paid-memberships-pro' ), rtrim( $matches[1], '.' ) )
+							: __( 'Stripe could not be reached.', 'paid-memberships-pro' );
+					}
+					$results['stripe_api'] = array( 'status' => 'fail', 'message' => $message );
+					$results['secret_key'] = array( 'status' => 'unknown', 'message' => __( 'Skipped because Stripe could not be reached.', 'paid-memberships-pro' ) );
+				} elseif ( 401 === $status ) {
+					$results['stripe_api'] = array( 'status' => 'pass', 'message' => __( 'Stripe responded normally.', 'paid-memberships-pro' ) );
+					$results['secret_key'] = array( 'status' => 'fail', 'message' => $message );
+				} else {
+					// Anything else, such as a restricted key without permission for this endpoint, means the key was accepted.
+					$results['stripe_api'] = array( 'status' => 'pass', 'message' => __( 'Stripe responded normally.', 'paid-memberships-pro' ) );
+					$results['secret_key'] = array( 'status' => 'pass', 'message' => __( 'Stripe accepted the saved secret key.', 'paid-memberships-pro' ) );
+				}
+			}
+		}
+
+		// Connect server. Retrieve the current platform publishable key now, ignoring the usual throttle.
+		if ( ! self::using_api_keys() && ! empty( $secret_key ) ) {
+			delete_transient( 'pmpro_stripe_connect_platform_keys_checked' );
+			if ( self::refresh_connect_publishable_keys() ) {
+				$results['connect_server'] = array( 'status' => 'pass', 'message' => __( 'The current platform publishable key was retrieved from Paid Memberships Pro.', 'paid-memberships-pro' ) );
+			} else {
+				$results['connect_server'] = array( 'status' => 'fail', 'message' => __( 'The Paid Memberships Pro Connect server could not be reached or returned an invalid response. Checkout is using the last known publishable key.', 'paid-memberships-pro' ) );
+			}
+		}
+
+		// Publishable key. Check the format for API key sites, then ask Stripe to accept the key that checkout will actually use.
+		$publishable_key = $this->get_publishablekey();
+		$expected_prefix = 'live' === $gateway_environment ? 'pk_live_' : 'pk_test_';
+		if ( empty( $secret_key ) ) {
+			$results['publishable_key'] = array( 'status' => 'unknown', 'message' => __( 'Skipped because no Stripe credentials are saved for this environment.', 'paid-memberships-pro' ) );
+		} elseif ( self::using_api_keys() && 0 !== strpos( $publishable_key, $expected_prefix ) ) {
+			if ( 0 === strpos( $publishable_key, 'pk_' ) ) {
+				$results['publishable_key'] = array(
+					'status'  => 'fail',
+					'message' => 'live' === $gateway_environment
+						? __( 'The saved publishable key is a test mode key, but the gateway environment is set to live.', 'paid-memberships-pro' )
+						: __( 'The saved publishable key is a live mode key, but the gateway environment is set to sandbox/testing.', 'paid-memberships-pro' ),
+				);
+			} else {
+				$results['publishable_key'] = array( 'status' => 'fail', 'message' => __( 'The saved publishable key does not look like a Stripe publishable key.', 'paid-memberships-pro' ) );
+			}
+		} elseif ( 'fail' === $results['stripe_api']['status'] ) {
+			$results['publishable_key'] = array( 'status' => 'unknown', 'message' => __( 'Skipped because Stripe could not be reached.', 'paid-memberships-pro' ) );
+		} else {
+			// Publishable keys may create tokens, so a throwaway PII token is a real check that Stripe accepts the key (and, for Connect, the connected account).
+			$exception = null;
+			$options   = array( 'api_key' => $publishable_key );
+			if ( ! self::using_api_keys() ) {
+				$options['stripe_account'] = $this->get_connect_user_id();
+			}
+			try {
+				Stripe_Token::create( array( 'pii' => array( 'id_number' => '000000000' ) ), $options );
+			} catch ( \Throwable $e ) {
+				$exception = $e;
+			} catch ( \Exception $e ) {
+				$exception = $e;
+			}
+
+			$status = ! empty( $exception ) && method_exists( $exception, 'getHttpStatus' ) ? (int) $exception->getHttpStatus() : 0;
+			if ( empty( $exception ) || ( ! empty( $status ) && 401 !== $status ) ) {
+				// Only a 401 means the key was rejected. Anything else means Stripe recognized the key.
+				$results['publishable_key'] = array(
+					'status'  => 'pass',
+					'message' => self::using_api_keys()
+						? __( 'Stripe accepted the saved publishable key.', 'paid-memberships-pro' )
+						: __( 'Stripe accepted the platform publishable key for the connected account.', 'paid-memberships-pro' ),
+				);
+			} elseif ( 401 === $status ) {
+				$results['publishable_key'] = array( 'status' => 'fail', 'message' => $exception->getMessage() ? $exception->getMessage() : __( 'Invalid API key.', 'paid-memberships-pro' ) );
+			} else {
+				/* translators: %s: The error message. */
+				$results['publishable_key'] = array( 'status' => 'unknown', 'message' => sprintf( __( 'The publishable key could not be checked: %s', 'paid-memberships-pro' ), $exception->getMessage() ) );
+			}
+		}
+
+		// Put the library's timeouts back.
+		if ( ! empty( $default_timeouts ) ) {
+			$http_client->setTimeout( $default_timeouts[0] );
+			$http_client->setConnectTimeout( $default_timeouts[1] );
+		}
+
+		// Show the two server checks first, then the two key checks.
+		$order   = array( 'stripe_api', 'connect_server', 'secret_key', 'publishable_key' );
+		$results = array_merge( array_flip( array_intersect( $order, array_keys( $results ) ) ), $results );
+
+		$test_results = array(
+			'timestamp'   => time(),
+			'environment' => $gateway_environment,
+			'results'     => $results,
+		);
+		update_option( 'pmpro_stripe_connection_test', $test_results, false );
+
+		return $test_results;
+	}
+
+	/**
+	 * Get the results of the last connection test.
+	 *
+	 * @since TBD
+	 *
+	 * Results are only returned if they were for the current gateway environment. Switching environments
+	 * changes every key being tested, so results from the other environment are treated as if the test never ran.
+	 *
+	 * @return array|false Array with 'timestamp', 'environment', and 'results' (test key => array with 'status' and 'message'), or false if the test has not run for the current environment.
+	 */
+	public static function get_connection_test_results() {
+		$results = get_option( 'pmpro_stripe_connection_test' );
+		if ( ! is_array( $results ) || empty( $results['timestamp'] ) || empty( $results['environment'] ) || empty( $results['results'] ) || ! is_array( $results['results'] ) ) {
+			return false;
+		}
+		if ( $results['environment'] !== ( 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox' ) ) {
+			return false;
+		}
+		return $results;
+	}
+
+	/**
+	 * Forget the results of the last connection test so that the next check starts fresh.
+	 *
+	 * @since TBD
+	 */
+	public static function clear_connection_test_results() {
+		delete_option( 'pmpro_stripe_connection_test' );
+	}
+
+	/**
+	 * Get the keys of the checks that failed in a set of connection test results.
+	 *
+	 * @since TBD
+	 *
+	 * @param array|false $results Results from get_connection_test_results() or run_connection_test().
+	 * @return string[] The failed test keys.
+	 */
+	public static function get_failed_connection_tests( $results ) {
+		$failed = array();
+		if ( empty( $results['results'] ) || ! is_array( $results['results'] ) ) {
+			return $failed;
+		}
+		foreach ( $results['results'] as $test => $result ) {
+			if ( isset( $result['status'] ) && 'fail' === $result['status'] ) {
+				$failed[] = $test;
+			}
+		}
+		return $failed;
+	}
+
+	/**
+	 * Run the connection test from the daily scheduled task.
+	 *
+	 * @since TBD
+	 */
+	public static function run_scheduled_connection_test() {
+		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return;
+		}
+
+		$stripe = new PMProGateway_stripe();
+		if ( empty( $stripe->get_secretkey() ) ) {
+			return;
+		}
+
+		$stripe->run_connection_test();
+	}
+
+	/**
+	 * Run the connection test from the payment settings page and return the refreshed Status cell.
+	 *
+	 * @since TBD
+	 */
+	public static function wp_ajax_pmpro_stripe_run_connection_test() {
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			wp_send_json_error( array( 'message' => __( 'You do not have permission to perform this action.', 'paid-memberships-pro' ) ), 403 );
+		}
+		check_ajax_referer( 'pmpro_stripe_connection_test', 'nonce' );
+
+		$stripe = new PMProGateway_stripe();
+		$stripe->run_connection_test();
+
+		ob_start();
+		$stripe->show_connection_status_cell( 'live' === get_option( 'pmpro_gateway_environment' ) );
+		wp_send_json_success( array( 'html' => ob_get_clean() ) );
+	}
+
+	/**
+	 * Run the connection test when an admin follows the button link without JavaScript.
+	 *
+	 * @since TBD
+	 */
+	public static function maybe_run_connection_test_on_demand() {
+		if ( ! isset( $_REQUEST['pmpro_stripe_connection_test'] ) || 'run' !== $_REQUEST['pmpro_stripe_connection_test'] ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_paymentsettings' ) ) {
+			return;
+		}
+
+		check_admin_referer( 'pmpro_stripe_connection_test' );
+
+		$stripe = new PMProGateway_stripe();
+		$stripe->run_connection_test();
+
+		wp_safe_redirect( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe' ), admin_url( 'admin.php' ) ) . '#pmpro_stripe_connection_test' );
+		exit;
+	}
+
+	/**
+	 * Get the human-readable name of a connection test check.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $test The test key.
+	 * @return string The label.
+	 */
+	private static function get_connection_test_label( $test ) {
+		$labels = array(
+			'stripe_api'      => __( 'Stripe API', 'paid-memberships-pro' ),
+			'secret_key'      => __( 'Secret Key', 'paid-memberships-pro' ),
+			'connect_server'  => __( 'Paid Memberships Pro Connect Server', 'paid-memberships-pro' ),
+			'publishable_key' => __( 'Publishable Key', 'paid-memberships-pro' ),
+		);
+		return isset( $labels[ $test ] ) ? $labels[ $test ] : $test;
+	}
+
+	/**
+	 * Get escaped HTML explaining how to fix a failed connection test check.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $test                The test key.
+	 * @param string $gateway_environment The gateway environment the test ran in, 'live' or 'sandbox'.
+	 * @return string Escaped HTML, or an empty string if there is no suggested fix.
+	 */
+	private static function get_connection_test_fix( $test, $gateway_environment ) {
+		if ( self::has_connect_credentials( $gateway_environment ) ) {
+			$credentials_fix = sprintf(
+				/* translators: %s: Link with the text "Reconnect with Stripe". */
+				esc_html__( '%s using the same Stripe account that this site was previously connected to.', 'paid-memberships-pro' ),
+				'<a href="' . esc_url( self::get_connect_url( $gateway_environment, 'authorize' ) ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>'
+			);
+		} elseif ( self::using_api_keys() ) {
+			$credentials_fix = esc_html__( 'Enter a new Publishable Key and Restricted Key below, then save your settings.', 'paid-memberships-pro' );
+		} else {
+			$credentials_fix = esc_html__( 'Connect with Stripe above.', 'paid-memberships-pro' );
+		}
+
+		switch ( $test ) {
+			case 'stripe_api':
+				return sprintf(
+					/* translators: %s: Link to the Stripe status page. */
+					esc_html__( 'Your web host may be blocking connections to api.stripe.com, or Stripe may be having an outage. Check %s and contact your host if this continues.', 'paid-memberships-pro' ),
+					'<a href="https://status.stripe.com/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'the Stripe status page', 'paid-memberships-pro' ) . '</a>'
+				);
+			case 'secret_key':
+			case 'publishable_key':
+				return $credentials_fix;
+			case 'connect_server':
+				return sprintf(
+					/* translators: %s: Link to Paid Memberships Pro support. */
+					esc_html__( 'Checkout continues to work with the last known publishable key. If this continues for more than a day, %s.', 'paid-memberships-pro' ),
+					'<a href="https://www.paidmembershipspro.com/support/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'contact Paid Memberships Pro support', 'paid-memberships-pro' ) . '</a>'
+				);
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get the nonce-protected URL that runs the connection test on demand.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The URL.
+	 */
+	private static function get_connection_test_url() {
+		return wp_nonce_url(
+			add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connection_test' => 'run' ), admin_url( 'admin.php' ) ),
+			'pmpro_stripe_connection_test'
+		);
+	}
+
+	/**
+	 * Check whether a Stripe account returned by the Connect server differs from the one already saved for an environment.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $gateway_environment The environment being connected, 'live' or 'sandbox'.
+	 * @param string $stripe_user_id      The Stripe account ID returned by the Connect server.
+	 * @return bool True if a different account is already saved for this environment.
+	 */
+	private static function is_different_connected_account( $gateway_environment, $stripe_user_id ) {
+		$saved_user_id = get_option( 'pmpro_' . ( 'live' === $gateway_environment ? 'live' : 'sandbox' ) . '_stripe_connect_user_id' );
+		return ! empty( $saved_user_id ) && $saved_user_id !== $stripe_user_id;
+	}
+
+	/**
+	 * Build the URL used to start or end a Stripe Connect session for an environment.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $environment The gateway environment, 'live' or 'sandbox'.
+	 * @param string $action      The Connect action, 'authorize' or 'disconnect'.
+	 * @return string The URL on the Connect server to send the admin to.
+	 */
+	private static function get_connect_url( $environment, $action ) {
+		$environment = 'live' === $environment ? 'live' : 'sandbox';
+
+		$return_url_args = array(
+			'page'         => 'pmpro-paymentsettings',
+			'edit_gateway' => 'stripe',
+		);
+		$connect_args = array(
+			'action'              => $action,
+			'gateway_environment' => 'live' === $environment ? 'live' : 'test', // The Connect server uses 'test' instead of 'sandbox'.
+		);
+		if ( 'disconnect' === $action ) {
+			$connect_args['stripe_user_id'] = get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' );
+			$return_url_args['pmpro_stripe_connect_deauthorize_nonce'] = wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' );
+		} else {
+			$return_url_args['pmpro_stripe_connect_nonce'] = wp_create_nonce( 'pmpro_stripe_connect_nonce' );
+		}
+		$connect_args['return_url'] = rawurlencode( add_query_arg( $return_url_args, admin_url( 'admin.php' ) ) );
+
+		return add_query_arg( $connect_args, apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' ) );
 	}
 
 	/**
@@ -2983,7 +3437,9 @@ class PMProGateway_stripe extends PMProGateway {
 	 */
 	private function show_connection_settings_section( $livemode ) {
 		$environment = $livemode ? 'live' : 'sandbox';
-		$environment2 = $livemode ? 'live' : 'test'; // For when 'test' is used instead of 'sandbox'.
+
+		// Determine if this is the active environment.
+		$active_environment = $environment === get_option( 'pmpro_gateway_environment' );
 
 		// Determine if the gateway is connected in live mode and set var.
 		if ( self::has_connect_credentials( $environment ) || self::using_api_keys() ) {
@@ -2991,9 +3447,6 @@ class PMProGateway_stripe extends PMProGateway {
 		} else {
 			$connection_selector = $livemode ? 'error' : 'alert';
 		}
-
-		// Determine if this is the active environment.
-		$active_environment = $environment === get_option( 'pmpro_gateway_environment' );
 
 		?>
 		<div id="pmpro_stripe_<?php echo esc_attr( $environment); ?>" class="pmpro_section" data-visibility="<?php echo esc_attr( $active_environment ? 'shown' : 'hidden' ); ?>" data-activated="<?php echo esc_attr( $active_environment ? 'true' : 'false' ); ?>">
@@ -3011,23 +3464,55 @@ class PMProGateway_stripe extends PMProGateway {
 								<th scope="row" valign="top">
 									<label><?php esc_html_e( 'Status', 'paid-memberships-pro' ); ?></label>
 								</th>
-								<td>
-									<span class="pmpro_tag pmpro_tag-<?php echo esc_attr( $connection_selector ); ?>">
-									<?php
-										echo ( $livemode ? esc_html__( 'Live Mode:', 'paid-memberships-pro' ) : esc_html__( 'Test Mode:', 'paid-memberships-pro' ) ) . ' ';
-										if ( self::using_legacy_keys() ) {
-											esc_html_e( 'Connected with Legacy Keys', 'paid-memberships-pro' );
-										} elseif ( self::using_api_keys() ) {
-											esc_html_e( 'Connected with API Keys', 'paid-memberships-pro' );
-										} elseif( self::has_connect_credentials( $environment ) ) {
-											esc_html_e( 'Connected', 'paid-memberships-pro' );
-										} else {
-											esc_html_e( 'Not Connected', 'paid-memberships-pro' );
-										}
-									?>
-									</span>
+								<td id="pmpro_stripe_connection_status" data-nonce="<?php echo esc_attr( wp_create_nonce( 'pmpro_stripe_connection_test' ) ); ?>" data-autorun="<?php echo esc_attr( self::has_connect_credentials( $environment ) || self::using_api_keys() ? '1' : '0' ); ?>">
+									<?php $this->show_connection_status_cell( $livemode ); ?>
 								</td>
 							</tr>
+							<script>
+								// Connection test: run on load and on demand, and toggle the details.
+								jQuery( document ).ready( function( $ ) {
+									var cell = $( '#pmpro_stripe_connection_status' );
+									var checking = <?php echo wp_json_encode( __( 'Checking the Stripe connection...', 'paid-memberships-pro' ) ); ?>;
+									var failed = <?php echo wp_json_encode( __( 'The connection test could not be run. Please reload the page and try again.', 'paid-memberships-pro' ) ); ?>;
+									var hide = <?php echo wp_json_encode( __( 'Hide details', 'paid-memberships-pro' ) ); ?>;
+									var show = <?php echo wp_json_encode( __( 'Show details', 'paid-memberships-pro' ) ); ?>;
+
+									function run() {
+										cell.find( '.pmpro_stripe_run_connection_test' ).addClass( 'disabled' ).attr( 'aria-disabled', 'true' );
+										cell.find( '.pmpro_stripe_connection_test_checking' ).remove();
+										cell.find( '.pmpro_tag' ).first().after( '<span class="pmpro_stripe_connection_test_checking"><span class="spinner is-active" style="float: none; margin: 0 4px 0 8px; vertical-align: middle;"></span>' + checking + '</span>' );
+										$.post( ajaxurl, { action: 'pmpro_stripe_run_connection_test', nonce: cell.data( 'nonce' ) } )
+											.done( function( response ) {
+												if ( response && response.success && response.data && response.data.html ) {
+													cell.html( response.data.html );
+												} else {
+													cell.find( '.pmpro_stripe_connection_test_checking' ).text( failed );
+												}
+											} )
+											.fail( function() {
+												cell.find( '.pmpro_stripe_connection_test_checking' ).text( failed );
+											} );
+									}
+
+									cell.on( 'click', '.pmpro_stripe_run_connection_test', function( e ) {
+										e.preventDefault();
+										if ( ! $( this ).hasClass( 'disabled' ) ) {
+											run();
+										}
+									} );
+
+									cell.on( 'click', '#pmpro_stripe_connection_test_toggle', function( e ) {
+										e.preventDefault();
+										var details = $( '#pmpro_stripe_connection_test' );
+										details.toggle();
+										$( this ).attr( 'aria-expanded', details.is( ':visible' ) ? 'true' : 'false' ).text( details.is( ':visible' ) ? hide : show );
+									} );
+
+									if ( '1' === String( cell.data( 'autorun' ) ) ) {
+										run();
+									}
+								} );
+							</script>
 						<?php } ?>
 						<?php if ( self::using_legacy_keys() && ! self::has_connect_credentials( $environment ) && $active_environment ) { ?>
 							<tr class="gateway gateway_stripe_<?php echo esc_attr( $environment ); ?>">
@@ -3059,17 +3544,8 @@ class PMProGateway_stripe extends PMProGateway {
 							</th>
 							<td>
 								<?php
-								$connect_url_base = apply_filters( 'pmpro_stripe_connect_url', 'https://connect.paidmembershipspro.com' );
 								if ( self::has_connect_credentials( $environment ) ) {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'disconnect',
-											'gateway_environment' => $environment2,
-											'stripe_user_id' => get_option( 'pmpro_' . $environment . '_stripe_connect_user_id' ),
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_deauthorize_nonce' => wp_create_nonce( 'pmpro_stripe_connect_deauthorize_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
+									$connect_url = self::get_connect_url( $environment, 'disconnect' );
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Disconnect From Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<p class="description">
@@ -3083,14 +3559,7 @@ class PMProGateway_stripe extends PMProGateway {
 									</p>
 									<?php
 								} else {
-									$connect_url = add_query_arg(
-										array(
-											'action' => 'authorize',
-											'gateway_environment' => $environment2,
-											'return_url' => rawurlencode( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_nonce' => wp_create_nonce( 'pmpro_stripe_connect_nonce' ) ), admin_url( 'admin.php' ) ) ),
-										),
-										$connect_url_base
-									);
+									$connect_url = self::get_connect_url( $environment, 'authorize' );
 									?>
 									<a href="<?php echo esc_url_raw( $connect_url ); ?>" class="pmpro-stripe-connect"><span><?php esc_html_e( 'Connect with Stripe', 'paid-memberships-pro' ); ?></span></a>
 									<?php
@@ -3180,6 +3649,100 @@ class PMProGateway_stripe extends PMProGateway {
 					}
 				?>
 			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show the contents of the Status cell for the active Stripe Connection section: the status tag and the connection test.
+	 *
+	 * Also used as the AJAX response after running the connection test.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $livemode True if showing the live environment, false for sandbox.
+	 */
+	private function show_connection_status_cell( $livemode ) {
+		$environment = $livemode ? 'live' : 'sandbox';
+		$connected   = self::has_connect_credentials( $environment ) || self::using_api_keys();
+		$results     = $connected ? self::get_connection_test_results() : false;
+		$failed      = self::get_failed_connection_tests( $results );
+		$key_failed  = array_intersect( $failed, array( 'secret_key', 'publishable_key' ) );
+
+		if ( ! empty( $key_failed ) ) {
+			$connection_selector = 'error';
+		} elseif ( $connected ) {
+			$connection_selector = $livemode ? 'success' : 'alert';
+		} else {
+			$connection_selector = $livemode ? 'error' : 'alert';
+		}
+		?>
+		<span class="pmpro_tag pmpro_tag-<?php echo esc_attr( $connection_selector ); ?>">
+		<?php
+			echo ( $livemode ? esc_html__( 'Live Mode:', 'paid-memberships-pro' ) : esc_html__( 'Test Mode:', 'paid-memberships-pro' ) ) . ' ';
+			if ( ! empty( $key_failed ) ) {
+				esc_html_e( 'Connection Error', 'paid-memberships-pro' );
+			} elseif ( ! empty( $failed ) ) {
+				esc_html_e( 'Connected, Issues Detected', 'paid-memberships-pro' );
+			} elseif ( self::using_legacy_keys() ) {
+				esc_html_e( 'Connected with Legacy Keys', 'paid-memberships-pro' );
+			} elseif ( self::using_api_keys() ) {
+				esc_html_e( 'Connected with API Keys', 'paid-memberships-pro' );
+			} elseif ( self::has_connect_credentials( $environment ) ) {
+				esc_html_e( 'Connected', 'paid-memberships-pro' );
+			} else {
+				esc_html_e( 'Not Connected', 'paid-memberships-pro' );
+			}
+		?>
+		</span>
+		<?php
+		if ( ! $connected ) {
+			return;
+		}
+
+		if ( empty( $results ) ) {
+			?>
+			<p class="description">
+				<?php esc_html_e( 'The connection has not been tested yet.', 'paid-memberships-pro' ); ?>
+				<a href="<?php echo esc_url( self::get_connection_test_url() ); ?>" class="pmpro_stripe_run_connection_test"><?php esc_html_e( 'Run connection test', 'paid-memberships-pro' ); ?></a>
+			</p>
+			<?php
+			return;
+		}
+
+		// Open the details automatically only when something failed.
+		$expanded = ! empty( $failed );
+		?>
+		<p class="description">
+			<?php
+			/* translators: %1$s: The date of the last test. %2$s: The time of the last test. */
+			echo esc_html( sprintf( __( 'Last checked on %1$s at %2$s.', 'paid-memberships-pro' ), wp_date( get_option( 'date_format' ), (int) $results['timestamp'] ), wp_date( get_option( 'time_format' ), (int) $results['timestamp'] ) ) );
+			?>
+			<a href="#pmpro_stripe_connection_test" id="pmpro_stripe_connection_test_toggle" aria-expanded="<?php echo esc_attr( $expanded ? 'true' : 'false' ); ?>" aria-controls="pmpro_stripe_connection_test"><?php echo esc_html( $expanded ? __( 'Hide details', 'paid-memberships-pro' ) : __( 'Show details', 'paid-memberships-pro' ) ); ?></a>
+		</p>
+		<div id="pmpro_stripe_connection_test" <?php if ( ! $expanded ) { ?>style="display: none;"<?php } ?>>
+			<?php foreach ( $results['results'] as $test => $result ) { ?>
+				<p>
+					<?php
+					if ( 'pass' === $result['status'] ) {
+						echo '<span class="pmpro_tag pmpro_tag-success">' . esc_html__( 'Passed', 'paid-memberships-pro' ) . '</span>';
+					} elseif ( 'fail' === $result['status'] ) {
+						echo '<span class="pmpro_tag pmpro_tag-error">' . esc_html__( 'Failed', 'paid-memberships-pro' ) . '</span>';
+					} else {
+						echo '<span class="pmpro_tag pmpro_tag-alert">' . esc_html__( 'Skipped', 'paid-memberships-pro' ) . '</span>';
+					}
+					?>
+					<strong><?php echo esc_html( self::get_connection_test_label( $test ) ); ?></strong>
+					<br /><span class="description"><?php echo esc_html( $result['message'] ); ?>
+					<?php if ( 'fail' === $result['status'] ) { ?>
+						<?php echo wp_kses( self::get_connection_test_fix( $test, $results['environment'] ), array( 'a' => array( 'href' => array(), 'target' => array(), 'rel' => array() ) ) ); ?>
+					<?php } ?>
+					</span>
+				</p>
+			<?php } ?>
+			<p>
+				<a class="button button-secondary pmpro_stripe_run_connection_test" href="<?php echo esc_url( self::get_connection_test_url() ); ?>"><?php esc_html_e( 'Run Connection Test', 'paid-memberships-pro' ); ?></a>
+			</p>
 		</div>
 		<?php
 	}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -2341,14 +2341,15 @@ class PMProGateway_stripe extends PMProGateway {
 	 * @return string Escaped HTML, or an empty string if there is no suggested fix.
 	 */
 	private static function get_connection_test_fix( $test, $gateway_environment ) {
-		if ( self::has_connect_credentials( $gateway_environment ) ) {
+		// API keys take precedence over Connect credentials when both are saved, so check them first.
+		if ( self::using_api_keys() ) {
+			$credentials_fix = esc_html__( 'Enter a new Publishable Key and Restricted Key below, then save your settings.', 'paid-memberships-pro' );
+		} elseif ( self::has_connect_credentials( $gateway_environment ) ) {
 			$credentials_fix = sprintf(
 				/* translators: %s: Link with the text "Reconnect with Stripe". */
 				esc_html__( '%s using the same Stripe account that this site was previously connected to.', 'paid-memberships-pro' ),
 				'<a href="' . esc_url( self::get_connect_url( $gateway_environment, 'authorize' ) ) . '">' . esc_html__( 'Reconnect with Stripe', 'paid-memberships-pro' ) . '</a>'
 			);
-		} elseif ( self::using_api_keys() ) {
-			$credentials_fix = esc_html__( 'Enter a new Publishable Key and Restricted Key below, then save your settings.', 'paid-memberships-pro' );
 		} else {
 			$credentials_fix = esc_html__( 'Connect with Stripe above.', 'paid-memberships-pro' );
 		}

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -181,7 +181,6 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'admin_init', array( 'PMProGateway_stripe', 'maybe_run_connection_test_on_demand' ) );
 		add_action( 'wp_ajax_pmpro_stripe_run_connection_test', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_run_connection_test' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_notice' ) );
-		add_filter( 'pmpro_payment_settings_gateway_status_html', array( 'PMProGateway_stripe', 'filter_payment_settings_gateway_status_html' ), 10, 2 );
 
 		// Show warning if webhooks are not set up.
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_webhook_setup_notice' ) );
@@ -1786,31 +1785,27 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Add a connection test tag to Stripe's status in the payment gateways list when the last test found problems.
+	 * Show a connection test tag after Stripe's status in the payment gateways list when the last test found problems.
 	 *
 	 * @since TBD
 	 *
-	 * @param string $gateway_status_html The status HTML for the gateway.
-	 * @param string $gateway_slug        The gateway being shown.
-	 * @return string The status HTML.
+	 * @return string HTML for the tag, or an empty string.
 	 */
-	public static function filter_payment_settings_gateway_status_html( $gateway_status_html, $gateway_slug ) {
-		if ( 'stripe' !== $gateway_slug || 'stripe' !== get_option( 'pmpro_gateway' ) ) {
-			return $gateway_status_html;
+	public static function get_status_tags_for_gateway_settings() {
+		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return '';
 		}
 
 		$failed = self::get_failed_connection_tests( self::get_connection_test_results() );
 		if ( empty( $failed ) ) {
-			return $gateway_status_html;
+			return '';
 		}
 
 		if ( array_intersect( $failed, array( 'secret_key', 'publishable_key' ) ) ) {
-			$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Connection Error', 'paid-memberships-pro' ) . '</span>';
-		} else {
-			$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-alert">' . esc_html__( 'Issues Detected', 'paid-memberships-pro' ) . '</span>';
+			return '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Connection Error', 'paid-memberships-pro' ) . '</span>';
 		}
 
-		return $gateway_status_html;
+		return '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-alert">' . esc_html__( 'Issues Detected', 'paid-memberships-pro' ) . '</span>';
 	}
 
 	/**

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1598,9 +1598,11 @@ class PMProGateway_stripe extends PMProGateway {
 			|| ! isset( $_REQUEST['pmpro_stripe_access_token'] )
 		) {
 			$error = __( 'Invalid response from the Stripe Connect server.', 'paid-memberships-pro' );
-		} elseif ( self::is_different_connected_account( $_REQUEST['pmpro_stripe_connected_environment'], $_REQUEST['pmpro_stripe_user_id'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			// Reconnecting with a different account would orphan every existing customer and subscription.
-			$error = __( 'The Stripe account you just connected is not the account this site was already connected to, so the connection was left unchanged. Existing memberships are tied to the original account. To switch Stripe accounts, disconnect from Stripe first. Note that disconnecting will disconnect all sites using the original Stripe account.', 'paid-memberships-pro' );
+		} elseif ( 'live' === $_REQUEST['pmpro_stripe_connected_environment'] && self::is_different_connected_account( 'live', $_REQUEST['pmpro_stripe_user_id'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			// Reconnecting live mode with a different account would orphan every existing customer and subscription.
+			// Redirect right away so the access token in the return URL doesn't linger in the address bar or server logs.
+			wp_safe_redirect( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connect_error' => 'different_account' ), admin_url( 'admin.php' ) ) );
+			exit;
 		} else {
 			// Change current gateway to Stripe. Only once the connection succeeded, so a failed or refused connection leaves the settings alone.
 			update_option( 'pmpro_gateway', 'stripe' );
@@ -1653,6 +1655,12 @@ class PMProGateway_stripe extends PMProGateway {
 
 	public static function stripe_connect_show_errors() {
 		global $pmpro_stripe_error;
+
+		// A live reconnect with a different Stripe account was refused by stripe_connect_save_options().
+		if ( empty( $pmpro_stripe_error ) && isset( $_GET['pmpro_stripe_connect_error'] ) && 'different_account' === $_GET['pmpro_stripe_connect_error'] && current_user_can( 'manage_options' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$pmpro_stripe_error = __( '<strong>Error:</strong> The Stripe account you just connected is not the account this site was already connected to, so the connection was left unchanged. Existing memberships are tied to the original account. To switch Stripe accounts, disconnect from Stripe first. Note that disconnecting will disconnect all sites using the original Stripe account.', 'paid-memberships-pro' );
+		}
+
 		if ( ! empty( $pmpro_stripe_error ) ) {
 			$class   = 'notice notice-error pmpro-stripe-connect-message';
 			$allowed_html = array(
@@ -1757,12 +1765,6 @@ class PMProGateway_stripe extends PMProGateway {
 			return;
 		}
 
-		// Nothing to test if Stripe isn't connected.
-		$stripe = new PMProGateway_stripe();
-		if ( empty( $stripe->get_secretkey() ) ) {
-			return;
-		}
-
 		// Only warn about failures the admin can fix. Reachability problems are usually temporary.
 		$results = self::get_connection_test_results();
 		$failed  = array_intersect( self::get_failed_connection_tests( $results ), array( 'secret_key', 'publishable_key' ) );
@@ -1775,7 +1777,7 @@ class PMProGateway_stripe extends PMProGateway {
 			<p><?php esc_html_e( 'The most recent Stripe connection test found problems that may prevent members from checking out or updating their billing information:', 'paid-memberships-pro' ); ?></p>
 			<ul>
 				<?php foreach ( $failed as $test ) { ?>
-					<li><strong><?php echo esc_html( self::get_connection_test_label( $test ) ); ?>:</strong> <?php echo esc_html( $results['results'][ $test ]['message'] ); ?></li>
+					<li><strong><?php echo esc_html( self::get_connection_test_label( $test ) ); ?>:</strong> <?php echo esc_html( isset( $results['results'][ $test ]['message'] ) ? $results['results'][ $test ]['message'] : '' ); ?></li>
 				<?php } ?>
 			</ul>
 			<p><a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe' ), admin_url( 'admin.php' ) ) . '#pmpro_stripe_connection_test' ); ?>"><?php esc_html_e( 'Review the Stripe connection test', 'paid-memberships-pro' ); ?></a></p>
@@ -2227,6 +2229,11 @@ class PMProGateway_stripe extends PMProGateway {
 		if ( $results['environment'] !== ( 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox' ) ) {
 			return false;
 		}
+		foreach ( $results['results'] as $result ) {
+			if ( ! is_array( $result ) || ! isset( $result['status'], $result['message'] ) ) {
+				return false;
+			}
+		}
 		return $results;
 	}
 
@@ -2292,8 +2299,11 @@ class PMProGateway_stripe extends PMProGateway {
 		$stripe = new PMProGateway_stripe();
 		$stripe->run_connection_test();
 
+		// Keep the details open if the admin had them open or clicked the button, so the result doesn't collapse under them.
+		$expanded = ! empty( $_POST['expanded'] ) && '1' === $_POST['expanded'];
+
 		ob_start();
-		$stripe->show_connection_status_cell( 'live' === get_option( 'pmpro_gateway_environment' ) );
+		$stripe->show_connection_status_cell( 'live' === get_option( 'pmpro_gateway_environment' ), $expanded );
 		wp_send_json_success( array( 'html' => ob_get_clean() ) );
 	}
 
@@ -2316,7 +2326,7 @@ class PMProGateway_stripe extends PMProGateway {
 		$stripe = new PMProGateway_stripe();
 		$stripe->run_connection_test();
 
-		wp_safe_redirect( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe' ), admin_url( 'admin.php' ) ) . '#pmpro_stripe_connection_test' );
+		wp_safe_redirect( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe', 'pmpro_stripe_connection_test' => 'complete' ), admin_url( 'admin.php' ) ) . '#pmpro_stripe_connection_test' );
 		exit;
 	}
 
@@ -2398,6 +2408,8 @@ class PMProGateway_stripe extends PMProGateway {
 
 	/**
 	 * Check whether a Stripe account returned by the Connect server differs from the one already saved for an environment.
+	 *
+	 * Only enforced for live mode. Sandboxes get a new account ID whenever one is created, so switching them is routine.
 	 *
 	 * @since TBD
 	 *
@@ -3465,7 +3477,12 @@ class PMProGateway_stripe extends PMProGateway {
 								<th scope="row" valign="top">
 									<label><?php esc_html_e( 'Status', 'paid-memberships-pro' ); ?></label>
 								</th>
-								<td id="pmpro_stripe_connection_status" data-nonce="<?php echo esc_attr( wp_create_nonce( 'pmpro_stripe_connection_test' ) ); ?>" data-autorun="<?php echo esc_attr( self::has_connect_credentials( $environment ) || self::using_api_keys() ? '1' : '0' ); ?>">
+								<?php
+								// Run the test on load only when Stripe is connected and there is no result from the last hour. The daily task and the button cover the rest.
+								$last_test = self::get_connection_test_results();
+								$autorun   = ( self::has_connect_credentials( $environment ) || self::using_api_keys() ) && ( empty( $last_test ) || $last_test['timestamp'] < time() - HOUR_IN_SECONDS );
+								?>
+								<td id="pmpro_stripe_connection_status" aria-live="polite" data-nonce="<?php echo esc_attr( wp_create_nonce( 'pmpro_stripe_connection_test' ) ); ?>" data-autorun="<?php echo esc_attr( $autorun ? '1' : '0' ); ?>">
 									<?php $this->show_connection_status_cell( $livemode ); ?>
 								</td>
 							</tr>
@@ -3478,27 +3495,32 @@ class PMProGateway_stripe extends PMProGateway {
 									var hide = <?php echo wp_json_encode( __( 'Hide details', 'paid-memberships-pro' ) ); ?>;
 									var show = <?php echo wp_json_encode( __( 'Show details', 'paid-memberships-pro' ) ); ?>;
 
-									function run() {
+									function showFailure( message ) {
+										cell.find( '.pmpro_stripe_connection_test_checking' ).text( message || failed );
+										cell.find( '.pmpro_stripe_run_connection_test' ).removeClass( 'disabled' ).removeAttr( 'aria-disabled' );
+									}
+
+									function run( expanded ) {
 										cell.find( '.pmpro_stripe_run_connection_test' ).addClass( 'disabled' ).attr( 'aria-disabled', 'true' );
 										cell.find( '.pmpro_stripe_connection_test_checking' ).remove();
 										cell.find( '.pmpro_tag' ).first().after( '<span class="pmpro_stripe_connection_test_checking"><span class="spinner is-active" style="float: none; margin: 0 4px 0 8px; vertical-align: middle;"></span>' + checking + '</span>' );
-										$.post( ajaxurl, { action: 'pmpro_stripe_run_connection_test', nonce: cell.data( 'nonce' ) } )
+										$.post( ajaxurl, { action: 'pmpro_stripe_run_connection_test', nonce: cell.data( 'nonce' ), expanded: expanded ? '1' : '0' } )
 											.done( function( response ) {
 												if ( response && response.success && response.data && response.data.html ) {
 													cell.html( response.data.html );
 												} else {
-													cell.find( '.pmpro_stripe_connection_test_checking' ).text( failed );
+													showFailure( response && response.data && response.data.message );
 												}
 											} )
-											.fail( function() {
-												cell.find( '.pmpro_stripe_connection_test_checking' ).text( failed );
+											.fail( function( jqXHR ) {
+												showFailure( jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message );
 											} );
 									}
 
 									cell.on( 'click', '.pmpro_stripe_run_connection_test', function( e ) {
 										e.preventDefault();
 										if ( ! $( this ).hasClass( 'disabled' ) ) {
-											run();
+											run( true );
 										}
 									} );
 
@@ -3510,7 +3532,7 @@ class PMProGateway_stripe extends PMProGateway {
 									} );
 
 									if ( '1' === String( cell.data( 'autorun' ) ) ) {
-										run();
+										run( $( '#pmpro_stripe_connection_test' ).is( ':visible' ) );
 									}
 								} );
 							</script>
@@ -3661,9 +3683,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since TBD
 	 *
-	 * @param bool $livemode True if showing the live environment, false for sandbox.
+	 * @param bool $livemode       True if showing the live environment, false for sandbox.
+	 * @param bool $force_expanded Whether to show the details even when every check passed.
 	 */
-	private function show_connection_status_cell( $livemode ) {
+	private function show_connection_status_cell( $livemode, $force_expanded = false ) {
 		$environment = $livemode ? 'live' : 'sandbox';
 		$connected   = self::has_connect_credentials( $environment ) || self::using_api_keys();
 		$results     = $connected ? self::get_connection_test_results() : false;
@@ -3711,8 +3734,9 @@ class PMProGateway_stripe extends PMProGateway {
 			return;
 		}
 
-		// Open the details automatically only when something failed.
-		$expanded = ! empty( $failed );
+		// Open the details automatically when something failed, or when the admin just ran the test without JavaScript.
+		$just_ran = isset( $_REQUEST['pmpro_stripe_connection_test'] ) && 'complete' === $_REQUEST['pmpro_stripe_connection_test']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$expanded = $force_expanded || $just_ran || ! empty( $failed );
 		?>
 		<p class="description">
 			<?php

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -181,6 +181,7 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'admin_init', array( 'PMProGateway_stripe', 'maybe_run_connection_test_on_demand' ) );
 		add_action( 'wp_ajax_pmpro_stripe_run_connection_test', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_run_connection_test' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_notice' ) );
+		add_filter( 'pmpro_payment_settings_gateway_status_html', array( 'PMProGateway_stripe', 'filter_payment_settings_gateway_status_html' ), 10, 2 );
 
 		// Show warning if webhooks are not set up.
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_webhook_setup_notice' ) );
@@ -1782,6 +1783,34 @@ class PMProGateway_stripe extends PMProGateway {
 			<p><a href="<?php echo esc_url( add_query_arg( array( 'page' => 'pmpro-paymentsettings', 'edit_gateway' => 'stripe' ), admin_url( 'admin.php' ) ) . '#pmpro_stripe_connection_test' ); ?>"><?php esc_html_e( 'Review the Stripe connection test', 'paid-memberships-pro' ); ?></a></p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Add a connection test tag to Stripe's status in the payment gateways list when the last test found problems.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $gateway_status_html The status HTML for the gateway.
+	 * @param string $gateway_slug        The gateway being shown.
+	 * @return string The status HTML.
+	 */
+	public static function filter_payment_settings_gateway_status_html( $gateway_status_html, $gateway_slug ) {
+		if ( 'stripe' !== $gateway_slug || 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return $gateway_status_html;
+		}
+
+		$failed = self::get_failed_connection_tests( self::get_connection_test_results() );
+		if ( empty( $failed ) ) {
+			return $gateway_status_html;
+		}
+
+		if ( array_intersect( $failed, array( 'secret_key', 'publishable_key' ) ) ) {
+			$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Connection Error', 'paid-memberships-pro' ) . '</span>';
+		} else {
+			$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-alert">' . esc_html__( 'Issues Detected', 'paid-memberships-pro' ) . '</span>';
+		}
+
+		return $gateway_status_html;
 	}
 
 	/**

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -14,7 +14,6 @@ use Stripe\ApplePayDomain as Stripe_ApplePayDomain;
 use Stripe\WebhookEndpoint as Stripe_Webhook;
 use Stripe\StripeClient as Stripe_Client; // Used for deleting webhook as of 2.4
 use Stripe\Account as Stripe_Account;
-use Stripe\Token as Stripe_Token;
 use Stripe\Checkout\Session as Stripe_Checkout_Session;
 
 define( "PMPRO_STRIPE_API_VERSION", "2025-09-30.clover" );
@@ -2059,9 +2058,10 @@ class PMProGateway_stripe extends PMProGateway {
 	 * Test the Stripe connection and save the results.
 	 *
 	 * Checks whether Stripe and the Paid Memberships Pro Connect server can be reached, and whether Stripe
-	 * accepts the saved secret key and the publishable key that checkout uses. Each check has a status of
-	 * 'pass', 'fail', or 'unknown' and a message. Only an authentication failure (a 401 response) counts as
-	 * a rejected key. Permission errors from a restricted key do not, since the key itself is fine.
+	 * accepts the saved secret key and the publishable key that checkout uses. Every request is read-only.
+	 * Each check has a status of 'pass', 'fail', or 'unknown' and a message. Only an authentication failure
+	 * (a 401 response) counts as a rejected key. Permission errors from a restricted key do not, since the
+	 * key itself is fine.
 	 *
 	 * @since TBD
 	 *
@@ -2160,14 +2160,15 @@ class PMProGateway_stripe extends PMProGateway {
 		} elseif ( 'fail' === $results['stripe_api']['status'] ) {
 			$results['publishable_key'] = array( 'status' => 'unknown', 'message' => __( 'Skipped because Stripe could not be reached.', 'paid-memberships-pro' ) );
 		} else {
-			// Publishable keys may create tokens, so a throwaway PII token is a real check that Stripe accepts the key (and, for Connect, the connected account).
+			// Stripe authenticates the key before it looks up the resource, so retrieving a PaymentIntent that doesn't exist with the
+			// publishable key is a read-only check: a valid key gets a 404, a rejected key gets a 401, and for Connect a revoked account gets a 403.
 			$exception = null;
 			$options   = array( 'api_key' => $publishable_key );
 			if ( ! self::using_api_keys() ) {
 				$options['stripe_account'] = $this->get_connect_user_id();
 			}
 			try {
-				Stripe_Token::create( array( 'pii' => array( 'id_number' => '000000000' ) ), $options );
+				Stripe_PaymentIntent::retrieve( array( 'id' => 'pi_pmpro_connection_test', 'client_secret' => 'pi_pmpro_connection_test_secret' ), $options );
 			} catch ( \Throwable $e ) {
 				$exception = $e;
 			} catch ( \Exception $e ) {

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -1585,10 +1585,6 @@ class PMProGateway_stripe extends PMProGateway {
 			return false;
 		}
 
-		// Change current gateway to Stripe
-		update_option( 'pmpro_gateway', 'stripe' );
-		update_option( 'pmpro_gateway_environment', $_REQUEST['pmpro_stripe_connected_environment'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-
 		$error = '';
 		if (
 			'false' === $_REQUEST['pmpro_stripe_connected']
@@ -1606,6 +1602,10 @@ class PMProGateway_stripe extends PMProGateway {
 			// Reconnecting with a different account would orphan every existing customer and subscription.
 			$error = __( 'The Stripe account you just connected is not the account this site was already connected to, so the connection was left unchanged. Existing memberships are tied to the original account. To switch Stripe accounts, disconnect from Stripe first. Note that disconnecting will disconnect all sites using the original Stripe account.', 'paid-memberships-pro' );
 		} else {
+			// Change current gateway to Stripe. Only once the connection succeeded, so a failed or refused connection leaves the settings alone.
+			update_option( 'pmpro_gateway', 'stripe' );
+			update_option( 'pmpro_gateway_environment', $_REQUEST['pmpro_stripe_connected_environment'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
 			// Update keys.
 			if ( $_REQUEST['pmpro_stripe_connected_environment'] === 'live' ) {
 				// Update live keys.
@@ -1991,10 +1991,11 @@ class PMProGateway_stripe extends PMProGateway {
 	 *
 	 * @since 3.8.6
 	 *
+	 * @param bool $force Whether to ignore the 5 minute throttle between attempts.
 	 * @return bool Whether the keys were refreshed.
 	 */
-	public static function refresh_connect_publishable_keys() {
-		if ( get_transient( 'pmpro_stripe_connect_platform_keys_checked' ) ) {
+	public static function refresh_connect_publishable_keys( $force = false ) {
+		if ( ! $force && get_transient( 'pmpro_stripe_connect_platform_keys_checked' ) ) {
 			return false;
 		}
 
@@ -2069,8 +2070,15 @@ class PMProGateway_stripe extends PMProGateway {
 		$gateway_environment = 'live' === get_option( 'pmpro_gateway_environment' ) ? 'live' : 'sandbox';
 		$secret_key          = $this->get_secretkey();
 
+		// If the Stripe library could not be loaded (missing curl or json extension), nothing below can run. Don't report that as a rejected key.
+		if ( ! self::$is_loaded ) {
+			$skipped = array( 'status' => 'unknown', 'message' => __( 'Skipped because the Stripe library could not be loaded. Check the PHP extension warnings on this page.', 'paid-memberships-pro' ) );
+			update_option( 'pmpro_stripe_connection_test', array( 'timestamp' => time(), 'environment' => $gateway_environment, 'results' => array( 'stripe_api' => $skipped, 'secret_key' => $skipped, 'publishable_key' => $skipped ) ), false );
+			return self::get_connection_test_results();
+		}
+
 		// Use short timeouts so a host that silently drops Stripe traffic can't stall the request for the library's 30 second default.
-		$http_client      = self::$is_loaded && class_exists( '\Stripe\HttpClient\CurlClient' ) ? \Stripe\HttpClient\CurlClient::instance() : null;
+		$http_client      = class_exists( '\Stripe\HttpClient\CurlClient' ) ? \Stripe\HttpClient\CurlClient::instance() : null;
 		$default_timeouts = null;
 		if ( $http_client && method_exists( $http_client, 'getTimeout' ) && method_exists( $http_client, 'setTimeout' ) && method_exists( $http_client, 'getConnectTimeout' ) && method_exists( $http_client, 'setConnectTimeout' ) ) {
 			$default_timeouts = array( $http_client->getTimeout(), $http_client->getConnectTimeout() );
@@ -2079,7 +2087,7 @@ class PMProGateway_stripe extends PMProGateway {
 		}
 
 		// Stripe API reachability and secret key. One small read-only request answers both.
-		if ( ! self::$is_loaded || empty( $secret_key ) ) {
+		if ( empty( $secret_key ) ) {
 			$results['stripe_api'] = array( 'status' => 'unknown', 'message' => __( 'Skipped because no Stripe credentials are saved for this environment.', 'paid-memberships-pro' ) );
 			$results['secret_key'] = array( 'status' => 'fail', 'message' => __( 'No Stripe credentials are saved for this environment.', 'paid-memberships-pro' ) );
 		} else {
@@ -2124,8 +2132,7 @@ class PMProGateway_stripe extends PMProGateway {
 
 		// Connect server. Retrieve the current platform publishable key now, ignoring the usual throttle.
 		if ( ! self::using_api_keys() && ! empty( $secret_key ) ) {
-			delete_transient( 'pmpro_stripe_connect_platform_keys_checked' );
-			if ( self::refresh_connect_publishable_keys() ) {
+			if ( self::refresh_connect_publishable_keys( true ) ) {
 				$results['connect_server'] = array( 'status' => 'pass', 'message' => __( 'The current platform publishable key was retrieved from Paid Memberships Pro.', 'paid-memberships-pro' ) );
 			} else {
 				$results['connect_server'] = array( 'status' => 'fail', 'message' => __( 'The Paid Memberships Pro Connect server could not be reached or returned an invalid response. Checkout is using the last known publishable key.', 'paid-memberships-pro' ) );
@@ -3441,13 +3448,6 @@ class PMProGateway_stripe extends PMProGateway {
 
 		// Determine if this is the active environment.
 		$active_environment = $environment === get_option( 'pmpro_gateway_environment' );
-
-		// Determine if the gateway is connected in live mode and set var.
-		if ( self::has_connect_credentials( $environment ) || self::using_api_keys() ) {
-			$connection_selector = $livemode ? 'success' : 'alert';
-		} else {
-			$connection_selector = $livemode ? 'error' : 'alert';
-		}
 
 		?>
 		<div id="pmpro_stripe_<?php echo esc_attr( $environment); ?>" class="pmpro_section" data-visibility="<?php echo esc_attr( $active_environment ? 'shown' : 'hidden' ); ?>" data-activated="<?php echo esc_attr( $active_environment ? 'true' : 'false' ); ?>">

--- a/classes/gateways/class.pmprogateway_stripe.php
+++ b/classes/gateways/class.pmprogateway_stripe.php
@@ -181,6 +181,7 @@ class PMProGateway_stripe extends PMProGateway {
 		add_action( 'admin_init', array( 'PMProGateway_stripe', 'maybe_run_connection_test_on_demand' ) );
 		add_action( 'wp_ajax_pmpro_stripe_run_connection_test', array( 'PMProGateway_stripe', 'wp_ajax_pmpro_stripe_run_connection_test' ) );
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_connection_notice' ) );
+		add_filter( 'pmpro_payment_settings_gateway_status_html', array( 'PMProGateway_stripe', 'filter_payment_settings_gateway_status_html' ), 10, 2 );
 
 		// Show warning if webhooks are not set up.
 		add_action( 'admin_notices', array( 'PMProGateway_stripe', 'show_stripe_webhook_setup_notice' ) );
@@ -1785,27 +1786,31 @@ class PMProGateway_stripe extends PMProGateway {
 	}
 
 	/**
-	 * Show a connection test tag after Stripe's status in the payment gateways list when the last test found problems.
+	 * Add a connection test tag to Stripe's status in the payment gateways list when the last test found problems.
 	 *
 	 * @since TBD
 	 *
-	 * @return string HTML for the tag, or an empty string.
+	 * @param string $gateway_status_html The status HTML for the gateway.
+	 * @param string $gateway_slug        The gateway being shown.
+	 * @return string The status HTML.
 	 */
-	public static function get_status_tags_for_gateway_settings() {
-		if ( 'stripe' !== get_option( 'pmpro_gateway' ) ) {
-			return '';
+	public static function filter_payment_settings_gateway_status_html( $gateway_status_html, $gateway_slug ) {
+		if ( 'stripe' !== $gateway_slug || 'stripe' !== get_option( 'pmpro_gateway' ) ) {
+			return $gateway_status_html;
 		}
 
 		$failed = self::get_failed_connection_tests( self::get_connection_test_results() );
 		if ( empty( $failed ) ) {
-			return '';
+			return $gateway_status_html;
 		}
 
 		if ( array_intersect( $failed, array( 'secret_key', 'publishable_key' ) ) ) {
-			return '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Connection Error', 'paid-memberships-pro' ) . '</span>';
+			$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-error">' . esc_html__( 'Connection Error', 'paid-memberships-pro' ) . '</span>';
+		} else {
+			$gateway_status_html .= ' <span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-alert">' . esc_html__( 'Issues Detected', 'paid-memberships-pro' ) . '</span>';
 		}
 
-		return '<span class="pmpro_tag pmpro_tag-has_icon pmpro_tag-alert">' . esc_html__( 'Issues Detected', 'paid-memberships-pro' ) . '</span>';
+		return $gateway_status_html;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Changes proposed in this Pull Request:
<img width="734" height="653" alt="Screenshot 2026-09-09 at 10 14 56 AM" src="https://github.com/user-attachments/assets/080e63ca-abf8-42ce-b8e9-bf63c0887d66" />
<img width="726" height="560" alt="Screenshot 2026-09-09 at 10 15 09 AM" src="https://github.com/user-attachments/assets/f81fe303-6661-4fbf-94b4-d74b5846d35b" />
<img width="728" height="624" alt="Screenshot 2026-09-09 at 10 16 28 AM" src="https://github.com/user-attachments/assets/c4d2a300-a4f0-47bf-9493-708699fe83c6" />
<img width="1104" height="223" alt="Screenshot 2026-09-09 at 10 16 39 AM" src="https://github.com/user-attachments/assets/df354c5a-4b3b-4e41-afb9-6a978a67a1f4" />

Follow-up hardening to #3791, which shipped the minimal platform publishable-key refresh. This replaces the closed #3789 and absorbs the secret-key probe and same-account guard from #3783 (left open for now).

**Stripe Connection Test.** `PMProGateway_stripe::run_connection_test()` runs four checks and stores one result in the `pmpro_stripe_connection_test` option (not autoloaded, scoped to the active gateway environment):

| Check | How | Fails when |
|---|---|---|
| Stripe API | One `Customer::all( limit 1 )` request with the active secret key | No response or a 5xx |
| PMPro Connect Server | Fetches the platform-key manifest, bypassing the 5-minute throttle | Manifest unreachable or invalid (Connect sites only) |
| Secret Key | Same request as above | HTTP 401 only. A 403 from a restricted key counts as accepted. |
| Publishable Key | API-key sites: prefix/mode check. Then a read-only `PaymentIntent::retrieve` of a non-existent ID authenticated with the publishable key checkout uses, with the `Stripe-Account` header for Connect (valid key = 404, rejected = 401, revoked account = 403) | HTTP 401 only |

Each check is pass / fail / skipped with a message and, on failure, a suggested fix. Stripe calls use 5s connect / 10s total timeouts and restore the library defaults afterward.

**When it runs**
- Daily via the existing `pmpro_schedule_daily` action (only when Stripe is the primary gateway).
- Asynchronously on load of the Stripe settings page when there is no result from the last hour (AJAX, nonce + capability checked). The stored result renders immediately, a spinner shows while checking, and the Status cell is replaced with the server-rendered result.
- On demand via a **Run Connection Test** button in the same cell. The button's href is a nonce URL that runs the test and redirects, so it also works without JavaScript.

**Where it shows**
- The **Status** row of the active Stripe Connection section: the tag reads *Connection Error* when a key is rejected or *Connected, Issues Detected* when a server was unreachable, followed by "Last checked on…" and a *Show details* link. Details open automatically only when something failed.
- One admin notice on other PMPro admin pages, only for rejected keys (reachability problems never trigger it), linking back to the settings page. This reads the stored result and makes no outbound calls.
- The payment gateways list on the main Payment Settings page appends a *Connection Error* or *Issues Detected* tag after Stripe's "Enabled (Primary Gateway)" status. This goes through a new `pmpro_payment_settings_gateway_status_html` filter on the status HTML (passes the gateway slug), which Stripe hooks from its own class. Other gateways and add-ons can use the same filter.
- Site Health gateway line gets a `Connection Test: passed|<check:status list> on date` fragment.
- The existing webhook admin notice is unchanged except it now bails when the last test shows a rejected secret key, since the webhook check would fail for the wrong reason.

**Same-account guard (live mode only).** The Connect return handler refuses to overwrite an existing live connection with a different Stripe account and redirects immediately so the OAuth token never lingers in the URL. The error copy warns that disconnecting affects all sites on the original account. Sandboxes are exempt since Stripe issues a new account ID per sandbox. This makes the *Reconnect with Stripe* fix link safe. The inline connect/disconnect URL builders were consolidated into `get_connect_url()`.

**Deliberately not included:** email alerts, a failed-call log or HTTP decorator, browser-side auto-reload, and anything on the checkout request path. The webhook is not part of the test because it has its own section and notice.

**Notes for review**
- Every request the test makes is read-only. Nothing is created on the Stripe account. The settings page only auto-runs when there is no result from the last hour.
- Sites where Stripe is not the primary gateway are never tested.
- The off-settings-page notice currently lists each failed check. Kim's spec is a thinner "something is wrong, go look here" message; happy to trim before this leaves draft.
- Verified via wp-cli on dev.local: happy path, rejected secret key (bogus key and a genuinely revoked Connect token), rotated publishable key, Stripe and Connect server unreachable, environment switch, notice visibility rules, AJAX handler with a valid nonce. The browser flow (spinner, cell replacement, toggle) was verified manually by David.

### How to test the changes in this Pull Request:

1. Connect Stripe in sandbox mode and load the Stripe settings page. The Status row should show a spinner briefly, then *Connected*, "Last checked on…", and a *Show details* link. Details should list four passing checks.
2. Click **Run Connection Test**. The spinner should appear and the cell should refresh in place.
3. Replace `pmpro_sandbox_stripe_connect_secretkey` with a bogus `sk_test_…` value and reload. The tag should read *Connection Error*, details should open with Secret Key failed and a *Reconnect with Stripe* link, and other PMPro admin pages should show the connection notice while the webhook notice is suppressed. Restore the key.
4. Set the `test` key in the `pmpro_stripe_connect_platform_keys` option to a bogus `pk_test_…` value, filter `pmpro_stripe_connect_publishable_key_manifest_url` to an unreachable URL, and reload. Connect Server and Publishable Key should both fail.
5. Filter the manifest URL to an unreachable host and set `\Stripe\Stripe::$apiBase` to an unreachable host (a small mu-plugin works). The tag should read *Connected, Issues Detected*, Stripe API and Connect Server should fail, and the two key checks should show *Skipped*. Other PMPro admin pages should show no connection notice.
6. Switch the gateway environment. The Status row should show "not tested yet" until the next run.
7. With a site connected in sandbox, complete the Connect flow with a different Stripe account. The connection should stay unchanged and the error should explain why.
8. Use restricted API keys instead of Connect. There should be no Connect Server row, and a live-mode publishable key on a sandbox site should fail with a mode-mismatch message.

### Proposed changelog entries

```
ENHANCEMENT: Added a Stripe connection test to the payment settings page that checks daily, on page load, and on demand whether Stripe and the Paid Memberships Pro Connect server can be reached and whether Stripe accepts the saved keys, with an admin notice when a key is rejected. #3783 #3789 #3791 (@dparker1005)
BUG FIX: Connecting to Stripe now refuses to overwrite an existing connection with a different Stripe account. #3783 (@dparker1005)
BUG FIX: The Stripe webhook notice no longer reports a missing webhook when the real problem is that Stripe is rejecting the saved credentials. #3783 (@dparker1005)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



