### PR TITLE
Show required asterisk once for radio user fields

### DIFF
--- a/js/pmpro-checkout.js
+++ b/js/pmpro-checkout.js
@@ -156,8 +156,14 @@ jQuery(document).ready(function(){
 	});
 
 	jQuery('.pmpro_form_input-required').each(function() {
+		// Radio options are each wrapped in their own .pmpro_form_field div, so look up the
+		// label from the radio group container to avoid marking every option as required.
+		var $fieldDiv = jQuery(this).closest('.pmpro_form_field-radio-items').parent();
+		if ( ! $fieldDiv.length ) {
+			$fieldDiv = jQuery(this).closest('.pmpro_form_field');
+		}
+
 		// Check if there's an asterisk already
-		var $fieldDiv = jQuery(this).closest('.pmpro_form_field');
 		var $firstLabel = $fieldDiv.find('.pmpro_form_label').first();
 		var $hasAsterisk = $firstLabel.find('.pmpro_asterisk').length > 0;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

`js/pmpro-checkout.js` adds the required asterisk to labels from two blocks. The second block walks up from each required input with `closest('.pmpro_form_field')` to find the label to mark. Radio options are each wrapped in their own `<div class="pmpro_form_field pmpro_form_field-radio-item">` (`class-pmpro-field.php`, radio branch), so the lookup stopped at the option wrapper and every option label (Yes, No, etc.) got its own asterisk instead of only the field label.

The fix resolves the wrapper through the radio group container first, with a fallback to the old lookup so every other field type is untouched. The first block already adds one asterisk to the field label, so its existing check prevents a duplicate and the result is a single asterisk on the label only.

`aria-required` is still set on all radio inputs, so screen reader behavior is unchanged.

Resolves #3794.

### How to test the changes in this Pull Request:

1. Go to Memberships > Settings > User Fields and create a Radio field with a few options (e.g. Red, Blue, Green) and set Required at Checkout to Yes.
2. View the checkout page.
3. The field label shows one asterisk and the individual radio options show none.
4. Repeat with a required Text field and a required Checkbox Grouped field to confirm they still show one asterisk on the label only.
5. Submit checkout with the radio field empty to confirm required validation still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

Checked with a headless DOM test against the markup the field classes generate: before the change a required radio field rendered 4 asterisks (label plus all 3 options), after the change exactly 1 on the field label. Text, checkbox_grouped and the Terms of Service checkbox rendered identically before and after. Note for context: the per-option asterisk behavior was introduced with #2499 (for #2293), which was about showing the asterisk only when required. This keeps that part and fixes the placement.

### Changelog entry

> Bug fix: Required radio user fields now show the required asterisk on the field label only, instead of on every option label.