### PR TITLE
Fix Stripe webhook 500 when InvoicePayment is missing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -210,6 +210,9 @@ Not sure? You can find out by doing a bit a research.
 4. [Ask using our contact form](https://www.paidmembershipspro.com/contact/)
 
 == Changelog ==
+= 3.8.7 - TBD =
+* BUG FIX: The Stripe webhook no longer returns an HTTP 500 error for `charge.failed` and `charge.refunded` events when another plugin has loaded an older version of the Stripe PHP library that does not include the `InvoicePayment` class. The webhook now logs the problem and skips the event instead of fataling. #3764 (@faisalahammad)
+
 = 3.8.6 - 2026-09-08 =
 * ENHANCEMENT: Changed the "Edit Membership" button on the Edit Member memberships panel to "Update Membership" to make it clear that it saves the level change. #3781 (@flintfromthebasement)
 * ENHANCEMENT: The password visibility toggle now shows only the eye icon in the log in widget and on narrow screens so the field label and the toggle no longer wrap into each other. #3769 (@kimcoleman)

--- a/services/class-pmpro-stripe-webhook-handler.php
+++ b/services/class-pmpro-stripe-webhook-handler.php
@@ -335,21 +335,37 @@ class PMPro_Stripe_Webhook_Handler {
 		$invoice = null;
 
 		// Make sure we have the charge in the desired API version.
-		$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
+		try {
+			$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
+		} catch ( Exception $e ) {
+			$logstr .= 'Error retrieving charge ' . $pmpro_stripe_event->data->object->id . ' from Stripe: ' . $e->getMessage() . '. No action taken for failed payment.';
+			return;
+		}
 
 		// Get the invoice for this charge if it exists.
 		if ( ! empty( $charge->payment_intent ) ) {
-			$invoice_payment = \Stripe\InvoicePayment::all(
-				array(
-					'payment' => array(
-						'type'           => 'payment_intent',
-						'payment_intent' => $charge->payment_intent,
-					),
-					'expand'  => array(
-						'data.invoice',
-					),
-				)
-			);
+			// Another plugin may have loaded a version of the Stripe library that predates the InvoicePayment class.
+			if ( ! class_exists( '\Stripe\InvoicePayment' ) ) {
+				$logstr .= 'The loaded Stripe library does not provide the \Stripe\InvoicePayment class, so we could not get the invoice for failed charge ' . $charge->id . '. No action taken for failed payment.';
+				return;
+			}
+
+			try {
+				$invoice_payment = \Stripe\InvoicePayment::all(
+					array(
+						'payment' => array(
+							'type'           => 'payment_intent',
+							'payment_intent' => $charge->payment_intent,
+						),
+						'expand'  => array(
+							'data.invoice',
+						),
+					)
+				);
+			} catch ( Exception $e ) {
+				$logstr .= 'Error retrieving invoice payments for failed charge ' . $charge->id . ': ' . $e->getMessage() . '. No action taken for failed payment.';
+				return;
+			}
 			// Using data[0] as only one invoice payment should match a search passing a specific payment intent ID.
 			$invoice = empty( $invoice_payment->data[0]->invoice ) ? null : $invoice_payment->data[0]->invoice;
 		}
@@ -403,7 +419,12 @@ class PMPro_Stripe_Webhook_Handler {
 	 */
 	private static function handle_charge_refunded( $pmpro_stripe_event, &$logstr ) {
 		// Make sure we have the charge in the desired API version.
-		$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
+		try {
+			$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
+		} catch ( Exception $e ) {
+			$logstr .= 'Error retrieving charge ' . $pmpro_stripe_event->data->object->id . ' from Stripe: ' . $e->getMessage() . '. No action taken for refunded charge.';
+			return;
+		}
 
 		$payment_transaction_id = $charge->id;
 		$morder = new MemberOrder();
@@ -411,18 +432,31 @@ class PMPro_Stripe_Webhook_Handler {
 
 		// Initial payment orders are stored using the invoice ID, so check that value too.
 		if ( empty( $morder->id ) && ! empty( $charge->payment_intent ) ) {
-			// Get the invoice for this charge if it exists.
-			$invoice_payment = \Stripe\InvoicePayment::all(
-				array(
-					'payment' => array(
-						'type'           => 'payment_intent',
-						'payment_intent' => $charge->payment_intent,
-					),
-				)
-			);
-			// Using data[0] as only one invoice payment should match a search passing a specific payment intent ID.
-			$payment_transaction_id = empty( $invoice_payment->data[0]->invoice ) ? null : $invoice_payment->data[0]->invoice;
-			$morder->getMemberOrderByPaymentTransactionID( $payment_transaction_id );
+			// Older copies of the Stripe library loaded by another plugin may not include the InvoicePayment class.
+			if ( ! class_exists( '\Stripe\InvoicePayment' ) ) {
+				$logstr .= 'The loaded Stripe library does not provide the \Stripe\InvoicePayment class, so we could not look up the invoice for refunded charge ' . $charge->id . '. ';
+			} else {
+				// Get the invoice for this charge if it exists.
+				try {
+					$invoice_payment = \Stripe\InvoicePayment::all(
+						array(
+							'payment' => array(
+								'type'           => 'payment_intent',
+								'payment_intent' => $charge->payment_intent,
+							),
+						)
+					);
+				} catch ( Exception $e ) {
+					$logstr .= 'Error retrieving invoice payments for refunded charge ' . $charge->id . ': ' . $e->getMessage() . '. ';
+					$invoice_payment = null;
+				}
+
+				if ( ! empty( $invoice_payment ) ) {
+					// Using data[0] as only one invoice payment should match a search passing a specific payment intent ID.
+					$payment_transaction_id = empty( $invoice_payment->data[0]->invoice ) ? null : $invoice_payment->data[0]->invoice;
+					$morder->getMemberOrderByPaymentTransactionID( $payment_transaction_id );
+				}
+			}
 		}
 
 		// We've got the right order.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

### Changes proposed in this Pull Request:

Resolves #3764.

The Stripe webhook returned an HTTP 500 for `charge.failed` events when another active plugin registered an older copy of the Stripe PHP library before PMPro loaded its bundled copy. `PMProStripeGateway::loadStripeLibrary()` only checks whether `Stripe\Stripe` exists, so it skips the bundled library and `\Stripe\InvoicePayment` is never defined. `handle_charge_failed()` then called `\Stripe\InvoicePayment::all()` with no guard. A missing class raises a PHP `Error`, which is not an `Exception`, so nothing caught it and the webhook returned a 500.

`handle_charge_refunded()` had the same unguarded fallback lookup, so `charge.refunded` could fail the same way. That path is fixed too.

**Before:**

```php
// handle_charge_failed()
$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );

if ( ! empty( $charge->payment_intent ) ) {
	$invoice_payment = \Stripe\InvoicePayment::all( ... );
```

**After:**

```php
try {
	$charge = Stripe_Charge::retrieve( $pmpro_stripe_event->data->object->id );
} catch ( Exception $e ) {
	$logstr .= 'Error retrieving charge ' . ... . '. No action taken for failed payment.';
	return;
}

if ( ! empty( $charge->payment_intent ) ) {
	if ( ! class_exists( '\Stripe\InvoicePayment' ) ) {
		$logstr .= 'The loaded Stripe library does not provide the \Stripe\InvoicePayment class ...';
		return;
	}

	try {
		$invoice_payment = \Stripe\InvoicePayment::all( ... );
	} catch ( Exception $e ) {
		$logstr .= 'Error retrieving invoice payments ...';
		return;
	}
```

The refund handler uses the same class check and try/catch around the fallback invoice lookup, but does not return early, so a refund that already matches an order by charge ID still gets recorded.

Also adds a changelog entry under `3.8.7 - TBD` in readme.txt.

### How to test the changes in this Pull Request:

1. On a site with PMPro and Stripe connected, trigger a declined payment (test card `4000000000000341` or `pm_card_chargeDeclined`) and check the Stripe webhook log. The `charge.failed` event is handled, the log describes the failed charge, and the response is not a 500.
2. Simulate the library collision by registering an older Stripe library that has no `\Stripe\InvoicePayment` before PMPro loads, then resend the `charge.failed` event from the Stripe dashboard. Expected: HTTP 200 and a log entry reading `The loaded Stripe library does not provide the \Stripe\InvoicePayment class`.
3. Resend a `charge.refunded` event under the same conditions. Expected: HTTP 200, and when the order is found by charge ID the refund is still recorded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

Testing done: `php -l` on the changed file, plus a headless harness that loads the handler with stubbed Stripe classes and reflection-invokes both handlers for the missing class, Stripe API error, and happy paths, and for the refund path where the order is found by charge ID. The same harness fatals on the pre-fix code with `Class "Stripe\InvoicePayment" not found`, which is the error reported in #3764. The patch was also installed on a test site and the affected Stripe events were resent.

Related but left out on purpose: `get_order_data_from_invoice()` still calls `Stripe_PaymentMethod::retrieve()`, `\Stripe\PaymentIntent::retrieve()`, and `Stripe_Customer::retrieve()` without a try/catch, so a Stripe API error later in the `charge.failed` flow can still fatal. Happy to send a separate issue or PR for that if you want it in the same release.

### Changelog entry

> BUG FIX: The Stripe webhook no longer returns an HTTP 500 error for `charge.failed` and `charge.refunded` events when another plugin has loaded an older version of the Stripe PHP library that does not include the `InvoicePayment` class. The webhook now logs the problem and skips the event instead of fataling. #3764