### PR TITLE
Add pmpro_view_as capability for the View As toolbar

### DIFF
--- a/includes/adminpages.php
+++ b/includes/adminpages.php
@@ -455,7 +455,7 @@ function pmpro_admin_membership_access_menu_bar() {
 	}
 
 	// View menu at all?
-	if ( ! current_user_can( 'manage_options' ) || ! is_admin_bar_showing() ) {
+	if ( ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'pmpro_view_as' ) ) || ! is_admin_bar_showing() ) {
 		return;
 	}
 

--- a/includes/capabilities.php
+++ b/includes/capabilities.php
@@ -75,7 +75,8 @@ function pmpro_get_capability_defs($role)
 		'pmpro_discountcodes',
 		'pmpro_userfields',
 		'pmpro_updates',
-		'pmpro_manage_pause_mode'
+		'pmpro_manage_pause_mode',
+		'pmpro_view_as'
 	);
 
     return apply_filters( "pmpro_assigned_{$role}_capabilities", $cap_array);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2564,8 +2564,8 @@ function pmpro_getMembershipLevelsForUser( $user_id = null, $include_inactive = 
 	// make sure user id is int for security
 	$user_id = intval( $user_id );
 
-	// Admins have special rules for membership levels. Check them here.
-	if ( $user_id == $current_user->ID && current_user_can( 'manage_options' ) ) {
+	// Admins and users with the View As capability have special rules for membership levels. Check them here.
+	if ( $user_id == $current_user->ID && ( current_user_can( 'manage_options' ) || current_user_can( 'pmpro_view_as' ) ) ) {
 		// Make sure that we are not on a page where we want to always show the user's true levels.
 		if (
 			! is_admin() &&


### PR DESCRIPTION
Replaces #3786 by @faisalahammad, re-based onto `v3.9` for the 3.9 milestone. The original branch was cut from `dev`, which has moved past `v3.9`, so retargeting it pulled in unrelated commits and conflicted. This branch cherry-picks the single commit with authorship preserved and drops the CHANGELOG.txt / readme.txt edits (we assemble the changelog at release time).

### Changes proposed in this Pull Request:

Adds a dedicated `pmpro_view_as` capability so the "View As" (Admin Membership Access) toolbar can be granted to roles that should not have `manage_options`. Requested in #3634.

- `pmpro_admin_membership_access_menu_bar()` shows the toolbar (and processes its save handler) for users with `manage_options` OR `pmpro_view_as`.
- `pmpro_getMembershipLevelsForUser()` applies the same gate so the preview actually takes effect for those users.
- `pmpro_view_as` is added to the administrator capability list. Existing admins pick it up automatically via the `admin_init` capability check.

These are the only two decision points for the View As feature; content access has no separate admin bypass. Note that the "yes" mode resolves to every level, so a user granted this capability can view all restricted content on the site. That is the intent of the capability and should be stated in the docs.

### How to test the changes in this Pull Request:

1. As an administrator, confirm the View As toolbar still appears and switching between No Access / Current / All Levels works on the frontend.
2. Create an Editor user. Confirm no toolbar appears.
3. Grant that Editor the `pmpro_view_as` capability (e.g. with the Members plugin). Confirm the toolbar appears and the preview takes effect on restricted content, while the WP Settings and PMPro License pages remain inaccessible.

### Proposed changelog entry

ENHANCEMENT: Added a new `pmpro_view_as` capability so the "View As" toolbar in the admin bar can be granted to roles that do not have `manage_options`. #3634 (@faisalahammad)
